### PR TITLE
Fix invalid address-of operations (#655)

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -88,6 +88,7 @@ pub enum ErrNo {
     type__unknown_nature,
     type__unresolved_generic,
     type__incompatible_size,
+    type__invalid_operation,
 
     //codegen related
     codegen__general,
@@ -759,6 +760,14 @@ impl Diagnostic {
             message: format!("{}: {}", name, additional_text),
             range: locations,
             err_no: ErrNo::duplicate_symbol,
+        }
+    }
+
+    pub fn invalid_operation(message: &str, range: SourceRange) -> Diagnostic {
+        Diagnostic::SyntaxError {
+            message: message.to_string(),
+            range: vec![range],
+            err_no: ErrNo::type__invalid_operation,
         }
     }
 }

--- a/src/validation/stmt_validator.rs
+++ b/src/validation/stmt_validator.rs
@@ -39,6 +39,25 @@ impl StatementValidator {
             AstStatement::Reference { name, location, .. } => {
                 self.validate_reference(statement, name, location, context);
             }
+
+            AstStatement::UnaryExpression {
+                operator,
+                value,
+                location,
+                ..
+            } => {
+                if operator == &Operator::Address {
+                    match value.as_ref() {
+                        AstStatement::Reference { .. } | AstStatement::ArrayAccess { .. } => (),
+
+                        _ => self.diagnostics.push(Diagnostic::invalid_operation(
+                            "Invalid address-of operation",
+                            location.to_owned(),
+                        )),
+                    }
+                }
+            }
+
             AstStatement::CastStatement {
                 location,
                 target,

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -783,3 +783,39 @@ fn program_call_parameter_validation() {
         ]
     );
 }
+
+#[test]
+fn address_of_operations() {
+    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+        "
+        PROGRAM main
+            VAR
+                a: INT;
+                b: ARRAY[0..5] OF INT;
+            END_VAR
+
+            // Should work
+            &(a);
+            &b[1];
+
+            // Should not work
+            &&a;
+            &100;
+            &(a+3);
+        END_PROGRAM
+        ",
+    );
+
+    assert_eq!(diagnostics.len(), 3);
+
+    let ranges = vec![(243..246), (260..264), (278..283)];
+    for (idx, diagnostic) in diagnostics.iter().enumerate() {
+        assert_eq!(
+            diagnostic,
+            &Diagnostic::invalid_operation(
+                "Invalid address-of operation",
+                ranges[idx].to_owned().into()
+            )
+        );
+    }
+}


### PR DESCRIPTION
Disallows the usage of the `Address` operator with anything other than a `Reference` and `ArrayAccess` statement.