### PR TITLE
WSTRINGs assignment now use the full WSRTING size

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
 
   test-windows:
     name: Test Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: check
     env:
       toolchain-version: 1.60.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,3 +25,4 @@ vscode:
     - hbenl.vscode-test-explorer
     - Swellaby.vscode-rust-test-adapter
     - hbenl.test-adapter-converter
+    - revng.llvm-ir

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,3 +24,4 @@ vscode:
     - matklad.rust-analyzer
     - hbenl.vscode-test-explorer
     - Swellaby.vscode-rust-test-adapter
+    - hbenl.test-adapter-converter

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -2254,16 +2254,14 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             let align_right = right_type.get_alignment();
             //Multiply by the string alignment to copy enough for widestrings
             //This is done at compile time to avoid generating an extra mul
-            let size = self.llvm.context.i32_type().const_int((size * align_left as i64) as u64, true);
+            let size = self
+                .llvm
+                .context
+                .i32_type()
+                .const_int((size * align_left as i64) as u64, true);
             self.llvm
                 .builder
-                .build_memcpy(
-                    left,
-                    align_left,
-                    right,
-                    align_right,
-                    size,
-                )
+                .build_memcpy(left, align_left, right, align_right, size)
                 .map_err(|err| Diagnostic::codegen_error(err, right_statement.get_location()))?;
         } else {
             let expression = self.generate_expression(right_statement)?;

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_special_chars_in_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_special_chars_in_string.snap
@@ -1,8 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 507
 expression: result
-
 ---
 ; ModuleID = 'main'
 source_filename = "main"
@@ -26,9 +24,9 @@ entry:
   %2 = bitcast [81 x i8]* %should_not_replace_s to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %2, i8* align 1 getelementptr inbounds ([19 x i8], [19 x i8]* @utf08_literal_0, i32 0, i32 0), i32 19, i1 false)
   %3 = bitcast [81 x i16]* %should_replace_ws to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 bitcast ([41 x i16]* @utf16_literal_1 to i8*), i32 41, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 2 %3, i8* align 2 bitcast ([41 x i16]* @utf16_literal_1 to i8*), i32 82, i1 false)
   %4 = bitcast [81 x i16]* %should_not_replace_ws to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %4, i8* align 1 bitcast ([19 x i16]* @utf16_literal_0 to i8*), i32 19, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 2 %4, i8* align 2 bitcast ([19 x i16]* @utf16_literal_0 to i8*), i32 38, i1 false)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_string_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_string_assignment.snap
@@ -1,8 +1,6 @@
 ---
 source: src/codegen/tests/code_gen_tests.rs
-assertion_line: 484
 expression: result
-
 ---
 ; ModuleID = 'main'
 source_filename = "main"
@@ -20,7 +18,7 @@ entry:
   %1 = bitcast [81 x i8]* %y to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([12 x i8], [12 x i8]* @utf08_literal_0, i32 0, i32 0), i32 12, i1 false)
   %2 = bitcast [81 x i16]* %z to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %2, i8* align 1 bitcast ([18 x i16]* @utf16_literal_0 to i8*), i32 18, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 2 %2, i8* align 2 bitcast ([18 x i16]* @utf16_literal_0 to i8*), i32 36, i1 false)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_casted_string_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_casted_string_assignment.snap
@@ -1,8 +1,6 @@
 ---
 source: src/codegen/tests/string_tests.rs
-assertion_line: 75
 expression: result
-
 ---
 ; ModuleID = 'main'
 source_filename = "main"
@@ -24,7 +22,7 @@ entry:
   store [18 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 117, i16 116, i16 102, i16 49, i16 54, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0], [18 x i16]* %4, align 2
   %5 = bitcast [81 x i16]* %z to i8*
   %6 = bitcast [18 x i16]* %4 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %5, i8* align 1 %6, i32 80, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 2 %5, i8* align 2 %6, i32 160, i1 false)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_string_type_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_string_type_assignment.snap
@@ -1,8 +1,6 @@
 ---
 source: src/codegen/tests/string_tests.rs
-assertion_line: 119
 expression: result
-
 ---
 ; ModuleID = 'main'
 source_filename = "main"
@@ -24,7 +22,7 @@ entry:
   %2 = bitcast [100 x i8]* %z to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %2, i8* align 1 getelementptr inbounds ([17 x i8], [17 x i8]* @utf08_literal_1, i32 0, i32 0), i32 17, i1 false)
   %3 = bitcast [100 x i16]* %zz to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 bitcast ([17 x i16]* @utf16_literal_0 to i8*), i32 17, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 2 %3, i8* align 2 bitcast ([17 x i16]* @utf16_literal_0 to i8*), i32 34, i1 false)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_can_be_created.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_can_be_created.snap
