### PR TITLE
Fix the linking issues when the path is relative

### DIFF
--- a/book/src/build_and_install.md
+++ b/book/src/build_and_install.md
@@ -4,21 +4,21 @@
 To be able to build the source code, you will need to [install Rust](https://www.rust-lang.org/tools/install)
 and the following dependencies:
 * the usual **standard build tools** (aka `build-essential`)
-* **LLVM 12**: On Ubuntu, the package manager version of LLVM (e.g. `llvm-12-dev`, `liblld-12-dev`) will work fine,
-on debian you'll need to add additional repository sources (`deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-12 main`), since Debian 11 (latest) only includes LLVM packages up to version 11. For Windows, you need a
-[special build](https://github.com/PLC-lang/llvm-package-windows/releases/tag/v12.0.1).
+* **LLVM 13**: On Ubuntu, the package manager version of LLVM (e.g. `llvm-13-dev`, `liblld-13-dev`) will work fine,
+on debian you'll need to add additional repository sources (`deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main`), since Debian 11 (latest) only includes LLVM packages up to version 11. For Windows, you need a
+[special build](https://github.com/PLC-lang/llvm-package-windows/releases/tag/v13.0.0).
 * **zlib** (apt: `libz-dev`)
-* **Polly** in the form of a static library (included in apt package `libclang-common-12-dev`). Alternatively,
+* **Polly** in the form of a static library (included in apt package `libclang-common-13-dev`). Alternatively,
 building LLVM from source should also provide you with that file. Building from source may take a while, though.
 * If you want to clone and work on the repository, you'll also need **git**.
 
 ### Tips for troubleshooting
 * Because of weak compatibility guarantees of the LLVM API, the LLVM installation must exactly match the
-major version of the `llvm-sys` crate. Currently you will need to install LLVM 12 to satisfy this constraint.
+major version of the `llvm-sys` crate. Currently you will need to install LLVM 13 to satisfy this constraint.
 [Read more](https://crates.io/crates/llvm-sys)
 * To avoid installation conflicts on Linux/Ubuntu, make sure you don't have a default installation available
 (like you get by just installing `llvm-dev`), which may break things. If you do, make sure you have set
-the appropriate environment variable (`LLVM_SYS_120_PREFIX=/usr/lib/llvm-12` for LLVM 12), so
+the appropriate environment variable (`LLVM_SYS_130_PREFIX=/usr/lib/llvm-13` for LLVM 13), so
 the build of the `llvm-sys` crate knows what files to grab.
 
 ## Cloning the repository

--- a/book/src/using_rusty/build_description_file.md
+++ b/book/src/using_rusty/build_description_file.md
@@ -49,15 +49,6 @@ Similarly to specifying an output file via the `-o` or `--output` option, in the
 
 
 ## Optional Keys
-### sysroot
-
-`rustyc` is using the `sysroot` key for linking purposes. It is considered to be the root directory for the purpose of locating headers and libraries.
-
-
-### target
-
-To build and compile [structured text](https://en.wikipedia.org/wiki/Structured_text) for the rigth platform we need to specify the `target`. As `rustyc` is using [LLVM](https://en.wikipedia.org/wiki/LLVM) a target-tripple supported by LLVM needs to be selected. The default `target` is the host machine's target. So if a dev container on an `x86_64-docker` is used the target is `x86_64-linux-gnu`.
-
 
 ### compile_type
 There are six options for choosing the `compile_type`. The valid options are:

--- a/examples/hello_world.st
+++ b/examples/hello_world.st
@@ -1,16 +1,10 @@
-@EXTERNAL FUNCTION puts : DINT
-VAR_INPUT
+{external} 
+FUNCTION puts : DINT
+VAR_INPUT {ref}
     text : STRING;
 END_VAR
 END_FUNCTION
 
-@EXTERNAL FUNCTION exit : DINT
-VAR_INPUT
-    status : DINT;
-END_VAR
-END_FUNCTION
-
-FUNCTION _start : DINT
-	puts('hello, world!');
-    exit(0);
+FUNCTION main : DINT
+	puts('hello, world!$N');
 END_FUNCTION

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -253,8 +253,11 @@ impl CompileParameters {
             Some(FormatOption::Static)
         } else if self.output_reloc_code {
             Some(FormatOption::Relocatable)
-        } else {
+        } else if self.check_only {
             None
+        } else {
+            //Keep the paramete default as static
+            Some(FormatOption::Static)
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -489,10 +489,7 @@ mod cli_tests {
 
         let parameters =
             CompileParameters::parse(vec_of_strings!("examples/test/echo.st")).unwrap();
-        assert_eq!(
-            parameters.output_format_or_default(),
-            FormatOption::default()
-        );
+        assert_eq!(parameters.output_format_or_default(), FormatOption::Static);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ impl FromStr for ConfigFormat {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct CompileOptions {
     pub format: FormatOption,
     pub build_location: Option<PathBuf>,
@@ -187,7 +187,7 @@ pub struct CompileOptions {
     pub error_format: ErrorFormat,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct LinkOptions {
     pub libraries: Vec<String>,
     pub library_pathes: Vec<String>,
@@ -898,6 +898,7 @@ fn copy_libs_to_build(libraries: &[Libraries], lib_location: &Path) -> Result<()
 /// Links any provided libraries
 /// Returns the location of the output file
 pub fn build_with_params(parameters: CompileParameters) -> Result<(), Diagnostic> {
+    dbg!(&parameters);
     let format = parameters.output_format_or_default();
     let output = parameters.output_name();
 
@@ -984,6 +985,9 @@ pub fn build_and_link(
     config_options: Option<ConfigurationOptions>,
     link_options: Option<LinkOptions>,
 ) -> Result<(), Diagnostic> {
+    dbg!(&files);
+    dbg!(&compile_options);
+    dbg!(&link_options);
     //Split files in objects and sources
     let mut objects = vec![];
     let mut sources = vec![];
@@ -1128,7 +1132,10 @@ pub fn link(
             .and_then(|triple| linker::Linker::new(triple, linker).map_err(|e| e.into()))?;
         linker.add_lib_path(".");
         if let Some(parent) = output.parent() {
-            linker.add_lib_path(&parent.to_string_lossy());
+            let parent = parent.to_string_lossy();
+            if !parent.is_empty() {
+                linker.add_lib_path(&parent);
+            }
         }
 
         for path in objects {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,7 +898,6 @@ fn copy_libs_to_build(libraries: &[Libraries], lib_location: &Path) -> Result<()
 /// Links any provided libraries
 /// Returns the location of the output file
 pub fn build_with_params(parameters: CompileParameters) -> Result<(), Diagnostic> {
-    dbg!(&parameters);
     let format = parameters.output_format_or_default();
     let output = parameters.output_name();
 
@@ -985,9 +984,6 @@ pub fn build_and_link(
     config_options: Option<ConfigurationOptions>,
     link_options: Option<LinkOptions>,
 ) -> Result<(), Diagnostic> {
-    dbg!(&files);
-    dbg!(&compile_options);
-    dbg!(&link_options);
     //Split files in objects and sources
     let mut objects = vec![];
     let mut sources = vec![];

--- a/tests/integration/data/linking/relative.st
+++ b/tests/integration/data/linking/relative.st
@@ -1,0 +1,2 @@
+FUNCTION relative : DINT
+END_FUNCTION

--- a/tests/integration/linking.rs
+++ b/tests/integration/linking.rs
@@ -298,3 +298,42 @@ fn link_missing_file() {
     //Delete it
     fs::remove_file(&out).unwrap();
 }
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "linker is not available for windows")]
+//This is a regression, see #548
+fn link_to_a_relative_location_with_no_parent() {
+    let file1 = FilePath {
+        path: get_test_file("linking/relative.st"),
+    };
+
+    //Compile file1 as shared object with file2 as param
+    build_and_link(
+        vec![file1],
+        vec![],
+        None,
+        &CompileOptions {
+            build_location: None,
+            output: "output.o".into(),
+            format: FormatOption::Static,
+            optimization: rusty::OptimizationLevel::Default,
+            error_format: ErrorFormat::Rich,
+        },
+        vec![],
+        None,
+        Some(LinkOptions {
+            libraries: vec![],
+            library_pathes: vec![],
+            format: FormatOption::Static,
+            linker: None,
+        }),
+    )
+    .unwrap();
+
+    //Make sure the file exists in the test location
+    let res = std::path::Path::new("output.o");
+    assert!(res.exists());
+
+    //Delete it
+    fs::remove_file(&res).unwrap();
+}


### PR DESCRIPTION
Fixes #548  and #551 

The linker will no longer try to add an empty parent directory to the
linked directory (`-L`)
The cc linker will now output its results to stdio/stderr and return an
error if the compilation fails
Updated the hello_world documentation
Update the documentation to mention llvm13 instead of 12 for
installation
Add information about target and sysroots in the build

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/552"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

