### PR TITLE
Minor documentation changes

### DIFF
--- a/book/src/build_and_install.md
+++ b/book/src/build_and_install.md
@@ -27,7 +27,7 @@ brew install llvm@13
 ````
 After the installation you have to add `/opt/homebrew/opt/llvm@13/bin` to your `$PATH` environment variable, e.g. with the following command
 ```bash
-echo 'export PATH="/opt/homebrew/opt/llvm@13/bin:$PATH"' >> ~/.bashrc
+echo 'export PATH="/opt/homebrew/opt/llvm@13/bin:$PATH"' >> ~/.zshrc
 ```
 
 ## Windows

--- a/book/src/pous.md
+++ b/book/src/pous.md
@@ -33,7 +33,7 @@ VAR_INPUT
 END_VAR
 ```
 
-In some cases, especially when passing large strings or arrays, or when interacting with foreign code (see {External Functions}(libraries/external_functions.md)) it is more efficient to avoid copying the variable values and just use a pointer to the required input. This can be done either using the in/out variables or by specifying a special property `ref` on the input block 
+In some cases, especially when passing large strings or arrays, or when interacting with foreign code (see [External Functions](libraries/external_functions.md)) it is more efficient to avoid copying the variable values and just use a pointer to the required input. This can be done either using the in/out variables or by specifying a special property `ref` on the input block 
 
 Example : 
 


### PR DESCRIPTION
- Replace `.bashrc` with `.zshrc` in MacOS build instructions because zsh is the default shell
- Fix markdown link in POUs section 