### PR TITLE
Add libffi7 to 'Build & Install' book chapter

### DIFF
--- a/book/src/build_and_install.md
+++ b/book/src/build_and_install.md
@@ -24,6 +24,7 @@ sudo apt install                \
     libz-dev                    \
     libclang-common-14-dev 
 ```
+Additionally you _might_ need `libffi7`, which can be installed with `sudo apt install libffi7`.
 
 ## Debian
 


### PR DESCRIPTION
Fixes https://github.com/PLC-lang/rusty/issues/757
Edit: Tested on my machine and it seems to be working with binaries downloaded from our build servers which previously failed.