@@ -1,8 +1,6 @@
 ---
 source: src/codegen/tests/string_tests.rs
-assertion_line: 138
 expression: result
-
 ---
 ; ModuleID = 'main'
 source_filename = "main"
@@ -24,7 +22,7 @@ entry:
   %1 = bitcast [16 x i8]* %y to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([12 x i8], [12 x i8]* @utf08_literal_0, i32 0, i32 0), i32 12, i1 false)
   %2 = bitcast [16 x i16]* %wy to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %2, i8* align 1 bitcast ([12 x i16]* @utf16_literal_0 to i8*), i32 12, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 2 %2, i8* align 2 bitcast ([12 x i16]* @utf16_literal_0 to i8*), i32 24, i1 false)
   ret void
 }
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_using_constants_can_be_created.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_using_constants_can_be_created.snap
@@ -24,7 +24,7 @@ entry:
   %1 = bitcast [16 x i8]* %y to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([12 x i8], [12 x i8]* @utf08_literal_0, i32 0, i32 0), i32 12, i1 false)
   %2 = bitcast [31 x i16]* %wy to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %2, i8* align 1 bitcast ([12 x i16]* @utf16_literal_0 to i8*), i32 12, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 2 %2, i8* align 2 bitcast ([12 x i16]* @utf16_literal_0 to i8*), i32 24, i1 false)
   ret void
 }
 

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -385,7 +385,7 @@ impl DataTypeInformation {
     pub fn get_alignment(&self) -> u32 {
         match self {
             DataTypeInformation::String { encoding, .. } if encoding == &StringEncoding::Utf8 => 1,
-            DataTypeInformation::String { encoding, .. } if encoding == &StringEncoding::Utf16 => 1,
+            DataTypeInformation::String { encoding, .. } if encoding == &StringEncoding::Utf16 => 2,
             _ => unimplemented!("Alignment for {}", self.get_name()),
         }
     }

--- a/tests/correctness/strings.rs
+++ b/tests/correctness/strings.rs
@@ -62,7 +62,7 @@ fn string_assignment_from_smaller_string() {
         PROGRAM main 
             VAR 
                 x : STRING[6]; y : STRING[5]; 
-                u : STRING[6]; v : STRING[5]; 
+                u : WSTRING[6]; v : WSTRING[5]; 
             END_VAR
             y := 'hello';
             x := y;
@@ -97,7 +97,7 @@ fn string_assignment_from_bigger_string() {
         PROGRAM main
             VAR 
                 x : STRING[4]; y : STRING[5];
-                u : STRING[4]; v : STRING[5]; 
+                u : WSTRING[4]; v : WSTRING[5]; 
             END_VAR
             y := 'hello';
             x := y;
@@ -107,6 +107,7 @@ fn string_assignment_from_bigger_string() {
     "#;
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 5],
         y: [u8; 6],
@@ -141,6 +142,7 @@ fn string_assignment_from_smaller_function() {
     ";
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 7],
     }
@@ -164,6 +166,7 @@ fn string_assignment_from_bigger_function() {
     ";
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 5],
     }
@@ -183,6 +186,7 @@ fn string_assignment_from_bigger_literal_do_not_leak() {
     ";
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 5],
         y: [u8; 5],
@@ -207,6 +211,7 @@ fn string_assignment_from_bigger_string_does_not_leak() {
     ";
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 5],
         y: [u8; 5],
@@ -248,6 +253,7 @@ fn string_parameter_assignment_in_functions_with_multiple_size2() {
     ";
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 21],
         y: [u8; 21],
@@ -283,6 +289,7 @@ fn string_assignment_from_bigger_function_does_not_leak() {
         END_PROGRAM
     ";
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 5],
         y: [u8; 5],

--- a/tests/correctness/strings.rs
+++ b/tests/correctness/strings.rs
@@ -23,7 +23,10 @@ fn string_assignment_from_smaller_literal() {
         x: [u8; 7],
         y: [u16; 7],
     }
-    let mut main_type = MainType { x: [0; 7], y : [0; 7] };
+    let mut main_type = MainType {
+        x: [0; 7],
+        y: [0; 7],
+    };
 
     let _: i32 = compile_and_run(src, &mut main_type);
     assert_eq!("hello\0\0".as_bytes(), &main_type.x);
@@ -49,7 +52,10 @@ fn string_assignment_from_bigger_literal() {
         x: [u8; 5],
         y: [u16; 5],
     }
-    let mut main_type = MainType { x: [0; 5], y: [0; 5] };
+    let mut main_type = MainType {
+        x: [0; 5],
+        y: [0; 5],
+    };
 
     let _: i32 = compile_and_run(src, &mut main_type);
     assert_eq!("hell\0".as_bytes(), &main_type.x);

--- a/tests/correctness/strings.rs
+++ b/tests/correctness/strings.rs
@@ -6,87 +6,123 @@ use std::ffi::CStr;
 
 #[test]
 fn string_assignment_from_smaller_literal() {
-    let src = "
+    let src = r#"
         PROGRAM main
-            VAR x : STRING[6]; END_VAR
+            VAR 
+                x : STRING[6]; 
+                y : WSTRING[6]; 
+            END_VAR
             x := 'hello';
+            y := "hello";
         END_PROGRAM
-    ";
+    "#;
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 7],
+        y: [u16; 7],
     }
