### PR TITLE
Multifile Compilation

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -39,14 +39,13 @@ impl<'ink> CodeGen<'ink> {
         CodeGen { context, module }
     }
 
-    fn generate_llvm_index(
+    pub fn generate_llvm_index(
         &self,
-        module: &Module<'ink>,
         annotations: &AnnotationMap,
         global_index: &Index,
     ) -> Result<LlvmTypedIndex<'ink>, CompileError> {
         let llvm = Llvm::new(self.context, self.context.create_builder());
-        let mut index = LlvmTypedIndex::new();
+        let mut index = LlvmTypedIndex::default();
         //Generate types index, and any global variables associated with them.
         let llvm_type_index =
             data_type_generator::generate_data_types(&llvm, global_index, annotations)?;
@@ -54,7 +53,7 @@ impl<'ink> CodeGen<'ink> {
 
         //Generate global variables
         let llvm_gv_index = variable_generator::generate_global_variables(
-            module,
+            &self.module,
             &llvm,
             global_index,
             annotations,
@@ -65,7 +64,7 @@ impl<'ink> CodeGen<'ink> {
         //Generate opaque functions for implementations and associate them with their types
         let llvm = Llvm::new(self.context, self.context.create_builder());
         let llvm_impl_index = pou_generator::generate_implementation_stubs(
-            module,
+            &self.module,
             llvm,
             global_index,
             annotations,
@@ -81,13 +80,11 @@ impl<'ink> CodeGen<'ink> {
         unit: &CompilationUnit,
         annotations: &AnnotationMap,
         global_index: &Index,
+        llvm_index: &LlvmTypedIndex,
     ) -> Result<String, CompileError> {
-        //Associate the index type with LLVM types
-        let llvm_index = self.generate_llvm_index(&self.module, annotations, global_index)?;
-
         //generate all pous
         let llvm = Llvm::new(self.context, self.context.create_builder());
-        let pou_generator = PouGenerator::new(llvm, global_index, annotations, &llvm_index);
+        let pou_generator = PouGenerator::new(llvm, global_index, annotations, llvm_index);
 
         //Generate the POU stubs in the first go to make sure they can be referenced.
         for implementation in &unit.implementations {

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -51,7 +51,7 @@ pub fn generate_data_types<'ink>(
         llvm,
         index,
         annotations,
-        types_index: LlvmTypedIndex::new(),
+        types_index: LlvmTypedIndex::default(),
     };
 
     let types = generator.index.get_types();

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -45,7 +45,7 @@ pub fn generate_implementation_stubs<'ink>(
     annotations: &AnnotationMap,
     types_index: &LlvmTypedIndex<'ink>,
 ) -> Result<LlvmTypedIndex<'ink>, CompileError> {
-    let mut llvm_index = LlvmTypedIndex::new();
+    let mut llvm_index = LlvmTypedIndex::default();
     let pou_generator = PouGenerator::new(llvm, index, annotations, types_index);
     for (name, implementation) in index.get_implementations() {
         let curr_f = pou_generator.generate_implementation_stub(implementation, module)?;

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -19,7 +19,7 @@ pub fn generate_global_variables<'ctx, 'b>(
     annotations: &'b AnnotationMap,
     types_index: &'b LlvmTypedIndex<'ctx>,
 ) -> Result<LlvmTypedIndex<'ctx>, CompileError> {
-    let mut index = LlvmTypedIndex::new();
+    let mut index = LlvmTypedIndex::default();
     let globals = global_index.get_globals();
     let enums = global_index.get_global_qualified_enums();
     for (name, variable) in globals.into_iter().chain(enums.into_iter()) {

--- a/src/codegen/llvm_index.rs
+++ b/src/codegen/llvm_index.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 /// Index view containing declared values for the current context
 /// Parent Index is the a fallback lookup index for values not declared locally
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LlvmTypedIndex<'ink> {
     parent_index: Option<&'ink LlvmTypedIndex<'ink>>,
     type_associations: HashMap<String, BasicTypeEnum<'ink>>,
@@ -17,17 +17,6 @@ pub struct LlvmTypedIndex<'ink> {
 }
 
 impl<'ink> LlvmTypedIndex<'ink> {
-    pub fn new() -> LlvmTypedIndex<'ink> {
-        LlvmTypedIndex {
-            parent_index: None,
-            type_associations: HashMap::new(),
-            initial_value_associations: HashMap::new(),
-            loaded_variable_associations: HashMap::new(),
-            implementations: HashMap::new(),
-            constants: HashMap::new(),
-        }
-    }
-
     pub fn create_child(parent: &'ink LlvmTypedIndex<'ink>) -> LlvmTypedIndex<'ink> {
         LlvmTypedIndex {
             parent_index: Some(parent),

--- a/src/codegen/tests/codegen_error_messages_tests.rs
+++ b/src/codegen/tests/codegen_error_messages_tests.rs
@@ -331,7 +331,7 @@ fn char_assigning_wstring_literal_results_in_casting_error() {
     // THEN result should be a casting error
     if let Err(msg) = result {
         assert_eq!(
-            CompileError::casting_error("WSTRING".into(), "CHAR".into(), (52..55).into()),
+            CompileError::casting_error("WSTRING", "CHAR", (52..55).into()),
             msg
         )
     } else {
@@ -355,7 +355,7 @@ fn wchar_assigning_string_literal_results_in_casting_error() {
     // THEN result shoud be a casting error
     if let Err(msg) = result {
         assert_eq!(
-            CompileError::casting_error("STRING".into(), "WCHAR".into(), (53..56).into()),
+            CompileError::casting_error("STRING", "WCHAR", (53..56).into()),
             msg
         )
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ impl From<&str> for SourceCode {
     fn from(src: &str) -> Self {
         SourceCode {
             source: src.into(),
-            path: "<undefined>".into(),
+            path: "external_file.st".into(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,6 +405,15 @@ impl From<&str> for SourceCode {
     }
 }
 
+impl From<String> for SourceCode {
+    fn from(source: String) -> Self {
+        SourceCode {
+            source,
+            path: "external_file.st".into(),
+        }
+    }
+}
+
 fn create_source_code<T: Read>(
     reader: &mut T,
     encoding: Option<&'static Encoding>,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -151,6 +151,11 @@ impl AnnotationMap {
         }
     }
 
+    pub fn import(&mut self, other: AnnotationMap) {
+        self.type_map.extend(other.type_map);
+        self.type_hint_map.extend(other.type_hint_map);
+    }
+
     /// annotates the given statement (using it's `get_id()`) with the given type-name
     pub fn annotate(&mut self, s: &AstStatement, annotation: StatementAnnotation) {
         self.type_map.insert(s.get_id(), annotation);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,15 +1,7 @@
 #[cfg(test)]
 pub mod tests {
 
-    use crate::{
-        ast::{self, CompilationUnit},
-        compile_error::CompileError,
-        index::{self, Index},
-        lexer::{self, IdProvider},
-        parser,
-        resolver::{const_evaluator::evaluate_constants, AnnotationMap, TypeAnnotator},
-        Diagnostic, Validator,
-    };
+    use crate::{Diagnostic, Validator, ast::{self, CompilationUnit}, compile_error::CompileError, index::{self, Index}, lexer::{self, IdProvider}, parser, resolver::{const_evaluator::evaluate_constants, AnnotationMap, TypeAnnotator}};
 
     pub fn parse(src: &str) -> (CompilationUnit, Vec<Diagnostic>) {
         parser::parse(lexer::lex_with_ids(src, IdProvider::default()))

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,7 +1,15 @@
 #[cfg(test)]
 pub mod tests {
 
-    use crate::{Diagnostic, Validator, ast::{self, CompilationUnit}, compile_error::CompileError, index::{self, Index}, lexer::{self, IdProvider}, parser, resolver::{const_evaluator::evaluate_constants, AnnotationMap, TypeAnnotator}};
+    use crate::{
+        ast::{self, CompilationUnit},
+        compile_error::CompileError,
+        index::{self, Index},
+        lexer::{self, IdProvider},
+        parser,
+        resolver::{const_evaluator::evaluate_constants, AnnotationMap, TypeAnnotator},
+        Diagnostic, Validator,
+    };
 
     pub fn parse(src: &str) -> (CompilationUnit, Vec<Diagnostic>) {
         parser::parse(lexer::lex_with_ids(src, IdProvider::default()))
@@ -38,7 +46,8 @@ pub mod tests {
 
         let context = inkwell::context::Context::create();
         let code_generator = crate::codegen::CodeGen::new(&context, "main");
-        code_generator.generate(&unit, &annotations, &index)
+        let llvm_index = code_generator.generate_llvm_index(&annotations, &index)?;
+        code_generator.generate(&unit, &annotations, &index, &llvm_index)
     }
 
     pub fn codegen(src: &str) -> String {

--- a/src/tests/multi_files.rs
+++ b/src/tests/multi_files.rs
@@ -1,0 +1,31 @@
+use crate::{SourceCode, compile_to_string};
+
+#[test]
+fn multiple_source_files_generated() {
+    //Given 2 sources
+    let src1 : SourceCode = "
+    FUNCTION main : INT
+    VAR_INPUT
+
+    END_VAR
+
+    VAR
+
+    END_VAR
+    mainProg();
+    END_FUNCTION
+
+    ".into();
+    let src2 : SourceCode = "
+    PROGRAM mainProg
+    VAR_TEMP
+    END_VAR
+    END_PROGRAM
+    ".into();
+    //When the are generated
+    let res = compile_to_string(vec![src1,src2], None).unwrap();
+    //The datatypes do not conflics
+    //The functions are defined correctly
+    insta::assert_snapshot!(res);
+    
+}

--- a/src/tests/multi_files.rs
+++ b/src/tests/multi_files.rs
@@ -1,9 +1,9 @@
-use crate::{SourceCode, compile_to_string};
+use crate::{compile_to_string, SourceCode};
 
 #[test]
 fn multiple_source_files_generated() {
     //Given 2 sources
-    let src1 : SourceCode = "
+    let src1: SourceCode = "
     FUNCTION main : INT
     VAR_INPUT
 
@@ -15,17 +15,18 @@ fn multiple_source_files_generated() {
     mainProg();
     END_FUNCTION
 
-    ".into();
-    let src2 : SourceCode = "
+    "
+    .into();
+    let src2: SourceCode = "
     PROGRAM mainProg
     VAR_TEMP
     END_VAR
     END_PROGRAM
-    ".into();
+    "
+    .into();
     //When the are generated
-    let res = compile_to_string(vec![src1,src2], None).unwrap();
+    let res = compile_to_string(vec![src1, src2], None).unwrap();
     //The datatypes do not conflics
     //The functions are defined correctly
     insta::assert_snapshot!(res);
-    
 }

--- a/src/tests/snapshots/rusty__tests__multi_files__multiple_source_files_generated.snap
+++ b/src/tests/snapshots/rusty__tests__multi_files__multiple_source_files_generated.snap
@@ -1,0 +1,38 @@
+---
+source: src/tests/multi_files.rs
+expression: res
+
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%mainProg_interface = type {}
+%main_interface = type {}
+
+@mainProg_instance = global %mainProg_interface zeroinitializer
+
+define i16 @main(%main_interface* %0) {
+entry:
+  %main = alloca i16, align 2
+  br label %input
+
+input:                                            ; preds = %entry
+  br label %call
+
+call:                                             ; preds = %input
+  call void @mainProg(%mainProg_interface* @mainProg_instance)
+  br label %output
+
+output:                                           ; preds = %call
+  br label %continue
+
+continue:                                         ; preds = %output
+  %main_ret = load i16, i16* %main, align 2
+  ret i16 %main_ret
+}
+
+define void @mainProg(%mainProg_interface* %0) {
+entry:
+  ret void
+}
+

--- a/tests/correctness/arrays.rs
+++ b/tests/correctness/arrays.rs
@@ -41,7 +41,7 @@ fn array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     for index in 0..5 {
         assert_eq!((index + 10) as i16, maintype.int_array[index]);
@@ -74,7 +74,7 @@ fn array_declaration_using_constants() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     for index in 0..5 {
         assert_eq!((index + 10) as i16, maintype.int_array[index]);
@@ -103,7 +103,7 @@ fn matrix_array_assignments() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -179,7 +179,7 @@ fn matrix_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -212,7 +212,7 @@ fn cube_array_assignments_array_of_array_of_array() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {
@@ -247,7 +247,7 @@ fn cube_array_assignments2() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {

--- a/tests/correctness/arrays.rs
+++ b/tests/correctness/arrays.rs
@@ -41,7 +41,7 @@ fn array_assignments() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     for index in 0..5 {
         assert_eq!((index + 10) as i16, maintype.int_array[index]);
@@ -74,7 +74,7 @@ fn array_declaration_using_constants() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     for index in 0..5 {
         assert_eq!((index + 10) as i16, maintype.int_array[index]);
@@ -103,7 +103,7 @@ fn matrix_array_assignments() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -179,7 +179,7 @@ fn matrix_array_assignments2() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             assert_eq!((x * y) as i16, maintype.matrix[x][y]);
@@ -212,7 +212,7 @@ fn cube_array_assignments_array_of_array_of_array() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {
@@ -247,7 +247,7 @@ fn cube_array_assignments2() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     for x in 0..5 {
         for y in 0..5 {
             for z in 0..5 {

--- a/tests/correctness/bitaccess.rs
+++ b/tests/correctness/bitaccess.rs
@@ -43,6 +43,7 @@ fn bitaccess_assignment() {
         b: u16,
         c: u32,
         d: u64,
+        two: i16,
     }
     let mut param = Type::default();
 

--- a/tests/correctness/bitaccess.rs
+++ b/tests/correctness/bitaccess.rs
@@ -47,7 +47,7 @@ fn bitaccess_assignment() {
     }
     let mut param = Type::default();
 
-    compile_and_run::<_, i32>(prog.to_string(), &mut param);
+    let _ : i32 = compile_and_run(prog, &mut param);
 
     assert_eq!(0b0000_0010, param.a);
     assert_eq!(0b0000_0010_0000_0000, param.b);
@@ -72,9 +72,7 @@ fn bitaccess_chained_assignment() {
     main := d;       //2#0000_0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000
     END_FUNCTION";
 
-    struct Type {}
-
-    let res: u64 = compile_and_run(prog.to_string(), &mut Type {});
+    let res: u64 = compile_and_run(prog, &mut MainType::default());
 
     assert_eq!(
         0b0000_0010_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000,
@@ -97,8 +95,7 @@ fn qualified_reference_assignment() {
         END_FUNCTION
 
         ";
-    struct Type {}
-    let res: u8 = compile_and_run(prog.to_string(), &mut Type {});
+    let res: u8 = compile_and_run(prog, &mut MainType::default);
     assert_eq!(2, res);
 }
 
@@ -126,7 +123,7 @@ fn bitaccess_test() {
     ";
     let mut main_type = MainType::default();
 
-    compile_and_run::<_, i32>(prog.to_string(), &mut main_type);
+    let _ : i32 = compile_and_run(prog, &mut main_type);
     assert_eq!(
         main_type,
         MainType {
@@ -169,7 +166,7 @@ fn bitaccess_with_var_test() {
     ";
     let mut main_type = MainType::default();
 
-    compile_and_run::<_, i32>(prog.to_string(), &mut main_type);
+    let _ : i32 = compile_and_run(prog, &mut main_type);
     assert_eq!(
         main_type,
         MainType {

--- a/tests/correctness/bitaccess.rs
+++ b/tests/correctness/bitaccess.rs
@@ -47,7 +47,7 @@ fn bitaccess_assignment() {
     }
     let mut param = Type::default();
 
-    let _ : i32 = compile_and_run(prog, &mut param);
+    let _: i32 = compile_and_run(prog, &mut param);
 
     assert_eq!(0b0000_0010, param.a);
     assert_eq!(0b0000_0010_0000_0000, param.b);
@@ -123,7 +123,7 @@ fn bitaccess_test() {
     ";
     let mut main_type = MainType::default();
 
-    let _ : i32 = compile_and_run(prog, &mut main_type);
+    let _: i32 = compile_and_run(prog, &mut main_type);
     assert_eq!(
         main_type,
         MainType {
@@ -166,7 +166,7 @@ fn bitaccess_with_var_test() {
     ";
     let mut main_type = MainType::default();
 
-    let _ : i32 = compile_and_run(prog, &mut main_type);
+    let _: i32 = compile_and_run(prog, &mut main_type);
     assert_eq!(
         main_type,
         MainType {

--- a/tests/correctness/classes.rs
+++ b/tests/correctness/classes.rs
@@ -46,8 +46,7 @@ fn class_reference_in_pou() {
         x := cl.testMethod(myMethodArg:= x);
         main := x;
         END_FUNCTION
-        "
-    .into();
+        ";
 
     let res: i32 = compile_and_run(
         source,

--- a/tests/correctness/custom_datatypes.rs
+++ b/tests/correctness/custom_datatypes.rs
@@ -43,7 +43,7 @@ fn using_structs() {
     END_PROGRAM
     "#;
 
-    let _ : i32 = compile_and_run(testcode, &mut main_data);
+    let _: i32 = compile_and_run(testcode, &mut main_data);
     assert_eq!(3, main_data.my_s.field1);
     assert_eq!(7, main_data.my_s.field2);
     assert_eq!(10, main_data.my_s.field3);
@@ -129,7 +129,7 @@ fn using_nested_structs() {
     END_PROGRAM
     "#;
 
-    let _ : i32 = compile_and_run(testcode, &mut main_data);
+    let _: i32 = compile_and_run(testcode, &mut main_data);
     assert_eq!(11, main_data.my_s.mys1.field1);
     assert_eq!(12, main_data.my_s.mys1.field2);
     assert_eq!(13, main_data.my_s.mys1.field3);
@@ -174,7 +174,7 @@ fn using_enums() {
     END_PROGRAM
     "#;
 
-    let _ : i32 = compile_and_run(testcode, &mut d);
+    let _: i32 = compile_and_run(testcode, &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -211,7 +211,7 @@ fn using_inline_enums() {
     END_PROGRAM
     "#;
 
-    let _ : i32 = compile_and_run(testcode, &mut d);
+    let _: i32 = compile_and_run(testcode, &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -253,7 +253,7 @@ fn using_inline_enums_in_structs() {
     END_PROGRAM
     "#;
 
-    let _ : i32 = compile_and_run(testcode, &mut data);
+    let _: i32 = compile_and_run(testcode, &mut data);
     assert_eq!(2, data.tf1); //yellow
     assert_eq!(3, data.tf2); //green
     assert_eq!(2, data.tf3); //yellow
@@ -301,7 +301,7 @@ fn using_inline_arrays_in_structs() {
     END_PROGRAM
     "#;
 
-    let _ : i32 = compile_and_run(testcode, &mut data);
+    let _: i32 = compile_and_run(testcode, &mut data);
     assert_eq!([0, 1, 2, 3], data.arr1);
     assert_eq!([0, 10, 20, 30, 0, 0, 0, 77], data.arr2);
     assert_eq!([77, 0, -1], data.arr3);
@@ -329,7 +329,7 @@ fn using_arrays() {
     END_PROGRAM
     "#;
 
-    let _ : i32 = compile_and_run(testcode, &mut main);
+    let _: i32 = compile_and_run(testcode, &mut main);
     for (i, j) in main.arr.iter_mut().enumerate() {
         assert_eq!(i as i32, *j);
     }

--- a/tests/correctness/custom_datatypes.rs
+++ b/tests/correctness/custom_datatypes.rs
@@ -43,7 +43,7 @@ fn using_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_, i32>(testcode.to_string(), &mut main_data);
+    let _ : i32 = compile_and_run(testcode, &mut main_data);
     assert_eq!(3, main_data.my_s.field1);
     assert_eq!(7, main_data.my_s.field2);
     assert_eq!(10, main_data.my_s.field3);
@@ -129,7 +129,7 @@ fn using_nested_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_, i32>(testcode.to_string(), &mut main_data);
+    let _ : i32 = compile_and_run(testcode, &mut main_data);
     assert_eq!(11, main_data.my_s.mys1.field1);
     assert_eq!(12, main_data.my_s.mys1.field2);
     assert_eq!(13, main_data.my_s.mys1.field3);
@@ -174,7 +174,7 @@ fn using_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_, i32>(testcode.to_string(), &mut d);
+    let _ : i32 = compile_and_run(testcode, &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -211,7 +211,7 @@ fn using_inline_enums() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_, i32>(testcode.to_string(), &mut d);
+    let _ : i32 = compile_and_run(testcode, &mut d);
     assert_eq!(1, d.field1);
     assert_eq!(2, d.field2);
     assert_eq!(3, d.field3);
@@ -253,7 +253,7 @@ fn using_inline_enums_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_, i32>(testcode.to_string(), &mut data);
+    let _ : i32 = compile_and_run(testcode, &mut data);
     assert_eq!(2, data.tf1); //yellow
     assert_eq!(3, data.tf2); //green
     assert_eq!(2, data.tf3); //yellow
@@ -301,7 +301,7 @@ fn using_inline_arrays_in_structs() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_, i32>(testcode.to_string(), &mut data);
+    let _ : i32 = compile_and_run(testcode, &mut data);
     assert_eq!([0, 1, 2, 3], data.arr1);
     assert_eq!([0, 10, 20, 30, 0, 0, 0, 77], data.arr2);
     assert_eq!([77, 0, -1], data.arr3);
@@ -329,7 +329,7 @@ fn using_arrays() {
     END_PROGRAM
     "#;
 
-    compile_and_run::<_, i32>(testcode.to_string(), &mut main);
+    let _ : i32 = compile_and_run(testcode, &mut main);
     for (i, j) in main.arr.iter_mut().enumerate() {
         assert_eq!(i as i32, *j);
     }

--- a/tests/correctness/datatypes.rs
+++ b/tests/correctness/datatypes.rs
@@ -47,7 +47,7 @@ fn same_type_addition() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function, &mut maintype);
+    let _: i32 = compile_and_run(function, &mut maintype);
     assert!(!maintype.bool_1);
     assert!(maintype.bool_2);
     assert!(!maintype.bool_3); //Overflow
@@ -85,7 +85,7 @@ fn byte_addition() {
         byte_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(2, maintype.byte_1);
     assert_eq!(0, maintype.byte_2);
     assert_eq!(254, maintype.byte_3); //Overflow
@@ -117,7 +117,7 @@ fn byte_mixed_addition() {
         int_1: 275,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(9, maintype.byte_1); //Overflow
 
     let mut maintype = Type {
@@ -126,7 +126,7 @@ fn byte_mixed_addition() {
         int_1: 10,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(20, maintype.byte_1);
 }
 
@@ -158,7 +158,7 @@ fn usint_addition() {
         usint_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(2, maintype.usint_1);
     assert_eq!(0, maintype.usint_2);
     assert_eq!(254, maintype.usint_3); //Overflow
@@ -190,7 +190,7 @@ fn usint_mixed_addition() {
         int_1: 275,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(9, maintype.usint_1); //Overflow
 
     let mut maintype = Type {
@@ -199,7 +199,7 @@ fn usint_mixed_addition() {
         int_1: 10,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(20, maintype.usint_1);
 }
 
@@ -231,7 +231,7 @@ fn sint_additions() {
         sint_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(2, maintype.sint_1);
     assert_eq!(0, maintype.sint_2);
     assert_eq!(119, maintype.sint_3); //Overflow
@@ -263,7 +263,7 @@ fn sint_mixed_addition() {
         int_1: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(-6, maintype.sint_1);
 
     let mut maintype = Type {
@@ -272,7 +272,7 @@ fn sint_mixed_addition() {
         int_1: 300,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(54, maintype.sint_1);
 }
 
@@ -304,7 +304,7 @@ fn word_addition() {
         byte_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -343,7 +343,7 @@ fn word_mixed_addition() {
         dint_1: -0xFFFFFFF,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(256, maintype.word_1);
     assert_eq!(65527, maintype.word_2);
 }
@@ -377,7 +377,7 @@ fn int_addition() {
         byte_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(-32757, maintype.byte_2);
     assert_eq!(32759, maintype.byte_3); //Overflow
@@ -411,7 +411,7 @@ fn uint_addition() {
         byte_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -445,7 +445,7 @@ fn dword_addition() {
         byte_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967286, maintype.byte_2);
     assert_eq!(10, maintype.byte_3); //Overflow
@@ -479,7 +479,7 @@ fn dint_addition() {
         byte_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(2147483638, maintype.byte_2);
     assert_eq!(-2147483639, maintype.byte_3); //overflow
@@ -513,7 +513,7 @@ fn udint_addition() {
         byte_3: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967285, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -543,7 +543,7 @@ fn unsinged_byte_expansion() {
         int_1: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(265, maintype.int_1);
 }
 
@@ -583,7 +583,7 @@ fn unsinged_byte_expansion2() {
         int_2: 0,
     };
 
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     assert_eq!(245, maintype.int_1);
     assert_eq!(65780, maintype.int_2);
 }
@@ -624,7 +624,7 @@ fn unsinged_byte_expansion3() {
         arg3: 10,
         result: 0,
     };
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     let arg1: u64 = maintype.arg1.into();
     let arg2: u64 = maintype.arg2.into();
     let arg3: u64 = maintype.arg3;
@@ -659,7 +659,7 @@ fn assign_short_string_to_long_string_variable() {
         text: [0; 81],
         text2: [0; 81],
     };
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     assert_eq!(t[0] as u8, b'a');
@@ -709,7 +709,7 @@ fn assign_string_to_string() {
         text: [0; 81],
         text2: [0; 81],
     };
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
 
     let t: [u8; 81] = maintype.text2;
     assert_eq!(t[0] as u8, b'a');
@@ -753,7 +753,7 @@ fn assign_long_string_to_short_string_variable() {
     for (i, b) in "hello".bytes().enumerate() {
         maintype.text2[i] = b;
     }
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
@@ -801,7 +801,7 @@ fn function_parameters_string() {
         text2: [0; 81],
         text3: [0; 81],
     };
-    let _ : i32 = compile_and_run(program, &mut maintype);
+    let _: i32 = compile_and_run(program, &mut maintype);
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
         assert_eq!(t[i], b'a');
@@ -853,7 +853,7 @@ fn real_to_int_assignment() {
         int_val2: 0,
     };
 
-    let _ : i32 = compile_and_run(function, &mut maintype);
+    let _: i32 = compile_and_run(function, &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_eq!(2, maintype.int_val);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -892,7 +892,7 @@ fn real_float_assingment() {
         lreal_target: 0.0,
     };
 
-    let _ : i32 = compile_and_run(function, &mut maintype);
+    let _: i32 = compile_and_run(function, &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_almost_eq!(2.0, maintype.lreal_target, f64::EPSILON);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);

--- a/tests/correctness/datatypes.rs
+++ b/tests/correctness/datatypes.rs
@@ -47,7 +47,7 @@ fn same_type_addition() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function, &mut maintype);
     assert!(!maintype.bool_1);
     assert!(maintype.bool_2);
     assert!(!maintype.bool_3); //Overflow
@@ -85,7 +85,7 @@ fn byte_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(2, maintype.byte_1);
     assert_eq!(0, maintype.byte_2);
     assert_eq!(254, maintype.byte_3); //Overflow
@@ -117,7 +117,7 @@ fn byte_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(9, maintype.byte_1); //Overflow
 
     let mut maintype = Type {
@@ -126,7 +126,7 @@ fn byte_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(20, maintype.byte_1);
 }
 
@@ -158,7 +158,7 @@ fn usint_addition() {
         usint_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(2, maintype.usint_1);
     assert_eq!(0, maintype.usint_2);
     assert_eq!(254, maintype.usint_3); //Overflow
@@ -190,7 +190,7 @@ fn usint_mixed_addition() {
         int_1: 275,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(9, maintype.usint_1); //Overflow
 
     let mut maintype = Type {
@@ -199,7 +199,7 @@ fn usint_mixed_addition() {
         int_1: 10,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(20, maintype.usint_1);
 }
 
@@ -231,7 +231,7 @@ fn sint_additions() {
         sint_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(2, maintype.sint_1);
     assert_eq!(0, maintype.sint_2);
     assert_eq!(119, maintype.sint_3); //Overflow
@@ -263,7 +263,7 @@ fn sint_mixed_addition() {
         int_1: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(-6, maintype.sint_1);
 
     let mut maintype = Type {
@@ -272,7 +272,7 @@ fn sint_mixed_addition() {
         int_1: 300,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(54, maintype.sint_1);
 }
 
@@ -304,7 +304,7 @@ fn word_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -343,7 +343,7 @@ fn word_mixed_addition() {
         dint_1: -0xFFFFFFF,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(256, maintype.word_1);
     assert_eq!(65527, maintype.word_2);
 }
@@ -377,7 +377,7 @@ fn int_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(-32757, maintype.byte_2);
     assert_eq!(32759, maintype.byte_3); //Overflow
@@ -411,7 +411,7 @@ fn uint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(65525, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -445,7 +445,7 @@ fn dword_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967286, maintype.byte_2);
     assert_eq!(10, maintype.byte_3); //Overflow
@@ -479,7 +479,7 @@ fn dint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(2147483638, maintype.byte_2);
     assert_eq!(-2147483639, maintype.byte_3); //overflow
@@ -513,7 +513,7 @@ fn udint_addition() {
         byte_3: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(1, maintype.byte_1);
     assert_eq!(4294967285, maintype.byte_2);
     assert_eq!(9, maintype.byte_3); //Overflow
@@ -543,7 +543,7 @@ fn unsinged_byte_expansion() {
         int_1: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(265, maintype.int_1);
 }
 
@@ -583,7 +583,7 @@ fn unsinged_byte_expansion2() {
         int_2: 0,
     };
 
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     assert_eq!(245, maintype.int_1);
     assert_eq!(65780, maintype.int_2);
 }
@@ -624,7 +624,7 @@ fn unsinged_byte_expansion3() {
         arg3: 10,
         result: 0,
     };
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     let arg1: u64 = maintype.arg1.into();
     let arg2: u64 = maintype.arg2.into();
     let arg3: u64 = maintype.arg3;
@@ -659,7 +659,7 @@ fn assign_short_string_to_long_string_variable() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     assert_eq!(t[0] as u8, b'a');
@@ -709,7 +709,7 @@ fn assign_string_to_string() {
         text: [0; 81],
         text2: [0; 81],
     };
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
 
     let t: [u8; 81] = maintype.text2;
     assert_eq!(t[0] as u8, b'a');
@@ -753,7 +753,7 @@ fn assign_long_string_to_short_string_variable() {
     for (i, b) in "hello".bytes().enumerate() {
         maintype.text2[i] = b;
     }
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
 
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
@@ -801,7 +801,7 @@ fn function_parameters_string() {
         text2: [0; 81],
         text3: [0; 81],
     };
-    compile_and_run::<_, i32>(program.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(program, &mut maintype);
     let t: [u8; 81] = maintype.text;
     for i in (0..75).step_by(3) {
         assert_eq!(t[i], b'a');
@@ -853,7 +853,7 @@ fn real_to_int_assignment() {
         int_val2: 0,
     };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function, &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_eq!(2, maintype.int_val);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);
@@ -892,7 +892,7 @@ fn real_float_assingment() {
         lreal_target: 0.0,
     };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function, &mut maintype);
     assert_almost_eq!(2.0, maintype.real_val, f32::EPSILON);
     assert_almost_eq!(2.0, maintype.lreal_target, f64::EPSILON);
     assert_almost_eq!(4.0, maintype.lreal_val, f64::EPSILON);

--- a/tests/correctness/expressions.rs
+++ b/tests/correctness/expressions.rs
@@ -25,7 +25,7 @@ fn real_negation() {
             END_FUNCTION
     ";
     let mut maintype = MainType::default();
-    let _ : i32 = compile_and_run(function, &mut maintype);
+    let _: i32 = compile_and_run(function, &mut maintype);
     assert_eq!(-2.0, maintype.a);
     assert_eq!(2.0, maintype.b);
     assert_eq!(-3.0, maintype.c);

--- a/tests/correctness/expressions.rs
+++ b/tests/correctness/expressions.rs
@@ -25,7 +25,7 @@ fn real_negation() {
             END_FUNCTION
     ";
     let mut maintype = MainType::default();
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function, &mut maintype);
     assert_eq!(-2.0, maintype.a);
     assert_eq!(2.0, maintype.b);
     assert_eq!(-3.0, maintype.c);

--- a/tests/correctness/external_functions.rs
+++ b/tests/correctness/external_functions.rs
@@ -5,11 +5,11 @@ use inkwell::targets::{InitializationConfig, Target};
 #[allow(dead_code)]
 #[repr(C)]
 struct MainType {
-    ret: i32,
+    val: i32,
 }
 
 extern "C" fn times_two(param: &MainType) -> i32 {
-    param.ret * 2
+    param.val * 2
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn test_external_function_called() {
     let fn_value = code_gen.module.get_function("times_two").unwrap();
 
     exec_engine.add_global_mapping(&fn_value, times_two as usize);
-    let res: i32 = run(&exec_engine, "main", &mut MainType { ret: 0 });
+    let res: i32 = run(&exec_engine, "main", &mut MainType { val: 0 });
     assert_eq!(res, 200)
 
     //Call that function

--- a/tests/correctness/functions.rs
+++ b/tests/correctness/functions.rs
@@ -212,7 +212,7 @@ fn function_block_instances_save_state_per_instance() {
         f: FooType { i: 0 },
         j: FooType { i: 0 },
     };
-    compile_and_run::<_, i32>(function.to_string(), &mut interface);
+    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
     assert_eq!(interface.f.i, 2);
     assert_eq!(interface.j.i, 7);
 }
@@ -270,7 +270,7 @@ fn functions_can_be_called_out_of_order() {
     "#;
 
     let mut interface = MainType { f: 0 };
-    compile_and_run::<_, i32>(function.to_string(), &mut interface);
+    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.f);
 }
@@ -336,7 +336,7 @@ fn function_block_instances_save_state_per_instance_2() {
             baz: BazType { i: 0 },
         },
     };
-    compile_and_run::<_, i32>(function.to_string(), &mut interface);
+    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(2, interface.f.baz.i);
     assert_eq!(4, interface.j.baz.i);
@@ -378,7 +378,7 @@ fn function_call_inout_variable() {
     "#;
 
     let mut interface = MainType { baz: 7 };
-    compile_and_run::<_, i32>(function.to_string(), &mut interface);
+    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(64, interface.baz);
 }
@@ -429,7 +429,7 @@ fn inouts_behave_like_pointers() {
         p2: 0,
         p3: 0,
     };
-    compile_and_run::<_, i32>(function.to_string(), &mut interface);
+    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.p1);
     assert_eq!(8, interface.p2);

--- a/tests/correctness/functions.rs
+++ b/tests/correctness/functions.rs
@@ -212,7 +212,7 @@ fn function_block_instances_save_state_per_instance() {
         f: FooType { i: 0 },
         j: FooType { i: 0 },
     };
-    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
+    let _: i32 = compile_and_run(function.to_string(), &mut interface);
     assert_eq!(interface.f.i, 2);
     assert_eq!(interface.j.i, 7);
 }
@@ -270,7 +270,7 @@ fn functions_can_be_called_out_of_order() {
     "#;
 
     let mut interface = MainType { f: 0 };
-    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
+    let _: i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.f);
 }
@@ -336,7 +336,7 @@ fn function_block_instances_save_state_per_instance_2() {
             baz: BazType { i: 0 },
         },
     };
-    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
+    let _: i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(2, interface.f.baz.i);
     assert_eq!(4, interface.j.baz.i);
@@ -378,7 +378,7 @@ fn function_call_inout_variable() {
     "#;
 
     let mut interface = MainType { baz: 7 };
-    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
+    let _: i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(64, interface.baz);
 }
@@ -429,7 +429,7 @@ fn inouts_behave_like_pointers() {
         p2: 0,
         p3: 0,
     };
-    let _ : i32 = compile_and_run(function.to_string(), &mut interface);
+    let _: i32 = compile_and_run(function.to_string(), &mut interface);
 
     assert_eq!(7, interface.p1);
     assert_eq!(8, interface.p2);

--- a/tests/correctness/global_variables.rs
+++ b/tests/correctness/global_variables.rs
@@ -5,7 +5,6 @@ use super::super::*;
 #[repr(C)]
 struct MainType {
     x: i32,
-    ret: i32,
 }
 
 #[derive(PartialEq, Debug)]
@@ -35,7 +34,7 @@ fn global_variable_can_be_referenced_in_fn() {
     main := gX;
     END_FUNCTION
     ";
-    let res: i32 = compile_and_run(function.to_string(), &mut MainType { x: 0, ret: 0 });
+    let res: i32 = compile_and_run(function.to_string(), &mut MainType { x: 0 });
     assert_eq!(res, 30);
 }
 
@@ -65,9 +64,9 @@ fn global_variable_can_be_referenced_in_two_functions() {
     let context = inkwell::context::Context::create();
     let exec_engine = compile(&context, function.to_string());
 
-    let res: i32 = run(&exec_engine, "main", &mut MainType { x: 0, ret: 0 });
+    let res: i32 = run(&exec_engine, "main", &mut MainType { x: 0 });
     assert_eq!(res, 30);
-    let res2: i32 = run(&exec_engine, "two", &mut MainType { x: 0, ret: 0 });
+    let res2: i32 = run(&exec_engine, "two", &mut MainType { x: 0 });
     assert_eq!(res2, 30)
 }
 

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -61,7 +61,7 @@ fn initia_values_of_programs_members() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -114,7 +114,7 @@ fn initia_values_of_programs_members_using_constants() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -162,7 +162,7 @@ fn initia_values_of_functionblock_members() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -208,7 +208,7 @@ fn initia_values_of_function_members() {
 
     let mut maintype = ThreeInts { x: 0, y: 0, z: 0 };
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(88, maintype.y);
@@ -253,7 +253,7 @@ fn initia_values_of_struct_type_members() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -299,7 +299,7 @@ fn initia_values_of_alias_type() {
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(7, maintype.x);
     assert_eq!(8, maintype.x_);
@@ -392,7 +392,7 @@ fn initial_values_in_single_dimension_array_variable() {
         h2: true,
     };
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(3, maintype.a2);
     assert_eq!(4, maintype.b0);
@@ -448,7 +448,7 @@ fn initial_values_in_multi_dimension_array_variable() {
         a3: 0,
     };
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(2, maintype.a1);
     assert_eq!(3, maintype.a2);
@@ -508,7 +508,7 @@ fn initial_values_in_array_of_array_variable() {
         a8: 0,
     };
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a1);
     assert_eq!(2, maintype.a2);
     assert_eq!(3, maintype.a3);
@@ -557,7 +557,7 @@ fn real_initial_values_in_array_variable() {
         r2: 0.0,
     };
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_almost_eq!(9.1415, maintype.f1, f32::EPSILON);
     assert_almost_eq!(0.001, maintype.f2, f32::EPSILON);
     assert_almost_eq!(9.141592653589, maintype.r1, f64::EPSILON);
@@ -623,7 +623,7 @@ fn initialization_of_complex_struct_instance() {
         f: 0.0,
     };
 
-    let _ : i32 = compile_and_run(src.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(2, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -682,7 +682,7 @@ fn initialization_of_complex_struct_instance_using_defaults() {
         f: 0.0,
     };
 
-    let _ : i32 = compile_and_run(src.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(7, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -742,7 +742,7 @@ fn initialization_of_string_variables() {
         string3: [1; 21],
     };
 
-    let _ : i32 = compile_and_run(src.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(src.to_string(), &mut maintype);
     assert_eq!(
         &maintype.mystring1[0..8],
         [97, 98, 99, 100, 101, 102, 103, 0]

--- a/tests/correctness/initial_values.rs
+++ b/tests/correctness/initial_values.rs
@@ -61,7 +61,7 @@ fn initia_values_of_programs_members() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -114,7 +114,7 @@ fn initia_values_of_programs_members_using_constants() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -162,7 +162,7 @@ fn initia_values_of_functionblock_members() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -208,7 +208,7 @@ fn initia_values_of_function_members() {
 
     let mut maintype = ThreeInts { x: 0, y: 0, z: 0 };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(88, maintype.y);
@@ -253,7 +253,7 @@ fn initia_values_of_struct_type_members() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(77, maintype.x);
     assert_eq!(0, maintype.x_);
@@ -299,7 +299,7 @@ fn initia_values_of_alias_type() {
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(7, maintype.x);
     assert_eq!(8, maintype.x_);
@@ -392,7 +392,7 @@ fn initial_values_in_single_dimension_array_variable() {
         h2: true,
     };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(3, maintype.a2);
     assert_eq!(4, maintype.b0);
@@ -448,7 +448,7 @@ fn initial_values_in_multi_dimension_array_variable() {
         a3: 0,
     };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a0);
     assert_eq!(2, maintype.a1);
     assert_eq!(3, maintype.a2);
@@ -508,7 +508,7 @@ fn initial_values_in_array_of_array_variable() {
         a8: 0,
     };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_eq!(1, maintype.a1);
     assert_eq!(2, maintype.a2);
     assert_eq!(3, maintype.a3);
@@ -557,7 +557,7 @@ fn real_initial_values_in_array_variable() {
         r2: 0.0,
     };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
     assert_almost_eq!(9.1415, maintype.f1, f32::EPSILON);
     assert_almost_eq!(0.001, maintype.f2, f32::EPSILON);
     assert_almost_eq!(9.141592653589, maintype.r1, f64::EPSILON);
@@ -623,7 +623,7 @@ fn initialization_of_complex_struct_instance() {
         f: 0.0,
     };
 
-    compile_and_run::<_, i32>(src.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(2, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -682,7 +682,7 @@ fn initialization_of_complex_struct_instance_using_defaults() {
         f: 0.0,
     };
 
-    compile_and_run::<_, i32>(src.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(src.to_string(), &mut maintype);
     assert_eq!(1, maintype.x);
     assert_eq!(7, maintype.y);
     assert_eq!(1, maintype.arr1);
@@ -742,7 +742,7 @@ fn initialization_of_string_variables() {
         string3: [1; 21],
     };
 
-    compile_and_run::<_, i32>(src.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(src.to_string(), &mut maintype);
     assert_eq!(
         &maintype.mystring1[0..8],
         [97, 98, 99, 100, 101, 102, 103, 0]

--- a/tests/correctness/math_operators/addition.rs
+++ b/tests/correctness/math_operators/addition.rs
@@ -1,10 +1,5 @@
-use crate::compile_and_run;
+use crate::{compile_and_run, MainType};
 use num::{Float, NumCast};
-
-#[derive(Default)]
-#[allow(dead_code)]
-#[repr(C)]
-struct MainType {}
 
 //addition tests
 

--- a/tests/correctness/math_operators/division.rs
+++ b/tests/correctness/math_operators/division.rs
@@ -1,10 +1,5 @@
-use crate::compile_and_run;
+use crate::{compile_and_run, MainType};
 use num::{Float, NumCast};
-
-#[derive(Default)]
-#[allow(dead_code)]
-#[repr(C)]
-struct MainType {}
 
 //--------------------------------------------------------------
 //division tests

--- a/tests/correctness/math_operators/mixed.rs
+++ b/tests/correctness/math_operators/mixed.rs
@@ -124,14 +124,6 @@ fn mixed_math_usint_type() {
 
 #[test]
 fn mixed_math_time_basic() {
-    #[derive(Default)]
-    #[allow(dead_code)]
-    #[repr(C)]
-    struct MainType {
-        t1: i32,
-        time_var2: i32,
-        time_var3: i32,
-    }
     let prog = "
     FUNCTION main : TIME
     VAR
@@ -151,14 +143,6 @@ fn mixed_math_time_basic() {
 
 #[test]
 fn mixed_math_tod_basic() {
-    #[derive(Default)]
-    #[allow(dead_code)]
-    #[repr(C)]
-    struct MainType {
-        t1: i32,
-        t2: i32,
-        t3: i32,
-    }
     let prog = "
     FUNCTION main : TOD
     VAR
@@ -178,15 +162,6 @@ fn mixed_math_tod_basic() {
 
 #[test]
 fn mixed_math_date_basic() {
-    #[derive(Default)]
-    #[allow(dead_code)]
-    #[repr(C)]
-    struct MainType {
-        date: i32,
-        date_10_days: i32,
-        date_1_day: i32,
-        result: i32,
-    }
     let prog = "
     FUNCTION main : DATE
     VAR
@@ -208,15 +183,6 @@ fn mixed_math_date_basic() {
 
 #[test]
 fn mixed_math_dt_basic() {
-    #[derive(Default)]
-    #[allow(dead_code)]
-    #[repr(C)]
-    struct MainType {
-        date: i32,
-        date_10_days: i32,
-        date_1_day: i32,
-        result: i32,
-    }
     let prog = "
     FUNCTION main : DT
     VAR

--- a/tests/correctness/math_operators/multiplication.rs
+++ b/tests/correctness/math_operators/multiplication.rs
@@ -1,10 +1,5 @@
-use crate::compile_and_run;
+use crate::{compile_and_run, MainType};
 use num::{Float, NumCast};
-
-#[derive(Default)]
-#[allow(dead_code)]
-#[repr(C)]
-struct MainType {}
 
 //--------------------------------------------------------------
 //multiplication tests

--- a/tests/correctness/math_operators/substraction.rs
+++ b/tests/correctness/math_operators/substraction.rs
@@ -1,10 +1,5 @@
-use crate::compile_and_run;
+use crate::{compile_and_run, MainType};
 use num::{Float, NumCast};
-
-#[derive(Default)]
-#[allow(dead_code)]
-#[repr(C)]
-struct MainType {}
 
 //--------------------------------------------------------------
 //substraction tests

--- a/tests/correctness/methods.rs
+++ b/tests/correctness/methods.rs
@@ -27,7 +27,7 @@ FUNCTION_BLOCK myFB
 END_FUNCTION_BLOCK
     ";
 
-    let res: i32 = compile_and_run(src.into(), &mut MainType::default());
+    let res: i32 = compile_and_run(src, &mut MainType::default());
     //Expecting it not to fail
     assert_eq!(res, 42);
 }
@@ -57,7 +57,7 @@ END_METHOD
 END_CLASS
     ";
 
-    let res: i32 = compile_and_run(src.into(), &mut MainType::default());
+    let res: i32 = compile_and_run(src, &mut MainType::default());
     //Expecting it not to fail
     assert_eq!(res, 42);
 }

--- a/tests/correctness/methods.rs
+++ b/tests/correctness/methods.rs
@@ -27,9 +27,7 @@ FUNCTION_BLOCK myFB
 END_FUNCTION_BLOCK
     ";
 
-    struct Main {}
-
-    let res: i32 = compile_and_run(src.into(), &mut Main {});
+    let res: i32 = compile_and_run(src.into(), &mut MainType::default());
     //Expecting it not to fail
     assert_eq!(res, 42);
 }
@@ -59,9 +57,7 @@ END_METHOD
 END_CLASS
     ";
 
-    struct Main {}
-
-    let res: i32 = compile_and_run(src.into(), &mut Main {});
+    let res: i32 = compile_and_run(src.into(), &mut MainType::default());
     //Expecting it not to fail
     assert_eq!(res, 42);
 }

--- a/tests/correctness/pointers.rs
+++ b/tests/correctness/pointers.rs
@@ -1,11 +1,7 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::compile_and_run;
+use crate::{compile_and_run, MainType};
 
 mod references;
-
-#[allow(dead_code)]
-#[repr(C)]
-struct MainType {}
 
 #[test]
 fn pointer_test() {
@@ -38,7 +34,7 @@ foo := y^;
 END_FUNCTION
  ";
 
-    let mut maintype = MainType {};
+    let mut maintype = MainType::default();
 
     let res: i32 = compile_and_run(function.to_string(), &mut maintype);
 

--- a/tests/correctness/pointers/references.rs
+++ b/tests/correctness/pointers/references.rs
@@ -132,7 +132,7 @@ END_PROGRAM
 
     let mut maintype = new();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
+    let _: i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(true, maintype.b_result_a);
     assert_eq!(true, maintype.b_result_b);
@@ -277,7 +277,7 @@ END_PROGRAM
 
     let mut new_with_struct: MainTypeWithStruct = MainTypeWithStruct::default();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut new_with_struct);
+    let _: i32 = compile_and_run(function.to_string(), &mut new_with_struct);
 
     assert_eq!(true, new_with_struct.b_result_a);
     assert_eq!(100, new_with_struct.b_result_b);
@@ -432,7 +432,7 @@ fn reference_call_array() {
 
     let mut new_with_array: MainTypeWithArray = MainTypeWithArray::default();
 
-    let _ : i32 = compile_and_run(function.to_string(), &mut new_with_array);
+    let _: i32 = compile_and_run(function.to_string(), &mut new_with_array);
 
     assert_eq!(100, new_with_array.b_result_a);
     assert_eq!(0, new_with_array.b_result_b);

--- a/tests/correctness/pointers/references.rs
+++ b/tests/correctness/pointers/references.rs
@@ -132,7 +132,7 @@ END_PROGRAM
 
     let mut maintype = new();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function.to_string(), &mut maintype);
 
     assert_eq!(true, maintype.b_result_a);
     assert_eq!(true, maintype.b_result_b);
@@ -277,7 +277,7 @@ END_PROGRAM
 
     let mut new_with_struct: MainTypeWithStruct = MainTypeWithStruct::default();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut new_with_struct);
+    let _ : i32 = compile_and_run(function.to_string(), &mut new_with_struct);
 
     assert_eq!(true, new_with_struct.b_result_a);
     assert_eq!(100, new_with_struct.b_result_b);
@@ -432,7 +432,7 @@ fn reference_call_array() {
 
     let mut new_with_array: MainTypeWithArray = MainTypeWithArray::default();
 
-    compile_and_run::<_, i32>(function.to_string(), &mut new_with_array);
+    let _ : i32 = compile_and_run(function.to_string(), &mut new_with_array);
 
     assert_eq!(100, new_with_array.b_result_a);
     assert_eq!(0, new_with_array.b_result_b);

--- a/tests/correctness/sub_range_types.rs
+++ b/tests/correctness/sub_range_types.rs
@@ -70,7 +70,7 @@ fn sub_range_chooses_right_implementation() {
         _ulint: 0,
     };
 
-    compile_and_run::<_, i32>(function.to_string(), &mut maintype);
+    let _ : i32 = compile_and_run(function, &mut maintype);
     let expected = MainType {
         _byte: 7,
         _sint: -7,

--- a/tests/correctness/sub_range_types.rs
+++ b/tests/correctness/sub_range_types.rs
@@ -70,7 +70,7 @@ fn sub_range_chooses_right_implementation() {
         _ulint: 0,
     };
 
-    let _ : i32 = compile_and_run(function, &mut maintype);
+    let _: i32 = compile_and_run(function, &mut maintype);
     let expected = MainType {
         _byte: 7,
         _sint: -7,

--- a/tests/integration/data/multi/func.st
+++ b/tests/integration/data/multi/func.st
@@ -1,0 +1,14 @@
+
+
+FUNCTION main : INT
+VAR_INPUT
+
+END_VAR
+
+VAR
+
+END_VAR
+mainProg();
+main := mainProg.a;
+
+END_FUNCTION

--- a/tests/integration/data/multi/prog.st
+++ b/tests/integration/data/multi/prog.st
@@ -1,0 +1,6 @@
+PROGRAM mainProg
+VAR
+	a: DINT := 0;
+END_VAR
+a := 42;
+END_PROGRAM

--- a/tests/integration/external_files.rs
+++ b/tests/integration/external_files.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
-use std::{env, fs, path::PathBuf};
+use std::{env, fs};
 
 use encoding_rs::Encoding;
 use rusty::{
@@ -8,8 +8,10 @@ use rusty::{
     compile_to_static_obj, FilePath,
 };
 
+use crate::get_test_file;
+
 fn compile_all(name: &str, encoding: Option<&'static Encoding>) {
-    let path = get_file(name);
+    let path = get_test_file(name);
     let mut out = env::temp_dir();
     let out_name = format!("{}.out", &name);
     out.push(out_name);
@@ -25,18 +27,6 @@ fn compile_all(name: &str, encoding: Option<&'static Encoding>) {
     fs::remove_file(&out).unwrap();
     compile_to_static_obj(vec![FilePath { path }], encoding, &out, None).unwrap();
     fs::remove_file(&out).unwrap();
-}
-
-fn get_file(name: &str) -> String {
-    let mut data_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    data_path.push("tests");
-    data_path.push("integration");
-    data_path.push("data");
-    data_path.push(name);
-
-    assert!(data_path.exists());
-
-    data_path.display().to_string()
 }
 
 #[test]

--- a/tests/integration/multi_files.rs
+++ b/tests/integration/multi_files.rs
@@ -1,0 +1,13 @@
+use rusty::FilePath;
+
+use crate::{compile_and_run_multi, get_test_file};
+
+#[test]
+fn sources_accross_multiple_files_compiled() {
+    let file1 = FilePath { path : get_test_file("multi/func.st") };
+    let file2 = FilePath { path : get_test_file("multi/prog.st") };
+
+    let res : i32 = compile_and_run_multi(vec![file1,file2], &mut ());
+    assert_eq!(42,res);
+
+}

--- a/tests/integration/multi_files.rs
+++ b/tests/integration/multi_files.rs
@@ -1,6 +1,6 @@
 use rusty::FilePath;
 
-use crate::{compile_and_run_multi, get_test_file};
+use crate::{compile_and_run, get_test_file};
 
 #[test]
 fn sources_accross_multiple_files_compiled() {
@@ -11,6 +11,6 @@ fn sources_accross_multiple_files_compiled() {
         path: get_test_file("multi/prog.st"),
     };
 
-    let res: i32 = compile_and_run_multi(vec![file1, file2], &mut ());
+    let res: i32 = compile_and_run(vec![file1, file2], &mut ());
     assert_eq!(42, res);
 }

--- a/tests/integration/multi_files.rs
+++ b/tests/integration/multi_files.rs
@@ -4,10 +4,13 @@ use crate::{compile_and_run_multi, get_test_file};
 
 #[test]
 fn sources_accross_multiple_files_compiled() {
-    let file1 = FilePath { path : get_test_file("multi/func.st") };
-    let file2 = FilePath { path : get_test_file("multi/prog.st") };
+    let file1 = FilePath {
+        path: get_test_file("multi/func.st"),
+    };
+    let file2 = FilePath {
+        path: get_test_file("multi/prog.st"),
+    };
 
-    let res : i32 = compile_and_run_multi(vec![file1,file2], &mut ());
-    assert_eq!(42,res);
-
+    let res: i32 = compile_and_run_multi(vec![file1, file2], &mut ());
+    assert_eq!(42, res);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,6 +7,18 @@ use rusty::*;
 
 type MainFunction<T, U> = unsafe extern "C" fn(*mut T) -> U;
 
+#[allow(dead_code)]
+#[repr(C)]
+pub struct MainType {
+    a: [usize; 1000],
+}
+
+impl Default for MainType {
+    fn default() -> Self {
+        MainType { a: [0; 1000] }
+    }
+}
+
 mod correctness {
     mod arrays;
     mod bitaccess;
@@ -74,12 +86,25 @@ fn get_test_file(name: &str) -> String {
 /// The int is the return value which can be verified
 /// The string will eventually be the Stdout of the function.
 ///
+#[inline(always)]
 pub fn compile(context: &Context, source: String) -> ExecutionEngine {
-    compile_multi::<SourceCode>(context, vec![source.as_str().into()])
+    let source: Vec<SourceCode> = vec![source.as_str().into()];
+    compile_multi(context, source)
 }
 
 pub fn compile_and_run<T, U>(source: String, params: &mut T) -> U {
-    compile_and_run_multi::<T, U, SourceCode>(vec![source.as_str().into()], params)
+    let context: Context = Context::create();
+    // let source: Vec<SourceCode> = vec![source.as_str().into()];
+    // compile_multi::<SourceCode>(context, source)
+    let src: Vec<SourceCode> = vec![source.as_str().into()];
+    let exec_engine = compile_multi(&context, src);
+    // let exec_engine = compile(&context, source);
+    let int_arr: [i32; 100] = [0; 100];
+    eprintln!("{:?}", int_arr);
+    let res = run::<T, U>(&exec_engine, "main", params);
+    eprintln!("{:?}", int_arr);
+    res
+    // compile_and_run_multi::<T, U, SourceCode>(vec![source.as_str().into()], params)
 }
 
 pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -93,18 +93,7 @@ pub fn compile(context: &Context, source: String) -> ExecutionEngine {
 }
 
 pub fn compile_and_run<T, U>(source: String, params: &mut T) -> U {
-    let context: Context = Context::create();
-    // let source: Vec<SourceCode> = vec![source.as_str().into()];
-    // compile_multi::<SourceCode>(context, source)
-    let src: Vec<SourceCode> = vec![source.as_str().into()];
-    let exec_engine = compile_multi(&context, src);
-    // let exec_engine = compile(&context, source);
-    let int_arr: [i32; 100] = [0; 100];
-    eprintln!("{:?}", int_arr);
-    let res = run::<T, U>(&exec_engine, "main", params);
-    eprintln!("{:?}", int_arr);
-    res
-    // compile_and_run_multi::<T, U, SourceCode>(vec![source.as_str().into()], params)
+    compile_and_run_multi::<T, U, SourceCode>(vec![source.as_str().into()], params)
 }
 
 pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -79,7 +79,7 @@ pub fn compile(context: &Context, source: String) -> ExecutionEngine {
 }
 
 pub fn compile_and_run<T, U>(source: String, params: &mut T) -> U {
-    compile_and_run_multi::<T,U, SourceCode>(vec![source.as_str().into()], params)
+    compile_and_run_multi::<T, U, SourceCode>(vec![source.as_str().into()], params)
 }
 
 pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
@@ -98,7 +98,7 @@ pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U
 /// The int is the return value which can be verified
 /// The string will eventually be the Stdout of the function.
 ///
-pub fn compile_multi<T : SourceContainer> (context: &Context, source: Vec<T>) -> ExecutionEngine {
+pub fn compile_multi<T: SourceContainer>(context: &Context, source: Vec<T>) -> ExecutionEngine {
     // let source : Vec<SourceCode> = source.iter().map(String::as_str).map(Into::into).collect();
     let code_gen = compile_module(context, source, None).unwrap();
     println!("{}", code_gen.module.print_to_string());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use inkwell::context::Context;
 use inkwell::execution_engine::{ExecutionEngine, JitFunction};
@@ -31,6 +33,7 @@ mod correctness {
 
 mod integration {
     mod external_files;
+    mod multi_files;
 }
 
 #[macro_export]
@@ -51,6 +54,19 @@ macro_rules! assert_almost_eq {
     }};
 }
 
+/// Gets a file from the integration data folder for tests
+fn get_test_file(name: &str) -> String {
+    let mut data_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    data_path.push("tests");
+    data_path.push("integration");
+    data_path.push("data");
+    data_path.push(name);
+
+    assert!(data_path.exists());
+
+    data_path.display().to_string()
+}
+
 ///
 /// Compiles and runs the given source
 /// Returns the std result as String
@@ -59,22 +75,11 @@ macro_rules! assert_almost_eq {
 /// The string will eventually be the Stdout of the function.
 ///
 pub fn compile(context: &Context, source: String) -> ExecutionEngine {
-    let source = SourceCode {
-        path: "external_test.st".to_string(),
-        source,
-    };
-    let code_gen = compile_module(context, vec![source], None).unwrap();
-    println!("{}", code_gen.module.print_to_string());
-    code_gen
-        .module
-        .create_jit_execution_engine(inkwell::OptimizationLevel::None)
-        .unwrap()
+    compile_multi::<SourceCode>(context, vec![source.as_str().into()])
 }
 
 pub fn compile_and_run<T, U>(source: String, params: &mut T) -> U {
-    let context: Context = Context::create();
-    let exec_engine = compile(&context, source);
-    run::<T, U>(&exec_engine, "main", params)
+    compile_and_run_multi::<T,U, SourceCode>(vec![source.as_str().into()], params)
 }
 
 pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
@@ -84,4 +89,27 @@ pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U
 
         main.call(main_t_ptr)
     }
+}
+
+///
+/// Compiles and runs the given sources
+/// Returns the std result as String
+/// Sources must define a main function that takes no arguments and returns an int and string
+/// The int is the return value which can be verified
+/// The string will eventually be the Stdout of the function.
+///
+pub fn compile_multi<T : SourceContainer> (context: &Context, source: Vec<T>) -> ExecutionEngine {
+    // let source : Vec<SourceCode> = source.iter().map(String::as_str).map(Into::into).collect();
+    let code_gen = compile_module(context, source, None).unwrap();
+    println!("{}", code_gen.module.print_to_string());
+    code_gen
+        .module
+        .create_jit_execution_engine(inkwell::OptimizationLevel::None)
+        .unwrap()
+}
+
+pub fn compile_and_run_multi<T, U, S: SourceContainer>(source: Vec<S>, params: &mut T) -> U {
+    let context: Context = Context::create();
+    let exec_engine = compile_multi(&context, source);
+    run::<T, U>(&exec_engine, "main", params)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -80,7 +80,7 @@ fn get_test_file(name: &str) -> String {
 }
 
 pub trait Compilable {
-    type T : SourceContainer;
+    type T: SourceContainer;
     fn containers(self) -> Vec<Self::T>;
 }
 
@@ -100,13 +100,12 @@ impl Compilable for String {
     }
 }
 
-impl<S : SourceContainer> Compilable for Vec<S> {
+impl<S: SourceContainer> Compilable for Vec<S> {
     type T = S;
     fn containers(self) -> Vec<Self::T> {
         self
     }
 }
-
 
 ///
 /// Compiles and runs the given source
@@ -150,7 +149,7 @@ pub fn compile<T: Compilable>(context: &Context, source: T) -> ExecutionEngine {
         .unwrap()
 }
 
-pub fn compile_and_run<T, U, S : Compilable>(source: S, params: &mut T) -> U {
+pub fn compile_and_run<T, U, S: Compilable>(source: S, params: &mut T) -> U {
     let context: Context = Context::create();
     let exec_engine = compile(&context, source);
     run::<T, U>(&exec_engine, "main", params)


### PR DESCRIPTION
There was a regression where multi-files were not compiled correctly anymore
This fixes the issue and adds tests (both unit and integration) to test multifile projects
It also adds test methods that could be used to simulate multiple files during compilation
I also fixed an issue where the correctness tests would sometimes crash with an illegal access exception.
To avoid that, there is now a MainType declared in the tests/tests.rs which can be used when the content of the test struct does not matter. It is currently 1000xusize.