### PR TITLE
Extract the test run code from  into a runner module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ mod test_utils;
 mod typesystem;
 mod validation;
 
+pub mod runner;
+
 #[macro_use]
 #[cfg(test)]
 extern crate pretty_assertions;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,9 @@
-use inkwell::{execution_engine::{ExecutionEngine, JitFunction}, context::Context};
+use inkwell::{
+    context::Context,
+    execution_engine::{ExecutionEngine, JitFunction},
+};
 
-use crate::{SourceContainer, SourceCode, compile_module, diagnostics::Diagnostician};
+use crate::{compile_module, diagnostics::Diagnostician, SourceCode, SourceContainer};
 
 type MainFunction<T, U> = unsafe extern "C" fn(*mut T) -> U;
 
@@ -47,7 +50,7 @@ impl<S: SourceContainer> Compilable for Vec<S> {
 ///
 /// Runs the function given by `name` inside the compiled execution engine code.
 /// Returns the value returned by calling the function
-/// 
+///
 pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
     unsafe {
         let main: JitFunction<MainFunction<T, U>> = exec_engine.get_function(name).unwrap();
@@ -80,7 +83,7 @@ pub fn compile<T: Compilable>(context: &Context, source: T) -> ExecutionEngine {
 
 ///
 /// A Convenience method to compile and then run the given source
-/// 
+///
 pub fn compile_and_run<T, U, S: Compilable>(source: S, params: &mut T) -> U {
     let context: Context = Context::create();
     let exec_engine = compile(&context, source);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -47,6 +47,14 @@ impl<S: SourceContainer> Compilable for Vec<S> {
     }
 }
 
+impl Compilable for SourceCode {
+    type T = Self;
+
+    fn containers(self) -> Vec<Self::T> {
+        vec![self]
+    }
+}
+
 ///
 /// Runs the function given by `name` inside the compiled execution engine code.
 /// Returns the value returned by calling the function

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,88 @@
+use inkwell::{execution_engine::{ExecutionEngine, JitFunction}, context::Context};
+
+use crate::{SourceContainer, SourceCode, compile_module, diagnostics::Diagnostician};
+
+type MainFunction<T, U> = unsafe extern "C" fn(*mut T) -> U;
+
+#[allow(dead_code)]
+#[repr(C)]
+pub struct MainType {
+    a: [usize; 1000],
+}
+
+impl Default for MainType {
+    fn default() -> Self {
+        MainType { a: [0; 1000] }
+    }
+}
+
+pub trait Compilable {
+    type T: SourceContainer;
+    fn containers(self) -> Vec<Self::T>;
+}
+
+impl Compilable for &str {
+    type T = SourceCode;
+    fn containers(self) -> Vec<Self::T> {
+        let code = Self::T::from(self);
+        vec![code]
+    }
+}
+
+impl Compilable for String {
+    type T = SourceCode;
+    fn containers(self) -> Vec<Self::T> {
+        let code = self.into();
+        vec![code]
+    }
+}
+
+impl<S: SourceContainer> Compilable for Vec<S> {
+    type T = S;
+    fn containers(self) -> Vec<Self::T> {
+        self
+    }
+}
+
+///
+/// Runs the function given by `name` inside the compiled execution engine code.
+/// Returns the value returned by calling the function
+/// 
+pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
+    unsafe {
+        let main: JitFunction<MainFunction<T, U>> = exec_engine.get_function(name).unwrap();
+        let main_t_ptr = &mut *params as *mut _;
+
+        main.call(main_t_ptr)
+    }
+}
+
+///
+/// Compiles and runs the given sources
+/// Sources must be `Compilable`, default implementations include `String` and `&str`
+/// An implementation is also provided for `Vec<SourceContainer>`
+///
+pub fn compile<T: Compilable>(context: &Context, source: T) -> ExecutionEngine {
+    let source = source.containers();
+    let code_gen = compile_module(
+        context,
+        source,
+        vec![],
+        None,
+        Diagnostician::null_diagnostician(),
+    )
+    .unwrap();
+    code_gen
+        .module
+        .create_jit_execution_engine(inkwell::OptimizationLevel::None)
+        .unwrap()
+}
+
+///
+/// A Convenience method to compile and then run the given source
+/// 
+pub fn compile_and_run<T, U, S: Compilable>(source: S, params: &mut T) -> U {
+    let context: Context = Context::create();
+    let exec_engine = compile(&context, source);
+    run::<T, U>(&exec_engine, "main", params)
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ use rusty::diagnostics::Diagnostician;
 use rusty::*;
 
 //Import the helper run methods into the tests
-pub use rusty::runner::{MainType, compile, run, compile_and_run };
+pub use rusty::runner::{compile, compile_and_run, run, MainType};
 
 mod correctness {
     mod arrays;
@@ -70,4 +70,3 @@ fn get_test_file(name: &str) -> String {
 
     data_path.display().to_string()
 }
-

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,23 +2,11 @@ use std::path::PathBuf;
 
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use inkwell::context::Context;
-use inkwell::execution_engine::{ExecutionEngine, JitFunction};
 use rusty::diagnostics::Diagnostician;
 use rusty::*;
 
-type MainFunction<T, U> = unsafe extern "C" fn(*mut T) -> U;
-
-#[allow(dead_code)]
-#[repr(C)]
-pub struct MainType {
-    a: [usize; 1000],
-}
-
-impl Default for MainType {
-    fn default() -> Self {
-        MainType { a: [0; 1000] }
-    }
-}
+//Import the helper run methods into the tests
+pub use rusty::runner::{MainType, compile, run, compile_and_run };
 
 mod correctness {
     mod arrays;
@@ -83,85 +71,3 @@ fn get_test_file(name: &str) -> String {
     data_path.display().to_string()
 }
 
-pub trait Compilable {
-    type T: SourceContainer;
-    fn containers(self) -> Vec<Self::T>;
-}
-
-impl Compilable for &str {
-    type T = SourceCode;
-    fn containers(self) -> Vec<Self::T> {
-        let code = Self::T::from(self);
-        vec![code]
-    }
-}
-
-impl Compilable for String {
-    type T = SourceCode;
-    fn containers(self) -> Vec<Self::T> {
-        let code = self.into();
-        vec![code]
-    }
-}
-
-impl<S: SourceContainer> Compilable for Vec<S> {
-    type T = S;
-    fn containers(self) -> Vec<Self::T> {
-        self
-    }
-}
-
-///
-/// Compiles and runs the given source
-/// Returns the std result as String
-/// Source must define a main function that takes no arguments and returns an int and string
-/// The int is the return value which can be verified
-/// The string will eventually be the Stdout of the function.
-///
-// pub fn compile(context: &Context, source: String) -> ExecutionEngine {
-//     let source: Vec<SourceCode> = vec![source.as_str().into()];
-//     compile_multi(context, source)
-// }
-
-// pub fn compile_and_run<T, U>(source: String, params: &mut T) -> U {
-//     compile_and_run_multi::<T, U, SourceCode>(vec![source.as_str().into()], params)
-// }
-
-pub fn run<T, U>(exec_engine: &ExecutionEngine, name: &str, params: &mut T) -> U {
-    unsafe {
-        let main: JitFunction<MainFunction<T, U>> = exec_engine.get_function(name).unwrap();
-        let main_t_ptr = &mut *params as *mut _;
-
-        main.call(main_t_ptr)
-    }
-}
-
-///
-/// Compiles and runs the given sources
-/// Returns the std result as String
-/// Sources must define a main function that takes no arguments and returns an int and string
-/// The int is the return value which can be verified
-/// The string will eventually be the Stdout of the function.
-///
-pub fn compile<T: Compilable>(context: &Context, source: T) -> ExecutionEngine {
-    let source = source.containers();
-    let code_gen = compile_module(
-        context,
-        source,
-        vec![],
-        None,
-        Diagnostician::null_diagnostician(),
-    )
-    .unwrap();
-    println!("{}", code_gen.module.print_to_string());
-    code_gen
-        .module
-        .create_jit_execution_engine(inkwell::OptimizationLevel::None)
-        .unwrap()
-}
-
-pub fn compile_and_run<T, U, S: Compilable>(source: S, params: &mut T) -> U {
-    let context: Context = Context::create();
-    let exec_engine = compile(&context, source);
-    run::<T, U>(&exec_engine, "main", params)
-}


### PR DESCRIPTION
This allows reuse of the compile/run methods we use in the correctness tests by other crates such as the Standard Functions