-    let mut main_type = MainType { x: [0; 7] };
+    let mut main_type = MainType { x: [0; 7], y : [0; 7] };
 
     let _: i32 = compile_and_run(src, &mut main_type);
     assert_eq!("hello\0\0".as_bytes(), &main_type.x);
+    assert_eq!("hello", String::from_utf16_lossy(&main_type.y[..5]));
 }
 
 #[test]
 fn string_assignment_from_bigger_literal() {
-    let src = "
+    let src = r#"
         PROGRAM main
-            VAR x : STRING[4];END_VAR
+            VAR 
+                x : STRING[4];
+                y : WSTRING[4];
+            END_VAR
             x := 'hello';
+            y := "hello";
         END_PROGRAM
-    ";
+    "#;
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 5],
+        y: [u16; 5],
     }
-    let mut main_type = MainType { x: [0; 5] };
+    let mut main_type = MainType { x: [0; 5], y: [0; 5] };
 
     let _: i32 = compile_and_run(src, &mut main_type);
     assert_eq!("hell\0".as_bytes(), &main_type.x);
+    assert_eq!("hell", String::from_utf16_lossy(&main_type.y[..4]));
 }
+
 #[test]
 fn string_assignment_from_smaller_string() {
-    let src = "
+    let src = r#"
         PROGRAM main 
-            VAR x : STRING[6]; y : STRING[5]; END_VAR
+            VAR 
+                x : STRING[6]; y : STRING[5]; 
+                u : STRING[6]; v : STRING[5]; 
+            END_VAR
             y := 'hello';
             x := y;
+            v := "hello";
+            u := v;
         END_PROGRAM
-    ";
+    "#;
 
     #[allow(dead_code)]
+    #[repr(C)]
     struct MainType {
         x: [u8; 7],
         y: [u8; 6],
+        u: [u16; 7],
+        v: [u16; 6],
     }
     let mut main_type = MainType {
         x: [0; 7],
         y: [0; 6],
+        u: [0; 7],
+        v: [0; 6],
     };
 
     let _: i32 = compile_and_run(src, &mut main_type);
     assert_eq!("hello\0\0".as_bytes(), &main_type.x);
+    assert_eq!("hello", String::from_utf16_lossy(&main_type.u[..5]));
 }
 
 #[test]
 fn string_assignment_from_bigger_string() {
-    let src = "
+    let src = r#"
         PROGRAM main
-            VAR x : STRING[4]; y : STRING[5]; END_VAR
+            VAR 
+                x : STRING[4]; y : STRING[5];
+                u : STRING[4]; v : STRING[5]; 
+            END_VAR
             y := 'hello';
             x := y;
+            v := "hello";
+            u := v;
         END_PROGRAM
-    ";
+    "#;
 
     #[allow(dead_code)]
     struct MainType {
         x: [u8; 5],
         y: [u8; 6],
+        u: [u16; 5],
+        v: [u16; 6],
     }
     let mut main_type = MainType {
         x: [0; 5],
         y: [0; 6],
+        u: [0; 5],
+        v: [0; 6],
     };
 
     let _: i32 = compile_and_run(src, &mut main_type);
     assert_eq!("hell\0".as_bytes(), &main_type.x);
+    assert_eq!("hell", String::from_utf16_lossy(&main_type.u[..4]));
 }
 
 #[test]


### PR DESCRIPTION
When `memcpy`ing WSTINGS the size is now doubled as the memcpy is always resulting in an i8 copy
I added correctness tests to make sure WSTRINGS are assigned correctly.
I also fixed the windows build
Fixes #502 