### PR TITLE
Issue 454 global variables in external files are not working

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,10 +19,10 @@ mod expressions_parser;
 pub mod tests;
 pub type ParsedAst = (CompilationUnit, Vec<Diagnostic>);
 
-pub fn parse(mut lexer: ParseSession, linkage: LinkageType) -> ParsedAst {
+pub fn parse(mut lexer: ParseSession, lnk: LinkageType) -> ParsedAst {
     let mut unit = CompilationUnit::default();
 
-    let mut linkage = linkage;
+    let mut linkage = lnk;
     loop {
         match lexer.token {
             PropertyExternal => {
@@ -79,7 +79,7 @@ pub fn parse(mut lexer: ParseSession, linkage: LinkageType) -> ParsedAst {
                 lexer.advance();
             }
         };
-        linkage = LinkageType::Internal;
+        linkage = lnk;
     }
     //the match in the loop will always return
 }

--- a/src/tests/external_files.rs
+++ b/src/tests/external_files.rs
@@ -15,7 +15,7 @@ fn external_file_function_call() {
     .into();
 
     let ext: SourceCode = "
-    FUNCTION external() : INT
+    FUNCTION external : INT
 	END_FUNCTION
     "
     .into();
@@ -29,6 +29,42 @@ fn external_file_function_call() {
     .unwrap();
     insta::assert_snapshot!(res);
 }
+
+#[test]
+fn external_file_global_var() {
+    //Given a program calling a function from an external file
+    let prog: SourceCode = "
+    FUNCTION main : INT
+        x := 2;
+        y := 2;
+    	external();
+    END_FUNCTION
+    "
+    .into();
+
+    let ext: SourceCode = "
+    VAR_GLOBAL
+        x : INT;
+    END_VAR
+    FUNCTION external : INT
+	END_FUNCTION
+    VAR_GLOBAL
+        y : INT;
+    END_VAR
+    "
+    .into();
+    //When they are generated
+    let res = compile_to_string(
+        vec![prog],
+        vec![ext],
+        None,
+        Diagnostician::null_diagnostician(),
+    )
+    .unwrap();
+    //x should be external
+    insta::assert_snapshot!(res);
+}
+
 
 #[test]
 fn calling_external_file_function_without_including_file_results_in_error() {

--- a/src/tests/external_files.rs
+++ b/src/tests/external_files.rs
@@ -65,7 +65,6 @@ fn external_file_global_var() {
     insta::assert_snapshot!(res);
 }
 
-
 #[test]
 fn calling_external_file_function_without_including_file_results_in_error() {
     //Given a program calling a function from an external file

--- a/src/tests/snapshots/rusty__tests__external_files__external_file_global_var.snap
+++ b/src/tests/snapshots/rusty__tests__external_files__external_file_global_var.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/external_files.rs
-assertion_line: 30
+assertion_line: 65
 expression: res
 
 ---
@@ -10,10 +10,15 @@ source_filename = "main"
 %main_interface = type {}
 %external_interface = type {}
 
+@x = available_externally global i16
+@y = available_externally global i16
+
 define i16 @main(%main_interface* %0) {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
+  store i16 2, i16* @x, align 2
+  store i16 2, i16* @y, align 2
   %external_instance = alloca %external_interface, align 8
   %call = call i16 @external(%external_interface* %external_instance)
   %main_ret = load i16, i16* %main, align 2


### PR DESCRIPTION
Fixes #454 

Made sure the parser does not loose its linkage parameter.