### PR TITLE
calls no longer use blocks for call phases

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 use inkwell::{
-    basic_block::BasicBlock,
     types::BasicTypeEnum,
     values::{
         ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, FloatValue, IntValue,
@@ -483,30 +482,16 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
 
         let (class_struct, instance, index_entry) = (class_ptr, call_ptr, implementation);
         let function_name = index_entry.get_call_name();
-        //Create parameters for input and output blocks
-        let current_f = function_context.function;
-        let input_block = self.llvm.context.append_basic_block(current_f, "input");
-        let call_block = self.llvm.context.append_basic_block(current_f, "call");
-        let output_block = self.llvm.context.append_basic_block(current_f, "output");
-        let continue_block = self.llvm.context.append_basic_block(current_f, "continue");
         //First go to the input block
         let builder = &self.llvm.builder;
-        builder.build_unconditional_branch(input_block);
-        builder.position_at_end(input_block);
         //Generate all parameters, this function may jump to the output block
-        let parameters = self.generate_function_parameters(
+        let parameters_data = self.generate_input_function_parameters(
             function_name,
             class_struct,
             instance,
             parameters,
-            &input_block,
-            &output_block,
         )?;
-        //Generate the label jumps from input to call to output
-        builder.build_unconditional_branch(call_block);
-        builder.position_at_end(output_block);
-        builder.build_unconditional_branch(continue_block);
-        builder.position_at_end(call_block);
+
         let function = self
             .llvm_index
             .find_associated_implementation(function_name) //using the non error option to control the output error
@@ -522,13 +507,13 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
         //If the target is a function, declare the struct locally
         //Assign all parameters into the struct values
         let call_result = builder
-            .build_call(function, &parameters, "call")
+            .build_call(function, &parameters_data, "call")
             .try_as_basic_value();
-        builder.build_unconditional_branch(output_block);
-        //Continue here after function call
-        builder.position_at_end(continue_block);
 
-        // !! REVIEW !! we return an uninitialized int pointer for void methods :-/
+        //build output-parameters
+        self.generate_output_function_parameters(function_name, instance, parameters)?;
+
+        // we return an uninitialized int pointer for void methods :-/
         // dont deref it!!
         let value = call_result.either(Ok, |_| {
             get_llvm_int_type(self.llvm.context, INT_SIZE, INT_TYPE).map(|int| {
@@ -573,61 +558,65 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
     /// - `parameter_struct` a pointer to a struct-instance that holds all function-parameters
     /// - `input_block` the block to generate the input-assignments into
     /// - `output_block` the block to generate the output-assignments into
-    fn generate_function_parameters(
+    fn generate_input_function_parameters(
         &self,
         function_name: &str,
         class_struct: Option<PointerValue<'a>>,
         parameter_struct: PointerValue<'a>,
         parameters: &Option<AstStatement>,
-        input_block: &BasicBlock,
-        output_block: &BasicBlock,
     ) -> Result<Vec<BasicMetadataValueEnum<'a>>, Diagnostic> {
-        let mut result = if let Some(class_struct) = class_struct {
-            vec![
-                class_struct.as_basic_value_enum().into(),
-                parameter_struct.as_basic_value_enum().into(),
-            ]
-        } else {
-            vec![parameter_struct.as_basic_value_enum().into()]
-        };
-        match &parameters {
-            Some(AstStatement::ExpressionList { expressions, .. }) => {
-                for (index, exp) in expressions.iter().enumerate() {
-                    let parameter = self.generate_single_parameter(
-                        &ParameterContext {
-                            assignment_statement: exp,
-                            function_name,
-                            parameter_type: None,
-                            index: index as u32,
-                            parameter_struct,
-                        },
-                        input_block,
-                        output_block,
-                    )?;
-                    if let Some(parameter) = parameter {
-                        result.push(parameter.into());
-                    };
-                }
-            }
-            Some(statement) => {
-                let parameter = self.generate_single_parameter(
-                    &ParameterContext {
-                        assignment_statement: statement,
-                        function_name,
-                        parameter_type: None,
-                        index: 0,
-                        parameter_struct,
-                    },
-                    input_block,
-                    output_block,
-                )?;
-                if let Some(parameter) = parameter {
-                    result.push(parameter.into());
-                };
-            }
-            None => {}
+        let mut result = class_struct
+            .map(|class_struct| {
+                vec![
+                    class_struct.as_basic_value_enum().into(),
+                    parameter_struct.as_basic_value_enum().into(),
+                ]
+            })
+            .unwrap_or_else(|| vec![parameter_struct.as_basic_value_enum().into()]);
+
+        let expressions = parameters
+            .as_ref()
+            .map(|exprs| ast::flatten_expression_list(exprs))
+            .unwrap_or_else(std::vec::Vec::new);
+
+        for (index, exp) in expressions.iter().enumerate() {
+            let parameter = self.generate_single_input_parameter(&ParameterContext {
+                assignment_statement: exp,
+                function_name,
+                parameter_type: None,
+                index: index as u32,
+                parameter_struct,
+            })?;
+            if let Some(parameter) = parameter {
+                result.push(parameter.into());
+            };
         }
         Ok(result)
+    }
+
+    /// generates the output assignments of a function-call's parameters
+    /// the call parameters are passed to the function using a struct-instance with all the parameters
+    ///
+    /// - `function_name` the name of the function we're calling
+    /// - `parameter_struct` a pointer to a struct-instance that holds all function-parameters
+    /// - `input_block` the block to generate the input-assignments into
+    fn generate_output_function_parameters(
+        &self,
+        function_name: &str,
+        parameter_struct: PointerValue,
+        parameters: &Option<AstStatement>,
+    ) -> Result<(), Diagnostic> {
+        let expressions = parameters
+            .as_ref()
+            .map(|exprs| ast::flatten_expression_list(exprs))
+            .unwrap_or_else(std::vec::Vec::new);
+
+        for exp in expressions.iter() {
+            if let AstStatement::OutputAssignment { left, right, .. } = exp {
+                self.generate_output_parameter(function_name, parameter_struct, left, right)?;
+            }
+        }
+        Ok(())
     }
 
     /// generates an assignemnt of a single call's parameter
@@ -639,29 +628,21 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
     /// - `parameter_struct' a pointer to a struct-instance that holds all function-parameters
     /// - `input_block` the block to generate the input-assignments into
     /// - `output_block` the block to generate the output-assignments into
-    fn generate_single_parameter(
+    fn generate_single_input_parameter(
         &self,
         param_context: &ParameterContext,
-        input_block: &BasicBlock,
-        output_block: &BasicBlock,
     ) -> Result<Option<BasicValueEnum<'a>>, Diagnostic> {
         let assignment_statement = param_context.assignment_statement;
 
         let parameter_value = match assignment_statement {
             // explicit call parameter: foo(param := value)
             AstStatement::Assignment { left, right, .. } => {
-                self.generate_formal_parameter(
-                    param_context,
-                    left,
-                    right,
-                    input_block,
-                    output_block,
-                )?;
+                self.generate_formal_parameter(param_context, left, right)?;
                 None
             }
             // foo (param => value)
-            AstStatement::OutputAssignment { left, right, .. } => {
-                self.generate_output_parameter(param_context, left, right, output_block)?;
+            AstStatement::OutputAssignment { .. } => {
+                //ignore here
                 None
             }
             // foo(x)
@@ -722,17 +703,13 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
 
     fn generate_output_parameter(
         &self,
-        param_context: &ParameterContext,
+        function_name: &str,
+        parameter_struct: PointerValue,
         left: &AstStatement,
         right: &AstStatement,
-        output_block: &BasicBlock,
     ) -> Result<(), Diagnostic> {
         let builder = &self.llvm.builder;
-        let function_name = param_context.function_name;
-        let parameter_struct = param_context.parameter_struct;
-        let current_block = builder.get_insert_block().expect(INTERNAL_LLVM_ERROR);
 
-        builder.position_at_end(*output_block);
         // (output => ) output assignments are optional, in this case  ignore codegen
         if !matches!(right, AstStatement::EmptyStatement { .. }) {
             if let AstStatement::Reference { name, .. } = left {
@@ -771,7 +748,6 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                 builder.build_store(l_value, value);
             }
         }
-        builder.position_at_end(current_block);
         Ok(())
     }
 
@@ -780,13 +756,9 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
         param_context: &ParameterContext,
         left: &AstStatement,
         right: &AstStatement,
-        input_block: &BasicBlock,
-        output_block: &BasicBlock,
     ) -> Result<(), Diagnostic> {
-        let builder = &self.llvm.builder;
         let function_name = param_context.function_name;
         let parameter_struct = param_context.parameter_struct;
-        builder.position_at_end(*input_block);
         if let AstStatement::Reference { name, .. } = left {
             let parameter = self
                 .index
@@ -794,17 +766,13 @@ impl<'a, 'b> ExpressionCodeGenerator<'a, 'b> {
                 .ok_or_else(|| Diagnostic::unresolved_reference(name, left.get_location()))?;
             let index = parameter.get_location_in_parent();
             let param_type = self.index.find_effective_type(parameter.get_type_name());
-            self.generate_single_parameter(
-                &ParameterContext {
-                    assignment_statement: right,
-                    function_name,
-                    parameter_type: param_type,
-                    index,
-                    parameter_struct,
-                },
-                input_block,
-                output_block,
-            )?;
+            self.generate_single_input_parameter(&ParameterContext {
+                assignment_statement: right,
+                function_name,
+                parameter_type: param_type,
+                index,
+                parameter_struct,
+            })?;
         };
         Ok(())
     }

--- a/src/codegen/tests/expression_tests.rs
+++ b/src/codegen/tests/expression_tests.rs
@@ -371,3 +371,24 @@ fn pointer_arithmetics_function_call() {
     );
     insta::assert_snapshot!(result);
 }
+
+#[test]
+fn nested_call_statements() {
+    // GIVEN some nested call statements
+    let result = codegen(
+        "
+        FUNCTION foo : DINT
+        VAR_INPUT
+            a : DINT;
+        END_VAR
+        END_FUNCTION
+
+		PROGRAM main
+            foo(foo(2));
+		END_PROGRAM
+		",
+    );
+    // WHEN compiled
+    // WE expect a flat sequence of calls, no regions and branching
+    insta::assert_snapshot!(result);
+}

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__class_struct_initialized_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__class_struct_initialized_in_function.snap
@@ -30,22 +30,10 @@ define void @main(%main_interface* %0) {
 entry:
   %fb0 = getelementptr inbounds %main_interface, %main_interface* %0, i32 0, i32 0
   %func_instance = alloca %func_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %func_interface, %func_interface* %func_instance, i32 0, i32 0
   %load_fb0 = load %fb_interface, %fb_interface* %fb0, align 2
   store %fb_interface %load_fb0, %fb_interface* %1, align 2
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @func(%func_interface* %func_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i32 @func(%func_interface* %func_instance)
   ret void
 }
 

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_block_struct_initialized_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_block_struct_initialized_in_function.snap
@@ -35,22 +35,10 @@ define void @main(%main_interface* %0) {
 entry:
   %fb0 = getelementptr inbounds %main_interface, %main_interface* %0, i32 0, i32 0
   %func_instance = alloca %func_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %func_interface, %func_interface* %func_instance, i32 0, i32 0
   %load_fb0 = load %fb_interface, %fb_interface* %fb0, align 1
   store %fb_interface %load_fb0, %fb_interface* %1, align 1
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @func(%func_interface* %func_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i32 @func(%func_interface* %func_instance)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__action_called_in_program.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1495
 expression: result
 
 ---
@@ -13,19 +14,7 @@ source_filename = "main"
 define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @prg.foo(%prg_interface* %0)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_method_in_pou.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_method_in_pou.snap
@@ -1,6 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 848
+assertion_line: 870
 expression: result
 
 ---
@@ -41,39 +41,15 @@ entry:
   %load_ = load i16, i16* %x1, align 2
   store i16 %load_, i16* %x, align 2
   %MyClass.testMethod_instance = alloca %MyClass.testMethod_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %MyClass.testMethod_interface, %MyClass.testMethod_interface* %MyClass.testMethod_instance, i32 0, i32 0
   %load_x = load i16, i16* %x, align 2
   store i16 %load_x, i16* %1, align 2
-  br label %call
-
-call:                                             ; preds = %input
   call void @MyClass.testMethod(%MyClass_interface* %cl, %MyClass.testMethod_interface* %MyClass.testMethod_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   %MyClass.testMethod_instance2 = alloca %MyClass.testMethod_interface, align 8
-  br label %input3
-
-input3:                                           ; preds = %continue
   %2 = getelementptr inbounds %MyClass.testMethod_interface, %MyClass.testMethod_interface* %MyClass.testMethod_instance2, i32 0, i32 0
-  %load_x7 = load i16, i16* %x, align 2
-  store i16 %load_x7, i16* %2, align 2
-  br label %call4
-
-call4:                                            ; preds = %input3
+  %load_x3 = load i16, i16* %x, align 2
+  store i16 %load_x3, i16* %2, align 2
   call void @MyClass.testMethod(%MyClass_interface* %cl, %MyClass.testMethod_interface* %MyClass.testMethod_instance2)
-  br label %output5
-
-output5:                                          ; preds = %call4
-  br label %continue6
-
-continue6:                                        ; preds = %output5
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_function_called_in_program.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1290
 expression: result
 
 ---
@@ -16,19 +17,7 @@ declare i32 @foo(%foo_interface*)
 define void @prg(%prg_interface* %0) {
 entry:
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i32 @foo(%foo_interface* %foo_instance)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__fb_method_in_pou.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__fb_method_in_pou.snap
@@ -1,6 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 882
+assertion_line: 904
 expression: result
 
 ---
@@ -48,39 +48,15 @@ entry:
   %load_ = load i16, i16* %x1, align 2
   store i16 %load_, i16* %x, align 2
   %MyClass.testMethod_instance = alloca %MyClass.testMethod_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %MyClass.testMethod_interface, %MyClass.testMethod_interface* %MyClass.testMethod_instance, i32 0, i32 0
   %load_x = load i16, i16* %x, align 2
   store i16 %load_x, i16* %1, align 2
-  br label %call
-
-call:                                             ; preds = %input
   call void @MyClass.testMethod(%MyClass_interface* %cl, %MyClass.testMethod_interface* %MyClass.testMethod_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   %MyClass.testMethod_instance2 = alloca %MyClass.testMethod_interface, align 8
-  br label %input3
-
-input3:                                           ; preds = %continue
   %2 = getelementptr inbounds %MyClass.testMethod_interface, %MyClass.testMethod_interface* %MyClass.testMethod_instance2, i32 0, i32 0
-  %load_x7 = load i16, i16* %x, align 2
-  store i16 %load_x7, i16* %2, align 2
-  br label %call4
-
-call4:                                            ; preds = %input3
+  %load_x3 = load i16, i16* %x, align 2
+  store i16 %load_x3, i16* %2, align 2
   call void @MyClass.testMethod(%MyClass_interface* %cl, %MyClass.testMethod_interface* %MyClass.testMethod_instance2)
-  br label %output5
-
-output5:                                          ; preds = %call4
-  br label %continue6
-
-continue6:                                        ; preds = %output5
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_instance_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_instance_call.snap
@@ -1,6 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 1848
+assertion_line: 1870
 expression: result
 
 ---
@@ -23,19 +23,7 @@ entry:
 define void @prg(%prg_interface* %0) {
 entry:
   %fb_inst = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* %fb_inst)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_qualified_instance_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_qualified_instance_call.snap
@@ -1,6 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 1870
+assertion_line: 1895
 expression: result
 
 ---
@@ -30,19 +30,7 @@ define void @prg(%prg_interface* %0) {
 entry:
   %foo_inst = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %bar_inst = getelementptr inbounds %foo_interface, %foo_interface* %foo_inst, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @bar(%bar_interface* %bar_inst)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_call_with_same_name_as_return_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_call_with_same_name_as_return_type.snap
@@ -23,19 +23,7 @@ entry:
 define void @prg(%prg_interface* %0) {
 entry:
   %TIME_instance = alloca %TIME_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i64 @TIME(%TIME_interface* %TIME_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i64 @TIME(%TIME_interface* %TIME_instance)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_in_program.snap
@@ -25,20 +25,8 @@ define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i32 %call1, i32* %x, align 4
+  %call = call i32 @foo(%foo_interface* %foo_instance)
+  store i32 %call, i32* %x, align 4
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_when_shadowed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_when_shadowed.snap
@@ -25,20 +25,8 @@ define void @prg(%prg_interface* %0) {
 entry:
   %froo = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i32 %call1, i32* %froo, align 4
+  %call = call i32 @foo(%foo_interface* %foo_instance)
+  store i32 %call, i32* %froo, align 4
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_temp_var_initialization.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_temp_var_initialization.snap
@@ -35,21 +35,9 @@ entry:
 define void @prg(%prg_interface* %0) {
 entry:
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
   store i32 5, i32* %1, align 4
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i32 @foo(%foo_interface* %foo_instance)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_var_initialization_and_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_var_initialization_and_call.snap
@@ -31,21 +31,9 @@ entry:
 define void @prg(%prg_interface* %0) {
 entry:
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
   store i32 5, i32* %1, align 4
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i32 @foo(%foo_interface* %foo_instance)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_parameters_called_in_program.snap
@@ -26,22 +26,10 @@ define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
   store i32 2, i32* %1, align 4
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i32 %call1, i32* %x, align 4
+  %call = call i32 @foo(%foo_interface* %foo_instance)
+  store i32 %call, i32* %x, align 4
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_two_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_two_parameters_called_in_program.snap
@@ -27,24 +27,12 @@ define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
   store i32 2, i32* %1, align 4
   %2 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 1
   store i8 1, i8* %2, align 1
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i32 %call1, i32* %x, align 4
+  %call = call i32 @foo(%foo_interface* %foo_instance)
+  store i32 %call, i32* %x, align 4
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_varargs_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_varargs_called_in_program.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1388
 expression: result
 
 ---
@@ -17,22 +18,10 @@ define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %load_x = load i32, i32* %x, align 4
   %tmpVar = add i32 %load_x, 1
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 (%foo_interface*, ...) @foo(%foo_interface* %foo_instance, i1 false, i32 3, i32 %tmpVar)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i32 %call1, i32* %x, align 4
+  %call = call i32 (%foo_interface*, ...) @foo(%foo_interface* %foo_instance, i1 false, i32 3, i32 %tmpVar)
+  store i32 %call, i32* %x, align 4
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_function_called_in_program.snap
@@ -36,36 +36,12 @@ define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
   %bar_instance = alloca %bar_interface, align 8
-  br label %input1
-
-call:                                             ; preds = %continue4
-  %call6 = call i32 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i32 %call6, i32* %x, align 4
+  %call = call i32 @bar(%bar_interface* %bar_instance)
+  store i32 %call, i32* %1, align 4
+  %call1 = call i32 @foo(%foo_interface* %foo_instance)
+  store i32 %call1, i32* %x, align 4
   ret void
-
-input1:                                           ; preds = %input
-  br label %call2
-
-call2:                                            ; preds = %input1
-  %call5 = call i32 @bar(%bar_interface* %bar_instance)
-  br label %output3
-
-output3:                                          ; preds = %call2
-  br label %continue4
-
-continue4:                                        ; preds = %output3
-  store i32 %call5, i32* %1, align 4
-  br label %call
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__optional_output_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__optional_output_assignment.snap
@@ -1,6 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 2760
+assertion_line: 2822
 expression: result
 
 ---
@@ -26,21 +26,9 @@ define void @main(%main_interface* %0) {
 entry:
   %var1 = getelementptr inbounds %main_interface, %main_interface* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main_interface, %main_interface* %0, i32 0, i32 1
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
   %output2 = load i32, i32* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 1), align 4
   store i32 %output2, i32* %var2, align 4
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pass_inout_to_inout.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pass_inout_to_inout.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1686
 expression: result
 
 ---
@@ -24,44 +25,20 @@ entry:
 define void @foo(%foo_interface* %0) {
 entry:
   %inout = getelementptr inbounds %foo_interface, %foo_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
   %deref = load i32*, i32** %inout, align 8
   store i32* %deref, i32** getelementptr inbounds (%foo2_interface, %foo2_interface* @foo2_instance, i32 0, i32 0), align 8
   %deref1 = load i32*, i32** %inout, align 8
   %load_inout = load i32, i32* %deref1, align 4
   store i32 %load_inout, i32* getelementptr inbounds (%foo2_interface, %foo2_interface* @foo2_instance, i32 0, i32 1), align 4
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo2(%foo2_interface* @foo2_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 
 define void @prg(%prg_interface* %0) {
 entry:
   %baz = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
   store i32* %baz, i32** getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 0), align 8
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_called_in_program.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1475
 expression: result
 
 ---
@@ -19,19 +20,7 @@ entry:
 
 define void @prg(%prg_interface* %0) {
 entry:
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_local_temp_var_initialization.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_local_temp_var_initialization.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1459
 expression: result
 
 ---
@@ -29,19 +30,7 @@ entry:
 
 define void @prg(%prg_interface* %0) {
 entry:
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_explicit_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_explicit_parameters_called_in_program.snap
@@ -22,21 +22,9 @@ entry:
 
 define void @prg(%prg_interface* %0) {
 entry:
-  br label %input
-
-input:                                            ; preds = %entry
   store i8 1, i8* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 1), align 1
   store i32 2, i32* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 0), align 4
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_parameters_called_in_program.snap
@@ -22,21 +22,9 @@ entry:
 
 define void @prg(%prg_interface* %0) {
 entry:
-  br label %input
-
-input:                                            ; preds = %entry
   store i32 2, i32* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 0), align 4
   store i8 1, i8* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 1), align 1
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_inout_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_inout_called_in_program.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1654
 expression: result
 
 ---
@@ -27,20 +28,8 @@ define void @prg(%prg_interface* %0) {
 entry:
   %baz = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   store i32 7, i32* %baz, align 4
-  br label %input
-
-input:                                            ; preds = %entry
   store i32* %baz, i32** getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 0), align 8
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_in_program.snap
@@ -23,22 +23,10 @@ entry:
 define void @prg(%prg_interface* %0) {
 entry:
   %baz = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
   store i32 2, i32* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 0), align 4
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
   %buz = load i8, i8* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 1), align 1
   store i8 %buz, i8* %baz, align 1
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_mixed_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_mixed_in_program.snap
@@ -23,22 +23,10 @@ entry:
 define void @prg(%prg_interface* %0) {
 entry:
   %baz = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
   store i32 2, i32* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 0), align 4
-  br label %call
-
-call:                                             ; preds = %input
   call void @foo(%foo_interface* @foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
   %buz = load i8, i8* getelementptr inbounds (%foo_interface, %foo_interface* @foo_instance, i32 0, i32 1), align 1
   store i8 %buz, i8* %baz, align 1
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_action_from_fb_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_action_from_fb_called_in_program.snap
@@ -1,6 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 1543
+assertion_line: 1565
 expression: result
 
 ---
@@ -16,19 +16,7 @@ source_filename = "main"
 define void @bar(%bar_interface* %0) {
 entry:
   %fb_inst = getelementptr inbounds %bar_interface, %bar_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @fb.foo(%fb_interface* %fb_inst)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_foreign_action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_foreign_action_called_in_program.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1538
 expression: result
 
 ---
@@ -14,19 +15,7 @@ source_filename = "main"
 
 define void @bar(%bar_interface* %0) {
 entry:
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @prg.foo(%prg_interface* @prg_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_local_action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_local_action_called_in_program.snap
@@ -1,5 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
+assertion_line: 1515
 expression: result
 
 ---
@@ -13,19 +14,7 @@ source_filename = "main"
 define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @prg.foo(%prg_interface* @prg_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__real_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__real_function_called_in_program.snap
@@ -25,20 +25,8 @@ define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call float @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  %1 = fptosi float %call1 to i32
+  %call = call float @foo(%foo_interface* %foo_instance)
+  %1 = fptosi float %call to i32
   store i32 %1, i32* %x, align 4
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_on_assigment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_on_assigment.snap
@@ -29,26 +29,14 @@ define void @Main(%Main_interface* %0) {
 entry:
   %x = getelementptr inbounds %Main_interface, %Main_interface* %0, i32 0, i32 0
   %CheckRangeSigned_instance = alloca %CheckRangeSigned_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %CheckRangeSigned_interface, %CheckRangeSigned_interface* %CheckRangeSigned_instance, i32 0, i32 0
   store i16 7, i16* %1, align 2
   %2 = getelementptr inbounds %CheckRangeSigned_interface, %CheckRangeSigned_interface* %CheckRangeSigned_instance, i32 0, i32 1
   store i16 0, i16* %2, align 2
   %3 = getelementptr inbounds %CheckRangeSigned_interface, %CheckRangeSigned_interface* %CheckRangeSigned_instance, i32 0, i32 2
   store i16 100, i16* %3, align 2
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i16 @CheckRangeSigned(%CheckRangeSigned_interface* %CheckRangeSigned_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i16 %call1, i16* %x, align 2
+  %call = call i16 @CheckRangeSigned(%CheckRangeSigned_interface* %CheckRangeSigned_instance)
+  store i16 %call, i16* %x, align 2
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_const_expression_in_range_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_const_expression_in_range_type.snap
@@ -31,9 +31,6 @@ define void @prg(%prg_interface* %0) {
 entry:
   %x = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %CheckRangeSigned_instance = alloca %CheckRangeSigned_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %CheckRangeSigned_interface, %CheckRangeSigned_interface* %CheckRangeSigned_instance, i32 0, i32 0
   store i16 5, i16* %1, align 2
   %2 = getelementptr inbounds %CheckRangeSigned_interface, %CheckRangeSigned_interface* %CheckRangeSigned_instance, i32 0, i32 1
@@ -44,17 +41,8 @@ input:                                            ; preds = %entry
   %tmpVar = add i32 %4, 1
   %5 = trunc i32 %tmpVar to i16
   store i16 %5, i16* %3, align 2
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i16 @CheckRangeSigned(%CheckRangeSigned_interface* %CheckRangeSigned_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i16 %call1, i16* %x, align 2
+  %call = call i16 @CheckRangeSigned(%CheckRangeSigned_interface* %CheckRangeSigned_instance)
+  store i16 %call, i16* %x, align 2
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__nested_call_statements.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__nested_call_statements.snap
@@ -1,0 +1,36 @@
+---
+source: src/codegen/tests/expression_tests.rs
+assertion_line: 393
+expression: result
+
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%main_interface = type {}
+%foo_interface = type { i32 }
+
+@main_instance = global %main_interface zeroinitializer
+
+define i32 @foo(%foo_interface* %0) {
+entry:
+  %a = getelementptr inbounds %foo_interface, %foo_interface* %0, i32 0, i32 0
+  %foo = alloca i32, align 4
+  store i32 0, i32* %foo, align 4
+  %foo_ret = load i32, i32* %foo, align 4
+  ret i32 %foo_ret
+}
+
+define void @main(%main_interface* %0) {
+entry:
+  %foo_instance = alloca %foo_interface, align 8
+  %1 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
+  %foo_instance1 = alloca %foo_interface, align 8
+  %2 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance1, i32 0, i32 0
+  store i32 2, i32* %2, align 4
+  %call = call i32 @foo(%foo_interface* %foo_instance1)
+  store i32 %call, i32* %1, align 4
+  %call2 = call i32 @foo(%foo_interface* %foo_instance)
+  ret void
+}
+

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics_function_call.snap
@@ -28,83 +28,35 @@ entry:
   store i16* %x, i16** %pt, align 8
   %load_pt = load i16*, i16** %pt, align 8
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i64 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  %access___main_pt = getelementptr inbounds i16, i16* %load_pt, i64 %call1
+  %call = call i64 @foo(%foo_interface* %foo_instance)
+  %access___main_pt = getelementptr inbounds i16, i16* %load_pt, i64 %call
   store i16* %access___main_pt, i16** %pt, align 8
+  %load_pt1 = load i16*, i16** %pt, align 8
   %load_pt2 = load i16*, i16** %pt, align 8
+  store i8 zext (i1 icmp eq (i64 ptrtoint (i16* %load_pt1 to i64), i64 ptrtoint (i16* %load_pt2 to i64)) to i8), i8* %comp, align 1
   %load_pt3 = load i16*, i16** %pt, align 8
-  store i8 zext (i1 icmp eq (i64 ptrtoint (i16* %load_pt2 to i64), i64 ptrtoint (i16* %load_pt3 to i64)) to i8), i8* %comp, align 1
-  %load_pt4 = load i16*, i16** %pt, align 8
-  %foo_instance5 = alloca %foo_interface, align 8
-  br label %input6
-
-input6:                                           ; preds = %continue
-  br label %call7
-
-call7:                                            ; preds = %input6
-  %call10 = call i64 @foo(%foo_interface* %foo_instance5)
-  br label %output8
-
-output8:                                          ; preds = %call7
-  br label %continue9
-
-continue9:                                        ; preds = %output8
-  %tmpVar = icmp ne i64 ptrtoint (i16* %load_pt4 to i64), %call10
+  %foo_instance4 = alloca %foo_interface, align 8
+  %call5 = call i64 @foo(%foo_interface* %foo_instance4)
+  %tmpVar = icmp ne i64 ptrtoint (i16* %load_pt3 to i64), %call5
   %1 = zext i1 %tmpVar to i8
   store i8 %1, i8* %comp, align 1
-  %load_pt11 = load i16*, i16** %pt, align 8
-  %load_pt12 = load i16*, i16** %pt, align 8
-  store i8 zext (i1 icmp slt (i64 ptrtoint (i16* %load_pt11 to i64), i64 ptrtoint (i16* %load_pt12 to i64)) to i8), i8* %comp, align 1
-  %load_pt13 = load i16*, i16** %pt, align 8
-  %foo_instance14 = alloca %foo_interface, align 8
-  br label %input15
-
-input15:                                          ; preds = %continue9
-  br label %call16
-
-call16:                                           ; preds = %input15
-  %call19 = call i64 @foo(%foo_interface* %foo_instance14)
-  br label %output17
-
-output17:                                         ; preds = %call16
-  br label %continue18
-
-continue18:                                       ; preds = %output17
-  %tmpVar20 = icmp sgt i64 ptrtoint (i16* %load_pt13 to i64), %call19
-  %2 = zext i1 %tmpVar20 to i8
+  %load_pt6 = load i16*, i16** %pt, align 8
+  %load_pt7 = load i16*, i16** %pt, align 8
+  store i8 zext (i1 icmp slt (i64 ptrtoint (i16* %load_pt6 to i64), i64 ptrtoint (i16* %load_pt7 to i64)) to i8), i8* %comp, align 1
+  %load_pt8 = load i16*, i16** %pt, align 8
+  %foo_instance9 = alloca %foo_interface, align 8
+  %call10 = call i64 @foo(%foo_interface* %foo_instance9)
+  %tmpVar11 = icmp sgt i64 ptrtoint (i16* %load_pt8 to i64), %call10
+  %2 = zext i1 %tmpVar11 to i8
   store i8 %2, i8* %comp, align 1
-  %load_pt21 = load i16*, i16** %pt, align 8
-  %load_pt22 = load i16*, i16** %pt, align 8
-  store i8 zext (i1 icmp sle (i64 ptrtoint (i16* %load_pt21 to i64), i64 ptrtoint (i16* %load_pt22 to i64)) to i8), i8* %comp, align 1
-  %foo_instance23 = alloca %foo_interface, align 8
-  br label %input24
-
-input24:                                          ; preds = %continue18
-  br label %call25
-
-call25:                                           ; preds = %input24
-  %call28 = call i64 @foo(%foo_interface* %foo_instance23)
-  br label %output26
-
-output26:                                         ; preds = %call25
-  br label %continue27
-
-continue27:                                       ; preds = %output26
-  %load_pt29 = load i16*, i16** %pt, align 8
-  %tmpVar30 = icmp sge i64 %call28, ptrtoint (i16* %load_pt29 to i64)
-  %3 = zext i1 %tmpVar30 to i8
+  %load_pt12 = load i16*, i16** %pt, align 8
+  %load_pt13 = load i16*, i16** %pt, align 8
+  store i8 zext (i1 icmp sle (i64 ptrtoint (i16* %load_pt12 to i64), i64 ptrtoint (i16* %load_pt13 to i64)) to i8), i8* %comp, align 1
+  %foo_instance14 = alloca %foo_interface, align 8
+  %call15 = call i64 @foo(%foo_interface* %foo_instance14)
+  %load_pt16 = load i16*, i16** %pt, align 8
+  %tmpVar17 = icmp sge i64 %call15, ptrtoint (i16* %load_pt16 to i64)
+  %3 = zext i1 %tmpVar17 to i8
   store i8 %3, i8* %comp, align 1
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_comparison_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_comparison_test.snap
@@ -36,49 +36,25 @@ entry:
   store i8 0, i8* %result, align 1
   store i16 0, i16* %baz, align 2
   %STRING_EQUAL_instance = alloca %STRING_EQUAL_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %3 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 0
   %4 = bitcast [1025 x i8]* %3 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %4, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
   %5 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 1
   %6 = bitcast [1025 x i8]* %5 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %6, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_1, i32 0, i32 0), i32 2, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i8 %call1, i8* %result, align 1
-  %STRING_EQUAL_instance2 = alloca %STRING_EQUAL_interface, align 8
-  br label %input3
-
-input3:                                           ; preds = %continue
-  %7 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance2, i32 0, i32 0
+  %call = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
+  store i8 %call, i8* %result, align 1
+  %STRING_EQUAL_instance1 = alloca %STRING_EQUAL_interface, align 8
+  %7 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance1, i32 0, i32 0
   %8 = bitcast [1025 x i8]* %7 to i8*
   %9 = bitcast [81 x i8]* %a to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %8, i8* align 1 %9, i32 81, i1 false)
-  %10 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance2, i32 0, i32 1
+  %10 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance1, i32 0, i32 1
   %11 = bitcast [1025 x i8]* %10 to i8*
   %12 = bitcast [81 x i8]* %b to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %11, i8* align 1 %12, i32 81, i1 false)
-  br label %call4
-
-call4:                                            ; preds = %input3
-  %call7 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance2)
-  br label %output5
-
-output5:                                          ; preds = %call4
-  br label %continue6
-
-continue6:                                        ; preds = %output5
-  store i8 %call7, i8* %result, align 1
+  %call2 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance1)
+  store i8 %call2, i8* %result, align 1
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_equal_with_constant_test.snap
@@ -36,9 +36,6 @@ entry:
   store i8 0, i8* %result, align 1
   store i16 0, i16* %baz, align 2
   %STRING_EQUAL_instance = alloca %STRING_EQUAL_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %3 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 0
   %4 = bitcast [1025 x i8]* %3 to i8*
   %5 = bitcast [81 x i8]* %a to i8*
@@ -46,39 +43,18 @@ input:                                            ; preds = %entry
   %6 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 1
   %7 = bitcast [1025 x i8]* %6 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %7, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_1, i32 0, i32 0), i32 2, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i8 %call1, i8* %result, align 1
-  %STRING_EQUAL_instance2 = alloca %STRING_EQUAL_interface, align 8
-  br label %input3
-
-input3:                                           ; preds = %continue
-  %8 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance2, i32 0, i32 0
+  %call = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
+  store i8 %call, i8* %result, align 1
+  %STRING_EQUAL_instance1 = alloca %STRING_EQUAL_interface, align 8
+  %8 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance1, i32 0, i32 0
   %9 = bitcast [1025 x i8]* %8 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %9, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  %10 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance2, i32 0, i32 1
+  %10 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance1, i32 0, i32 1
   %11 = bitcast [1025 x i8]* %10 to i8*
   %12 = bitcast [81 x i8]* %b to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %11, i8* align 1 %12, i32 81, i1 false)
-  br label %call4
-
-call4:                                            ; preds = %input3
-  %call7 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance2)
-  br label %output5
-
-output5:                                          ; preds = %call4
-  br label %continue6
-
-continue6:                                        ; preds = %output5
-  store i8 %call7, i8* %result, align 1
+  %call2 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance1)
+  store i8 %call2, i8* %result, align 1
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_greater_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_greater_or_equal_with_constant_test.snap
@@ -46,58 +46,34 @@ entry:
   store i8 0, i8* %result, align 1
   store i16 0, i16* %baz, align 2
   %STRING_EQUAL_instance = alloca %STRING_EQUAL_interface, align 8
-  br label %input
+  %3 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 0
+  %4 = bitcast [1025 x i8]* %3 to i8*
+  %5 = bitcast [81 x i8]* %a to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %4, i8* align 1 %5, i32 81, i1 false)
+  %6 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 1
+  %7 = bitcast [1025 x i8]* %6 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %7, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
+  %call = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
+  %8 = icmp ne i8 %call, 0
+  br i1 %8, label %15, label %9
 
-3:                                                ; preds = %continue
+9:                                                ; preds = %entry
   %STRING_GREATER_instance = alloca %STRING_GREATER_interface, align 8
-  br label %input2
+  %10 = getelementptr inbounds %STRING_GREATER_interface, %STRING_GREATER_interface* %STRING_GREATER_instance, i32 0, i32 0
+  %11 = bitcast [1025 x i8]* %10 to i8*
+  %12 = bitcast [81 x i8]* %a to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %11, i8* align 1 %12, i32 81, i1 false)
+  %13 = getelementptr inbounds %STRING_GREATER_interface, %STRING_GREATER_interface* %STRING_GREATER_instance, i32 0, i32 1
+  %14 = bitcast [1025 x i8]* %13 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %14, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
+  %call1 = call i8 @STRING_GREATER(%STRING_GREATER_interface* %STRING_GREATER_instance)
+  br label %15
 
-4:                                                ; preds = %continue5, %continue
-  %5 = phi i8 [ %call1, %continue ], [ %call6, %continue5 ]
-  store i8 %5, i8* %result, align 1
+15:                                               ; preds = %9, %entry
+  %16 = phi i8 [ %call, %entry ], [ %call1, %9 ]
+  store i8 %16, i8* %result, align 1
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
-
-input:                                            ; preds = %entry
-  %6 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 0
-  %7 = bitcast [1025 x i8]* %6 to i8*
-  %8 = bitcast [81 x i8]* %a to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %7, i8* align 1 %8, i32 81, i1 false)
-  %9 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 1
-  %10 = bitcast [1025 x i8]* %9 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %10, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  %11 = icmp ne i8 %call1, 0
-  br i1 %11, label %4, label %3
-
-input2:                                           ; preds = %3
-  %12 = getelementptr inbounds %STRING_GREATER_interface, %STRING_GREATER_interface* %STRING_GREATER_instance, i32 0, i32 0
-  %13 = bitcast [1025 x i8]* %12 to i8*
-  %14 = bitcast [81 x i8]* %a to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %13, i8* align 1 %14, i32 81, i1 false)
-  %15 = getelementptr inbounds %STRING_GREATER_interface, %STRING_GREATER_interface* %STRING_GREATER_instance, i32 0, i32 1
-  %16 = bitcast [1025 x i8]* %15 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %16, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  br label %call3
-
-call3:                                            ; preds = %input2
-  %call6 = call i8 @STRING_GREATER(%STRING_GREATER_interface* %STRING_GREATER_instance)
-  br label %output4
-
-output4:                                          ; preds = %call3
-  br label %continue5
-
-continue5:                                        ; preds = %output4
-  br label %4
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_greater_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_greater_with_constant_test.snap
@@ -32,9 +32,6 @@ entry:
   store i8 0, i8* %result, align 1
   store i16 0, i16* %baz, align 2
   %STRING_GREATER_instance = alloca %STRING_GREATER_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %2 = getelementptr inbounds %STRING_GREATER_interface, %STRING_GREATER_interface* %STRING_GREATER_instance, i32 0, i32 0
   %3 = bitcast [1025 x i8]* %2 to i8*
   %4 = bitcast [81 x i8]* %a to i8*
@@ -42,17 +39,8 @@ input:                                            ; preds = %entry
   %5 = getelementptr inbounds %STRING_GREATER_interface, %STRING_GREATER_interface* %STRING_GREATER_instance, i32 0, i32 1
   %6 = bitcast [1025 x i8]* %5 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %6, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i8 @STRING_GREATER(%STRING_GREATER_interface* %STRING_GREATER_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i8 %call1, i8* %result, align 1
+  %call = call i8 @STRING_GREATER(%STRING_GREATER_interface* %STRING_GREATER_instance)
+  store i8 %call, i8* %result, align 1
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_less_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_less_with_constant_test.snap
@@ -32,9 +32,6 @@ entry:
   store i8 0, i8* %result, align 1
   store i16 0, i16* %baz, align 2
   %STRING_LESS_instance = alloca %STRING_LESS_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %2 = getelementptr inbounds %STRING_LESS_interface, %STRING_LESS_interface* %STRING_LESS_instance, i32 0, i32 0
   %3 = bitcast [1025 x i8]* %2 to i8*
   %4 = bitcast [81 x i8]* %a to i8*
@@ -42,17 +39,8 @@ input:                                            ; preds = %entry
   %5 = getelementptr inbounds %STRING_LESS_interface, %STRING_LESS_interface* %STRING_LESS_instance, i32 0, i32 1
   %6 = bitcast [1025 x i8]* %5 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %6, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i8 @STRING_LESS(%STRING_LESS_interface* %STRING_LESS_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  store i8 %call1, i8* %result, align 1
+  %call = call i8 @STRING_LESS(%STRING_LESS_interface* %STRING_LESS_instance)
+  store i8 %call, i8* %result, align 1
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_not_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_not_equal_with_constant_test.snap
@@ -32,9 +32,6 @@ entry:
   store i8 0, i8* %result, align 1
   store i16 0, i16* %baz, align 2
   %STRING_EQUAL_instance = alloca %STRING_EQUAL_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %2 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 0
   %3 = bitcast [1025 x i8]* %2 to i8*
   %4 = bitcast [81 x i8]* %a to i8*
@@ -42,17 +39,8 @@ input:                                            ; preds = %entry
   %5 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 1
   %6 = bitcast [1025 x i8]* %5 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %6, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  %tmpVar = xor i8 %call1, -1
+  %call = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
+  %tmpVar = xor i8 %call, -1
   store i8 %tmpVar, i8* %result, align 1
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_smaller_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__string_smaller_or_equal_with_constant_test.snap
@@ -46,58 +46,34 @@ entry:
   store i8 0, i8* %result, align 1
   store i16 0, i16* %baz, align 2
   %STRING_EQUAL_instance = alloca %STRING_EQUAL_interface, align 8
-  br label %input
+  %3 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 0
+  %4 = bitcast [1025 x i8]* %3 to i8*
+  %5 = bitcast [81 x i8]* %a to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %4, i8* align 1 %5, i32 81, i1 false)
+  %6 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 1
+  %7 = bitcast [1025 x i8]* %6 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %7, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
+  %call = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
+  %8 = icmp ne i8 %call, 0
+  br i1 %8, label %15, label %9
 
-3:                                                ; preds = %continue
+9:                                                ; preds = %entry
   %STRING_LESS_instance = alloca %STRING_LESS_interface, align 8
-  br label %input2
+  %10 = getelementptr inbounds %STRING_LESS_interface, %STRING_LESS_interface* %STRING_LESS_instance, i32 0, i32 0
+  %11 = bitcast [1025 x i8]* %10 to i8*
+  %12 = bitcast [81 x i8]* %a to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %11, i8* align 1 %12, i32 81, i1 false)
+  %13 = getelementptr inbounds %STRING_LESS_interface, %STRING_LESS_interface* %STRING_LESS_instance, i32 0, i32 1
+  %14 = bitcast [1025 x i8]* %13 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %14, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
+  %call1 = call i8 @STRING_LESS(%STRING_LESS_interface* %STRING_LESS_instance)
+  br label %15
 
-4:                                                ; preds = %continue5, %continue
-  %5 = phi i8 [ %call1, %continue ], [ %call6, %continue5 ]
-  store i8 %5, i8* %result, align 1
+15:                                               ; preds = %9, %entry
+  %16 = phi i8 [ %call, %entry ], [ %call1, %9 ]
+  store i8 %16, i8* %result, align 1
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
-
-input:                                            ; preds = %entry
-  %6 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 0
-  %7 = bitcast [1025 x i8]* %6 to i8*
-  %8 = bitcast [81 x i8]* %a to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %7, i8* align 1 %8, i32 81, i1 false)
-  %9 = getelementptr inbounds %STRING_EQUAL_interface, %STRING_EQUAL_interface* %STRING_EQUAL_instance, i32 0, i32 1
-  %10 = bitcast [1025 x i8]* %9 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %10, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i8 @STRING_EQUAL(%STRING_EQUAL_interface* %STRING_EQUAL_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  %11 = icmp ne i8 %call1, 0
-  br i1 %11, label %4, label %3
-
-input2:                                           ; preds = %3
-  %12 = getelementptr inbounds %STRING_LESS_interface, %STRING_LESS_interface* %STRING_LESS_instance, i32 0, i32 0
-  %13 = bitcast [1025 x i8]* %12 to i8*
-  %14 = bitcast [81 x i8]* %a to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %13, i8* align 1 %14, i32 81, i1 false)
-  %15 = getelementptr inbounds %STRING_LESS_interface, %STRING_LESS_interface* %STRING_LESS_instance, i32 0, i32 1
-  %16 = bitcast [1025 x i8]* %15 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %16, i8* align 1 getelementptr inbounds ([2 x i8], [2 x i8]* @utf08_literal_0, i32 0, i32 0), i32 2, i1 false)
-  br label %call3
-
-call3:                                            ; preds = %input2
-  %call6 = call i8 @STRING_LESS(%STRING_LESS_interface* %STRING_LESS_instance)
-  br label %output4
-
-output4:                                          ; preds = %call3
-  br label %continue5
-
-continue5:                                        ; preds = %output4
-  br label %4
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__type_mix_in_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__type_mix_in_call.snap
@@ -24,21 +24,9 @@ entry:
   %baz = alloca i16, align 2
   store i16 0, i16* %baz, align 2
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
   store i16 1, i16* %1, align 2
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i16 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i16 @foo(%foo_interface* %foo_instance)
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_function_call_generates_real_type_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_function_call_generates_real_type_call.snap
@@ -28,43 +28,19 @@ entry:
   %a = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 1
   %MAX__DINT_instance = alloca %MAX__DINT_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %MAX__DINT_interface, %MAX__DINT_interface* %MAX__DINT_instance, i32 0, i32 0
   store i32 1, i32* %1, align 4
   %2 = getelementptr inbounds %MAX__DINT_interface, %MAX__DINT_interface* %MAX__DINT_instance, i32 0, i32 1
   store i32 2, i32* %2, align 4
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i32 @MAX__DINT(%MAX__DINT_interface* %MAX__DINT_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call i32 @MAX__DINT(%MAX__DINT_interface* %MAX__DINT_instance)
   %MAX__INT_instance = alloca %MAX__INT_interface, align 8
-  br label %input2
-
-input2:                                           ; preds = %continue
   %3 = getelementptr inbounds %MAX__INT_interface, %MAX__INT_interface* %MAX__INT_instance, i32 0, i32 0
   %load_a = load i16, i16* %a, align 2
   store i16 %load_a, i16* %3, align 2
   %4 = getelementptr inbounds %MAX__INT_interface, %MAX__INT_interface* %MAX__INT_instance, i32 0, i32 1
   %load_b = load i16, i16* %b, align 2
   store i16 %load_b, i16* %4, align 2
-  br label %call3
-
-call3:                                            ; preds = %input2
-  %call6 = call i16 @MAX__INT(%MAX__INT_interface* %MAX__INT_instance)
-  br label %output4
-
-output4:                                          ; preds = %call3
-  br label %continue5
-
-continue5:                                        ; preds = %output4
+  %call1 = call i16 @MAX__INT(%MAX__INT_interface* %MAX__INT_instance)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
@@ -19,9 +19,6 @@ entry:
   %LIST_ADD = alloca i8, align 1
   store i8 0, i8* %LIST_ADD, align 1
   %CONCAT_instance = alloca %CONCAT_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %CONCAT_interface, %CONCAT_interface* %CONCAT_instance, i32 0, i32 0
   %2 = bitcast [1025 x i8]* %1 to i8*
   %3 = bitcast [2 x i8]* %sx to i8*
@@ -30,18 +27,9 @@ input:                                            ; preds = %entry
   %5 = bitcast [1025 x i8]* %4 to i8*
   %6 = bitcast [1001 x i8]* %INS to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %5, i8* align 1 %6, i32 1001, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call [1025 x i8] @CONCAT(%CONCAT_interface* %CONCAT_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call [1025 x i8] @CONCAT(%CONCAT_interface* %CONCAT_instance)
   %7 = alloca [1025 x i8], align 1
-  store [1025 x i8] %call1, [1025 x i8]* %7, align 1
+  store [1025 x i8] %call, [1025 x i8]* %7, align 1
   %8 = bitcast [1001 x i8]* %INS to i8*
   %9 = bitcast [1025 x i8]* %7 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %8, i8* align 1 %9, i32 1000, i1 false)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
@@ -19,9 +19,6 @@ entry:
   %LIST_ADD = alloca i8, align 1
   store i8 0, i8* %LIST_ADD, align 1
   %CONCAT_instance = alloca %CONCAT_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %CONCAT_interface, %CONCAT_interface* %CONCAT_instance, i32 0, i32 0
   %2 = bitcast [1025 x i8]* %1 to i8*
   %3 = bitcast [2 x i8]* %sx to i8*
@@ -30,18 +27,9 @@ input:                                            ; preds = %entry
   %5 = bitcast [1025 x i8]* %4 to i8*
   %6 = bitcast [1001 x i8]* %INS to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %5, i8* align 1 %6, i32 1001, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call [1025 x i8] @CONCAT(%CONCAT_interface* %CONCAT_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call [1025 x i8] @CONCAT(%CONCAT_interface* %CONCAT_instance)
   %7 = alloca [1025 x i8], align 1
-  store [1025 x i8] %call1, [1025 x i8]* %7, align 1
+  store [1025 x i8] %call, [1025 x i8]* %7, align 1
   %8 = bitcast [1001 x i8]* %INS to i8*
   %9 = bitcast [1025 x i8]* %7 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %8, i8* align 1 %9, i32 1000, i1 false)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_parameters_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_parameters_string.snap
@@ -33,46 +33,22 @@ entry:
   %text2 = getelementptr inbounds %main_interface, %main_interface* %0, i32 0, i32 1
   %text3 = getelementptr inbounds %main_interface, %main_interface* %0, i32 0, i32 2
   %read_string_instance = alloca %read_string_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %1 = getelementptr inbounds %read_string_interface, %read_string_interface* %read_string_instance, i32 0, i32 0
   %2 = bitcast [81 x i8]* %1 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %2, i8* align 1 getelementptr inbounds ([154 x i8], [154 x i8]* @utf08_literal_0, i32 0, i32 0), i32 80, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call [81 x i8] @read_string(%read_string_interface* %read_string_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
+  %call = call [81 x i8] @read_string(%read_string_interface* %read_string_instance)
   %3 = alloca [81 x i8], align 1
-  store [81 x i8] %call1, [81 x i8]* %3, align 1
+  store [81 x i8] %call, [81 x i8]* %3, align 1
   %4 = bitcast [81 x i8]* %text1 to i8*
   %5 = bitcast [81 x i8]* %3 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %4, i8* align 1 %5, i32 80, i1 false)
-  %read_string_instance2 = alloca %read_string_interface, align 8
-  br label %input3
-
-input3:                                           ; preds = %continue
-  %6 = getelementptr inbounds %read_string_interface, %read_string_interface* %read_string_instance2, i32 0, i32 0
+  %read_string_instance1 = alloca %read_string_interface, align 8
+  %6 = getelementptr inbounds %read_string_interface, %read_string_interface* %read_string_instance1, i32 0, i32 0
   %7 = bitcast [81 x i8]* %6 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %7, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_1, i32 0, i32 0), i32 6, i1 false)
-  br label %call4
-
-call4:                                            ; preds = %input3
-  %call7 = call [81 x i8] @read_string(%read_string_interface* %read_string_instance2)
-  br label %output5
-
-output5:                                          ; preds = %call4
-  br label %continue6
-
-continue6:                                        ; preds = %output5
+  %call2 = call [81 x i8] @read_string(%read_string_interface* %read_string_instance1)
   %8 = alloca [81 x i8], align 1
-  store [81 x i8] %call7, [81 x i8]* %8, align 1
+  store [81 x i8] %call2, [81 x i8]* %8, align 1
   %9 = bitcast [81 x i8]* %text3 to i8*
   %10 = bitcast [81 x i8]* %8 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %9, i8* align 1 %10, i32 80, i1 false)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__string_function_parameters.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__string_function_parameters.snap
@@ -37,40 +37,16 @@ entry:
   %3 = bitcast [81 x i8]* %a to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_0, i32 0, i32 0), i32 6, i1 false)
   %foo_instance = alloca %foo_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
   %4 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance, i32 0, i32 0
   %5 = bitcast [81 x i8]* %4 to i8*
   %6 = bitcast [11 x i8]* %s to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %5, i8* align 1 %6, i32 11, i1 false)
-  br label %call
-
-call:                                             ; preds = %input
-  %call1 = call i16 @foo(%foo_interface* %foo_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
-  %foo_instance2 = alloca %foo_interface, align 8
-  br label %input3
-
-input3:                                           ; preds = %continue
-  %7 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance2, i32 0, i32 0
+  %call = call i16 @foo(%foo_interface* %foo_instance)
+  %foo_instance1 = alloca %foo_interface, align 8
+  %7 = getelementptr inbounds %foo_interface, %foo_interface* %foo_instance1, i32 0, i32 0
   %8 = bitcast [81 x i8]* %7 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %8, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_0, i32 0, i32 0), i32 6, i1 false)
-  br label %call4
-
-call4:                                            ; preds = %input3
-  %call7 = call i16 @foo(%foo_interface* %foo_instance2)
-  br label %output5
-
-output5:                                          ; preds = %call4
-  br label %continue6
-
-continue6:                                        ; preds = %output5
+  %call2 = call i16 @foo(%foo_interface* %foo_instance1)
   ret void
 }
 

--- a/src/tests/snapshots/rusty__tests__external_files__external_file_function_call.snap
+++ b/src/tests/snapshots/rusty__tests__external_files__external_file_function_call.snap
@@ -15,19 +15,7 @@ entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
   %external_instance = alloca %external_interface, align 8
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @external(%external_interface* %external_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }

--- a/src/tests/snapshots/rusty__tests__multi_files__multiple_source_files_generated.snap
+++ b/src/tests/snapshots/rusty__tests__multi_files__multiple_source_files_generated.snap
@@ -16,19 +16,7 @@ define i16 @main(%main_interface* %0) {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
-  br label %input
-
-input:                                            ; preds = %entry
-  br label %call
-
-call:                                             ; preds = %input
   call void @mainProg(%mainProg_interface* @mainProg_instance)
-  br label %output
-
-output:                                           ; preds = %call
-  br label %continue
-
-continue:                                         ; preds = %output
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }


### PR DESCRIPTION
call statements used to use different blocks (input, call, output,
continue) to structure the generated code. This had several issues:

   1. it added a lot of unnecessary blocks and unconditional branches
   2. nested calls foo(baz()) messed up the block sequence and lead
to dead code

this implementation uses no blocks and no branching, it simply generates
the input-assignment, call and output-assignment in a sequence which
allows nested calls.

fixes #453