### PR TITLE
annotate string literals with correct length

### DIFF
--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -6,8 +6,8 @@ use crate::{
     resolver::{AnnotationMap, AnnotationMapImpl, StatementAnnotation},
     test_utils::tests::annotate,
     typesystem::{
-        DataTypeInformation, BOOL_TYPE, BYTE_TYPE, CONST_STRING_TYPE, DINT_TYPE, DWORD_TYPE,
-        INT_TYPE, REAL_TYPE, SINT_TYPE, UINT_TYPE, USINT_TYPE, VOID_TYPE,
+        DataTypeInformation, BOOL_TYPE, BYTE_TYPE, DINT_TYPE, DWORD_TYPE, INT_TYPE, REAL_TYPE,
+        SINT_TYPE, UINT_TYPE, USINT_TYPE, VOID_TYPE,
     },
 };
 
@@ -1342,7 +1342,7 @@ fn nested_function_parameter_assignments_resolve_types() {
 
 #[test]
 fn type_initial_values_are_resolved() {
-    let (unit, index) = index(
+    let (unit, mut index) = index(
         "
         TYPE MyStruct : STRUCT
             x : INT := 20;
@@ -1353,7 +1353,9 @@ fn type_initial_values_are_resolved() {
         ",
     );
 
-    let annotations = TypeAnnotator::visit_unit(&index, &unit);
+    let mut annotations = TypeAnnotator::visit_unit(&index, &unit);
+    index.import(std::mem::take(&mut annotations.new_index));
+
     let UserTypeDeclaration { data_type, .. } = &unit.types[0];
 
     if let DataType::StructType { variables, .. } = data_type {
@@ -1369,10 +1371,7 @@ fn type_initial_values_are_resolved() {
         let _type_of_z = index.find_member("MyStruct", "z").unwrap().get_type_name();
         assert_eq!(
             Some(&StatementAnnotation::value(
-                index
-                    .find_effective_type(CONST_STRING_TYPE)
-                    .unwrap()
-                    .get_name()
+                index.find_effective_type("__STRING_3").unwrap().get_name()
             )),
             annotations.get(variables[2].initializer.as_ref().unwrap())
         );
@@ -2598,7 +2597,7 @@ fn literals_passed_to_function_get_annotated() {
             &annotations,
             &index,
             parameters[1],
-            CONST_STRING_TYPE,
+            "__STRING_3",
             Some("__foo_in")
         );
     } else {

--- a/src/resolver/tests/resolve_literals_tests.rs
+++ b/src/resolver/tests/resolve_literals_tests.rs
@@ -3,7 +3,7 @@ use crate::{
     ast::AstStatement,
     resolver::{AnnotationMap, TypeAnnotator},
     test_utils::tests::{annotate, index},
-    typesystem::{DataTypeInformation, CONST_STRING_TYPE, CONST_WSTRING_TYPE, DINT_TYPE},
+    typesystem::{DataType, DataTypeInformation, DINT_TYPE},
 };
 
 #[test]
@@ -33,28 +33,46 @@ fn bool_literals_are_annotated() {
 
 #[test]
 fn string_literals_are_annotated() {
-    let (unit, index) = index(
+    //GIVEN some string literals
+    let (unit, mut index) = index(
         r#"PROGRAM PRG
-                "abc";
-                'xyz';
+                'abc';
+                "xyzxyz";
             END_PROGRAM"#,
     );
-    let annotations = TypeAnnotator::visit_unit(&index, &unit);
-    let statements = &unit.implementations[0].statements;
 
-    assert_type_and_hint!(
-        &annotations,
-        &index,
-        &statements[0],
-        CONST_WSTRING_TYPE,
-        None
+    //WHEN they are annotated
+    let mut annotations = TypeAnnotator::visit_unit(&index, &unit);
+    index.import(std::mem::take(&mut annotations.new_index));
+
+    // THEN we expect them to be annotated with correctly sized string types
+    let statements = &unit.implementations[0].statements;
+    assert_type_and_hint!(&annotations, &index, &statements[0], "__STRING_3", None);
+    assert_type_and_hint!(&annotations, &index, &statements[1], "__WSTRING_6", None);
+    // AND we expect some newly created String-types
+    assert_eq!(
+        index.get_type_or_panic("__STRING_3"),
+        &DataType {
+            initial_value: None,
+            name: "__STRING_3".into(),
+            nature: crate::ast::TypeNature::Chars,
+            information: DataTypeInformation::String {
+                encoding: crate::typesystem::StringEncoding::Utf8,
+                size: crate::typesystem::TypeSize::LiteralInteger(4)
+            }
+        }
     );
-    assert_type_and_hint!(
-        &annotations,
-        &index,
-        &statements[1],
-        CONST_STRING_TYPE,
-        None
+    assert_eq!(
+        index.get_type_or_panic("__WSTRING_6"),
+        &DataType {
+            initial_value: None,
+            name: "__WSTRING_6".into(),
+            nature: crate::ast::TypeNature::Chars,
+            information: DataTypeInformation::String {
+                encoding: crate::typesystem::StringEncoding::Utf16,
+                size: crate::typesystem::TypeSize::LiteralInteger(7)
+            }
+        }
     );
 }
 

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -63,10 +63,6 @@ pub const STRING_TYPE: &str = "STRING";
 pub const WSTRING_TYPE: &str = "WSTRING";
 pub const CHAR_TYPE: &str = "CHAR";
 pub const WCHAR_TYPE: &str = "WCHAR";
-
-pub const CONST_STRING_TYPE: &str = "___CONST_STRING";
-pub const CONST_WSTRING_TYPE: &str = "___CONST_WSTRING";
-
 pub const VOID_TYPE: &str = "VOID";
 
 #[cfg(test)]
@@ -595,24 +591,6 @@ pub fn get_builtin_types() -> Vec<DataType> {
             initial_value: None,
             information: DataTypeInformation::String {
                 size: TypeSize::from_literal(DEFAULT_STRING_LEN + 1),
-                encoding: StringEncoding::Utf16,
-            },
-            nature: TypeNature::String,
-        },
-        DataType {
-            name: CONST_STRING_TYPE.into(),
-            initial_value: None,
-            information: DataTypeInformation::String {
-                size: TypeSize::from_literal(u16::MAX as u32),
-                encoding: StringEncoding::Utf8,
-            },
-            nature: TypeNature::String,
-        },
-        DataType {
-            name: CONST_WSTRING_TYPE.into(),
-            initial_value: None,
-            information: DataTypeInformation::String {
-                size: TypeSize::from_literal(u16::MAX as u32),
                 encoding: StringEncoding::Utf16,
             },
             nature: TypeNature::String,


### PR DESCRIPTION
now that the annotator is able to create new types on the fly, we
can create correct string-types when visiting literals and annotate
the literal with the newly created type.