### PR TITLE
Issue 389 strings assignments don't work on function calls

### DIFF
--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -229,7 +229,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             && right_type.is_string() &&
                 //Only handle assignments and references here, we have no chance of handling other
                 //types
-            matches!(dbg!(right_statement),
+            matches!(right_statement,
                 AstStatement::QualifiedReference {..} | AstStatement::Reference{..} | AstStatement::CallStatement{..})
         {
             let right = match right_statement {

--- a/src/codegen/llvm_typesystem.rs
+++ b/src/codegen/llvm_typesystem.rs
@@ -325,7 +325,7 @@ pub fn cast_if_needed<'ctx>(
                                 Ok(value)
                             }
                         } else {
-                            unreachable!()
+                            Ok(value) //Don't break, just don't cast
                         }
                     }
                 } else {

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
@@ -1,0 +1,52 @@
+---
+source: src/codegen/tests/statement_codegen_test.rs
+expression: result
+
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%CONCAT_interface = type { [1025 x i8], [1025 x i8] }
+%LIST_ADD_interface = type { [1001 x i8], [2 x i8] }
+
+declare [1025 x i8] @CONCAT(%CONCAT_interface*)
+
+define i1 @LIST_ADD(%LIST_ADD_interface* %0) {
+entry:
+  %INS = getelementptr inbounds %LIST_ADD_interface, %LIST_ADD_interface* %0, i32 0, i32 0
+  %sx = getelementptr inbounds %LIST_ADD_interface, %LIST_ADD_interface* %0, i32 0, i32 1
+  %LIST_ADD = alloca i1, align 1
+  %CONCAT_instance = alloca %CONCAT_interface, align 8
+  br label %input
+
+input:                                            ; preds = %entry
+  %1 = getelementptr inbounds %CONCAT_interface, %CONCAT_interface* %CONCAT_instance, i32 0, i32 0
+  %load_sx = load [2 x i8], [2 x i8]* %sx, align 1
+  store [2 x i8] %load_sx, [1025 x i8]* %1, align 1
+  %2 = getelementptr inbounds %CONCAT_interface, %CONCAT_interface* %CONCAT_instance, i32 0, i32 1
+  %load_INS = load [1001 x i8], [1001 x i8]* %INS, align 1
+  store [1001 x i8] %load_INS, [1025 x i8]* %2, align 1
+  br label %call
+
+call:                                             ; preds = %input
+  %call1 = call [1025 x i8] @CONCAT(%CONCAT_interface* %CONCAT_instance)
+  br label %output
+
+output:                                           ; preds = %call
+  br label %continue
+
+continue:                                         ; preds = %output
+  %3 = alloca [1025 x i8], align 1
+  store [1025 x i8] %call1, [1025 x i8]* %3, align 1
+  %4 = bitcast [1001 x i8]* %INS to i8*
+  %5 = bitcast [1025 x i8]* %3 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %4, i8* align 1 %5, i32 1001, i1 false)
+  %LIST_ADD_ret = load i1, i1* %LIST_ADD, align 1
+  ret i1 %LIST_ADD_ret
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
+
+attributes #0 = { argmemonly nofree nosync nounwind willreturn }
+

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
@@ -1,0 +1,43 @@
+---
+source: src/codegen/tests/statement_codegen_test.rs
+expression: result
+
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%CONCAT_interface = type { [1025 x i8], [1025 x i8] }
+%LIST_ADD_interface = type { [1001 x i8], [2 x i8] }
+
+declare [1025 x i8] @CONCAT(%CONCAT_interface*)
+
+define i1 @LIST_ADD(%LIST_ADD_interface* %0) {
+entry:
+  %INS = getelementptr inbounds %LIST_ADD_interface, %LIST_ADD_interface* %0, i32 0, i32 0
+  %sx = getelementptr inbounds %LIST_ADD_interface, %LIST_ADD_interface* %0, i32 0, i32 1
+  %LIST_ADD = alloca i1, align 1
+  %CONCAT_instance = alloca %CONCAT_interface, align 8
+  br label %input
+
+input:                                            ; preds = %entry
+  %1 = getelementptr inbounds %CONCAT_interface, %CONCAT_interface* %CONCAT_instance, i32 0, i32 0
+  %load_sx = load [2 x i8], [2 x i8]* %sx, align 1
+  store [2 x i8] %load_sx, [1025 x i8]* %1, align 1
+  %2 = getelementptr inbounds %CONCAT_interface, %CONCAT_interface* %CONCAT_instance, i32 0, i32 1
+  %load_INS = load [1001 x i8], [1001 x i8]* %INS, align 1
+  store [1001 x i8] %load_INS, [1025 x i8]* %2, align 1
+  br label %call
+
+call:                                             ; preds = %input
+  %call1 = call [1025 x i8] @CONCAT(%CONCAT_interface* %CONCAT_instance)
+  br label %output
+
+output:                                           ; preds = %call
+  br label %continue
+
+continue:                                         ; preds = %output
+  store [1025 x i8] %call1, [1001 x i8]* %INS, align 1
+  %LIST_ADD_ret = load i1, i1* %LIST_ADD, align 1
+  ret i1 %LIST_ADD_ret
+}
+

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
@@ -36,8 +36,17 @@ output:                                           ; preds = %call
   br label %continue
 
 continue:                                         ; preds = %output
-  store [1025 x i8] %call1, [1001 x i8]* %INS, align 1
+  %3 = alloca [1025 x i8], align 1
+  store [1025 x i8] %call1, [1025 x i8]* %3, align 1
+  %4 = bitcast [1001 x i8]* %INS to i8*
+  %5 = bitcast [1025 x i8]* %3 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %4, i8* align 1 %5, i32 1001, i1 false)
   %LIST_ADD_ret = load i1, i1* %LIST_ADD, align 1
   ret i1 %LIST_ADD_ret
 }
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
+
+attributes #0 = { argmemonly nofree nosync nounwind willreturn }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_parameters_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_parameters_string.snap
@@ -43,13 +43,17 @@ output:                                           ; preds = %call
   br label %continue
 
 continue:                                         ; preds = %output
