### PR TITLE
Generics passed by referenced can be resolved

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -305,7 +305,7 @@ mod cli_tests {
     where
         T: Debug + AsRef<OsStr>,
     {
-        let params = CompileParameters::parse(&args);
+        let params = CompileParameters::parse(args);
         match params {
             Err(e) => {
                 assert_eq!(e.kind(), expected_error_kind);

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -329,7 +329,7 @@ impl AstAnnotations {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AnnotationMapImpl {
     /// maps a statement to the type it resolves to
     type_map: IndexMap<AstId, StatementAnnotation>,

--- a/src/resolver/generics.rs
+++ b/src/resolver/generics.rs
@@ -186,6 +186,9 @@ impl<'i> TypeAnnotator<'i> {
                 inner_type_name,
                 auto_deref: true,
             }) => {
+                // This is an auto deref pointer (VAR_IN_OUT or VAR_INPUT {ref}) that points to a
+                // generic. We first resolve the generic type, then create a new pointer type of
+                // the combination
                 let inner_type_name = self.find_or_create_datatype(inner_type_name, generics);
                 let name = format!("{name}__{inner_type_name}");
                 let new_type_info = DataTypeInformation::Pointer {
@@ -194,6 +197,7 @@ impl<'i> TypeAnnotator<'i> {
                     auto_deref: true,
                 };
 
+                // Registers a new pointer type to the index
                 self.annotation_map.new_index.register_type(DataType {
                     information: new_type_info,
                     initial_value: None,

--- a/src/resolver/generics.rs
+++ b/src/resolver/generics.rs
@@ -5,7 +5,7 @@ use crate::{
     builtins,
     index::{Index, PouIndexEntry, VariableIndexEntry},
     resolver::AnnotationMap,
-    typesystem::{self, DataTypeInformation},
+    typesystem::{self, DataTypeInformation, DataType},
 };
 
 use super::{AnnotationMapImpl, StatementAnnotation, TypeAnnotator, VisitorContext};
@@ -153,29 +153,52 @@ impl<'i> TypeAnnotator<'i> {
                 self.index.get_members(generic_function.get_name())
             {
                 for (_, member) in generic_function_members {
-                    let new_type_name =
-                        if let Some(DataTypeInformation::Generic { generic_symbol, .. }) =
-                            self.index.find_effective_type_info(member.get_type_name())
-                        {
-                            // this is a generic member, so lets see what it's generic symbol is and translate it
-                            generics
-                                .get(generic_symbol)
-                                .map(String::as_str)
-                                .unwrap_or_else(|| member.get_type_name())
-                        } else {
-                            // not a generic member, just use the original type
-                            member.get_type_name()
-                        };
+                    let new_type_name = self.find_or_create_datatype(member.get_type_name(), generics);
 
                     //register the member under the new container (old: foo__T, new: foo__INT)
                     //with its new type-name (old: T, new: INT)
-                    let entry = member.into_typed(new_name, new_type_name);
+                    let entry = member.into_typed(new_name, &new_type_name);
                     self.annotation_map
                         .new_index
                         .register_member_entry(new_name, entry);
                 }
             }
         }
+    }
+
+    fn find_or_create_datatype(&mut self, member_name: &str, generics: &HashMap<String, String>) -> String {
+        match self.index.find_effective_type_info(member_name) {
+                Some(DataTypeInformation::Generic { generic_symbol, .. }) => {
+                    // this is a generic member, so lets see what it's generic symbol is and translate it
+                    generics
+                        .get(generic_symbol)
+                        .map(String::as_str)
+                        .unwrap_or_else(|| member_name)
+                        .to_string()
+                },
+                Some(DataTypeInformation::Pointer {name, inner_type_name, auto_deref: true}) => {
+                    let inner_type_name = self.find_or_create_datatype(inner_type_name, generics);
+                    let name = format!("{name}__{inner_type_name}");
+                    let new_type_info = DataTypeInformation::Pointer { 
+                        name : name.clone(), 
+                        inner_type_name, 
+                        auto_deref: true 
+                    };
+
+                    self.annotation_map.new_index.register_type(DataType {
+                        information: new_type_info,
+                        initial_value: None,
+                        name: name.clone(),
+                        nature: TypeNature::Any,
+                    });
+
+                    name
+                },
+                _ => {
+                            // not a generic member, just use the original type
+                            member_name.to_string()
+                }
+            }
     }
 
     fn update_generic_function_parameters(

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -18,7 +18,7 @@ macro_rules! assert_type_and_hint {
     ($annotations:expr, $index:expr, $stmt:expr, $expected_type:expr, $expected_type_hint:expr) => {
         assert_eq!(
             (
-                crate::resolver::AnnotationMap::get_type($annotations, $stmt, $index),
+                $crate::resolver::AnnotationMap::get_type($annotations, $stmt, $index),
                 crate::resolver::AnnotationMap::get_type_hint($annotations, $stmt, $index),
             ),
             (

--- a/src/resolver/tests/resolve_generic_calls.rs
+++ b/src/resolver/tests/resolve_generic_calls.rs
@@ -2,8 +2,11 @@ use crate::{
     assert_type_and_hint,
     ast::{self, flatten_expression_list, AstStatement},
     resolver::{AnnotationMap, TypeAnnotator},
-    test_utils::tests::{index, annotate},
-    typesystem::{BYTE_TYPE, DINT_TYPE, INT_TYPE, LREAL_TYPE, LWORD_TYPE, REAL_TYPE, SINT_TYPE, STRING_TYPE, DataTypeInformation}, index::VariableIndexEntry,
+    test_utils::tests::{annotate, index},
+    typesystem::{
+        DataTypeInformation, BYTE_TYPE, DINT_TYPE, INT_TYPE, LREAL_TYPE, LWORD_TYPE, REAL_TYPE,
+        SINT_TYPE, STRING_TYPE,
+    },
 };
 
 #[test]
@@ -738,17 +741,24 @@ fn auto_pointer_of_generic_resolved() {
         END_VAR
             LEFT_EXT(IN);
         END_FUNCTION
-        "
+        ",
     );
 
     annotate(&unit, &mut index);
-   
+
     let member = index.find_member("LEFT_EXT__DINT", "IN").unwrap();
-    let dt = index.find_effective_type_info(&member.data_type_name).unwrap();
-    if let DataTypeInformation::Pointer { inner_type_name, auto_deref: true, ..} = dt {
+    let dt = index
+        .find_effective_type_info(&member.data_type_name)
+        .unwrap();
+    if let DataTypeInformation::Pointer {
+        inner_type_name,
+        auto_deref: true,
+        ..
+    } = dt
+    {
         assert_eq!(inner_type_name, "DINT")
     } else {
-        panic!("Expecting a pointer to dint, found {:?}",dt)
+        panic!("Expecting a pointer to dint, found {:?}", dt)
     }
 }
 
@@ -773,17 +783,16 @@ fn string_ref_as_generic_resolved() {
         END_VAR
             LEFT_EXT(IN);
         END_FUNCTION
-        "
+        ",
     );
 
     let annotations = annotate(&unit, &mut index);
-   
+
     let call_statement = &unit.implementations[2].statements[0];
 
-    if let AstStatement::CallStatement { parameters, ..} = call_statement {
+    if let AstStatement::CallStatement { parameters, .. } = call_statement {
         let parameters = flatten_expression_list(parameters.as_ref().as_ref().unwrap());
 
-        
         assert_type_and_hint!(
             &annotations,
             &index,
@@ -794,21 +803,21 @@ fn string_ref_as_generic_resolved() {
     } else {
         unreachable!("Should be a call statement")
     }
-    
-    assert_type_and_hint!(
-        &annotations,
-        &index,
-        call_statement,
-        DINT_TYPE,
-        None
-    );
+
+    assert_type_and_hint!(&annotations, &index, call_statement, DINT_TYPE, None);
 
     let member = index.find_member("LEFT_EXT__STRING", "IN").unwrap();
-    let dt = index.find_effective_type_info(&member.data_type_name).unwrap();
-    if let DataTypeInformation::Pointer { inner_type_name, auto_deref: true, ..} = dt {
-        assert_eq!(inner_type_name, "__LEFT__STRING_IN")
+    let dt = index
+        .find_effective_type_info(&member.data_type_name)
+        .unwrap();
+    if let DataTypeInformation::Pointer {
+        inner_type_name,
+        auto_deref: true,
+        ..
+    } = dt
+    {
+        assert_eq!(inner_type_name, STRING_TYPE)
     } else {
-        panic!("Expecting auto deref pointer to string, found {:?}",dt)
+        panic!("Expecting auto deref pointer to string, found {:?}", dt)
     }
-
-} 
+}

--- a/tests/correctness/generic_functions.rs
+++ b/tests/correctness/generic_functions.rs
@@ -105,3 +105,39 @@ fn test_generic_function_implemented_in_st_called() {
     assert_eq!(main_type.a, 200);
     assert_eq!(main_type.b, 5.0f32);
 }
+
+
+#[allow(dead_code)]
+#[repr(C)]
+struct MainType2 {
+    s: [u8; 6],
+}
+
+#[test]
+fn test_generic_function_with_param_by_ref_called() {
+    //Given some external function.
+    let prog = "
+    FUNCTION LEFT <T: ANY_STRING> : T
+    VAR_INPUT {ref}
+        IN : T;
+    END_VAR
+    END_FUNCTION
+
+    FUNCTION LEFT_EXT<T: ANY_STRING> : DINT
+    VAR_INPUT {ref}
+        IN : T;
+    END_VAR
+    END_FUNCTION
+
+    FUNCTION LEFT__STRING : STRING 
+    VAR_INPUT
+        IN : STRING;
+    END_VAR
+        LEFT_EXT(IN);
+    END_FUNCTION
+    ";
+
+    let mut main_type = MainType2 { s: *b"hello\0" };
+    let _: i32 = compile_and_run(prog.to_string(), &mut main_type);
+    assert_eq!(main_type.s, *b"hello\0");
+}

--- a/tests/correctness/generic_functions.rs
+++ b/tests/correctness/generic_functions.rs
@@ -1,3 +1,5 @@
+use std::ffi::CStr;
+
 use super::super::*;
 use inkwell::targets::{InitializationConfig, Target};
 
@@ -106,11 +108,22 @@ fn test_generic_function_implemented_in_st_called() {
     assert_eq!(main_type.b, 5.0f32);
 }
 
-
 #[allow(dead_code)]
 #[repr(C)]
 struct MainType2 {
     s: [u8; 6],
+}
+
+#[allow(non_snake_case, dead_code)]
+unsafe extern "C" fn left_ext__string(in_param: *const u8, out: *mut u8) -> i32 {
+    let mut in_param = in_param;
+    let mut out = out;
+    while *in_param != 0 {
+        *out = *in_param;
+        out = out.add(1);
+        in_param = in_param.add(1)
+    }
+    0
 }
 
 #[test]
@@ -135,9 +148,40 @@ fn test_generic_function_with_param_by_ref_called() {
     END_VAR
         LEFT_EXT(IN);
     END_FUNCTION
+
+    PROGRAM main 
+    VAR
+    END_VAR
+    END_PROGRAM
     ";
 
+    Target::initialize_native(&InitializationConfig::default()).unwrap();
+    let context: Context = Context::create();
+    let source = SourceCode {
+        path: "external_test.st".to_string(),
+        source: prog.to_string(),
+    };
+    let (_, code_gen) = compile_module(
+        &context,
+        vec![source],
+        vec![],
+        None,
+        Diagnostician::default(),
+    )
+    .unwrap();
+    let exec_engine = code_gen
+        .module
+        .create_jit_execution_engine(inkwell::OptimizationLevel::None)
+        .unwrap();
+
+    let fn_value = code_gen.module.get_function("LEFT_EXT__STRING").unwrap();
+    exec_engine.add_global_mapping(&fn_value, left_ext__string as usize);
+
     let mut main_type = MainType2 { s: *b"hello\0" };
-    let _: i32 = compile_and_run(prog.to_string(), &mut main_type);
-    assert_eq!(main_type.s, *b"hello\0");
+    let _: i32 = run(&exec_engine, "main", &mut main_type);
+    let result = CStr::from_bytes_with_nul(&main_type.s)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(result, "hello");
 }


### PR DESCRIPTION
Generic functions with by ref variables like VAR_IN_OUT or VAR_INPUT {ref} were failing to generate.
This was due to pointers not being recreated in the new types

This change fixes that behaviour and adds tests for different by ref cases.

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/543"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

