### PR TITLE
586 custom aliased int types cannot be compared

### DIFF
--- a/src/validation/stmt_validator.rs
+++ b/src/validation/stmt_validator.rs
@@ -551,19 +551,8 @@ impl StatementValidator {
             .get_type_or_void(right, context.index)
             .get_type_information();
 
-        // if the type is a subrange type, use referenced type to check if it is numerical
-        let is_numerical = if let DataTypeInformation::SubRange {
-            referenced_type, ..
-        } = left_type
-        {
-            context
-                .index
-                .find_effective_type_info(referenced_type)
-                .unwrap_or(left_type)
-        } else {
-            left_type
-        }
-        .is_numerical();
+        // if the type is a subrange, check if the intrinsic type is numerical
+        let is_numerical = context.index.find_intrinsic_type(left_type).is_numerical();
 
         if std::mem::discriminant(left_type) == std::mem::discriminant(right_type)
             && !(is_numerical || left_type.is_pointer())

--- a/src/validation/stmt_validator.rs
+++ b/src/validation/stmt_validator.rs
@@ -551,8 +551,22 @@ impl StatementValidator {
             .get_type_or_void(right, context.index)
             .get_type_information();
 
+        // if the type is a subrange type, use referenced type to check if it is numerical
+        let is_numerical = if let DataTypeInformation::SubRange {
+            referenced_type, ..
+        } = left_type
+        {
+            context
+                .index
+                .find_effective_type_info(referenced_type)
+                .unwrap_or(left_type)
+        } else {
+            left_type
+        }
+        .is_numerical();
+
         if std::mem::discriminant(left_type) == std::mem::discriminant(right_type)
-            && !(left_type.is_numerical() || left_type.is_pointer())
+            && !(is_numerical || left_type.is_pointer())
         {
             //see if we have the right compare-function (non-numbers are compared using user-defined callback-functions)
             if operator.is_comparison_operator()

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -492,3 +492,58 @@ fn switch_case_duplicate_integer() {
         ]
     );
 }
+
+#[test]
+fn subrange_compare_function_causes_no_error() {
+    // GIVEN switch case with duplicate constant conditions
+    // WHEN it is validated
+    let diagnostics = parse_and_validate(
+        r#"
+        PROGRAM main
+        VAR 
+            a, b, c, d, e, f : BOOL;
+        END_VAR      
+        VAR_TEMP
+            x,y : INT(0..500);
+        END_VAR
+            a := x < y;
+            b := x = y;
+            c := x = 3;
+            d := y = 500;
+            e := x >= 0 AND x <= 500;
+            f := x < 0 OR x > 500;
+        END_PROGRAM
+        "#,
+    );
+
+    // THEN the non constant variables are reported
+    assert_eq!(diagnostics, vec![]);
+}
+
+#[test]
+fn aliased_subrange_compare_function_causes_no_error() {
+    // GIVEN switch case with duplicate constant conditions
+    // WHEN it is validated
+    let diagnostics = parse_and_validate(
+        r#"
+        TYPE MyInt: INT(0..500); END_TYPE
+        PROGRAM main
+        VAR 
+            a, b, c, d, e, f : BOOL;
+        END_VAR      
+        VAR_TEMP
+            x,y : MyInt;
+        END_VAR
+            a := x < y;
+            b := x = y;
+            c := x = 3;
+            d := y = 500;
+            e := x >= 0 AND x <= 500;
+            f := x < 0 OR x > 500;
+        END_PROGRAM
+        "#,
+    );
+
+    // THEN the non constant variables are reported
+    assert_eq!(diagnostics, vec![]);
+}

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -495,7 +495,7 @@ fn switch_case_duplicate_integer() {
 
 #[test]
 fn subrange_compare_function_causes_no_error() {
-    // GIVEN switch case with duplicate constant conditions
+    // GIVEN comparison of subranges
     // WHEN it is validated
     let diagnostics = parse_and_validate(
         r#"
@@ -516,13 +516,13 @@ fn subrange_compare_function_causes_no_error() {
         "#,
     );
 
-    // THEN the non constant variables are reported
+    // THEN the validator does not throw an error
     assert_eq!(diagnostics, vec![]);
 }
 
 #[test]
 fn aliased_subrange_compare_function_causes_no_error() {
-    // GIVEN switch case with duplicate constant conditions
+    // GIVEN comparison of aliased subranges
     // WHEN it is validated
     let diagnostics = parse_and_validate(
         r#"
@@ -544,6 +544,34 @@ fn aliased_subrange_compare_function_causes_no_error() {
         "#,
     );
 
-    // THEN the non constant variables are reported
+    // THEN the validator does not throw an error
+    assert_eq!(diagnostics, vec![]);
+}
+
+#[test]
+fn aliased_int_compare_function_causes_no_error() {
+    // GIVEN comparison of aliased integers
+    // WHEN it is validated
+    let diagnostics = parse_and_validate(
+        r#"
+        TYPE MyInt: INT; END_TYPE
+        PROGRAM main
+        VAR 
+            a, b, c, d, e, f : BOOL;
+        END_VAR      
+        VAR_TEMP
+            x,y : MyInt;
+        END_VAR
+            a := x < y;
+            b := x = y;
+            c := x = 3;
+            d := y = 500;
+            e := x >= 0 AND x <= 500;
+            f := x < 0 OR x > 500;
+        END_PROGRAM
+        "#,
+    );
+
+    // THEN the validator does not throw an error
     assert_eq!(diagnostics, vec![]);
 }

--- a/tests/correctness/expressions.rs
+++ b/tests/correctness/expressions.rs
@@ -257,3 +257,42 @@ fn amp_as_and_correctness_test() {
     let _: i32 = compile_and_run(function, &mut main);
     assert_eq!([true, true], [main.d, main.e]);
 }
+
+#[test]
+fn aliased_ranged_numbers_can_be_compared() {
+    #[derive(Default)]
+    #[repr(C)]
+    struct Main {
+        a: bool,
+        b: bool,
+        c: bool,
+        d: bool,
+        e: bool,
+        f: bool,
+    }
+
+    let mut main = Main::default();
+
+    let src = r#"
+    TYPE MyInt: INT(0..500); END_TYPE
+    PROGRAM main
+    VAR 
+        a, b, c, d, e, f : BOOL;
+    END_VAR      
+    VAR_TEMP
+        x,y : MyInt;
+    END_VAR
+        a := x < y;
+        b := y <= 0;
+        c := x = 3;
+        d := y = 500;
+        e := x >= 0 AND x <= 500;
+        f := x < 0 OR x > 500;
+    END_PROGRAM
+    "#;
+    let _: i32 = compile_and_run(src, &mut main);
+    assert_eq!(
+        [main.a, main.b, main.c, main.d, main.e, main.f],
+        [false, true, false, false, true, false]
+    );
+}


### PR DESCRIPTION
Trying to compare subranges still caused a SyntaxError (for aliased and non-aliased types):
```
        PROGRAM main
        VAR 
            a : BOOL;
        END_VAR      
        VAR_TEMP
            x,y : INT(0..500);
        END_VAR
            a := x < y;
        END_PROGRAM
```
```
` message: "Missing compare function 'FUNCTION __main_x_LESS : BOOL VAR_INPUT a,b : __main_x; END_VAR ...'.",`
```
This happened during statement validation because the validator was looking for a function matching the SubRange name, not its referenced type.

This pull request resolves that issue.

<a href="https://gitpod.io/#https://github.com/PLC-lang/rusty/pull/598"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

