### PR TITLE
Fix for loop behaviour

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -10,7 +10,7 @@ use self::{
     },
     llvm_index::LlvmTypedIndex,
 };
-use crate::{diagnostics::Diagnostic, resolver::AnnotationMap};
+use crate::{diagnostics::Diagnostic, resolver::AstAnnotations};
 
 use super::ast::*;
 use super::index::*;
@@ -41,7 +41,7 @@ impl<'ink> CodeGen<'ink> {
 
     pub fn generate_llvm_index(
         &self,
-        annotations: &AnnotationMap,
+        annotations: &AstAnnotations,
         global_index: &Index,
     ) -> Result<LlvmTypedIndex<'ink>, Diagnostic> {
         let llvm = Llvm::new(self.context, self.context.create_builder());
@@ -78,7 +78,7 @@ impl<'ink> CodeGen<'ink> {
     pub fn generate(
         &self,
         unit: &CompilationUnit,
-        annotations: &AnnotationMap,
+        annotations: &AstAnnotations,
         global_index: &Index,
         llvm_index: &LlvmTypedIndex,
     ) -> Result<String, Diagnostic> {

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 /// - sized Strings
 use crate::ast::SourceRange;
 use crate::index::{Index, VariableIndexEntry, VariableType};
-use crate::resolver::AnnotationMap;
+use crate::resolver::AstAnnotations;
 use crate::typesystem::{Dimension, StringEncoding, StructSource};
 use crate::Diagnostic;
 use crate::{ast::AstStatement, typesystem::DataTypeInformation};
@@ -31,7 +31,7 @@ use super::{expression_generator::ExpressionCodeGenerator, llvm::Llvm};
 pub struct DataTypeGenerator<'ink, 'b> {
     llvm: &'b Llvm<'ink>,
     index: &'b Index,
-    annotations: &'b AnnotationMap,
+    annotations: &'b AstAnnotations,
     types_index: LlvmTypedIndex<'ink>,
 }
 
@@ -45,7 +45,7 @@ pub struct DataTypeGenerator<'ink, 'b> {
 pub fn generate_data_types<'ink>(
     llvm: &Llvm<'ink>,
     index: &Index,
-    annotations: &AnnotationMap,
+    annotations: &AstAnnotations,
 ) -> Result<LlvmTypedIndex<'ink>, Diagnostic> {
     let mut generator = DataTypeGenerator {
         llvm,

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -4,7 +4,7 @@ use crate::{
     codegen::llvm_typesystem,
     diagnostics::{Diagnostic, INTERNAL_LLVM_ERROR},
     index::{ImplementationIndexEntry, ImplementationType, Index, VariableIndexEntry},
-    resolver::{AnnotationMap, StatementAnnotation},
+    resolver::{AnnotationMap, AstAnnotations, StatementAnnotation},
     typesystem::{is_same_type_class, Dimension, StringEncoding, INT_SIZE, INT_TYPE, LINT_TYPE},
 };
 use inkwell::{
@@ -35,7 +35,7 @@ use chrono::{LocalResult, TimeZone, Utc};
 pub struct ExpressionCodeGenerator<'a, 'b> {
     llvm: &'b Llvm<'a>,
     index: &'b Index,
-    annotations: &'b AnnotationMap,
+    annotations: &'b AstAnnotations,
     llvm_index: &'b LlvmTypedIndex<'a>,
     /// the current function to create blocks in
     function_context: Option<&'b FunctionContext<'a>>,
@@ -65,7 +65,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
     pub fn new(
         llvm: &'b Llvm<'a>,
         index: &'b Index,
-        annotations: &'b AnnotationMap,
+        annotations: &'b AstAnnotations,
         llvm_index: &'b LlvmTypedIndex<'a>,
         function_context: &'b FunctionContext<'a>,
     ) -> ExpressionCodeGenerator<'a, 'b> {
@@ -90,7 +90,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
     pub fn new_context_free(
         llvm: &'b Llvm<'a>,
         index: &'b Index,
-        annotations: &'b AnnotationMap,
+        annotations: &'b AstAnnotations,
         llvm_index: &'b LlvmTypedIndex<'a>,
     ) -> ExpressionCodeGenerator<'a, 'b> {
         ExpressionCodeGenerator {
@@ -142,7 +142,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
     ) -> Result<BasicValueEnum<'a>, Diagnostic> {
         //see if this is a constant - maybe we can short curcuit this codegen
         if let Some(StatementAnnotation::Variable { qualified_name, .. }) =
-            self.annotations.get_annotation(expression)
+            self.annotations.get(expression)
         {
             if let Some(basic_value_enum) = self.llvm_index.find_constant_value(qualified_name) {
                 //this is a constant and we have a value for it
@@ -859,7 +859,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
         if let Some(qualifier) = qualifier {
             //if we're loading a reference like PLC_PRG.ACTION we already loaded PLC_PRG pointer into qualifier,
             //so we should not load anything in addition for the action (or the method)
-            match self.annotations.get_annotation(context) {
+            match self.annotations.get(context) {
                 Some(StatementAnnotation::Function { qualified_name, .. })
                 | Some(StatementAnnotation::Program { qualified_name, .. }) => {
                     if self.index.find_implementation(qualified_name).is_some() {
@@ -924,7 +924,7 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
         if let Some(StatementAnnotation::Variable {
             is_auto_deref: true,
             ..
-        }) = self.annotations.get_annotation(statement)
+        }) = self.annotations.get(statement)
         {
             Ok(self.deref(accessor_ptr))
         } else {

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -9,7 +9,7 @@ use crate::{
     codegen::llvm_index::LlvmTypedIndex,
     diagnostics::{Diagnostic, INTERNAL_LLVM_ERROR},
     index::ImplementationType,
-    resolver::AnnotationMap,
+    resolver::AstAnnotations,
 };
 
 /// The pou_generator contains functions to generate the code for POUs (PROGRAM, FUNCTION, FUNCTION_BLOCK)
@@ -34,7 +34,7 @@ use inkwell::{
 pub struct PouGenerator<'ink, 'cg> {
     llvm: Llvm<'ink>,
     index: &'cg Index,
-    annotations: &'cg AnnotationMap,
+    annotations: &'cg AstAnnotations,
     llvm_index: &'cg LlvmTypedIndex<'ink>,
 }
 
@@ -44,7 +44,7 @@ pub fn generate_implementation_stubs<'ink>(
     module: &Module<'ink>,
     llvm: Llvm<'ink>,
     index: &Index,
-    annotations: &AnnotationMap,
+    annotations: &AstAnnotations,
     types_index: &LlvmTypedIndex<'ink>,
 ) -> Result<LlvmTypedIndex<'ink>, Diagnostic> {
     let mut llvm_index = LlvmTypedIndex::default();
@@ -67,7 +67,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
     pub fn new(
         llvm: Llvm<'ink>,
         index: &'cg Index,
-        annotations: &'cg AnnotationMap,
+        annotations: &'cg AstAnnotations,
         llvm_index: &'cg LlvmTypedIndex<'ink>,
     ) -> PouGenerator<'ink, 'cg> {
         PouGenerator {

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -5,7 +5,7 @@ use crate::{
     ast::SourceRange,
     diagnostics::{Diagnostic, ErrNo},
     index::Index,
-    resolver::AnnotationMap,
+    resolver::AstAnnotations,
 };
 use inkwell::{module::Module, values::GlobalValue};
 
@@ -19,7 +19,7 @@ pub fn generate_global_variables<'ctx, 'b>(
     module: &'b Module<'ctx>,
     llvm: &'b Llvm<'ctx>,
     global_index: &'b Index,
-    annotations: &'b AnnotationMap,
+    annotations: &'b AstAnnotations,
     types_index: &'b LlvmTypedIndex<'ctx>,
 ) -> Result<LlvmTypedIndex<'ctx>, Diagnostic> {
     let mut index = LlvmTypedIndex::default();
@@ -55,7 +55,7 @@ pub fn generate_global_variable<'ctx, 'b>(
     module: &'b Module<'ctx>,
     llvm: &'b Llvm<'ctx>,
     global_index: &'b Index,
-    annotations: &'b AnnotationMap,
+    annotations: &'b AstAnnotations,
     index: &'b LlvmTypedIndex<'ctx>,
     global_variable: &VariableIndexEntry,
 ) -> Result<GlobalValue<'ctx>, Diagnostic> {

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -1365,35 +1365,7 @@ fn for_statement_with_steps_test() {
         ",
     );
 
-    let expected = generate_program_boiler_plate(
-        "prg",
-        &[("i32", "x")],
-        "void",
-        "",
-        "",
-        r#"store i32 3, i32* %x, align 4
-  br label %condition_check
-
-condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x, 10
-  br i1 %tmpVar, label %for_body, label %continue
-
-for_body:                                         ; preds = %condition_check
-  %load_x1 = load i32, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %for_body
-  %tmpVar2 = add i32 %load_x, 7
-  store i32 %tmpVar2, i32* %x, align 4
-  br label %condition_check
-
-continue:                                         ; preds = %condition_check
-  ret void
-"#,
-    );
-
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
 }
 
 #[test]
@@ -1432,43 +1404,7 @@ fn for_statement_with_exit() {
         ",
     );
 
-    let expected = generate_program_boiler_plate(
-        "prg",
-        &[("i32", "x")],
-        "void",
-        "",
-        "",
-        r#"store i32 3, i32* %x, align 4
-  br label %condition_check
-
-condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x, 10
-  br i1 %tmpVar, label %for_body, label %continue
-
-for_body:                                         ; preds = %condition_check
-  %load_x1 = load i32, i32* %x, align 4
-  %tmpVar2 = add i32 %load_x1, 2
-  store i32 %tmpVar2, i32* %x, align 4
-  br label %continue
-
-buffer_block:                                     ; No predecessors!
-  %load_x3 = load i32, i32* %x, align 4
-  %tmpVar4 = add i32 %load_x3, 5
-  store i32 %tmpVar4, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block
-  %tmpVar5 = add i32 %load_x, 7
-  store i32 %tmpVar5, i32* %x, align 4
-  br label %condition_check
-
-continue:                                         ; preds = %for_body, %condition_check
-  ret void
-"#,
-    );
-
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
 }
 
 #[test]
@@ -1874,35 +1810,61 @@ fn for_statement_without_steps_test() {
         ",
     );
 
-    let expected = generate_program_boiler_plate(
-        "prg",
-        &[("i32", "x")],
-        "void",
-        "",
-        "",
-        r#"store i32 3, i32* %x, align 4
-  br label %condition_check
+    insta::assert_snapshot!(result);
+}
 
-condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x, 10
-  br i1 %tmpVar, label %for_body, label %continue
-
-for_body:                                         ; preds = %condition_check
-  %load_x1 = load i32, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %for_body
-  %tmpVar2 = add i32 %load_x, 1
-  store i32 %tmpVar2, i32* %x, align 4
-  br label %condition_check
-
-continue:                                         ; preds = %condition_check
-  ret void
-"#,
+#[test]
+fn for_statement_sint() {
+    let result = codegen(
+        "
+        PROGRAM prg 
+        VAR
+            x : SINT;
+        END_VAR
+        FOR x := 3 TO 10 DO 
+            x;
+        END_FOR
+        END_PROGRAM
+        ",
     );
 
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn for_statement_int() {
+    let result = codegen(
+        "
+        PROGRAM prg 
+        VAR
+            x : INT;
+        END_VAR
+        FOR x := 3 TO 10 DO 
+            x;
+        END_FOR
+        END_PROGRAM
+        ",
+    );
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn for_statement_lint() {
+    let result = codegen(
+        "
+        PROGRAM prg 
+        VAR
+            x : LINT;
+        END_VAR
+        FOR x := 3 TO 10 DO 
+            x;
+        END_FOR
+        END_PROGRAM
+        ",
+    );
+
+    insta::assert_snapshot!(result);
 }
 
 #[test]
@@ -1920,35 +1882,7 @@ fn for_statement_continue() {
         ",
     );
 
-    let expected = generate_program_boiler_plate(
-        "prg",
-        &[("i32", "x")],
-        "void",
-        "",
-        "",
-        r#"store i32 3, i32* %x, align 4
-  br label %condition_check
-
-condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x, 10
-  br i1 %tmpVar, label %for_body, label %continue
-
-for_body:                                         ; preds = %condition_check
-  br label %increment
-
-increment:                                        ; preds = %for_body
-  %tmpVar1 = add i32 %load_x, 1
-  store i32 %tmpVar1, i32* %x, align 4
-  br label %condition_check
-
-continue:                                         ; preds = %condition_check
-  %load_x2 = load i32, i32* %x, align 4
-  ret void
-"#,
-    );
-
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
 }
 
 #[test]
@@ -1969,38 +1903,7 @@ fn for_statement_with_references_steps_test() {
         ",
     );
 
-    let expected = generate_program_boiler_plate(
-        "prg",
-        &[("i32", "step"), ("i32", "x"), ("i32", "y"), ("i32", "z")],
-        "void",
-        "",
-        "",
-        r#"%load_y = load i32, i32* %y, align 4
-  store i32 %load_y, i32* %x, align 4
-  br label %condition_check
-
-condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %load_z = load i32, i32* %z, align 4
-  %tmpVar = icmp sle i32 %load_x, %load_z
-  br i1 %tmpVar, label %for_body, label %continue
-
-for_body:                                         ; preds = %condition_check
-  %load_x1 = load i32, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %for_body
-  %load_step = load i32, i32* %step, align 4
-  %tmpVar2 = add i32 %load_x, %load_step
-  store i32 %tmpVar2, i32* %x, align 4
-  br label %condition_check
-
-continue:                                         ; preds = %condition_check
-  ret void
-"#,
-    );
-
-    assert_eq!(result, expected);
+    insta::assert_snapshot!(result);
 }
 
 #[test]

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_continue.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_continue.snap
@@ -24,23 +24,15 @@ condition_check:                                  ; preds = %increment, %entry
   br i1 %1, label %6, label %7
 
 for_body:                                         ; preds = %4
-  %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
-  store i32 %tmpVar9, i32* %x, align 4
   br label %increment
 
-buffer_block:                                     ; No predecessors!
-  %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
-  store i32 %tmpVar11, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block, %for_body
-  %tmpVar12 = add i32 %load_x, 7
-  store i32 %tmpVar12, i32* %x, align 4
+increment:                                        ; preds = %for_body
+  %tmpVar8 = add i32 %load_x, 1
+  store i32 %tmpVar8, i32* %x, align 4
   br label %condition_check
 
 continue:                                         ; preds = %4
+  %load_x9 = load i32, i32* %x, align 4
   ret void
 
 2:                                                ; preds = %7

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_int.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_int.snap
@@ -6,46 +6,38 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-%prg_interface = type { i32 }
+%prg_interface = type { i16 }
 
 @prg_instance = global %prg_interface zeroinitializer
 
 define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  store i32 3, i32* %x, align 4
+  store i16 3, i16* %x, align 2
   br label %condition_check
 
 condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %load_x1 = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x1, 10
+  %load_x = load i16, i16* %x, align 2
+  %load_x1 = load i16, i16* %x, align 2
+  %tmpVar = icmp sle i16 %load_x1, 10
   %1 = icmp ne i1 %tmpVar, false
   br i1 %1, label %6, label %7
 
 for_body:                                         ; preds = %4
-  %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
-  store i32 %tmpVar9, i32* %x, align 4
+  %load_x8 = load i16, i16* %x, align 2
   br label %increment
 
-buffer_block:                                     ; No predecessors!
-  %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
-  store i32 %tmpVar11, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block, %for_body
-  %tmpVar12 = add i32 %load_x, 7
-  store i32 %tmpVar12, i32* %x, align 4
+increment:                                        ; preds = %for_body
+  %tmpVar9 = add i16 %load_x, 1
+  store i16 %tmpVar9, i16* %x, align 2
   br label %condition_check
 
 continue:                                         ; preds = %4
   ret void
 
 2:                                                ; preds = %7
-  %load_x4 = load i32, i32* %x, align 4
-  %tmpVar5 = icmp sge i32 %load_x4, 10
+  %load_x4 = load i16, i16* %x, align 2
+  %tmpVar5 = icmp sge i16 %load_x4, 10
   %3 = icmp ne i1 %tmpVar5, false
   br i1 %3, label %10, label %11
 
@@ -54,8 +46,8 @@ continue:                                         ; preds = %4
   br i1 %5, label %for_body, label %continue
 
 6:                                                ; preds = %condition_check
-  %load_x2 = load i32, i32* %x, align 4
-  %tmpVar3 = icmp sge i32 %load_x2, 3
+  %load_x2 = load i16, i16* %x, align 2
+  %tmpVar3 = icmp sge i16 %load_x2, 3
   br label %7
 
 7:                                                ; preds = %6, %condition_check
@@ -64,8 +56,8 @@ continue:                                         ; preds = %4
   br i1 %9, label %4, label %2
 
 10:                                               ; preds = %2
-  %load_x6 = load i32, i32* %x, align 4
-  %tmpVar7 = icmp sle i32 %load_x6, 3
+  %load_x6 = load i16, i16* %x, align 2
+  %tmpVar7 = icmp sle i16 %load_x6, 3
   br label %11
 
 11:                                               ; preds = %10, %2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_lint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_lint.snap
@@ -6,46 +6,38 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-%prg_interface = type { i32 }
+%prg_interface = type { i64 }
 
 @prg_instance = global %prg_interface zeroinitializer
 
 define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  store i32 3, i32* %x, align 4
+  store i64 3, i64* %x, align 4
   br label %condition_check
 
 condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %load_x1 = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x1, 10
+  %load_x = load i64, i64* %x, align 4
+  %load_x1 = load i64, i64* %x, align 4
+  %tmpVar = icmp sle i64 %load_x1, 10
   %1 = icmp ne i1 %tmpVar, false
   br i1 %1, label %6, label %7
 
 for_body:                                         ; preds = %4
-  %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
-  store i32 %tmpVar9, i32* %x, align 4
+  %load_x8 = load i64, i64* %x, align 4
   br label %increment
 
-buffer_block:                                     ; No predecessors!
-  %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
-  store i32 %tmpVar11, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block, %for_body
-  %tmpVar12 = add i32 %load_x, 7
-  store i32 %tmpVar12, i32* %x, align 4
+increment:                                        ; preds = %for_body
+  %tmpVar9 = add i64 %load_x, 1
+  store i64 %tmpVar9, i64* %x, align 4
   br label %condition_check
 
 continue:                                         ; preds = %4
   ret void
 
 2:                                                ; preds = %7
-  %load_x4 = load i32, i32* %x, align 4
-  %tmpVar5 = icmp sge i32 %load_x4, 10
+  %load_x4 = load i64, i64* %x, align 4
+  %tmpVar5 = icmp sge i64 %load_x4, 10
   %3 = icmp ne i1 %tmpVar5, false
   br i1 %3, label %10, label %11
 
@@ -54,8 +46,8 @@ continue:                                         ; preds = %4
   br i1 %5, label %for_body, label %continue
 
 6:                                                ; preds = %condition_check
-  %load_x2 = load i32, i32* %x, align 4
-  %tmpVar3 = icmp sge i32 %load_x2, 3
+  %load_x2 = load i64, i64* %x, align 4
+  %tmpVar3 = icmp sge i64 %load_x2, 3
   br label %7
 
 7:                                                ; preds = %6, %condition_check
@@ -64,8 +56,8 @@ continue:                                         ; preds = %4
   br i1 %9, label %4, label %2
 
 10:                                               ; preds = %2
-  %load_x6 = load i32, i32* %x, align 4
-  %tmpVar7 = icmp sle i32 %load_x6, 3
+  %load_x6 = load i64, i64* %x, align 4
+  %tmpVar7 = icmp sle i64 %load_x6, 3
   br label %11
 
 11:                                               ; preds = %10, %2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_sint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_sint.snap
@@ -6,46 +6,38 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-%prg_interface = type { i32 }
+%prg_interface = type { i8 }
 
 @prg_instance = global %prg_interface zeroinitializer
 
 define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  store i32 3, i32* %x, align 4
+  store i8 3, i8* %x, align 1
   br label %condition_check
 
 condition_check:                                  ; preds = %increment, %entry
-  %load_x = load i32, i32* %x, align 4
-  %load_x1 = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x1, 10
+  %load_x = load i8, i8* %x, align 1
+  %load_x1 = load i8, i8* %x, align 1
+  %tmpVar = icmp sle i8 %load_x1, 10
   %1 = icmp ne i1 %tmpVar, false
   br i1 %1, label %6, label %7
 
 for_body:                                         ; preds = %4
-  %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
-  store i32 %tmpVar9, i32* %x, align 4
+  %load_x8 = load i8, i8* %x, align 1
   br label %increment
 
-buffer_block:                                     ; No predecessors!
-  %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
-  store i32 %tmpVar11, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block, %for_body
-  %tmpVar12 = add i32 %load_x, 7
-  store i32 %tmpVar12, i32* %x, align 4
+increment:                                        ; preds = %for_body
+  %tmpVar9 = add i8 %load_x, 1
+  store i8 %tmpVar9, i8* %x, align 1
   br label %condition_check
 
 continue:                                         ; preds = %4
   ret void
 
 2:                                                ; preds = %7
-  %load_x4 = load i32, i32* %x, align 4
-  %tmpVar5 = icmp sge i32 %load_x4, 10
+  %load_x4 = load i8, i8* %x, align 1
+  %tmpVar5 = icmp sge i8 %load_x4, 10
   %3 = icmp ne i1 %tmpVar5, false
   br i1 %3, label %10, label %11
 
@@ -54,8 +46,8 @@ continue:                                         ; preds = %4
   br i1 %5, label %for_body, label %continue
 
 6:                                                ; preds = %condition_check
-  %load_x2 = load i32, i32* %x, align 4
-  %tmpVar3 = icmp sge i32 %load_x2, 3
+  %load_x2 = load i8, i8* %x, align 1
+  %tmpVar3 = icmp sge i8 %load_x2, 3
   br label %7
 
 7:                                                ; preds = %6, %condition_check
@@ -64,8 +56,8 @@ continue:                                         ; preds = %4
   br i1 %9, label %4, label %2
 
 10:                                               ; preds = %2
-  %load_x6 = load i32, i32* %x, align 4
-  %tmpVar7 = icmp sle i32 %load_x6, 3
+  %load_x6 = load i8, i8* %x, align 1
+  %tmpVar7 = icmp sle i8 %load_x6, 3
   br label %11
 
 11:                                               ; preds = %10, %2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_exit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_exit.snap
@@ -25,22 +25,22 @@ condition_check:                                  ; preds = %increment, %entry
 
 for_body:                                         ; preds = %4
   %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
+  %tmpVar9 = add i32 %load_x8, 2
   store i32 %tmpVar9, i32* %x, align 4
-  br label %increment
+  br label %continue
 
 buffer_block:                                     ; No predecessors!
   %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
+  %tmpVar11 = add i32 %load_x10, 5
   store i32 %tmpVar11, i32* %x, align 4
   br label %increment
 
-increment:                                        ; preds = %buffer_block, %for_body
+increment:                                        ; preds = %buffer_block
   %tmpVar12 = add i32 %load_x, 7
   store i32 %tmpVar12, i32* %x, align 4
   br label %condition_check
 
-continue:                                         ; preds = %4
+continue:                                         ; preds = %for_body, %4
   ret void
 
 2:                                                ; preds = %7

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_references_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_references_steps_test.snap
@@ -6,37 +6,35 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-%prg_interface = type { i32 }
+%prg_interface = type { i32, i32, i32, i32 }
 
 @prg_instance = global %prg_interface zeroinitializer
 
 define void @prg(%prg_interface* %0) {
 entry:
-  %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  store i32 3, i32* %x, align 4
+  %step = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
+  %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 1
+  %y = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 2
+  %z = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 3
+  %load_y = load i32, i32* %y, align 4
+  store i32 %load_y, i32* %x, align 4
   br label %condition_check
 
 condition_check:                                  ; preds = %increment, %entry
   %load_x = load i32, i32* %x, align 4
   %load_x1 = load i32, i32* %x, align 4
-  %tmpVar = icmp sle i32 %load_x1, 10
+  %load_z = load i32, i32* %z, align 4
+  %tmpVar = icmp sle i32 %load_x1, %load_z
   %1 = icmp ne i1 %tmpVar, false
   br i1 %1, label %6, label %7
 
 for_body:                                         ; preds = %4
-  %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
-  store i32 %tmpVar9, i32* %x, align 4
+  %load_x11 = load i32, i32* %x, align 4
   br label %increment
 
-buffer_block:                                     ; No predecessors!
-  %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
-  store i32 %tmpVar11, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block, %for_body
-  %tmpVar12 = add i32 %load_x, 7
+increment:                                        ; preds = %for_body
+  %load_step = load i32, i32* %step, align 4
+  %tmpVar12 = add i32 %load_x, %load_step
   store i32 %tmpVar12, i32* %x, align 4
   br label %condition_check
 
@@ -44,9 +42,10 @@ continue:                                         ; preds = %4
   ret void
 
 2:                                                ; preds = %7
-  %load_x4 = load i32, i32* %x, align 4
-  %tmpVar5 = icmp sge i32 %load_x4, 10
-  %3 = icmp ne i1 %tmpVar5, false
+  %load_x5 = load i32, i32* %x, align 4
+  %load_z6 = load i32, i32* %z, align 4
+  %tmpVar7 = icmp sge i32 %load_x5, %load_z6
+  %3 = icmp ne i1 %tmpVar7, false
   br i1 %3, label %10, label %11
 
 4:                                                ; preds = %11, %7
@@ -55,21 +54,23 @@ continue:                                         ; preds = %4
 
 6:                                                ; preds = %condition_check
   %load_x2 = load i32, i32* %x, align 4
-  %tmpVar3 = icmp sge i32 %load_x2, 3
+  %load_y3 = load i32, i32* %y, align 4
+  %tmpVar4 = icmp sge i32 %load_x2, %load_y3
   br label %7
 
 7:                                                ; preds = %6, %condition_check
-  %8 = phi i1 [ %tmpVar, %condition_check ], [ %tmpVar3, %6 ]
+  %8 = phi i1 [ %tmpVar, %condition_check ], [ %tmpVar4, %6 ]
   %9 = icmp ne i1 %8, false
   br i1 %9, label %4, label %2
 
 10:                                               ; preds = %2
-  %load_x6 = load i32, i32* %x, align 4
-  %tmpVar7 = icmp sle i32 %load_x6, 3
+  %load_x8 = load i32, i32* %x, align 4
+  %load_y9 = load i32, i32* %y, align 4
+  %tmpVar10 = icmp sle i32 %load_x8, %load_y9
   br label %11
 
 11:                                               ; preds = %10, %2
-  %12 = phi i1 [ %tmpVar5, %2 ], [ %tmpVar7, %10 ]
+  %12 = phi i1 [ %tmpVar7, %2 ], [ %tmpVar10, %10 ]
   br label %4
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_steps_test.snap
@@ -25,19 +25,11 @@ condition_check:                                  ; preds = %increment, %entry
 
 for_body:                                         ; preds = %4
   %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
+  br label %increment
+
+increment:                                        ; preds = %for_body
+  %tmpVar9 = add i32 %load_x, 7
   store i32 %tmpVar9, i32* %x, align 4
-  br label %increment
-
-buffer_block:                                     ; No predecessors!
-  %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
-  store i32 %tmpVar11, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block, %for_body
-  %tmpVar12 = add i32 %load_x, 7
-  store i32 %tmpVar12, i32* %x, align 4
   br label %condition_check
 
 continue:                                         ; preds = %4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_without_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_without_steps_test.snap
@@ -25,19 +25,11 @@ condition_check:                                  ; preds = %increment, %entry
 
 for_body:                                         ; preds = %4
   %load_x8 = load i32, i32* %x, align 4
-  %tmpVar9 = add i32 %load_x8, 1
+  br label %increment
+
+increment:                                        ; preds = %for_body
+  %tmpVar9 = add i32 %load_x, 1
   store i32 %tmpVar9, i32* %x, align 4
-  br label %increment
-
-buffer_block:                                     ; No predecessors!
-  %load_x10 = load i32, i32* %x, align 4
-  %tmpVar11 = sub i32 %load_x10, 1
-  store i32 %tmpVar11, i32* %x, align 4
-  br label %increment
-
-increment:                                        ; preds = %buffer_block, %for_body
-  %tmpVar12 = add i32 %load_x, 7
-  store i32 %tmpVar12, i32* %x, align 4
   br label %condition_check
 
 continue:                                         ; preds = %4

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -96,7 +96,7 @@ impl<'s> VisitorContext<'s> {
 
 pub struct TypeAnnotator<'i> {
     index: &'i Index,
-    annotation_map: AnnotationMap,
+    annotation_map: AnnotationMapImpl,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -129,8 +129,106 @@ impl StatementAnnotation {
     }
 }
 
+fn get_type_for_annotation<'a>(
+    index: &'a Index,
+    annotation: &StatementAnnotation,
+) -> Option<&'a typesystem::DataType> {
+    match annotation {
+        StatementAnnotation::Value { resulting_type } => Some(resulting_type.as_str()),
+        StatementAnnotation::Variable { resulting_type, .. } => Some(resulting_type.as_str()),
+        StatementAnnotation::Function { .. } => None,
+        StatementAnnotation::Type { .. } => None,
+        StatementAnnotation::Program { .. } => None,
+    }
+    .and_then(|type_name| index.get_type(type_name).ok())
+}
+
+pub trait AnnotationMap {
+    fn get(&self, s: &AstStatement) -> Option<&StatementAnnotation>;
+
+    fn get_hint(&self, s: &AstStatement) -> Option<&StatementAnnotation>;
+
+    fn get_type_or_void<'i>(&self, s: &AstStatement, index: &'i Index) -> &'i typesystem::DataType {
+        self.get_type(s, index)
+            .unwrap_or_else(|| index.get_void_type())
+    }
+
+    fn get_hint_or_void<'i>(&self, s: &AstStatement, index: &'i Index) -> &'i typesystem::DataType {
+        self.get_type_hint(s, index)
+            .unwrap_or_else(|| index.get_void_type())
+    }
+
+    fn get_type_hint<'i>(
+        &self,
+        s: &AstStatement,
+        index: &'i Index,
+    ) -> Option<&'i typesystem::DataType> {
+        self.get_hint(s)
+            .and_then(|it| get_type_for_annotation(index, it))
+    }
+
+    fn get_type<'i>(&self, s: &AstStatement, index: &'i Index) -> Option<&'i typesystem::DataType> {
+        self.get(s)
+            .and_then(|it| get_type_for_annotation(index, it))
+    }
+
+    /// returns the name of the callable that is refered by the given statemt
+    /// or none if this thing may not be callable
+    fn get_call_name(&self, s: &AstStatement) -> Option<&str> {
+        match self.get(s) {
+            Some(StatementAnnotation::Function { qualified_name, .. }) => {
+                Some(qualified_name.as_str())
+            }
+            Some(StatementAnnotation::Program { qualified_name }) => Some(qualified_name.as_str()),
+            Some(StatementAnnotation::Variable { resulting_type, .. }) => {
+                Some(resulting_type.as_str())
+            }
+            _ => None,
+        }
+    }
+}
+
+pub struct AstAnnotations {
+    annotation_map: AnnotationMapImpl,
+    bool_id: AstId,
+
+    bool_annotation: StatementAnnotation,
+}
+
+impl AnnotationMap for AstAnnotations {
+    fn get(&self, s: &AstStatement) -> Option<&StatementAnnotation> {
+        if s.get_id() == self.bool_id {
+            Some(&self.bool_annotation)
+        } else {
+            self.annotation_map.get(s)
+        }
+    }
+
+    fn get_hint(&self, s: &AstStatement) -> Option<&StatementAnnotation> {
+        if s.get_id() == self.bool_id {
+            Some(&self.bool_annotation)
+        } else {
+            self.annotation_map.get_hint(s)
+        }
+    }
+}
+
+impl AstAnnotations {
+    pub fn new(annotation_map: AnnotationMapImpl, bool_id: AstId) -> Self {
+        AstAnnotations {
+            annotation_map,
+            bool_id,
+            bool_annotation: StatementAnnotation::value(BOOL_TYPE),
+        }
+    }
+
+    pub fn get_bool_id(&self) -> AstId {
+        self.bool_id
+    }
+}
+
 #[derive(Default)]
-pub struct AnnotationMap {
+pub struct AnnotationMapImpl {
     /// maps a statement to the type it resolves to
     type_map: IndexMap<AstId, StatementAnnotation>,
 
@@ -150,13 +248,13 @@ pub struct AnnotationMap {
     pub new_index: Index,
 }
 
-impl AnnotationMap {
+impl AnnotationMapImpl {
     /// creates a new empty AnnotationMap
     pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn import(&mut self, other: AnnotationMap) {
+    pub fn import(&mut self, other: AnnotationMapImpl) {
         self.type_map.extend(other.type_map);
         self.type_hint_map.extend(other.type_hint_map);
         self.new_index.import(other.new_index);
@@ -176,90 +274,6 @@ impl AnnotationMap {
         self.generic_nature_map.insert(s.get_id(), nature);
     }
 
-    pub fn get(&self, s: &AstStatement) -> Option<&StatementAnnotation> {
-        self.type_map.get(&s.get_id())
-    }
-
-    pub fn get_hint(&self, s: &AstStatement) -> Option<&StatementAnnotation> {
-        self.type_hint_map.get(&s.get_id())
-    }
-
-    /// returns the annotated type or void if none was annotated
-    pub fn get_type_or_void<'i>(
-        &self,
-        s: &AstStatement,
-        index: &'i Index,
-    ) -> &'i typesystem::DataType {
-        self.get_type(s, index)
-            .unwrap_or_else(|| index.get_void_type())
-    }
-
-    pub fn get_type_hint<'i>(
-        &self,
-        s: &AstStatement,
-        index: &'i Index,
-    ) -> Option<&'i typesystem::DataType> {
-        self.get_from_map(s, &self.type_hint_map, index)
-    }
-
-    pub fn get_hint_or_void<'i>(
-        &self,
-        s: &AstStatement,
-        index: &'i Index,
-    ) -> &'i typesystem::DataType {
-        self.get_from_map(s, &self.type_hint_map, index)
-            .unwrap_or_else(|| index.get_void_type())
-    }
-
-    /// returns the annotated type
-    pub fn get_type<'i>(
-        &self,
-        s: &AstStatement,
-        index: &'i Index,
-    ) -> Option<&'i typesystem::DataType> {
-        self.get_from_map(s, &self.type_map, index)
-    }
-
-    /// returns the annotated type from the given map
-    fn get_from_map<'i>(
-        &self,
-        s: &AstStatement,
-        map: &IndexMap<AstId, StatementAnnotation>,
-        index: &'i Index,
-    ) -> Option<&'i typesystem::DataType> {
-        map.get(&s.get_id())
-            .and_then(|annotation| match annotation {
-                StatementAnnotation::Value { resulting_type } => Some(resulting_type.as_str()),
-                StatementAnnotation::Variable { resulting_type, .. } => {
-                    Some(resulting_type.as_str())
-                }
-                StatementAnnotation::Function { .. } => None,
-                StatementAnnotation::Type { .. } => None,
-                StatementAnnotation::Program { .. } => None,
-            })
-            .and_then(|type_name| index.get_type(type_name).ok())
-    }
-
-    /// reutrns the name of the callable that is refered by the given statemt
-    /// or none if this thing may not be callable
-    pub fn get_call_name(&self, s: &AstStatement) -> Option<&str> {
-        match self.type_map.get(&s.get_id()) {
-            Some(StatementAnnotation::Function { qualified_name, .. }) => {
-                Some(qualified_name.as_str())
-            }
-            Some(StatementAnnotation::Program { qualified_name }) => Some(qualified_name.as_str()),
-            Some(StatementAnnotation::Variable { resulting_type, .. }) => {
-                Some(resulting_type.as_str())
-            }
-            _ => None,
-        }
-    }
-
-    /// returns the annotation of the given statement or none if it was not annotated
-    pub fn get_annotation(&self, s: &AstStatement) -> Option<&StatementAnnotation> {
-        self.type_map.get(&s.get_id())
-    }
-
     pub fn has_type_annotation(&self, id: &usize) -> bool {
         self.type_map.contains_key(id)
     }
@@ -269,18 +283,28 @@ impl AnnotationMap {
     }
 }
 
