### PR TITLE
Allow arrays to be passed as function arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rusty"
 version = "0.2.0"
-authors = ["Ghaith Hachem <ghaith.hachem@gmail.com>", "Mathias Rieder <mathias.rieder@gmail.com>"]
+authors = [
+    "Ghaith Hachem <ghaith.hachem@gmail.com>",
+    "Mathias Rieder <mathias.rieder@gmail.com>",
+]
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/ghaith/rusty/"
@@ -16,7 +19,9 @@ verify = []
 
 [dependencies]
 logos = "0.12.0"
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features= ["llvm14-0"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = [
+    "llvm14-0",
+] }
 thiserror = "1.0"
 clap = { version = "3.0", features = ["derive"] }
 indexmap = "1.6"

--- a/book/src/build_and_install.md
+++ b/book/src/build_and_install.md
@@ -24,6 +24,7 @@ sudo apt install                \
     libz-dev                    \
     libclang-common-14-dev 
 ```
+Additionally you _might_ need `libffi7`, which can be installed with `sudo apt install libffi7`.
 
 ## Debian
 

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -973,31 +973,18 @@ pub fn is_same_type_class(ltype: &DataTypeInformation, rtype: &DataTypeInformati
             matches!(rtype, DataTypeInformation::String { encoding, .. } if encoding == lenc)
         }
 
-        DataTypeInformation::Array { inner_type_name: l_name, dimensions: l_dimensions, .. } => match rtype {
-            DataTypeInformation::Array { inner_type_name: r_name, dimensions: r_dimensions, .. } => {
-                // TODO:
-                // - [ ] This is ugly, let's rewrite it
-                //   - [ ] In general are arrays incompatible if they have different dimensions?
-                //         => clang does not generate a warning
-                // - [ ] Add more test cases
-
-                // dbg!((&l_name, r_name));
-                // dbg!((&l_dimensions, r_dimensions));
-                // dbg!((&l_dimensions[0].get_length(index), r_dimensions));
-                if l_dimensions.len() != r_dimensions.len() {
+        DataTypeInformation::Array { inner_type_name: l_name, dimensions: l_dim, .. } => match rtype {
+            DataTypeInformation::Array { inner_type_name: r_name, dimensions: r_dim, .. } => {
+                // Check if the inner type name as well as the dimension length are equal
+                if !(l_name == r_name && l_dim.len() == r_dim.len()) {
                     return false;
                 }
 
-                if l_dimensions
-                    .iter()
-                    .zip(r_dimensions)
-                    .map(|(x, y)| x.get_length(index) == y.get_length(index))
-                    .any(|x| !x)
-                {
-                    return false;
-                }
+                // Check if the dimension's lengths are equal
+                let l_dim_len = l_dim.iter().map(|x| x.get_length(index)).collect::<Vec<_>>();
+                let r_dim_len = r_dim.iter().map(|x| x.get_length(index)).collect::<Vec<_>>();
 
-                l_name == r_name
+                l_dim_len == r_dim_len
             }
 
             _ => false,

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -973,6 +973,36 @@ pub fn is_same_type_class(ltype: &DataTypeInformation, rtype: &DataTypeInformati
             matches!(rtype, DataTypeInformation::String { encoding, .. } if encoding == lenc)
         }
 
+        DataTypeInformation::Array { inner_type_name: l_name, dimensions: l_dimensions, .. } => match rtype {
+            DataTypeInformation::Array { inner_type_name: r_name, dimensions: r_dimensions, .. } => {
+                // TODO:
+                // - [ ] This is ugly, let's rewrite it
+                //   - [ ] In general are arrays incompatible if they have different dimensions?
+                //         => clang does not generate a warning
+                // - [ ] Add more test cases
+
+                // dbg!((&l_name, r_name));
+                // dbg!((&l_dimensions, r_dimensions));
+                // dbg!((&l_dimensions[0].get_length(index), r_dimensions));
+                if l_dimensions.len() != r_dimensions.len() {
+                    return false;
+                }
+
+                if l_dimensions
+                    .iter()
+                    .zip(r_dimensions)
+                    .map(|(x, y)| x.get_length(index) == y.get_length(index))
+                    .any(|x| !x)
+                {
+                    return false;
+                }
+
+                l_name == r_name
+            }
+
+            _ => false,
+        },
+
         // We have to handle 3 different cases here:
         // 1. foo := ADR(bar)
         // 2. foo := REF(bar)

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -973,18 +973,9 @@ pub fn is_same_type_class(ltype: &DataTypeInformation, rtype: &DataTypeInformati
             matches!(rtype, DataTypeInformation::String { encoding, .. } if encoding == lenc)
         }
 
-        DataTypeInformation::Array { inner_type_name: l_name, dimensions: l_dim, .. } => match rtype {
-            DataTypeInformation::Array { inner_type_name: r_name, dimensions: r_dim, .. } => {
-                // Check if the inner type name as well as the dimension length are equal
-                if !(l_name == r_name && l_dim.len() == r_dim.len()) {
-                    return false;
-                }
-
-                // Check if the dimension's lengths are equal
-                let l_dim_len = l_dim.iter().map(|x| x.get_length(index)).collect::<Vec<_>>();
-                let r_dim_len = r_dim.iter().map(|x| x.get_length(index)).collect::<Vec<_>>();
-
-                l_dim_len == r_dim_len
+        DataTypeInformation::Array { inner_type_name: l_inner_type, .. } => match rtype {
+            DataTypeInformation::Array { inner_type_name: r_inner_type, .. } => {
+                l_inner_type == r_inner_type && ltype.get_size(index) == rtype.get_size(index)
             }
 
             _ => false,

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -973,7 +973,7 @@ fn validate_call_by_ref() {
 }
 
 #[test]
-fn validate_call_by_ref_arrays() {
+fn validate_array_elements_passed_to_functions_by_ref() {
     let diagnostics: Vec<Diagnostic> = parse_and_validate(
         "
         FUNCTION func : DINT
@@ -1004,4 +1004,27 @@ fn validate_call_by_ref_arrays() {
 
     assert_eq!(diagnostics[1].get_message(), "Invalid assignment: cannot assign '__main_x' to 'INT'");
     assert_eq!(diagnostics[1].get_affected_ranges(), &[(326..327).into()]);
+}
+
+#[test]
+fn validate_arrays_passed_to_functions() {
+    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+        "
+        FUNCTION func : DINT
+            VAR_INPUT
+                arr_dint : ARRAY[0..1] OF DINT;
+            END_VAR
+        END_FUNCTION
+
+        PROGRAM main
+            VAR
+                local_arr_dint : ARRAY[0..1] OF DINT;
+            END_VAR
+
+            func(local_arr_dint);
+        END_PROGRAM
+        ",
+    );
+
+    assert_eq!(diagnostics.len(), 0);
 }


### PR DESCRIPTION
Fixes https://github.com/PLC-lang/rusty/issues/759

Trying to pass an array as a function argument triggered a validation error
because we we're checking if the passed argument is of the same type as the declared
parameter. The detection of such code in the `is_same_type_class` function was non-existing however.
 This commit adds such a check such that passing array arguments is allowed.
