### PR TITLE
Use dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,11 +79,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.toolchain-version }}
-          profile: minimal
-          override: true
 
       - name: Install LLVM
         uses: ghaith/install-llvm-action@latest


### PR DESCRIPTION
The original toolchain is unmaintained, see https://github.com/actions-rs/toolchain/issues/216

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/521"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

