### PR TITLE
Update the dev container to the latest build script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,37 +1,16 @@
 # FROM mcr.microsoft.com/vscode/devcontainers/rust:latest
-ARG VARIANT="bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/rust:1-${VARIANT}
+FROM ghcr.io/plc-lang/rust-llvm:latest
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
-# # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
-# # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# # will be updated to match your local UID/GID (when using the dockerFile property).
-# # See https://aka.ms/vscode-remote/containers/non-root-user for details.
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
 # ARG USERNAME=vscode
 # ARG USER_UID=1000
 # ARG USER_GID=$USER_UID
-
-RUN apt-get update && apt-get install -y vim git
-
-
-ARG LLVM_VER=14
-# Use the bullseye llvm version because there is no newer one yet
-ARG LLVM_DISTRO_VERSION=bullseye 
-
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-# Setup llvm sources
-RUN echo "deb http://apt.llvm.org/$LLVM_DISTRO_VERSION/ llvm-toolchain-$LLVM_DISTRO_VERSION-$LLVM_VER  main" >> /etc/apt/sources.list.d/llvm.list
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-
-RUN apt-get update
-#Install Clang dependencies
-RUN apt-get install -y zip clang-$LLVM_VER lldb-$LLVM_VER lld-$LLVM_VER clangd-$LLVM_VER liblld-$LLVM_VER-dev llvm-$LLVM_VER-dev
-
-#Install documentation and coverage tools
-RUN cargo install mdbook grcov
 
 # # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
 # RUN groupadd --gid $USER_GID $USERNAME \
@@ -51,4 +30,4 @@ RUN chmod -R a+rw $CARGO_HOME \
 ENV DEBIAN_FRONTEND=dialog
 
 # Required if we want to use `lld` as the default linker for RuSTy
-RUN ln -sf /usr/bin/ld.lld-$LLVM_VER /usr/bin/ld.lld
+# RUN ln -sf /usr/bin/ld.lld-$LLVM_VER /usr/bin/ld.lld

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,35 +1,43 @@
 {
 	"name": "Rust",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "./Dockerfile"
 	},
-	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
+	// "image": "ghcr.io/plc-lang/rust-llvm:latest",
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "true",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "true"
+        }
+	},
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"lldb.executable": "/usr/bin/lldb",
-		// VS Code don't watch files under ./target
-		"files.watcherExclude": {
-			"**/target/**": true
-		},
-		"rust-analyzer.checkOnSave.command": "clippy",
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"lldb.executable": "/usr/bin/lldb",
+				// VS Code don't watch files under ./target
+				"files.watcherExclude": {
+					"**/target/**": true
+				},
+				"rust-analyzer.checkOnSave.command": "clippy"
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"bungcip.better-toml",
+				"vadimcn.vscode-lldb",
+				"mutantdino.resourcemonitor",
+				"rust-lang.rust-analyzer"
+			]
+		}
 	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"bungcip.better-toml",
-		"vadimcn.vscode-lldb",
-		"mutantdino.resourcemonitor",
-		"rust-lang.rust-analyzer"
-	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"containerUser": "vscode"
 }


### PR DESCRIPTION
This will currently not work on AARCH64 hosts like the M1/M2 because the base image is not (yet) available.
The docker file is currently only needed because of the chmod and the insta installation commands, i think we could move both to a devcontainer build on the rust-llvm-images side