### PR TITLE
generic function types can be determined by VAR_OUT

### DIFF
--- a/src/codegen/tests/generics_test.rs
+++ b/src/codegen/tests/generics_test.rs
@@ -31,3 +31,44 @@ fn generic_function_call_generates_real_type_call() {
 
     insta::assert_snapshot!(prg);
 }
+
+#[test]
+fn generic_output_parameter() {
+    // GIVEN ... (see comments in st-code)
+    let src = r"
+        // ... a generic function FOO with a T, defined by a VAR_OUT 
+        // parameter (which will be interally treated as a pointer)
+            FUNCTION foo <T: ANY_INT> : T
+                VAR_INPUT   in1 : DATE; END_VAR
+                VAR_OUTPUT  out1: T;    END_VAR
+            END_FUNCTION
+
+        // ...AND an implementatino for INT
+            FUNCTION foo__INT : INT
+                VAR_INPUT   in1 : DATE; END_VAR
+                VAR_OUTPUT  out1: INT;  END_VAR
+            END_FUNCTION
+
+        // ...AND an implementatino for BYTE
+            FUNCTION foo__BYTE : BYTE
+                VAR_INPUT   in1 : DATE; END_VAR
+                VAR_OUTPUT  out1: BYTE; END_VAR
+            END_FUNCTION
+
+        // ... AND a program calling foo with an INT-parameter
+            PROGRAM prg
+            VAR 
+                theInt, iResult : INT; 
+                theByte, bResult : BYTE; 
+                data : DATE;
+            END_VAR
+
+            iResult := foo(data, theInt);
+            bResult := foo(data, theByte);
+            END_VAR
+        ";
+
+    // THEN we expect a first call to foo__INT with out1 passed as a pointer
+    // AND we expect a second call to foo__BYTE with out1 passed as a pointer
+    insta::assert_snapshot!(codegen(src));
+}

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_output_parameter.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_output_parameter.snap
@@ -1,0 +1,51 @@
+---
+source: src/codegen/tests/generics_test.rs
+expression: codegen(src)
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%prg_interface = type { i16, i16, i8, i8, i64 }
+
+@prg_instance = global %prg_interface zeroinitializer
+
+define i16 @foo__INT(i64 %0, i16* %1) {
+entry:
+  %in1 = alloca i64, align 8
+  store i64 %0, i64* %in1, align 4
+  %out1 = alloca i16*, align 8
+  store i16* %1, i16** %out1, align 8
+  %foo__INT = alloca i16, align 2
+  store i16 0, i16* %foo__INT, align 2
+  %foo__INT_ret = load i16, i16* %foo__INT, align 2
+  ret i16 %foo__INT_ret
+}
+
+define i8 @foo__BYTE(i64 %0, i8* %1) {
+entry:
+  %in1 = alloca i64, align 8
+  store i64 %0, i64* %in1, align 4
+  %out1 = alloca i8*, align 8
+  store i8* %1, i8** %out1, align 8
+  %foo__BYTE = alloca i8, align 1
+  store i8 0, i8* %foo__BYTE, align 1
+  %foo__BYTE_ret = load i8, i8* %foo__BYTE, align 1
+  ret i8 %foo__BYTE_ret
+}
+
+define void @prg(%prg_interface* %0) {
+entry:
+  %theInt = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 0
+  %iResult = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 1
+  %theByte = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 2
+  %bResult = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 3
+  %data = getelementptr inbounds %prg_interface, %prg_interface* %0, i32 0, i32 4
+  %load_data = load i64, i64* %data, align 4
+  %call = call i16 @foo__INT(i64 %load_data, i16* %theInt)
+  store i16 %call, i16* %iResult, align 2
+  %load_data1 = load i64, i64* %data, align 4
+  %call2 = call i8 @foo__BYTE(i64 %load_data1, i8* %theByte)
+  store i8 %call2, i8* %bResult, align 1
+  ret void
+}
+

--- a/src/index.rs
+++ b/src/index.rs
@@ -522,14 +522,11 @@ impl PouIndexEntry {
                 instance_struct_name,
                 ..
             }
-            | PouIndexEntry::Function {
-                instance_struct_name,
-                ..
-            }
             | PouIndexEntry::Class {
                 instance_struct_name,
                 ..
             } => Some(instance_struct_name.as_str()),
+            _ => None, //functions have no struct type
         }
     }
 

--- a/src/resolver/tests/resolve_generic_calls.rs
+++ b/src/resolver/tests/resolve_generic_calls.rs
@@ -11,9 +11,11 @@ fn resolved_generic_call_added_to_index() {
     let (unit, index) = index(
         "
         FUNCTION myFunc<G: ANY_NUM> : G
-        VAR_INPUT
-            x : G;
-        END_VAR
+        VAR_INPUT   x : G;  END_VAR
+        END_FUNCTION
+
+        FUNCTION myFunc__BYTE : BYTE
+        VAR_INPUT   x : BYTE; END_VAR
         END_FUNCTION
 
         PROGRAM PRG
@@ -23,24 +25,23 @@ fn resolved_generic_call_added_to_index() {
             myFunc(x := a);
             myFunc(6);
             myFunc(1.0);
+            myFunc(BYTE#1);
         END_PROGRAM",
     );
     let (annotations, _) = TypeAnnotator::visit_unit(&index, &unit);
-    //The implementations are added to the index
+    // The implementations are added to the index
     let implementations = annotations.new_index.get_implementations();
-    dbg!(&annotations.new_index);
-    dbg!(&index);
     assert!(implementations.contains_key("myfunc__int"));
     assert!(implementations.contains_key("myfunc__dint"));
     assert!(implementations.contains_key("myfunc__real"));
-    assert_eq!(3, implementations.len());
+    assert_eq!(3, implementations.len()); //make sure BYTE-implementation was not added by the annotator
 
     //The pous are added to the index
-    let pous = annotations.new_index.get_pou_types();
+    let pous = annotations.new_index.get_pous();
     assert!(pous.contains_key("myfunc__int"));
     assert!(pous.contains_key("myfunc__dint"));
     assert!(pous.contains_key("myfunc__real"));
-    assert_eq!(3, pous.len());
+    assert_eq!(3, pous.len()); //make sure BYTE-implementation was not added by the annotator
 
     //Each POU has members
     assert_eq!(


### PR DESCRIPTION
VAR_OUTs used to confuse the resolver to find out what
real type T is, if T is defined by a VAR_OUT or VAR_INOUT
since its real type was no longer 'T' but rather 'POINTER TO
T'.

fixes #499