### PR TITLE
Disallow passing literals as function arguments where references are expected (#698)

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -12,7 +12,10 @@ use codespan_reporting::{
 };
 use inkwell::support::LLVMString;
 
-use crate::ast::{DataTypeDeclaration, DiagnosticInfo, PouType, SourceRange};
+use crate::{
+    ast::{DataTypeDeclaration, DiagnosticInfo, PouType, SourceRange},
+    index::VariableType,
+};
 
 pub const INTERNAL_LLVM_ERROR: &str = "internal llvm codegen error";
 
@@ -623,9 +626,17 @@ impl Diagnostic {
         }
     }
 
-    pub fn invalid_argument_type(range: SourceRange) -> Diagnostic {
+    pub fn invalid_argument_type(
+        parameter_name: &str,
+        parameter_type: VariableType,
+        range: SourceRange,
+    ) -> Diagnostic {
         Diagnostic::SyntaxError {
-            message: "Expected a reference here but found a literal".into(),
+            message: format!(
+                "Expected a reference for parameter {} because their type is {:?}",
+                parameter_name, parameter_type,
+            )
+            .into(),
             range: vec![range],
             err_no: ErrNo::call__invalid_parameter_type,
         }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -625,7 +625,7 @@ impl Diagnostic {
 
     pub fn invalid_argument_type(range: SourceRange) -> Diagnostic {
         Diagnostic::SyntaxError {
-            message: format!("Expected a reference here but found a literal"),
+            message: "Expected a reference here but found a literal".into(),
             range: vec![range],
             err_no: ErrNo::call__invalid_parameter_type,
         }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -623,6 +623,14 @@ impl Diagnostic {
         }
     }
 
+    pub fn invalid_argument_type(range: SourceRange) -> Diagnostic {
+        Diagnostic::SyntaxError {
+            message: "Cannot pass a literal where a reference was expected".into(),
+            range: vec![range],
+            err_no: ErrNo::call__invalid_parameter_type,
+        }
+    }
+
     pub fn duplicate_pou(name: &str, range: SourceRange) -> Diagnostic {
         Diagnostic::SyntaxError {
             message: format!("Duplicate POU {}", name),

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -635,8 +635,7 @@ impl Diagnostic {
             message: format!(
                 "Expected a reference for parameter {} because their type is {:?}",
                 parameter_name, parameter_type,
-            )
-            .into(),
+            ),
             range: vec![range],
             err_no: ErrNo::call__invalid_parameter_type,
         }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -625,7 +625,7 @@ impl Diagnostic {
 
     pub fn invalid_argument_type(range: SourceRange) -> Diagnostic {
         Diagnostic::SyntaxError {
-            message: "Cannot pass a literal where a reference was expected".into(),
+            message: format!("Expected a reference here but found a literal"),
             range: vec![range],
             err_no: ErrNo::call__invalid_parameter_type,
         }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -254,7 +254,10 @@ impl Validator {
                                     context.index,
                                 );
 
-                                if is_implicit && left.variable_type.is_by_ref() {
+                                if is_implicit
+                                    && left.variable_type.is_by_ref()
+                                    && left.variable_type.get_variable_type() != VariableType::Input
+                                {
                                     match p {
                                         AstStatement::Reference { .. }
                                         | AstStatement::LiteralString { .. }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -387,20 +387,20 @@ impl Validator {
     /// [`VariableType::InOut`] parameter types by checking if the argument is a reference (e.g. `foo(x)`) or
     /// an assignment (e.g. `foo(x := 1)`, `foo(x => y)`). If neither is the case a diagnostic is generated.
     fn validate_call_by_ref(&mut self, param: &VariableIndexEntry, arg: &AstStatement) {
-        if matches!(param.variable_type.get_variable_type(), VariableType::Output | VariableType::InOut) {
-            if !matches!(
+        if matches!(param.variable_type.get_variable_type(), VariableType::Output | VariableType::InOut)
+            && !matches!(
                 arg,
                 AstStatement::Reference { .. }
                     | AstStatement::QualifiedReference { .. }
                     | AstStatement::Assignment { .. }
                     | AstStatement::OutputAssignment { .. }
-            ) {
-                self.stmt_validator.diagnostics.push(Diagnostic::invalid_argument_type(
-                    param.get_name(),
-                    param.get_variable_type(),
-                    arg.get_location(),
-                ));
-            }
+            )
+        {
+            self.stmt_validator.diagnostics.push(Diagnostic::invalid_argument_type(
+                param.get_name(),
+                param.get_variable_type(),
+                arg.get_location(),
+            ));
         }
     }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -253,6 +253,19 @@ impl Validator {
                                     p.get_location(),
                                     context.index,
                                 );
+
+                                if is_implicit && left.variable_type.is_by_ref() {
+                                    match p {
+                                        AstStatement::Reference { .. }
+                                        | AstStatement::LiteralString { .. }
+                                        | AstStatement::QualifiedReference { .. } => (),
+
+                                        _ => self
+                                            .stmt_validator
+                                            .diagnostics
+                                            .push(Diagnostic::invalid_argument_type(p.get_location())),
+                                    }
+                                }
                             }
 
                             // mixing implicit and explicit parameters is not allowed

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -901,7 +901,7 @@ fn address_of_operations() {
 }
 
 #[test]
-fn call_by_ref_and_val_for_input_inout_and_output() {
+fn by_ref_and_val_for_input_inout_and_output() {
     let diagnostics: Vec<Diagnostic> = parse_and_validate(
         "
         FUNCTION func : DINT 
@@ -919,7 +919,7 @@ fn call_by_ref_and_val_for_input_inout_and_output() {
 
             VAR_INPUT
                 byValInput : INT;
-            END_INPUT
+            END_VAR
         END_FUNCTION
 
         VAR_GLOBAL
@@ -947,16 +947,19 @@ fn call_by_ref_and_val_for_input_inout_and_output() {
             func(x, x, 3, x);
             func(x, x, x, 4); // Valid
             func(x, x, x, x); // Valid
+
+            // Also valid for explicit assignments
+            func(byRefInput := 1, byRefInOut := 2, byRefOutput => 3, byValInput := 4);
         END_PROGRAM
         ",
     );
 
     #[rustfmt::skip]
     let ranges = vec![
-        (916..917), (919..920), (946..947), (949..950),
-        (976..977), (1006..1007), (1039..1040), (1069..1070),
-        (1174..1175), (1177..1178), (1204..1205), (1207..1208),
-        (1234..1235), (1264..1265), (1297..1298), (1327..1328),
+        (914..915), (917..918), (944..945), (947..948),
+        (974..975), (1004..1005), (1037..1038), (1067..1068),
+        (1172..1173), (1175..1176), (1202..1203), (1205..1206),
+        (1232..1233), (1262..1263), (1295..1296), (1325..1326),
     ];
 
     assert_eq!(diagnostics.len(), 16);

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -901,7 +901,7 @@ fn address_of_operations() {
 }
 
 #[test]
-fn temp() {
+fn call_by_ref_and_val_for_input_inout_and_output() {
     let diagnostics: Vec<Diagnostic> = parse_and_validate(
         "
         FUNCTION func : DINT 
@@ -927,10 +927,10 @@ fn temp() {
         END_VAR
 
         PROGRAM main
-            // Expect for 4 function calls marked with a 'Valid' comment everything should be
-            // invalid and generate error message. The reasoning here is that the second and third 
-            // function parameters are expected to be references but literal arguments are passed.
-            // Note: Although the first parameter (VAR_INPUT) expects a reference, we make an exception for it
+            // Expect for 4 function calls flagged with a 'Valid' comment everything else should be invalid
+            // and generate error messages. The reasoning here is that the second and third function parameters
+            // are expected to be references but literal arguments are passed. Note that the first function
+            // parameter also expects a reference, but we decided that `VAR_INPUT` can be called by ref and val.
             func(1, 2, 3, 4);
             func(1, 2, 3, x);
             func(1, 2, x, 4);
@@ -953,10 +953,10 @@ fn temp() {
 
     #[rustfmt::skip]
     let ranges = vec![
-        (879..880), (882..883), (909..910), (912..913), 
-        (939..940), (969..970), (1002..1003), (1032..1033), 
-        (1137..1138), (1140..1141), (1167..1168), (1170..1171), 
-        (1197..1198), (1227..1228), (1260..1261), (1290..1291), 
+        (916..917), (919..920), (946..947), (949..950),
+        (976..977), (1006..1007), (1039..1040), (1069..1070),
+        (1174..1175), (1177..1178), (1204..1205), (1207..1208),
+        (1234..1235), (1264..1265), (1297..1298), (1327..1328),
     ];
 
     assert_eq!(diagnostics.len(), 16);

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -927,39 +927,39 @@ fn temp() {
         END_VAR
 
         PROGRAM main
-            // The function `func` expects the first three arguments to be references, 
-            // in these calls we pass literals however which should be invalid and yield errors.
+            // Expect for 4 function calls marked with a 'Valid' comment everything should be
+            // invalid and generate error message. The reasoning here is that the second and third 
+            // function parameters are expected to be references but literal arguments are passed.
+            // Note: Although the first parameter (VAR_INPUT) expects a reference, we make an exception for it
             func(1, 2, 3, 4);
             func(1, 2, 3, x);
             func(1, 2, x, 4);
             func(1, 2, x, x);
             func(1, x, 3, 4);
             func(1, x, 3, x);
-            func(1, x, x, 4);
-            func(1, x, x, x);
+            func(1, x, x, 4); // Valid
+            func(1, x, x, x); // Valid
             func(x, 2, 3, 4);
             func(x, 2, 3, x);
             func(x, 2, x, 4);
             func(x, 2, x, x);
             func(x, x, 3, 4);
             func(x, x, 3, x);
-
-            // Contrary to the previous calls we actually pass references here, 
-            // hence these calls should work. 
-            func(x, x, x, 4);
-            func(x, x, x, x);
+            func(x, x, x, 4); // Valid
+            func(x, x, x, x); // Valid
         END_PROGRAM
         ",
     );
 
     #[rustfmt::skip]
     let ranges = vec![
-        (657..658), (660..661), (663..664), (687..688), (690..691), (693..694), (717..718), (720..721), 
-        (747..748), (750..751), (777..778), (783..784), (807..808), (813..814), (837..838), (867..868), 
-        (900..901), (903..904), (930..931), (933..934), (960..961), (990..991), (1023..1024), (1053..1054)
+        (879..880), (882..883), (909..910), (912..913), 
+        (939..940), (969..970), (1002..1003), (1032..1033), 
+        (1137..1138), (1140..1141), (1167..1168), (1170..1171), 
+        (1197..1198), (1227..1228), (1260..1261), (1290..1291), 
     ];
 
-    assert_eq!(diagnostics.len(), 24);
+    assert_eq!(diagnostics.len(), 16);
     for (idx, diagnostic) in diagnostics.iter().enumerate() {
         assert_eq!(diagnostic, &Diagnostic::invalid_argument_type(ranges[idx].to_owned().into()));
     }

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -902,7 +902,7 @@ fn address_of_operations() {
 }
 
 #[test]
-fn validate_by_ref_for_output_and_inout() {
+fn validate_call_by_ref() {
     let diagnostics: Vec<Diagnostic> = parse_and_validate(
         "
         FUNCTION func : DINT
@@ -935,22 +935,35 @@ fn validate_by_ref_for_output_and_inout() {
             func(x, x, 3);
             func(x, x, x); // Valid
             
-            // Explicit argument assignments are also valid
+            // Explicit argument assignments are also valid, IF their right side is a LValue
             func(byValInput := 1, byRefInOut := 2, byRefOutput =>  );
+            func(byValInput := 1, byRefInOut := x, byRefOutput =>  ); // Valid (Output assignments are optional)
+            func(byValInput := 1, byRefInOut := 2, byRefOutput => 3); 
             func(byValInput := 1, byRefInOut := 2, byRefOutput => x);
+            func(byValInput := 1, byRefInOut := x, byRefOutput => 3);
+            func(byValInput := 1, byRefInOut := x, byRefOutput => x); // Valid
+
         END_PROGRAM
         ",
     );
 
-    #[rustfmt::skip]
     let ranges = vec![
-        ("byRefInOut", VariableType::InOut, (589..590)), ("byRefOutput", VariableType::Output, (592..593)),
-        ("byRefInOut", VariableType::InOut, (616..617)), ("byRefOutput", VariableType::Output, (646..647)),
-        ("byRefInOut", VariableType::InOut, (706..707)), ("byRefOutput", VariableType::Output, (709..710)),
-        ("byRefInOut", VariableType::InOut, (733..734)), ("byRefOutput", VariableType::Output, (763..764)),
+        ("byRefInOut", VariableType::InOut, (589..590)),
+        ("byRefOutput", VariableType::Output, (592..593)),
+        ("byRefInOut", VariableType::InOut, (616..617)),
+        ("byRefOutput", VariableType::Output, (646..647)),
+        ("byRefInOut", VariableType::InOut, (706..707)),
+        ("byRefOutput", VariableType::Output, (709..710)),
+        ("byRefInOut", VariableType::InOut, (733..734)),
+        ("byRefOutput", VariableType::Output, (763..764)),
+        ("byRefInOut", VariableType::InOut, (957..958)),
+        ("byRefInOut", VariableType::InOut, (1140..1141)),
+        ("byRefOutput", VariableType::Output, (1158..1159)),
+        ("byRefInOut", VariableType::InOut, (1211..1212)),
+        ("byRefOutput", VariableType::Output, (1299..1300)),
     ];
 
-    assert_eq!(diagnostics.len(), 8);
+    assert_eq!(diagnostics.len(), 13);
     for (idx, diagnostic) in diagnostics.iter().enumerate() {
         assert_eq!(
             diagnostic,


### PR DESCRIPTION
Kind of fixes #698 where previously something like
```ST
FUNCTION func : DINT 
    VAR_INPUT {ref}
        byRefInput : INT;
    END_VAR 

    VAR_INPUT
        byValInput : INT;
    END_INPUT
END_FUNCTION

PROGRAM main
    func(1, 2); // This should be invalid because the first argument is expected
                // to be a reference  but we pass a integer literal here
    func(x, 2); // This is what a valid function call should look like
END_PROGRAM
```
was accepted. When running with the `verify` feature enabled this would result in errors however, because the LLVM IR is not what one would expect it to be. Instead of fixing the LLVM IR generated code, we settled with a validation solution since this code should in general be invalid.