### PR TITLE
Add init tasks for gitpod to run a cargo build

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,6 @@ vscode:
     - llvm-vs-code-extensions.vscode-clangd
     - vadimcn.vscode-lldb
     - matklad.rust-analyzer
-    - revng.llvm-ir
 tasks:
   - name: Run build and watch
     init: cargo build --tests

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,8 @@ vscode:
     - llvm-vs-code-extensions.vscode-clangd
     - vadimcn.vscode-lldb
     - matklad.rust-analyzer
-    - hbenl.vscode-test-explorer
-    - Swellaby.vscode-rust-test-adapter
-    - hbenl.test-adapter-converter
     - revng.llvm-ir
+tasks:
+  - name: Run build and watch
+    init: cargo build --tests
+    command: cargo watch -x 'test'


### PR DESCRIPTION
The prebuild should now also have a compiled version of rusty
Meaning subsequent builds should be faster.

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/503"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

