### PR TITLE
allow trailing comma in expression lists

### DIFF
--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -63,7 +63,7 @@ pub fn parse_expression_list(lexer: &mut ParseSession) -> AstStatement {
             }
         }
         // we may have parsed no additional expression because of trailing comma
-        if expressions.is_empty() {
+        if !expressions.is_empty() {
             expressions.insert(0, left);
             return AstStatement::ExpressionList {
                 expressions,

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -54,16 +54,22 @@ pub fn parse_expression(lexer: &mut ParseSession) -> AstStatement {
 pub fn parse_expression_list(lexer: &mut ParseSession) -> AstStatement {
     let left = parse_range_statement(lexer);
     if lexer.token == KeywordComma {
-        let mut expressions = vec![left];
+        let mut expressions = vec![];
         // this starts an expression list
         while lexer.token == KeywordComma {
             lexer.advance();
-            expressions.push(parse_range_statement(lexer));
+            if !lexer.closes_open_region(&lexer.token) {
+                expressions.push(parse_range_statement(lexer));
+            }
         }
-        return AstStatement::ExpressionList {
-            expressions,
-            id: lexer.next_id(),
-        };
+        // we may have parsed no additional expression because of trailing comma
+        if expressions.is_empty() {
+            expressions.insert(0, left);
+            return AstStatement::ExpressionList {
+                expressions,
+                id: lexer.next_id(),
+            };
+        }
     }
     left
 }

--- a/src/parser/tests/control_parser_tests.rs
+++ b/src/parser/tests/control_parser_tests.rs
@@ -507,6 +507,45 @@ fn case_statement_with_one_condition() {
 }
 
 #[test]
+fn case_statement_with_one_condition_with_trailling_comma() {
+    let src = "
+        PROGRAM exp 
+        CASE StateMachine OF
+        1,: x;
+        END_CASE
+        END_PROGRAM
+        ";
+    let (result, diagnostics) = parse(src);
+
+    assert_eq!(diagnostics, vec![]);
+
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    let ast_string = format!("{:#?}", statement);
+    let expected_ast = r#"CaseStatement {
+    selector: Reference {
+        name: "StateMachine",
+    },
+    case_blocks: [
+        ConditionalBlock {
+            condition: LiteralInteger {
+                value: 1,
+            },
+            body: [
+                Reference {
+                    name: "x",
+                },
+            ],
+        },
+    ],
+    else_block: [],
+}"#;
+
+    assert_eq!(ast_string, expected_ast);
+}
+
+#[test]
 fn case_statement_with_else_and_no_condition() {
     let src = "
         PROGRAM exp 

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -2122,6 +2122,45 @@ fn function_call_params() {
 }
 
 #[test]
+fn function_call_params_with_trailling_comma() {
+    let src = "
+    PROGRAM prg
+    fn(1,2,3,);
+    END_PROGRAM
+    ";
+    let (parse_result, diagnostics) = parse(src);
+
+    assert_eq!(diagnostics, vec![]);
+
+    let statement = &parse_result.implementations[0].statements[0];
+
+    let ast_string = format!("{:#?}", statement);
+
+    let expected_ast = r#"CallStatement {
+    operator: Reference {
+        name: "fn",
+    },
+    parameters: Some(
+        ExpressionList {
+            expressions: [
+                LiteralInteger {
+                    value: 1,
+                },
+                LiteralInteger {
+                    value: 2,
+                },
+                LiteralInteger {
+                    value: 3,
+                },
+            ],
+        },
+    ),
+}"#;
+
+    assert_eq!(ast_string, expected_ast);
+}
+
+#[test]
 fn string_can_be_parsed() {
     let src = "PROGRAM buz VAR x : STRING; END_VAR x := 'Hello, World!'; x := ''; END_PROGRAM";
     let result = parse(src).0;


### PR DESCRIPTION
call parameters and case-statements may have trailing commas that made the parser stumble.

example: `foo(1,2,3,);` or
```
CASE x OF
1,2,3,: ...
```

fixes #579

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/583"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

