### PR TITLE
improved validation of FUNCs without return types

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -23,7 +23,10 @@ pub struct Pou {
     pub variable_blocks: Vec<VariableBlock>,
     pub pou_type: PouType,
     pub return_type: Option<DataTypeDeclaration>,
+    /// the SourceRange of the whole POU
     pub location: SourceRange,
+    /// the SourceRange of the POU's name
+    pub name_location: SourceRange,
     pub poly_mode: Option<PolymorphismMode>,
     pub generics: Vec<GenericBinding>,
     pub linkage: LinkageType,

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -2700,6 +2700,7 @@ fn sized_string_as_function_return() {
         }),
         variable_blocks: vec![],
         location: SourceRange::undefined(),
+        name_location: SourceRange::undefined(),
         generics: vec![],
         linkage: crate::ast::LinkageType::Internal,
     };
@@ -2747,6 +2748,7 @@ fn array_type_as_function_return() {
         }),
         variable_blocks: vec![],
         location: SourceRange::undefined(),
+        name_location: SourceRange::undefined(),
         generics: vec![],
         linkage: crate::ast::LinkageType::Internal,
     };

--- a/src/parser/tests/function_parser_tests.rs
+++ b/src/parser/tests/function_parser_tests.rs
@@ -162,6 +162,7 @@ fn varargs_parameters_can_be_parsed() {
             ],
         }],
         location: SourceRange::undefined(),
+        name_location: SourceRange::undefined(),
         poly_mode: None,
         generics: vec![],
         linkage: crate::ast::LinkageType::Internal,

--- a/src/parser/tests/misc_parser_tests.rs
+++ b/src/parser/tests/misc_parser_tests.rs
@@ -61,6 +61,7 @@ fn exponent_literals_parsed_as_variables() {
             }],
         }],
         location: SourceRange::undefined(),
+        name_location: SourceRange::undefined(),
         generics: vec![],
         linkage: crate::ast::LinkageType::Internal,
     };

--- a/src/validation/pou_validator.rs
+++ b/src/validation/pou_validator.rs
@@ -23,8 +23,9 @@ impl PouValidator {
         let return_type = context.index.find_return_type(&pou.name);
         // functions must have a return type
         if return_type.is_none() {
-            self.diagnostics
-                .push(Diagnostic::function_return_missing(pou.location.to_owned()));
+            self.diagnostics.push(Diagnostic::function_return_missing(
+                pou.name_location.to_owned(),
+            ));
         }
     }
 }

--- a/src/validation/tests.rs
+++ b/src/validation/tests.rs
@@ -1,10 +1,9 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 mod array_access_validation_test;
 mod bitaccess_validation_test;
-mod literals_validation_tests;
-mod reference_resolve_tests;
-mod variable_validation_tests;
-
-mod statement_validation_tests;
-
 mod generic_validation_tests;
+mod literals_validation_tests;
+mod pou_validation_tests;
+mod reference_resolve_tests;
+mod statement_validation_tests;
+mod variable_validation_tests;

--- a/src/validation/tests/pou_validation_tests.rs
+++ b/src/validation/tests/pou_validation_tests.rs
@@ -1,6 +1,5 @@
-use crate::{validation::tests::parse_and_validate, Diagnostic};
+use crate::{test_utils::tests::parse_and_validate, Diagnostic};
 
-// unsupported return types
 #[test]
 fn function_no_return_unsupported() {
     // GIVEN FUNCTION with no return type
@@ -9,6 +8,6 @@ fn function_no_return_unsupported() {
     // THEN there should be one diagnostic -> missing return type
     assert_eq!(
         diagnostics,
-        vec![Diagnostic::function_return_missing((0..43).into())]
+        vec![Diagnostic::function_return_missing((9..12).into())]
     );
 }


### PR DESCRIPTION
Functions with missing return types used to report a problem on the
whole POU (declaration and body). I added an additional location field
to the POU (AST) that stores the location of the POU's name so we can
report the error more nicely where it actually happened.

also activated dead test (pou_validation_tests)

resolves #491