### PR TITLE
Split the junit report into multiple files, and move it to test results

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -103,7 +103,14 @@ function run_test() {
 	CARGO_OPTIONS=$(set_cargo_options)
 	log "Running cargo test"
 	if [[ $junit -ne 0 ]]; then
-		cargo test $CARGO_OPTIONS -- --format=junit -Zunstable-options >> test_report.xml
+		#Delete the test results if they exist
+		rm -rf "$project_location/test_results"
+		make_dir "$project_location/test_results"
+		#Passing through tail here will remove the first line which is currently empty.
+		cargo test $CARGO_OPTIONS --lib -- --format=junit -Zunstable-options | tail -n +2 > "$project_location"/test_results/rusty_unit_tests.xml
+		# Run only the integration tests
+		#https://stackoverflow.com/questions/62447864/how-can-i-run-only-integration-tests
+		cargo test $CARGO_OPTIONS --test '*' -- --format=junit -Zunstable-options | tail -n +2 > "$project_location"/test_results/rusty_integration_tests.xml
 	else
 		cargo test $CARGO_OPTIONS
 	fi


### PR DESCRIPTION
The junit report generated by cargo is not formatted correctly
This is because the underlying library (libtest) will generate a report per test class (unit/integration)
libtest expects the tests to be run individually
The script will now run unit tests and the integration tests
It also removes the leading empty line from the result