### PR TITLE
660 time literals are case sensitive

### DIFF
--- a/src/lexer/tests/lexer_tests.rs
+++ b/src/lexer/tests/lexer_tests.rs
@@ -392,7 +392,7 @@ fn time_literals_test() {
     let mut lexer = lex(r#"
     T#12d T#13h TIME#14m TIME#15s T#16ms
     T#12d10ms T#12h10m TIME#12m4s3ns
-    TIME#4d6h8m7s12ms04us2ns
+    TIME#4d6h8M7s12ms04US2ns
     "#);
     for _ in 1..9 {
         assert_eq!(
@@ -410,7 +410,7 @@ fn time_literals_test() {
 fn ltime_literals_test() {
     let mut lexer = lex(r#"
     LTIME#12d
-	LTIME#10m4s
+	LTIME#10M4S
 	LT#10d
     DINT#10
     "#);

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -7,7 +7,7 @@ use crate::{
     parser::parse_any_in_region,
     Diagnostic,
 };
-use core::{str::Split, unicode::conversions::to_lower};
+use core::str::Split;
 use regex::{Captures, Regex};
 use std::str::FromStr;
 
@@ -839,10 +839,11 @@ fn parse_literal_time(lexer: &mut ParseSession) -> Result<AstStatement, Diagnost
             //just eat all the characters
             char = chars.find(|(_, ch)| !ch.is_ascii_alphabetic());
             &slice[start..char.unwrap_or((slice.len(), ' ')).0]
-        }.to_lowercase().as_str();
+        }
+        .to_lowercase();
 
         //now assign the number to the according segment of the value's array
-        let position = match unit {
+        let position = match unit.as_str() {
             "d" => Some(POS_D),
             "h" => Some(POS_H),
             "m" => Some(POS_M),

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -847,9 +847,9 @@ fn parse_literal_time(lexer: &mut ParseSession) -> Result<AstStatement, Diagnost
             "h" | "H" => Some(POS_H),
             "m" | "M" => Some(POS_M),
             "s" | "S" => Some(POS_S),
-            "ms"| "MS" => Some(POS_MS),
-            "us"| "US" => Some(POS_US),
-            "ns"| "NS"=> Some(POS_NS),
+            "ms" | "MS" => Some(POS_MS),
+            "us" | "US" => Some(POS_US),
+            "ns" | "NS" => Some(POS_NS),
             _ => None,
         };
         if let Some(position) = position {

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -7,7 +7,7 @@ use crate::{
     parser::parse_any_in_region,
     Diagnostic,
 };
-use core::str::Split;
+use core::{str::Split, unicode::conversions::to_lower};
 use regex::{Captures, Regex};
 use std::str::FromStr;
 
@@ -839,17 +839,17 @@ fn parse_literal_time(lexer: &mut ParseSession) -> Result<AstStatement, Diagnost
             //just eat all the characters
             char = chars.find(|(_, ch)| !ch.is_ascii_alphabetic());
             &slice[start..char.unwrap_or((slice.len(), ' ')).0]
-        };
+        }.to_lowercase().as_str();
 
         //now assign the number to the according segment of the value's array
         let position = match unit {
-            "d" | "D" => Some(POS_D),
-            "h" | "H" => Some(POS_H),
-            "m" | "M" => Some(POS_M),
-            "s" | "S" => Some(POS_S),
-            "ms" | "MS" => Some(POS_MS),
-            "us" | "US" => Some(POS_US),
-            "ns" | "NS" => Some(POS_NS),
+            "d" => Some(POS_D),
+            "h" => Some(POS_H),
+            "m" => Some(POS_M),
+            "s" => Some(POS_S),
+            "ms" => Some(POS_MS),
+            "us" => Some(POS_US),
+            "ns" => Some(POS_NS),
             _ => None,
         };
         if let Some(position) = position {

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -843,13 +843,13 @@ fn parse_literal_time(lexer: &mut ParseSession) -> Result<AstStatement, Diagnost
 
         //now assign the number to the according segment of the value's array
         let position = match unit {
-            "d" => Some(POS_D),
-            "h" => Some(POS_H),
-            "m" => Some(POS_M),
-            "s" => Some(POS_S),
-            "ms" => Some(POS_MS),
-            "us" => Some(POS_US),
-            "ns" => Some(POS_NS),
+            "d" | "D" => Some(POS_D),
+            "h" | "H" => Some(POS_H),
+            "m" | "M" => Some(POS_M),
+            "s" | "S" => Some(POS_S),
+            "ms"| "MS" => Some(POS_MS),
+            "us"| "US" => Some(POS_US),
+            "ns"| "NS"=> Some(POS_NS),
             _ => None,
         };
         if let Some(position) = position {


### PR DESCRIPTION
changes the expression parser to also accept uppercase time literals. 