### PR TITLE
Make sure the private variable validator allows actions

### DIFF
--- a/src/validation/stmt_validator.rs
+++ b/src/validation/stmt_validator.rs
@@ -381,7 +381,11 @@ impl StatementValidator {
             if variable_type.is_private()
                 && context
                     .qualifier
-                    .map_or(false, |q| !qualified_name.starts_with(q))
+                    .and_then(|it| context.index.find_pou(it)) //Get the container pou (for actions this is the program/fb)
+                    .map(|it| (it.get_name(), it.get_container()))
+                    .map_or(false, |(it, container)| {
+                        !qualified_name.starts_with(it) && !qualified_name.starts_with(container)
+                    })
             {
                 self.diagnostics.push(Diagnostic::illegal_access(
                     qualified_name.as_str(),

--- a/src/validation/tests/reference_resolve_tests.rs
+++ b/src/validation/tests/reference_resolve_tests.rs
@@ -298,3 +298,23 @@ fn reference_to_private_variable_in_intermediate_fb() {
         vec![Diagnostic::illegal_access("fb1.f", (413..414).into()),]
     );
 }
+
+#[test]
+fn program_vars_are_allowed_in_their_actions() {
+    let diagnostics = parse_and_validate(
+        "
+            PROGRAM prg
+                VAR 
+                    s : INT;
+                END_VAR
+            END_PROGRAM
+
+            ACTION prg.foo
+                prg.s := 7;
+                s := 7;
+            END_ACTION
+       ",
+    );
+
+    assert_eq!(diagnostics, vec![]);
+}


### PR DESCRIPTION
The validator now looks at container names when validating

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/526"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

