### PR TITLE
increase coverage(#411)

### DIFF
--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -494,6 +494,19 @@ fn date_comparisons() {
 }
 
 #[test]
+#[should_panic]
+fn date_invalid_declaration() {
+    let result = codegen(
+        r#"PROGRAM prg
+        VAR
+          a : DATE := D#2001-02-29; (* feb29 on non-leap year should not pass *)
+        END_VAR
+        END_PROGRAM"#,
+    );
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn program_with_string_assignment() {
     let result = codegen(
         r#"PROGRAM prg

--- a/tests/correctness/math_operators/addition.rs
+++ b/tests/correctness/math_operators/addition.rs
@@ -247,12 +247,12 @@ fn add_date_basic() {
 
     let res: u64 = compile_and_run(prog.to_string(), &mut main);
     let date_var = chrono::Utc
-        .ymd(2021, 1, 1)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(2021, 1, 1, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_10_days = chrono::Utc
-        .ymd(1970, 1, 10)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(1970, 1, 10, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     assert_eq!(res, date_10_days + date_var);
 }

--- a/tests/correctness/math_operators/division.rs
+++ b/tests/correctness/math_operators/division.rs
@@ -210,12 +210,12 @@ fn division_date_basic() {
 
     let res: u64 = compile_and_run(prog.to_string(), &mut main);
     let date_var = chrono::Utc
-        .ymd(2021, 1, 1)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(2021, 1, 1, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_10_days = chrono::Utc
-        .ymd(1970, 1, 10)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(1970, 1, 10, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     assert_eq!(res, date_var + date_10_days / 2);
 }

--- a/tests/correctness/math_operators/mixed.rs
+++ b/tests/correctness/math_operators/mixed.rs
@@ -180,16 +180,16 @@ fn mixed_math_date_basic() {
 
     let res: u64 = compile_and_run(prog.to_string(), &mut main);
     let date_var = chrono::Utc
-        .ymd(2021, 1, 1)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(2021, 1, 1, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_10_days = chrono::Utc
-        .ymd(1970, 1, 10)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(1970, 1, 10, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_1_day = chrono::Utc
-        .ymd(1970, 1, 2)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(1970, 1, 2, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     assert_eq!(res, date_var + date_10_days * 2 - date_1_day / 2);
 }
@@ -213,16 +213,16 @@ fn mixed_math_dt_basic() {
 
     let res: u64 = compile_and_run(prog.to_string(), &mut main);
     let date_var = chrono::Utc
-        .ymd(2021, 1, 1)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(2021, 1, 1, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_10_days = chrono::Utc
-        .ymd(1970, 1, 10)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(1970, 1, 10, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_1_day = chrono::Utc
-        .ymd(1970, 1, 2)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(1970, 1, 2, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     assert_eq!(res, date_var + date_10_days * 2 - date_1_day / 2);
 }

--- a/tests/correctness/math_operators/multiplication.rs
+++ b/tests/correctness/math_operators/multiplication.rs
@@ -173,12 +173,12 @@ fn multiplication_date_basic() {
 
     let res: u64 = compile_and_run(prog.to_string(), &mut main);
     let date_var = chrono::Utc
-        .ymd(2021, 1, 1)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(2021, 1, 1, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_10_days = chrono::Utc
-        .ymd(1970, 1, 10)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(1970, 1, 10, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     assert_eq!(res, date_var + date_10_days * 2);
 }

--- a/tests/correctness/math_operators/substraction.rs
+++ b/tests/correctness/math_operators/substraction.rs
@@ -233,12 +233,12 @@ fn substract_date_basic() {
 
     let res: u64 = compile_and_run(prog.to_string(), &mut main);
     let date_var = chrono::Utc
-        .ymd(2021, 1, 1)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(2021, 1, 1, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     let date_temp = chrono::Utc
-        .ymd(2021, 1, 10)
-        .and_hms(0, 0, 0)
+        .with_ymd_and_hms(2021, 1, 10, 0, 0, 0)
+        .unwrap()
         .timestamp_nanos() as u64;
     assert_eq!(res, date_temp - date_var);
 }


### PR DESCRIPTION
date_time_utils : invalid date test coverage
replacement of deprecated functions chrono::TimeZone::ymd() and and_hms() that were giving deprecation warnings