-  store [81 x i8] %call1, [81 x i8]* %text1, align 1
+  %2 = alloca [81 x i8], align 1
+  store [81 x i8] %call1, [81 x i8]* %2, align 1
+  %3 = bitcast [81 x i8]* %text1 to i8*
+  %4 = bitcast [81 x i8]* %2 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 %4, i32 81, i1 false)
   %read_string_instance2 = alloca %read_string_interface, align 8
   br label %input3
 
 input3:                                           ; preds = %continue
-  %2 = getelementptr inbounds %read_string_interface, %read_string_interface* %read_string_instance2, i32 0, i32 0
-  store [6 x i8] c"hello\00", [81 x i8]* %2, align 1
+  %5 = getelementptr inbounds %read_string_interface, %read_string_interface* %read_string_instance2, i32 0, i32 0
+  store [6 x i8] c"hello\00", [81 x i8]* %5, align 1
   br label %call4
 
 call4:                                            ; preds = %input3
@@ -60,7 +64,11 @@ output5:                                          ; preds = %call4
   br label %continue6
 
 continue6:                                        ; preds = %output5
-  store [81 x i8] %call7, [81 x i8]* %text3, align 1
+  %6 = alloca [81 x i8], align 1
+  store [81 x i8] %call7, [81 x i8]* %6, align 1
+  %7 = bitcast [81 x i8]* %text3 to i8*
+  %8 = bitcast [81 x i8]* %6 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %7, i8* align 1 %8, i32 81, i1 false)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_string_assignment_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_string_assignment_test.snap
@@ -19,7 +19,7 @@ entry:
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 %2, i32 16, i1 false)
   %3 = bitcast [31 x i8]* %z to i8*
   %4 = bitcast [16 x i8]* %y to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 %4, i32 31, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 %4, i32 16, i1 false)
   ret void
 }
 

--- a/src/codegen/tests/statement_codegen_test.rs
+++ b/src/codegen/tests/statement_codegen_test.rs
@@ -256,3 +256,29 @@ fn function_result_assignment_on_string() {
 
     insta::assert_snapshot!(result);
 }
