### PR TITLE
Clean-up `Build & Install` section

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,7 +1,8 @@
 # Summary
 
 - [RuSTy](./intro_1.md)
-- [Build and Install](./build_and_install.md)
+- [Build & Install](./build_and_install.md)
+  - [Development Tips](./development_tips.md)
 - [Using RuSTy](./using_rusty.md)
   - [Build Configuration](using_rusty/build_configuration.md)
 - [Writing ST Programs]()

--- a/book/src/build_and_install.md
+++ b/book/src/build_and_install.md
@@ -1,9 +1,8 @@
-# Building and Installing
+# Build & Install
 
 RuSTys code can be found on [GitHub](https://github.com/PLC-lang/rusty).
-By default a `Dockerfile` and a `devcontainer.json` file are provided.
-
-If you wish to develop natively however, you will need some additional dependencies namely :
+By default a `Dockerfile` and a `devcontainer.json` file are provided. If you wish to develop natively 
+however, you will need some additional dependencies namely:
 
 - [Rust](https://www.rust-lang.org/tools/install)
 - LLVM 14
@@ -11,7 +10,10 @@ If you wish to develop natively however, you will need some additional dependenc
 - Build Tools (e.g. `build-essential` on Ubuntu)
 - zlib
 
-The next sections will cover how to install these dependencies on different platforms.
+The next sections cover how to install these dependencies on different platforms, if you already have them
+however, RuSTy can be build using the `cargo` command. For debug builds this can be accomplished by executing
+`cargo build` and for release builds (smaller & faster) you would execute `cargo build --release`. The 
+resulting binaries can be found at `target/debug/rustyc` and `target/release/rustyc` respectively.
 
 ## Ubuntu
 
@@ -50,6 +52,9 @@ echo 'export PATH="/opt/homebrew/opt/llvm@14/bin:$PATH"' >> ~/.zshrc
 ## Windows
 
 For Windows you will need a [custom build](https://github.com/plc-lang/llvm-package-windows/releases/tag/v14.0.6).
+## Installing
+
+_TODO_
 
 ## Troubleshooting
 
@@ -60,20 +65,3 @@ major version of the `llvm-sys` crate.Currently you will need to install LLVM 14
 (like you get by just installing `llvm-dev`), which may break things. If you do, make sure you have set
 the appropriate environment variable (`LLVM_SYS_140_PREFIX=/usr/lib/llvm-14` for LLVM 14), so
 the build of the `llvm-sys` crate knows what files to grab.
-
-## Building
-
-Just like any Rust project, binaries can be built with `cargo build`.
-For release builds, i.e. faster and smaller binaries, you have to pass the `--release` flag, like so `cargo build --release`.
-The resulting binaries can be found at `target/release/rustyc`.
-
-## Improving Compile Times
-
-By default Rust uses the GNU Linker on Linux which compared to [lld](https://lld.llvm.org/) is slower by a margin of [~2x - 4x](https://llvm.org/devmtg/2016-10/slides/Ueyama-lld.pdf).
-To improve compile times we can therefore use `lld`.
-To do so you will need to run the `rusty/scripts/lld.sh` script inside the `rusty` root folder, i.e. by executing `./scripts/lld.sh`.
-**Note** that the script was only tested on Ubuntu based distributions thus far.
-
-## Installing
-
-_TODO_

--- a/book/src/development_tips.md
+++ b/book/src/development_tips.md
@@ -1,0 +1,6 @@
+## Improving Compile Times
+
+By default Rust uses the GNU Linker on Linux which compared to [lld](https://lld.llvm.org/) is slower by a margin of [~2x - 4x](https://llvm.org/devmtg/2016-10/slides/Ueyama-lld.pdf).
+To improve compile times we can therefore use `lld`.
+To do so you will need to run the `rusty/scripts/lld.sh` script inside the `rusty` root folder, i.e. by executing `./scripts/lld.sh`.
+**Note** that the script was only tested on Ubuntu based distributions thus far.


### PR DESCRIPTION
- Added a `Development Tips` chapter, transfering the `Improving Compile Times` section to it
- Merged the `Building` section with the introduction section of `Build & Install`