### PR TITLE
Force the docker version to remain on 13

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_NAME: rust-llvm
-  IMAGE_VERSION: v13-1.60
+  IMAGE_VERSION: 13-1.60
 
 jobs:
   cargo-docs:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_NAME: rust-llvm
-  IMAGE_VERSION: latest
+  IMAGE_VERSION: v13-1.60
 
 jobs:
   cargo-docs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
   
 env:
   IMAGE_NAME: rust-llvm
-  IMAGE_VERSION: v13-1.60
+  IMAGE_VERSION: 13-1.60
 
 jobs:
   check: 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
   
 env:
   IMAGE_NAME: rust-llvm
-  IMAGE_VERSION: latest
+  IMAGE_VERSION: v13-1.60
 
 jobs:
   check: 


### PR DESCRIPTION
While we update the rust llvm repo to version 1.67/LLVM 14 we force the current builds to stay on 13 until the move is done