+
+#[test]
+fn function_result_assignment_on_aliased_string() {
+    let result = codegen(
+        r#"
+        TYPE MyStr : STRING[1000]; END_TYPE
+        TYPE LongStr : STRING[1024]; END_TYPE
+
+        @EXTERNAL
+        FUNCTION CONCAT : LongStr
+        VAR_INPUT a,b : LongStr; END_VAR
+        END_FUNCTION
+
+        FUNCTION LIST_ADD : BOOL
+        VAR_INPUT
+            INS : MyStr;
+            sx : STRING[1] := ' ';
+        END_VAR
+
+        INS := CONCAT(sx, INS);
+        END_FUNCTION
+        "#,
+    );
+
+    insta::assert_snapshot!(result);
+}

--- a/src/codegen/tests/statement_codegen_test.rs
+++ b/src/codegen/tests/statement_codegen_test.rs
@@ -236,7 +236,6 @@ END_PROGRAM
 
 #[test]
 fn function_result_assignment_on_string() {
-
     let result = codegen(
         r#"
         @EXTERNAL

--- a/src/codegen/tests/statement_codegen_test.rs
+++ b/src/codegen/tests/statement_codegen_test.rs
@@ -233,3 +233,27 @@ END_PROGRAM
 
     assert_eq!(result, expected);
 }
+
+#[test]
+fn function_result_assignment_on_string() {
+
+    let result = codegen(
+        r#"
+        @EXTERNAL
+        FUNCTION CONCAT : STRING[1024]
+        VAR_INPUT a,b : STRING[1024]; END_VAR
+        END_FUNCTION
+
+        FUNCTION LIST_ADD : BOOL
+        VAR_INPUT
+            INS : STRING[1000];
+            sx : STRING[1] := ' ';
+        END_VAR
+
+        INS := CONCAT(sx, INS);
+        END_FUNCTION
+        "#,
+    );
+
+    insta::assert_snapshot!(result);
+}

--- a/tests/correctness/strings.rs
+++ b/tests/correctness/strings.rs
@@ -147,3 +147,82 @@ fn string_assignment_from_bigger_function() {
     assert_eq!("hello".as_bytes(),&main_type.x); //TODO: Should this be "hell\0"?
     
 }
+
+#[test]
+fn string_assignment_from_bigger_literal_do_not_leak() {
+    let src = "
+        FUNCTION main : DINT
+            VAR x,y : STRING[4]; END_VAR
+            x := 'hello';
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 5],
+        y : [u8; 5],
+    }
+    let mut main_type = MainType{
+        x : [0; 5],
+        y : [0; 5],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!(&[0;5], &main_type.y);
+}
+
+#[test]
+fn string_assignment_from_bigger_string_does_not_leak() {
+    let src = "
+        FUNCTION main : DINT
+            VAR x,y : STRING[4]; z : STRING[10]; END_VAR
+            z := 'hello foo';
+            x := z;
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 5],
+        y : [u8; 5],
+        z : [u8; 11],
+    }
+    let mut main_type = MainType{
+        x : [0; 5],
+        y : [0; 5],
+        z : [0; 11],
+    };
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!(&[0;5], &main_type.y);
+}
+
+#[test]
+fn string_assignment_from_bigger_function_does_not_leak() {
+    let src = "
+        FUNCTION hello : STRING[10]
+        hello := 'hello foo';
+        END_FUNCTION
+
+        FUNCTION main : DINT
+            VAR x,y : STRING[4]; END_VAR
+            x := hello();
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 5],
+        y : [u8; 5],
+    }
+    let mut main_type = MainType{
+        x : [0; 5],
+        y : [0; 5],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!(&[0;5], &main_type.y);
+    
+}

