### PR TITLE
use default initializer for uninitialized globals

### DIFF
--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -4414,19 +4414,15 @@ fn structs_are_generated() {
 
         VAR_GLOBAL
           x : MyStruct;
+          y : STRUCT
+            a : BYTE;
+            b : BYTE;
+          END_STRUCT;
         END_VAR
         ",
     );
 
-    let expected = r#"; ModuleID = 'main'
-source_filename = "main"
-
-%MyStruct = type { i32, i32 }
-
-@x = global %MyStruct zeroinitializer
-"#;
-
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
 }
 
 #[test]
@@ -4437,17 +4433,12 @@ fn arrays_are_generated() {
 
         VAR_GLOBAL
           x : MyArray;
+          y : ARRAY[0..5] OF REAL;
         END_VAR
         ",
     );
 
-    let expected = r#"; ModuleID = 'main'
-source_filename = "main"
-
-@x = external global [10 x i16]
-"#;
-
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
 }
 
 #[test]
@@ -4472,20 +4463,7 @@ fn arrays_with_global_const_size_are_generated() {
         ",
     );
 
-    let expected = r#"; ModuleID = 'main'
-source_filename = "main"
-
-@THREE = global i16 3
-@ZERO = global i16 0
-@LEN = global i16 9
-@x = external global [10 x i16]
-@y = external global [11 x i32]
-@z = external global [19 x i8]
-@zz = external global [10 x [10 x i8]]
-@zzz = external global [10 x [8 x i8]]
-"#;
-
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
 }
 
 #[test]
@@ -5569,6 +5547,25 @@ fn initial_values_in_array_of_array_variable() {
 source_filename = "main"
 
 @a = global [2 x [2 x i8]] [[2 x i8] c"\01\02", [2 x i8] c"\03\04"]
+"#;
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn uninitialized_global_array() {
+    let result = codegen(
+        "
+         VAR_GLOBAL 
+           a : ARRAY[0..1] OF BYTE; 
+         END_VAR
+         ",
+    );
+
+    let expected = r#"; ModuleID = 'main'
+source_filename = "main"
+
+@a = global [2 x i8] zeroinitializer
 "#;
 
     assert_eq!(result, expected);

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__arrays_are_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__arrays_are_generated.snap
@@ -1,0 +1,11 @@
+---
+source: src/codegen/tests/code_gen_tests.rs
+expression: result
+
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+@x = global [10 x i16] zeroinitializer
+@y = global [6 x float] zeroinitializer
+

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__arrays_with_global_const_size_are_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__arrays_with_global_const_size_are_generated.snap
@@ -1,0 +1,17 @@
+---
+source: src/codegen/tests/code_gen_tests.rs
+expression: result
+
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+@THREE = global i16 3
+@ZERO = global i16 0
+@LEN = global i16 9
+@x = global [10 x i16] zeroinitializer
+@y = global [11 x i32] zeroinitializer
+@z = global [19 x i8] zeroinitializer
+@zz = global [10 x [10 x i8]] zeroinitializer
+@zzz = global [10 x [8 x i8]] zeroinitializer
+

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__structs_are_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__structs_are_generated.snap
@@ -1,0 +1,14 @@
+---
+source: src/codegen/tests/code_gen_tests.rs
+expression: result
+
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%MyStruct = type { i32, i32 }
+%__global_y = type { i8, i8 }
+
+@x = global %MyStruct zeroinitializer
+@y = global %__global_y zeroinitializer
+

--- a/tests/correctness/global_variables.rs
+++ b/tests/correctness/global_variables.rs
@@ -114,3 +114,65 @@ fn global_variables_with_initialization() {
         }
     );
 }
+
+#[test]
+fn uninitialized_global_array() {
+    let function = r"
+        VAR_GLOBAL
+            gX : ARRAY[0..2] OF INT;  /* this should be zero-initialized */
+            gZ : INT;
+        END_VAR
+        FUNCTION main : REAL
+            VAR
+                x,y : INT;
+                z : INT;
+            END_VAR
+            gX[0] := 10;
+            gX[1] := 21;
+            gZ := 5;
+            x := gX[0];
+            y := gX[1];
+            z := gZ;
+            main := (x + y) / z;
+        END_FUNCTION
+    ";
+
+    struct MainType {}
+    let mut maintype = MainType {};
+    let res: f32 = compile_and_run(function.to_string(), &mut maintype);
+    assert!((res - 31f32 / 5f32) <= f32::EPSILON);
+}
+
+#[test]
+fn uninitialized_global_struct() {
+    let function = r"
+        TYPE Point : STRUCT
+            x : INT;
+            y : INT;
+        END_STRUCT
+        END_TYPE
+
+        VAR_GLOBAL
+            gX : Point; /* this should be zero-initialized */
+            gZ : INT;
+        END_VAR
+        FUNCTION main : REAL
+            VAR
+                x,y : INT;
+                z : INT;
+            END_VAR
+            gX.x := 10;
+            gX.y := 21;
+            gZ := 5;
+            x := gX.x;
+            y := gX.y;
+            z := gZ;
+            main := (x + y) / z;
+        END_FUNCTION
+    ";
+
+    struct MainType {}
+    let mut maintype = MainType {};
+    let res: f32 = compile_and_run(function.to_string(), &mut maintype);
+    assert!((res - 31f32 / 5f32) <= f32::EPSILON);
+}


### PR DESCRIPTION
especially complex global variables (arrays, struct) need
an initial value, or llvm will generate them as a external.
So when accessing that global variable it would result in an
ACCESS_VIOLATION

fixes #361