### PR TITLE
adds correctness test for aliased ranged number comparison

### DIFF
--- a/tests/correctness/expressions.rs
+++ b/tests/correctness/expressions.rs
@@ -257,3 +257,42 @@ fn amp_as_and_correctness_test() {
     let _: i32 = compile_and_run(function, &mut main);
     assert_eq!([true, true], [main.d, main.e]);
 }
+
+#[test]
+fn aliased_ranged_numbers_can_be_compared() {
+    #[derive(Default)]
+    #[repr(C)]
+    struct Main {
+        a: bool,
+        b: bool,
+        c: bool,
+        d: bool,
+        e: bool,
+        f: bool,
+    }
+
+    let mut main = Main::default();
+
+    let src = r#"
+    TYPE MyInt: INT(0..500); END_TYPE
+    PROGRAM main
+    VAR 
+        a, b, c, d, e, f : BOOL;
+    END_VAR      
+    VAR_TEMP
+        x,y : MyInt;
+    END_VAR
+        a := x < y;
+        b := y <= 0;
+        c := x = 3;
+        d := y = 500;
+        e := x >= 0 AND x <= 500;
+        f := x < 0 OR x > 500;
+    END_PROGRAM
+    "#;
+    let _: i32 = compile_and_run(src, &mut main);
+    assert_eq!(
+        [main.a, main.b, main.c, main.d, main.e, main.f],
+        [false, true, false, false, true, false]
+    );
+}


### PR DESCRIPTION
Issue seems to be fixed already. Are there any other tests we should do? 

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/596"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