--- a/tests/correctness/strings.rs
+++ b/tests/correctness/strings.rs
@@ -1,0 +1,149 @@
+use pretty_assertions::assert_eq;
+
+use super::super::*;
+
+#[test]
+fn string_assignment_from_smaller_literal() {
+    let src = "
+        FUNCTION main : DINT
+            VAR x : STRING[6]; END_VAR
+            x := 'hello';
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 7],
+    }
+    let mut main_type = MainType{
+        x : [0; 7],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!("hello\0\0".as_bytes(),&main_type.x);
+}
+
+#[test]
+fn string_assignment_from_bigger_literal() {
+    let src = "
+        FUNCTION main : DINT
+            VAR x : STRING[4];END_VAR
+            x := 'hello';
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 5],
+    }
+    let mut main_type = MainType{
+        x : [0; 5],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!("hell\0".as_bytes(),&main_type.x);
+}
+#[test]
+fn string_assignment_from_smaller_string() {
+    let src = "
+        FUNCTION main : DINT
+            VAR x : STRING[6]; y : STRING[5]; END_VAR
+            y := 'hello';
+            x := y;
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 7],
+        y : [u8; 6],
+    }
+    let mut main_type = MainType{
+        x : [0; 7],
+        y : [0; 6],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!("hello\0\0".as_bytes(),&main_type.x);
+}
+
+#[test]
+fn string_assignment_from_bigger_string() {
+    let src = "
+        FUNCTION main : DINT
+            VAR x : STRING[4]; y : STRING[5]; END_VAR
+            y := 'hello';
+            x := y;
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 5],
+        y : [u8; 6],
+    }
+    let mut main_type = MainType{
+        x : [0; 5],
+        y : [0; 6],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!("hello".as_bytes(),&main_type.x); //TODO: Should this be "hell\0"?
+}
+
+#[test]
+fn string_assignment_from_smaller_function() {
+    let src = "
+        FUNCTION hello : STRING[5]
+        hello := 'hello';
+        END_FUNCTION
+
+        FUNCTION main : DINT
+            VAR x : STRING[6]; END_VAR
+            x := hello();
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 7],
+    }
+    let mut main_type = MainType{
+        x : [0; 7],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!("hello\0\0".as_bytes(),&main_type.x);
+}
+
+#[test]
+fn string_assignment_from_bigger_function() {
+    let src = "
+        FUNCTION hello : STRING[5]
+        hello := 'hello';
+        END_FUNCTION
+
+        FUNCTION main : DINT
+            VAR x : STRING[4]; END_VAR
+            x := hello();
+        END_FUNCTION
+    ";
+
+    #[allow(dead_code)]
+    struct MainType {
+        x : [u8; 5],
+    }
+    let mut main_type = MainType{
+        x : [0; 5],
+    };
+
+
+    let _: i32 = compile_and_run(src, &mut main_type);
+    assert_eq!("hello".as_bytes(),&main_type.x); //TODO: Should this be "hell\0"?
+    
+}

--- a/tests/correctness/strings.rs
+++ b/tests/correctness/strings.rs
@@ -13,15 +13,12 @@ fn string_assignment_from_smaller_literal() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 7],
+        x: [u8; 7],
     }
-    let mut main_type = MainType{
-        x : [0; 7],
-    };
-
+    let mut main_type = MainType { x: [0; 7] };
 
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!("hello\0\0".as_bytes(),&main_type.x);
+    assert_eq!("hello\0\0".as_bytes(), &main_type.x);
 }
 
 #[test]
@@ -35,15 +32,12 @@ fn string_assignment_from_bigger_literal() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 5],
+        x: [u8; 5],
     }
-    let mut main_type = MainType{
-        x : [0; 5],
-    };
-
+    let mut main_type = MainType { x: [0; 5] };
 
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!("hell\0".as_bytes(),&main_type.x);
+    assert_eq!("hell\0".as_bytes(), &main_type.x);
 }
 #[test]
 fn string_assignment_from_smaller_string() {
@@ -57,17 +51,16 @@ fn string_assignment_from_smaller_string() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 7],
-        y : [u8; 6],
+        x: [u8; 7],
+        y: [u8; 6],
     }
-    let mut main_type = MainType{
-        x : [0; 7],
-        y : [0; 6],
+    let mut main_type = MainType {
+        x: [0; 7],
+        y: [0; 6],
     };
 
-
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!("hello\0\0".as_bytes(),&main_type.x);
+    assert_eq!("hello\0\0".as_bytes(), &main_type.x);
 }
 
 #[test]
