### PR TITLE
Improve compile times (#679)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,3 +49,6 @@ RUN chmod -R a+rw $CARGO_HOME \
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog
+
+# Required if we want to use `lld` as the default linker for RuSTy
+RUN ln -sf /usr/bin/ld.lld-$LLVM_VER /usr/bin/ld.lld

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,3 +49,6 @@ RUN chmod -R a+rw $CARGO_HOME \
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog
+
+# Required for `.cargo/config.toml` to recognize lld
+RUN ln -sf /usr/bin/ld.lld-$LLVM_VER /usr/bin/ld.lld

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,6 +49,3 @@ RUN chmod -R a+rw $CARGO_HOME \
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog
-
-# Required for `.cargo/config.toml` to recognize lld
-RUN ln -sf /usr/bin/ld.lld-$LLVM_VER /usr/bin/ld.lld

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 *.bc
 *.a
 *.elf
+
+# Introduced with issue #679: 
+# We're assuming config.toml to be a local config file for now.
+# This entry has to be removed if a global config file is needed in the near future.
+.cargo/config.toml

--- a/book/src/build_and_install.md
+++ b/book/src/build_and_install.md
@@ -38,5 +38,9 @@ cargo build --release
 
 You can find the binary at `./target/release/rustyc`.
 
+## Improving Compile Times
+By default Rust uses the GNU Linker on Linux which compared to [lld](https://lld.llvm.org/) is slower by a margin of [~2x - 4x](https://llvm.org/devmtg/2016-10/slides/Ueyama-lld.pdf). To improve compile times we can therefore use `lld`. To do so you will need to run the `rusty/scripts/lld.sh` script inside the `rusty` root folder, i.e. by executing `./scripts/lld.sh`. **Note** that the script was only tested on Ubuntu based distributions thus far.
+
+
 ## Installing
 _TODO_

--- a/scripts/lld.sh
+++ b/scripts/lld.sh
@@ -25,13 +25,14 @@ if [ -z $LD_LLD_WITHOUT_VERSION ]; then
     mkdir -p $HOME/.local/bin
     ln -svf $LD_LLD_WITH_VERSION $HOME/.local/bin/ld.lld
 
-    echo "\nYou might need to update your \$PATH environment variable for cargo to recognize lld, like so:"
-    echo "${TEXT_BOLD}echo 'export PATH=\$HOME/.local/bin:\$PATH' >> $HOME/.bashrc${TEXT_NORMAL}"
+    # Append new $PATH to `.bashrc`
+    echo 'export PATH=$HOME/.local/bin:$PATH' >> $HOME/.bashrc
+    echo 'A new $PATH entry has been added to your .bashrc'
+    echo 'For changes to take effect close and reopen your current shell.'
 
 else 
     # Present, do nothing because we don't want to modifiy system-wide configurations
     echo "Note: Using already present $LD_LLD_WITHOUT_VERSION binary"
-    echo "      Make sure $LD_LLD_WITHOUT_VERSION matches with RuSTys LLVM version"
 fi
 
 # Create `config.toml` to make `lld` the default linker for RuSTy

--- a/scripts/lld.sh
+++ b/scripts/lld.sh
@@ -1,23 +1,35 @@
 #!/usr/bin/env sh
 
+LD_LLD_WITH_VERSION=$(command -v ld.lld-$1)
+LD_LLD_WITHOUT_VERSION=$(command -v ld.lld)
+
 if [ -z $1 ]; then
+    echo "No version specified!"
     echo "Usage:   $0 <LLD version>"
     echo "Example: $0 13"
     exit 1
 fi
 
-# Check if the specified LLD version is installed
-if ! [ -x "$(command -v ld.lld-$1)" ]; then
-    echo "LLD-$1 was not found!"
+# Check if the specified `lld` version is present on the system
+if [ -z $LD_LLD_WITH_VERSION ]; then
+    echo "Could not find ld.lld-$1 binary, aborting"
     exit 1
 fi
 
-# Symlink `lld` to `ld.lld` which is needed by `.cargo/config.toml`
-sudo ln -svf $(command -v ld.lld-$1) /usr/bin/ld.lld
+# Check if `ld.lld` is present on the system
+if [ -z $LD_LLD_WITHOUT_VERSION ]; then 
+    # Not present, create a `/usr/bin/ld.lld -> /usr/bin/ld.lld-$1` symlink
+    sudo ln -sf $LD_LLD_WITH_VERSION /usr/bin/ld.lld
+else 
+    # Present, do nothing because we don't want to modifiy system-wide configurations
+    echo "Note: Using already present $LD_LLD_WITHOUT_VERSION binary"
+    echo "      Make sure $LD_LLD_WITHOUT_VERSION matches with RuSTys LLVM version"
+fi
 
-# Create the `.cargo/config.toml` file
+# Create `config.toml` to make `lld` the default linker for RuSTy
 mkdir -p .cargo
 echo -n '[build]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]' > .cargo/config.toml
 
+# Makes sure new builds with lld succeed
 cargo clean

--- a/scripts/lld.sh
+++ b/scripts/lld.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 
+TEXT_BOLD=$(tput bold)
+TEXT_NORMAL=$(tput sgr0)
+
 LD_LLD_WITH_VERSION=$(command -v ld.lld-$1)
 LD_LLD_WITHOUT_VERSION=$(command -v ld.lld)
 
@@ -12,14 +15,19 @@ fi
 
 # Check if the specified `lld` version is present on the system
 if [ -z $LD_LLD_WITH_VERSION ]; then
-    echo "Could not find ld.lld-$1 binary, aborting"
+    echo "Could not find ld.lld-$1, make sure lld is installed"
     exit 1
 fi
 
 # Check if `ld.lld` is present on the system
 if [ -z $LD_LLD_WITHOUT_VERSION ]; then 
-    # Not present, create a `/usr/bin/ld.lld -> /usr/bin/ld.lld-$1` symlink
-    sudo ln -sf $LD_LLD_WITH_VERSION /usr/bin/ld.lld
+    # Not present, create a symlink into ~/.local/bin
+    mkdir -p $HOME/.local/bin
+    ln -svf $LD_LLD_WITH_VERSION $HOME/.local/bin/ld.lld
+
+    echo "\nYou might need to update your \$PATH environment variable for cargo to recognize lld, like so:"
+    echo "${TEXT_BOLD}echo 'export PATH=\$HOME/.local/bin:\$PATH' >> $HOME/.bashrc${TEXT_NORMAL}"
+
 else 
     # Present, do nothing because we don't want to modifiy system-wide configurations
     echo "Note: Using already present $LD_LLD_WITHOUT_VERSION binary"

--- a/scripts/lld.sh
+++ b/scripts/lld.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env sh
 
-TEXT_BOLD=$(tput bold)
-TEXT_NORMAL=$(tput sgr0)
-
 LD_LLD_WITH_VERSION=$(command -v ld.lld-$1)
 LD_LLD_WITHOUT_VERSION=$(command -v ld.lld)
 

--- a/scripts/lld.sh
+++ b/scripts/lld.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+if [ -z $1 ]; then
+    echo "Usage:   $0 <LLD version>"
+    echo "Example: $0 13"
+    exit 1
+fi
+
+# Check if the specified LLD version is installed
+if ! [ -x "$(command -v ld.lld-$1)" ]; then
+    echo "LLD-$1 was not found!"
+    exit 1
+fi
+
+# Symlink `lld` to `ld.lld` which is needed by `.cargo/config.toml`
+sudo ln -svf $(command -v ld.lld-$1) /usr/bin/ld.lld
+
+# Create the `.cargo/config.toml` file
+mkdir -p .cargo
+echo -n '[build]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]' > .cargo/config.toml
+
+cargo clean


### PR DESCRIPTION
@ghaith and I conducted some tests regarding performance differences between `lld` and `mold` on our workstations and came to the conclusion that there's (almost) hardly a difference. For reference those were my recorded times on my local VM
```bash
default: 9.16s, 8.47s, 8.23s
lld:     4.78s, 4.80s, 4.86s
mold:    4.28s, 3.76s, 3.90s
```
Because of that we decided to stick with `lld` since the installation of it is much simpler, i.e. `lld` is present on most Linux distributions whereas `mold` has to be compiled manually and may need additional dependencies. Furthermore we decided to give control over to the developer by not forcing anyone to use `lld` by default. The motivation behind this was because builiding the project may result in linker errors otherwise since we do not know if e.g. `/usr/bin/ld.lld` exists and is a symlink to `/usr/bin/ld.lld-13` which is required - for anyone not using Docker that is. Instead anyone using this project can run the `scripts/lld.sh` file which automates the process. IIRC we discussed including the given script file into the Dockerfile, but is the current approach also OK for you @riederm ?