+impl AnnotationMap for AnnotationMapImpl {
+    fn get(&self, s: &AstStatement) -> Option<&StatementAnnotation> {
+        self.type_map.get(&s.get_id())
+    }
+
+    fn get_hint(&self, s: &AstStatement) -> Option<&StatementAnnotation> {
+        self.type_hint_map.get(&s.get_id())
+    }
+}
+
 impl<'i> TypeAnnotator<'i> {
     /// constructs a new TypeAnnotater that works with the given index for type-lookups
     fn new(index: &'i Index) -> TypeAnnotator<'i> {
         TypeAnnotator {
-            annotation_map: AnnotationMap::new(),
+            annotation_map: AnnotationMapImpl::new(),
             index,
         }
     }
 
     /// annotates the given AST elements with the type-name resulting for the statements/expressions.
     /// Returns an AnnotationMap with the resulting types for all visited Statements. See `AnnotationMap`
-    pub fn visit_unit(index: &Index, unit: &'i CompilationUnit) -> AnnotationMap {
+    pub fn visit_unit(index: &Index, unit: &'i CompilationUnit) -> AnnotationMapImpl {
         let mut visitor = TypeAnnotator::new(index);
         let ctx = &VisitorContext {
             pou: None,
@@ -586,6 +610,21 @@ impl<'i> TypeAnnotator<'i> {
                 if let Some(by_step) = by_step {
                     self.visit_statement(ctx, by_step);
                 }
+                //Hint annotate start, end and step with the counter's real type
+                if let Some(type_name) = self
+                    .annotation_map
+                    .get_type(counter, self.index)
+                    .map(typesystem::DataType::get_name)
+                {
+                    let annotation = StatementAnnotation::value(type_name);
+                    self.annotation_map
+                        .annotate_type_hint(start, annotation.clone());
+                    self.annotation_map
+                        .annotate_type_hint(end, annotation.clone());
+                    if let Some(by_step) = by_step {
+                        self.annotation_map.annotate_type_hint(by_step, annotation);
+                    }
+                }
                 body.iter().for_each(|s| self.visit_statement(ctx, s));
             }
             AstStatement::WhileLoopStatement {
@@ -846,7 +885,7 @@ impl<'i> TypeAnnotator<'i> {
 
                     let (qualifier, constant) = self
                         .annotation_map
-                        .get_annotation(s)
+                        .get(s)
                         .map(|it| match it {
                             StatementAnnotation::Value { resulting_type } => {
                                 (resulting_type.as_str(), false)
@@ -870,7 +909,7 @@ impl<'i> TypeAnnotator<'i> {
 
                 //the last guy represents the type of the whole qualified expression
                 if let Some(last) = elements.last() {
-                    if let Some(annotation) = self.annotation_map.get_annotation(last).cloned() {
+                    if let Some(annotation) = self.annotation_map.get(last).cloned() {
                         self.annotation_map.annotate(statement, annotation);
                     }
                 }
@@ -911,7 +950,7 @@ impl<'i> TypeAnnotator<'i> {
                 self.visit_statement(ctx, operator);
                 let operator_qualifier = self
                     .annotation_map
-                    .get_annotation(operator)
+                    .get(operator)
                     .and_then(|it| match it {
                         StatementAnnotation::Function { qualified_name, .. } => {
                             Some(qualified_name.clone())
@@ -1020,7 +1059,7 @@ impl<'i> TypeAnnotator<'i> {
     // Returns a possible generic for the current statement
     fn get_generic_candidate<'idx>(
         index: &'idx Index,
-        annotation_map: &AnnotationMap,
+        annotation_map: &AnnotationMapImpl,
         member: &VariableIndexEntry,
         statement: &AstStatement,
     ) -> Option<(&'idx str, &'idx str)> {
@@ -1066,7 +1105,7 @@ impl<'i> TypeAnnotator<'i> {
                 if let Some(StatementAnnotation::Function {
                     qualified_name,
                     return_type,
-                }) = self.annotation_map.get_annotation(operator)
+                }) = self.annotation_map.get(operator)
                 {
                     //Figure out the new name for the call
                     let (name, annotation) = self.get_generic_function_annotation(

--- a/src/resolver/tests/const_resolver_tests.rs
+++ b/src/resolver/tests/const_resolver_tests.rs
@@ -3,6 +3,7 @@ use crate::index::const_expressions::ConstExpression;
 use crate::index::Index;
 
 use crate::resolver::const_evaluator::{evaluate_constants, UnresolvableConstant};
+use crate::resolver::AnnotationMap;
 use crate::test_utils::tests::{annotate, index};
 use crate::typesystem::DataTypeInformation;
 

--- a/src/resolver/tests/resolve_control_statments.rs
+++ b/src/resolver/tests/resolve_control_statments.rs
@@ -1,6 +1,6 @@
 use core::panic;
 
-use crate::{ast::AstStatement, test_utils::tests::index, TypeAnnotator};
+use crate::{assert_type_and_hint, ast::AstStatement, test_utils::tests::index, TypeAnnotator};
 
 #[test]
 fn binary_expressions_resolves_types() {
@@ -23,14 +23,10 @@ fn binary_expressions_resolves_types() {
         ..
     } = &statements[0]
     {
-        let types = vec![
-            annotations.get_type_or_void(counter, &index).get_name(),
-            annotations.get_type_or_void(start, &index).get_name(),
-            annotations.get_type_or_void(end, &index).get_name(),
-            annotations.get_type_or_void(by_step, &index).get_name(),
-        ];
-
-        assert_eq!(vec!["INT", "DINT", "DINT", "DINT"], types);
+        assert_type_and_hint!(&annotations, &index, counter, "INT", None);
+        assert_type_and_hint!(&annotations, &index, start, "DINT", Some("INT"));
+        assert_type_and_hint!(&annotations, &index, end, "DINT", Some("INT"));
+        assert_type_and_hint!(&annotations, &index, by_step, "DINT", Some("INT"));
     } else {
         panic!("no for loop statement");
     }

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -3,7 +3,7 @@ use core::panic;
 use crate::{
     ast::{self, AstStatement, DataType, Pou, UserTypeDeclaration},
     index::Index,
-    resolver::{AnnotationMap, StatementAnnotation},
+    resolver::{AnnotationMap, AnnotationMapImpl, StatementAnnotation},
     test_utils::tests::annotate,
     typesystem::{
         DataTypeInformation, BOOL_TYPE, BYTE_TYPE, CONST_STRING_TYPE, DINT_TYPE, INT_TYPE,
@@ -18,8 +18,8 @@ macro_rules! assert_type_and_hint {
     ($annotations:expr, $index:expr, $stmt:expr, $expected_type:expr, $expected_type_hint:expr) => {
         assert_eq!(
             (
-                $annotations.get_type($stmt, $index),
-                $annotations.get_type_hint($stmt, $index)
+                crate::resolver::AnnotationMap::get_type($annotations, $stmt, $index),
+                crate::resolver::AnnotationMap::get_type_hint($annotations, $stmt, $index),
             ),
             (
                 $index.get_type($expected_type).ok(),
@@ -744,20 +744,20 @@ fn pou_expressions_resolve_types() {
         Some(&StatementAnnotation::Program {
             qualified_name: "OtherPrg".into()
         }),
-        annotations.get_annotation(&statements[0])
+        annotations.get(&statements[0])
     );
     assert_eq!(
         Some(&StatementAnnotation::Function {
             qualified_name: "OtherFunc".into(),
             return_type: "INT".into()
         }),
-        annotations.get_annotation(&statements[1])
+        annotations.get(&statements[1])
     );
     assert_eq!(
         Some(&StatementAnnotation::Type {
             type_name: "OtherFuncBlock".into()
         }),
-        annotations.get_annotation(&statements[2])
+        annotations.get(&statements[2])
     );
 }
 
@@ -924,7 +924,7 @@ fn function_expression_resolves_to_the_function_itself_not_its_return_type() {
     let statements = &unit.implementations[1].statements;
 
     // THEN we expect it to be annotated with the function itself
-    let foo_annotation = annotations.get_annotation(&statements[0]);
+    let foo_annotation = annotations.get(&statements[0]);
     assert_eq!(
         Some(&StatementAnnotation::Function {
             qualified_name: "foo".into(),
@@ -937,7 +937,7 @@ fn function_expression_resolves_to_the_function_itself_not_its_return_type() {
     assert_eq!(None, associated_type);
 
     let statements = &unit.implementations[0].statements;
-    let foo_annotation = annotations.get_annotation(&statements[0]);
+    let foo_annotation = annotations.get(&statements[0]);
     assert_eq!(
         Some(&StatementAnnotation::Variable {
             qualified_name: "foo.foo".into(),
@@ -968,7 +968,7 @@ fn function_call_expression_resolves_to_the_function_itself_not_its_return_type(
     let statements = &unit.implementations[1].statements;
 
     // THEN we expect it to be annotated with the function itself
-    let foo_annotation = annotations.get_annotation(&statements[0]);
+    let foo_annotation = annotations.get(&statements[0]);
     assert_eq!(
         Some(&StatementAnnotation::Value {
             resulting_type: "INT".into()
@@ -1123,7 +1123,7 @@ fn qualified_expressions_dont_fallback_to_globals() {
     let annotations = TypeAnnotator::visit_unit(&index, &unit);
     let statements = &unit.implementations[0].statements;
 
-    assert_eq!(None, annotations.get_annotation(&statements[0]));
+    assert_eq!(None, annotations.get(&statements[0]));
     assert_eq!(
         Some(&StatementAnnotation::Variable {
             qualified_name: "MyStruct.y".into(),
@@ -1131,7 +1131,7 @@ fn qualified_expressions_dont_fallback_to_globals() {
             constant: false,
             is_auto_deref: false
         }),
-        annotations.get_annotation(&statements[1])
+        annotations.get(&statements[1])
     );
 }
 
@@ -1166,7 +1166,7 @@ fn function_parameter_assignments_resolve_types() {
         "INT"
     );
     assert_eq!(
-        annotations.get_annotation(&statements[0]),
+        annotations.get(&statements[0]),
         Some(&StatementAnnotation::value("INT"))
     );
     if let AstStatement::CallStatement {
@@ -1181,7 +1181,7 @@ fn function_parameter_assignments_resolve_types() {
             VOID_TYPE
         );
         assert_eq!(
-            annotations.get_annotation(operator),
+            annotations.get(operator),
             Some(&StatementAnnotation::Function {
                 qualified_name: "foo".into(),
                 return_type: "MyType".into()
@@ -1329,7 +1329,7 @@ fn actions_are_resolved() {
 
     let annotations = TypeAnnotator::visit_unit(&index, &unit);
     let foo_reference = &unit.implementations[0].statements[0];
-    let annotation = annotations.get_annotation(foo_reference);
+    let annotation = annotations.get(foo_reference);
     assert_eq!(
         Some(&StatementAnnotation::Program {
             qualified_name: "prg.foo".into(),
@@ -1337,7 +1337,7 @@ fn actions_are_resolved() {
         annotation
     );
     let foo_reference = &unit.implementations[0].statements[1];
-    let annotation = annotations.get_annotation(foo_reference);
+    let annotation = annotations.get(foo_reference);
     assert_eq!(
         Some(&StatementAnnotation::Program {
             qualified_name: "prg.foo".into(),
@@ -1376,7 +1376,7 @@ fn method_references_are_resolved() {
 
     let annotations = TypeAnnotator::visit_unit(&index, &unit);
     let foo_reference = &unit.implementations[0].statements[0];
-    let annotation = annotations.get_annotation(foo_reference);
+    let annotation = annotations.get(foo_reference);
     assert_eq!(
         Some(&StatementAnnotation::Variable {
             qualified_name: "cls.foo.foo".into(),
@@ -1481,7 +1481,7 @@ fn assert_parameter_assignment(
     param_index: usize,
     left_type: &str,
     right_type: &str,
-    annotations: &AnnotationMap,
+    annotations: &AnnotationMapImpl,
     index: &Index,
 ) {
     if let Some(AstStatement::ExpressionList { expressions, .. }) = parameters {
@@ -2196,7 +2196,7 @@ fn action_call_should_be_annotated() {
 
     // then accessing inout should be annotated with DINT, because it is auto-dereferenced
     if let AstStatement::CallStatement { operator, .. } = action_call {
-        let a = annotations.get_annotation(operator);
+        let a = annotations.get(operator);
         assert_eq!(
             Some(&StatementAnnotation::Program {
                 qualified_name: "prg.foo".to_string()
@@ -2231,7 +2231,7 @@ fn action_body_gets_resolved() {
 
     // then accessing inout should be annotated with DINT, because it is auto-dereferenced
     if let AstStatement::Assignment { left, right, .. } = x_assignment {
-        let a = annotations.get_annotation(left);
+        let a = annotations.get(left);
         assert_eq!(
             Some(&StatementAnnotation::Variable {
                 qualified_name: "prg.x".to_string(),
@@ -2242,7 +2242,7 @@ fn action_body_gets_resolved() {
             a
         );
 
-        let two = annotations.get_annotation(right);
+        let two = annotations.get(right);
         assert_eq!(Some(&StatementAnnotation::value(DINT_TYPE)), two);
     }
 }
@@ -2481,7 +2481,7 @@ fn resolve_function_with_same_name_as_return_type() {
     let statements = &unit.implementations[1].statements;
 
     // THEN we expect it to be annotated with the function itself
-    let function_annotation = annotations.get_annotation(&statements[0]);
+    let function_annotation = annotations.get(&statements[0]);
     assert_eq!(
         Some(&StatementAnnotation::Value {
             resulting_type: "TIME".into()
@@ -2521,7 +2521,7 @@ fn int_compare_should_resolve_to_bool() {
         Some(&StatementAnnotation::Value {
             resulting_type: "BOOL".to_string(),
         }),
-        annotations.get_annotation(a_eq_b),
+        annotations.get(a_eq_b),
     );
 }
 
@@ -2549,6 +2549,6 @@ fn string_compare_should_resolve_to_bool() {
     let a_eq_b = &unit.implementations[1].statements[0];
     assert_eq!(
         Some(&StatementAnnotation::value("BOOL")),
-        annotations.get_annotation(a_eq_b),
+        annotations.get(a_eq_b),
     );
 }

--- a/src/resolver/tests/resolve_generic_calls.rs
+++ b/src/resolver/tests/resolve_generic_calls.rs
@@ -1,7 +1,7 @@
 use crate::{
     assert_type_and_hint,
     ast::{self, AstStatement},
-    resolver::TypeAnnotator,
+    resolver::{AnnotationMap, TypeAnnotator},
     test_utils::tests::index,
     typesystem::{BYTE_TYPE, DINT_TYPE, INT_TYPE, REAL_TYPE},
 };

--- a/src/resolver/tests/resolve_literals_tests.rs
+++ b/src/resolver/tests/resolve_literals_tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     assert_type_and_hint,
     ast::AstStatement,
-    resolver::TypeAnnotator,
+    resolver::{AnnotationMap, TypeAnnotator},
     test_utils::tests::{annotate, index},
     typesystem::{DataTypeInformation, CONST_STRING_TYPE, CONST_WSTRING_TYPE},
 };

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -4,7 +4,7 @@ use crate::{
         UserTypeDeclaration, Variable, VariableBlock,
     },
     index::Index,
-    resolver::AnnotationMap,
+    resolver::AnnotationMapImpl,
     Diagnostic,
 };
 
@@ -32,7 +32,7 @@ macro_rules! visit_all_statements {
    }
 
 pub struct ValidationContext<'s> {
-    ast_annotation: &'s AnnotationMap,
+    ast_annotation: &'s AnnotationMapImpl,
     index: &'s Index,
     qualifier: Option<&'s str>,
 }
@@ -63,7 +63,7 @@ impl Validator {
 
     pub fn visit_unit(
         &mut self,
-        annotations: &AnnotationMap,
+        annotations: &AnnotationMapImpl,
         index: &Index,
         unit: &CompilationUnit,
     ) {

--- a/src/validation/stmt_validator.rs
+++ b/src/validation/stmt_validator.rs
@@ -4,7 +4,7 @@ use super::ValidationContext;
 use crate::{
     ast::{AstStatement, DirectAccessType, Operator, SourceRange},
     index::{VariableIndexEntry, VariableType},
-    resolver::StatementAnnotation,
+    resolver::{AnnotationMap, StatementAnnotation},
     typesystem::{
         DataType, DataTypeInformation, BOOL_TYPE, DATE_AND_TIME_TYPE, DATE_TYPE, DINT_TYPE,
         INT_TYPE, LINT_TYPE, LREAL_TYPE, SINT_TYPE, STRING_TYPE, TIME_OF_DAY_TYPE, TIME_TYPE,


### PR DESCRIPTION
For loops counter variables were overflowing into other variables if the size was less than 32bit
Also decrement was not working correctly

We now correctly annotated the type for the for loop variables and we check if the counter is between the specified values.