@@ -82,17 +75,16 @@ fn string_assignment_from_bigger_string() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 5],
-        y : [u8; 6],
+        x: [u8; 5],
+        y: [u8; 6],
     }
-    let mut main_type = MainType{
-        x : [0; 5],
-        y : [0; 6],
+    let mut main_type = MainType {
+        x: [0; 5],
+        y: [0; 6],
     };
 
-
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!("hello".as_bytes(),&main_type.x); //TODO: Should this be "hell\0"?
+    assert_eq!("hello".as_bytes(), &main_type.x); //TODO: Should this be "hell\0"?
 }
 
 #[test]
@@ -110,15 +102,12 @@ fn string_assignment_from_smaller_function() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 7],
+        x: [u8; 7],
     }
-    let mut main_type = MainType{
-        x : [0; 7],
-    };
-
+    let mut main_type = MainType { x: [0; 7] };
 
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!("hello\0\0".as_bytes(),&main_type.x);
+    assert_eq!("hello\0\0".as_bytes(), &main_type.x);
 }
 
 #[test]
@@ -136,16 +125,12 @@ fn string_assignment_from_bigger_function() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 5],
+        x: [u8; 5],
     }
-    let mut main_type = MainType{
-        x : [0; 5],
-    };
-
+    let mut main_type = MainType { x: [0; 5] };
 
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!("hello".as_bytes(),&main_type.x); //TODO: Should this be "hell\0"?
-    
+    assert_eq!("hello".as_bytes(), &main_type.x); //TODO: Should this be "hell\0"?
 }
 
 #[test]
@@ -159,17 +144,16 @@ fn string_assignment_from_bigger_literal_do_not_leak() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 5],
-        y : [u8; 5],
+        x: [u8; 5],
+        y: [u8; 5],
     }
-    let mut main_type = MainType{
-        x : [0; 5],
-        y : [0; 5],
+    let mut main_type = MainType {
+        x: [0; 5],
+        y: [0; 5],
     };
 
-
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!(&[0;5], &main_type.y);
+    assert_eq!(&[0; 5], &main_type.y);
 }
 
 #[test]
@@ -184,18 +168,18 @@ fn string_assignment_from_bigger_string_does_not_leak() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 5],
-        y : [u8; 5],
-        z : [u8; 11],
+        x: [u8; 5],
+        y: [u8; 5],
+        z: [u8; 11],
     }
-    let mut main_type = MainType{
-        x : [0; 5],
-        y : [0; 5],
-        z : [0; 11],
+    let mut main_type = MainType {
+        x: [0; 5],
+        y: [0; 5],
+        z: [0; 11],
     };
 
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!(&[0;5], &main_type.y);
+    assert_eq!(&[0; 5], &main_type.y);
 }
 
 #[test]
@@ -213,16 +197,14 @@ fn string_assignment_from_bigger_function_does_not_leak() {
 
     #[allow(dead_code)]
     struct MainType {
-        x : [u8; 5],
-        y : [u8; 5],
+        x: [u8; 5],
+        y: [u8; 5],
     }
-    let mut main_type = MainType{
-        x : [0; 5],
-        y : [0; 5],
+    let mut main_type = MainType {
+        x: [0; 5],
+        y: [0; 5],
     };
 
-
     let _: i32 = compile_and_run(src, &mut main_type);
-    assert_eq!(&[0;5], &main_type.y);
-    
+    assert_eq!(&[0; 5], &main_type.y);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,8 +35,8 @@ mod correctness {
     mod initial_values;
     mod methods;
     mod pointers;
-    mod sub_range_types;
     mod strings;
+    mod sub_range_types;
     mod math_operators {
         mod addition;
         mod division;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -36,6 +36,7 @@ mod correctness {
     mod methods;
     mod pointers;
     mod sub_range_types;
+    mod strings;
     mod math_operators {
         mod addition;
         mod division;


### PR DESCRIPTION
Fixes #389 
Call statements now use an intermediate allocated variable to store the result of a string.
This variable is then written to the assignment using memcpy.
The size of the mem copy no longer uses the hint, but the actual string size.