### PR TITLE
Book fixes

### DIFF
--- a/book/src/arch/codegen.md
+++ b/book/src/arch/codegen.md
@@ -59,7 +59,7 @@ A FunctionBlock is an POU that is instantiated in a declaration.
 So in contrast to Programs, a FunctionBlock can have multiple instances.
 Nevertheless the code-generator uses a very similar strategy.
 A struct-type for the FunctionBlock's interface is created but no global instance-variable is allocated.
-Instead the function block can be used as a DataType to declare instances like in the following example :
+Instead the function block can be used as a DataType to declare instances like in the following example:
 
 ```iecst
 FUNCTION_BLOCK foo
@@ -134,7 +134,7 @@ TYPE MyStruct:
 END_TYPE
 ```
 
-This struct simply generates a llvm struct type :
+This struct simply generates a llvm struct type:
 
 ```llvm
 %MyStruct = type { i32, i16 }
@@ -180,7 +180,7 @@ Custom array data types are not reflected as dedicated types on the llvm-level.
 
 #### Multi dimensional arrays
 
-Arrays can be declared as multi-dimensional :
+Arrays can be declared as multi-dimensional:
 
 ```iecst
 VAR_GLOBAL
@@ -189,20 +189,20 @@ END_VAR
 ```
 
 The compiler will flatten these type of arrays to a single-dimension. To accomplish that, it calculates the total
-length by mulitplying the sizes of all dimensions :
+length by mulitplying the sizes of all dimensions:
 
 ```ignore
     0..5 x 2..5 x 0..1
       6  x   4  x   2  = 64
 ```
 
-So the array `x : ARRAY[0..5, 2..5, 0..1] OF INT;` will be generated as :
+So the array `x : ARRAY[0..5, 2..5, 0..1] OF INT;` will be generated as:
 
 ```llvm
 @x = global [64 x i16] zeroinitializer
 ```
 
-This means that such a multidimensional array must be initialized like a single-dimensional array :
+This means that such a multidimensional array must be initialized like a single-dimensional array:
 
 - *wrong*
 

--- a/book/src/arch/codegen.md
+++ b/book/src/arch/codegen.md
@@ -6,7 +6,8 @@ To generate the *IR* we use a crate that wraps the native llvm [C-API](https://g
 The code-generator is basically a transformation from the ST-AST into an IR-Tree representation.
 Therefore the AST is traversed in a visitor-like way and transformed simultaneously.
 
-The code generation is split into specialized sub-generators for different tasks :
+The code generation is split into specialized sub-generators for different tasks:
+
 | Generator            | Responsibilities |
 | -------------------- | ---------------- |
 | pou_generator        | The pou-generator takes care of generating the programming organization units (Programs, FunctionBlocks, Functions) including their signature and body. More specialized tasks are delegated to other generators.  |

--- a/book/src/arch/linker.md
+++ b/book/src/arch/linker.md
@@ -304,7 +304,8 @@ The assignment `z := x + y` is loaded with different types :
 In order to make life easier for validation and code-generation we add an additional annotation to `x + y` to indicate, that while it technically results in a *DINT*, it should rather be treated as a *BYTE* since it is going to be assigned to `z`.
 This second annotation is called the *type-hint*. It indicates that while it technically is not the real type of this expression, the program's semantic wants the compiler to treat it as this type.
 
-The expression `z := x + y` is annotated like this :
+The expression `z := x + y` is annotated like this:
+
 | expression | type annotation | type-hint annotation | explanation                                                          |
 | ---------- | --------------- | -------------------- | -------------------------------------------------------------------- |
 | `x`        | SINT            | DINT                 | auto-upgraded to DINT                                                |

--- a/book/src/arch/linker.md
+++ b/book/src/arch/linker.md
@@ -1,7 +1,7 @@
 # Linker
 
 The linker's task is to decide where all references in the source code point to.
-There are different references in Structured Text :
+There are different references in Structured Text:
 
 - variable references  
 `x := 4` where *x* is a reference to the variable x.  
@@ -12,7 +12,7 @@ There are different references in Structured Text :
 - Function references  
 `max(a, b)` where *max* is a reference to a Function-POU called *max*.
 
-So the linker decides where a reference points to. A reference has a corresponding declaration that matches the reference's name :
+So the linker decides where a reference points to. A reference has a corresponding declaration that matches the reference's name:
 
 ```iecst
         PROGRAM PLC_PRG
@@ -48,7 +48,7 @@ The AnnotationMap can store two type of annotations for any AST-element.
 So the first step is that we need a way to uniquely identify every single AST-node so we can use this ID as a key for the annotations stored in the AnnotationMap to automatically associate it with the given AST-Node.
 The parser assigns a unique ID to every Statement-Tree-Node (Note that we only assign IDs to Statements, not every AST-Node).
 
-So the expression `a + 3` now looks like this :
+So the expression `a + 3` now looks like this:
 
 ```ignore
                       ┌─────────────────┐
@@ -127,7 +127,7 @@ The Type-annotation indicates that this AST-Element resolves to a DataType (e.g.
         │   Type                  │
         ├─────────────────────────┤
         │                         │
-        │  type_name : String     │
+        │  type_name: String      │
         │                         │
         └─────────────────────────┘
 ```
@@ -196,13 +196,13 @@ So the example expression from above `a + 3* will be annotated like this:
 ```
 
 Another example where the annotated AST carries a lot of useful information is with complex expressions like array-expressions or qualified references.
-Lets consider the following statement :
+Lets consider the following statement:
 
 ```iecst
 PLC_PRG.a.b[2]
 ```
 
-It is annotated in the following way :
+It is annotated in the following way:
 
 ```ignore
                 ┌────────────────────┐
@@ -279,7 +279,7 @@ It is annotated in the following way :
 
 The AnnotationMap not only offers annotations regarding the AST-node's type, but it also offers a second type of annotation.
 
-Consider the following snippet :
+Consider the following snippet:
 
 ```iecst
 PROGRAM PLC_PRG
@@ -294,7 +294,7 @@ PROGRAM PLC_PRG
 END_PROGRAM
 ```
 
-The assignment `z := x + y` is loaded with different types :
+The assignment `z := x + y` is loaded with different types:
 
 - `x` is annotated as *Variable* of type *SINT* and will be auto-upgraded to *DINT*.
 - `y` is annotated as *Variable* of type *INT* and will be auto-upgraded to *DINT*.

--- a/book/src/arch/parser.md
+++ b/book/src/arch/parser.md
@@ -50,7 +50,7 @@ The number of tokens identified by the RuSTy-lexer is quite high, so as of janua
 
 The tokens identified by the lexer follow the formal definition provided by the IEC61131-3 (2013) standard.
 
-Following strategies increase the number of tokens and should be reconsidered :
+Following strategies increase the number of tokens and should be reconsidered:
 
 - case insensitivity
 - optional underscores in keywords (e.g. `END_IF` == `ENDIF`)
@@ -77,7 +77,7 @@ It is impossible to construct it differently.
 
 #### Example
 
-So an assignment `a := 3;` will be parsed with the help of the following Structures :
+So an assignment `a := 3;` will be parsed with the help of the following Structures:
 
 ```rs
 struct Reference {

--- a/book/src/arch/validation.md
+++ b/book/src/arch/validation.md
@@ -5,11 +5,13 @@ The validator is a hand-written visitor that offers a callback when visiting the
 
 The validation rules are implemented in dedicated validator-structs:
 
-| Validator          | Responsibilities                                                                                   |
-| ------------------ | -------------------------------------------------------------------------------------------------- |
-| pou_validator      | Semantic rules on the level of Programs, Functionblocks and Functions.                             |
-| variable_validator | Semantic rules on the level of variable declarations (e.g. empty var-blocks, empty structs, etc.). |
-| stmt_validator     | Semantic rules on the level of statements (e.g. invalid type-casts).                               |
+| Validator           | Responsibilities                                                                                   |
+| ------------------- | -------------------------------------------------------------------------------------------------- |
+| global_validator    | Semantic rules on the level of declarations as a whole (e.g. name-conflicts)                       |
+| pou_validator       | Semantic rules on the level of programs, function- and function-blocks.                            |
+| recursive_validator | Semantic rules on the level of recursion (e.g. struct referencing itself)                          |
+| stmt_validator      | Semantic rules on the level of statements (e.g. invalid type-casts).                               |
+| variable_validator  | Semantic rules on the level of variable declarations (e.g. empty var-blocks, empty structs, etc.). |
 
 ## Diagnostics
 

--- a/book/src/arch/validation.md
+++ b/book/src/arch/validation.md
@@ -3,7 +3,8 @@
 The validation module implements the semantic validation step of the compiler.
 The validator is a hand-written visitor that offers a callback when visiting the single AST-nodes to then perform the different validation tasks.
 
-The validation rules are implemented in dedicated validator-structs :
+The validation rules are implemented in dedicated validator-structs:
+
 | Validator          | Responsibilities                                                                                   |
 | ------------------ | -------------------------------------------------------------------------------------------------- |
 | pou_validator      | Semantic rules on the level of Programs, Functionblocks and Functions.                             |
@@ -15,7 +16,8 @@ The validation rules are implemented in dedicated validator-structs :
 Problems (semantic or syntactic) are represented as *Diagnostics* [^1].
 Diagnostics carry information on the exact location inside the source-string (start- & end-offset), a custom message and a unique error-number to identify the problem.
 
-There are 3 types of *Diagnostics* :
+There are 3 types of *Diagnostics*:
+
 | Diagnostic   | Description |
 | ------------ | ----------------- |
 | SyntaxError  | A syntax error is a diagnostic that is created by the parser if it discovers a token-stream that does not match the language's grammar. |

--- a/book/src/build_and_install.md
+++ b/book/src/build_and_install.md
@@ -17,7 +17,7 @@ resulting binaries can be found at `target/debug/rustyc` and `target/release/rus
 
 ## Ubuntu
 
-The specified dependencies can be installed with the following command on Ubuntu :
+The specified dependencies can be installed with the following command on Ubuntu:
 
 ```bash
 sudo apt install                \
@@ -43,7 +43,7 @@ Furthermore LLVM 14 is needed, which can be easily installed with [homebrew](htt
 brew install llvm@14
 ````
 
-After the installation you have to add `/opt/homebrew/opt/llvm@14/bin` to your `$PATH` environment variable, e.g. with the following command :
+After the installation you have to add `/opt/homebrew/opt/llvm@14/bin` to your `$PATH` environment variable, e.g. with the following command:
 
 ```bash
 echo 'export PATH="/opt/homebrew/opt/llvm@14/bin:$PATH"' >> ~/.zshrc

--- a/book/src/datatypes.md
+++ b/book/src/datatypes.md
@@ -27,7 +27,7 @@ be default-initialized with a value of `0` or `0.0` respectively.
 Integer literals can be prefixed with either `2#` (binary), `8#` (octal) or `16#` (hexadecimal).
 They will then be treated with regard to the respective number system.
 
-Examples :
+Examples:
 
 - `i1 : DINT := 42;` - declares and initializes a 32bit signed integer with value 42.
 - `i1 : DINT := 2#101010;` - declares and initializes a 32bit signed integer with value 42.
@@ -56,7 +56,7 @@ A String has a well defined length which can be defined similar to the array-syn
 A String-variable `myVariable: STRING[20]` declares a byte array of length 21, to store 20 utf8 character bytes.
 When declaring a `STRING`, the length-attribute is optional. The default length is 80.
 
-Examples :
+Examples:
 
 - `s1 : STRING;` - declares a String of length 80.
 - `s2 : STRING[20];` - declares a String of length 20.
@@ -74,7 +74,7 @@ A `WSTRING` has a well defined length which can be defined similar to the array-
 A `WSTRING`-variable `myVariable: WSTRING[20]` declares a byte array of length 42, to store 20 utf16 character bytes.
 When declaring a `WSTRING`, the length-attribute is optional. The default length is 80.
 
-Examples :
+Examples:
 
 - `ws1 : WSTRING;` - declares a Wide-String of length 80.
 - `ws2 : WSTRING[20];` - declares a Wide-String of length 20.
@@ -102,7 +102,7 @@ Such a value is stored as an i64 with a precision in nanoseconds and denotes the
 that have elapsed since January 1, 1970 UTC not counting leap seconds.
 DATE literals start with `DATE#` or `D#` followed by a date in the format of `yyyy-mm-dd`.
 
-Examples :
+Examples:
 
 - `d1 : DATE := DATE#2021-05-02;`
 - `d2 : DATE := DATE#1-12-24;`
@@ -118,7 +118,7 @@ format of `yyyy-mm-dd-hh:mm:ss`.
 
 Note that only the seconds-segment can have a fraction denoting the milliseconds.
 
-Examples :
+Examples:
 
 - `d1 : DATE_AND_TIME := DATE_AND_TIME#2021-05-02-14:20:10.25;`
 - `d2 : DATE_AND_TIME := DATE_AND_TIME#1-12-24-00:00:1;`
@@ -135,7 +135,7 @@ format of `hh:mm:ss`.
 
 Note that only the seconeds-segment can have a fraction denoting the milliseconds.
 
-Examples :
+Examples:
 
 - `t1 : TIME_OF_DAY := TIME_OF_DAY#14:20:10.25;`
 - `t2 : TIME_OF_DAY := TIME_OF_DY#0:00:1;`
@@ -147,7 +147,7 @@ The `TIME` datatype is used to represent a time-span.
 A `TIME` value is stored as an `i64` value with a precision in nanoseconds.
 TIME literals start with `TIME#` or `T#` followed by the `TIME` segements.
 
-Supported segements are :
+Supported segements are:
 
 - `d` ... `f64` days
 - `h` ... `f64` hours
@@ -159,7 +159,7 @@ Supported segements are :
 
 Note that only the last segment of a `TIME` literal can have a fraction.
 
-Examples :
+Examples:
 
 - `t1 : TIME := TIME#2d4h6m8s10ms;`
 - `t2 : TIME := T#2d4.2h;`

--- a/book/src/direct_variables.md
+++ b/book/src/direct_variables.md
@@ -7,7 +7,8 @@ RuSTy supports this functionalty and extends it to support all `INT` types.
 
 To access a bit sequence in a variable, a direct access instruction `%<Type><Value>` is used.
 
-`Type` is the bit sequence size required and is described as follows :
+`Type` is the bit sequence size required and is described as follows:
+
 | Type | Size | Example |
 | ---- | ---- | ------- |
 | X    | 1    | `%X1    |

--- a/book/src/libraries.md
+++ b/book/src/libraries.md
@@ -10,7 +10,7 @@ System functions can also be added using [External Function](libraries/external_
 
 ## Library Structure
 
-A library is defined by :
+A library is defined by:
 
 - A set of `st` interfaces, each interface represents a function that has been precompiled.
 
@@ -110,7 +110,7 @@ Since libraries can be compiled for multiple targets, the lib path can contain e
 
 ### Configuration Example (`plc.json`)
 
-A configuration example for a `Copy` library called _mylib_ and a `System` library called _std_ :
+A configuration example for a `Copy` library called _mylib_ and a `System` library called _std_:
 
 ```json
 "libraries" : [

--- a/book/src/libraries/external_functions.md
+++ b/book/src/libraries/external_functions.md
@@ -17,21 +17,21 @@ END_FUNCTION
 
 At compilation time, the function `log` will be defined as an externally available function, and can be called from `ST` code.
 
-> Note : At linking time, a `log` function with a compatible signature must be available on the system.
+> Note: At linking time, a `log` function with a compatible signature must be available on the system.
 
 ## Calling C functions
 
 `ST` code can call into foreign functions natively.
 To achieve this, the called function must be defined in a `C` compatible API, e.g. `extern "C"` blocks.
 
-The interface of the function has to :
+The interface of the function has to:
 
 - either be included with the `-i` flag
 - or be declared in `ST` using the `{external}` keyword
 
 ### Example
 
-Given a `min` function defined in `C` as follows :
+Given a `min` function defined in `C` as follows:
 
 ```C
 int min(int a, int b) {
@@ -39,7 +39,7 @@ int min(int a, int b) {
 }
 ```
 
-an interface of that function in `ST` can be defined as :
+an interface of that function in `ST` can be defined as:
 
 ```iecst
 {external}
@@ -63,13 +63,13 @@ Calling a variadic function is supported in `ST`. To mark an external function a
 
 #### Variadic function example
 
-Given the `printf` function defined as :
+Given the `printf` function defined as:
 
 ```C
 int printf( const char *restrict format, ... );
 ```
 
-the `ST` interface can be defined as :
+the `ST` interface can be defined as:
 
 ```iecst
 {external}
@@ -88,7 +88,7 @@ END_FUNCTION
 With the `printf` function available on the system, there is no need to declare
 the C function.
 
-An `ST` program called `ExternalFunctions.st` with the following code can be declared :
+An `ST` program called `ExternalFunctions.st` with the following code can be declared:
 
 ```iecst
 (*ExternalFunctions.st*)
@@ -123,7 +123,7 @@ END_VAR
 END_FUNCTION
 ```
 
-Compiling the previous code with the following command :
+Compiling the previous code with the following command:
 
 ```sh
 rustyc ExternalFunctions.st -o ExternalFunctions --linker=clang

--- a/book/src/pous.md
+++ b/book/src/pous.md
@@ -7,7 +7,7 @@ It can be defined as either a Program, a Function, a Function Block, or an Actio
 
 > Methods on classes are also considered POUs but are not covered by this document
 
-A POU is defined as :
+A POU is defined as:
 
 ```iecst
 <POU Type> name 
@@ -27,7 +27,7 @@ Supported parameter types are `VAR_INPUT`, `VAR_INPUT {ref}`, `VAR_OUTPUT` and `
 
 Input parameters are typically copied into the target POU to be stored and read for later references.
 
-A definition for input parameters is as follows :
+A definition for input parameters is as follows:
 
 ```iecst
 VAR_INPUT
@@ -38,7 +38,7 @@ END_VAR
 In some cases, especially when passing large strings or arrays, or when interacting with foreign code (see [External Functions](libraries/external_functions.md)) it is more efficient to avoid copying the variable values and just use a pointer to the required input.
 This can be done either using the in/out variables or by specifying a special property `ref` on the input block.
 
-Example :
+Example:
 
 ```iecst
 VAR_INPUT {ref}
@@ -74,7 +74,7 @@ In addition to the default behavior, each type of POU has some special cases.
 Functions are _stateless_ sequences of callable code. They are not backed by any structs, and cannot hold any state accross multiple calls.
 A function's input parameter can be passed by value, or by reference.
 
-Functions also support a return type, the resulting definition is :
+Functions also support a return type, the resulting definition is:
 
 ```iecst
     FUNCTION fnName : <TYPE>
@@ -103,7 +103,7 @@ Programs are a static (i.e. `GLOBAL`) `STRUCT` that holds its state accross mult
 A Program exists once, and only once in an application, and subsequent calls to a program will change and store the passed parameters as well as internal variables.
 A program does not support passing input parameters by reference.
 
-Example :
+Example:
 
 ```iecst
 PROGRAM prg 
@@ -154,7 +154,7 @@ An action can only be defined for Programs and Function Blocks.
 
 An action is defined in 3 different ways, either in a container (`ACTIONS`) directly below the POU, in a named `ACTIONS` container, or using a qualified name on the action.
 
-Example :
+Example:
 
 ```iecst
 FUNCTION_BLOCK fb

--- a/book/src/using_rusty.md
+++ b/book/src/using_rusty.md
@@ -13,10 +13,10 @@ Similarly, if you do not specify an output filename via the `-o` or `--output` o
 the output filename will consist of the first input filename, but with an appropriate
 file extension depending on the output file format.
 
-A minimal invocation looks like this :
+A minimal invocation looks like this:
 `rustyc input.st` ... this will take in the file input.st and compile it into a static object that will be written to a file named input.o.
 
-More examples :
+More examples:
 
 - `rustyc --ir file1.st file2.st` will compile file1.st and file2.st.
 - `rustyc --ir src/*.st` will compile all st files in the src-folder.
@@ -50,7 +50,7 @@ END_FUNCTION
 
 The RuSTy command line interface is similar to that of other compilers.
 
-If you just want to build an object file, then do this :
+If you just want to build an object file, then do this:
 
 ```bash
 rustyc -c hello_world.st -o hello_world.o
@@ -60,7 +60,7 @@ rustyc -c hello_world.st -o hello_world.o
 
 `rustyc` offers 4 levels of optimization which correspond to the levels established by llvm respectively [clang](https://clang.llvm.org/docs/CommandGuide/clang.html#code-generation-options) (`none` to `aggressive`, respectively `-O0` to `-O3`).
 
-To use an optimization, the flag `-O` or `--optimization` is required :
+To use an optimization, the flag `-O` or `--optimization` is required:
 
 - `rustyc -c "**/*.st" -O none`
 - `rustyc -c "**/*.st" -O less`
@@ -71,7 +71,7 @@ By default `rustyc` will use `default` which corresponds to clang's `-O2`.
 
 ### Linking an executable
 
-Instead, you can also compile this into an executable and run it :
+Instead, you can also compile this into an executable and run it:
 
 ```bash
 rustyc hello_world.st -o hello_world --linker=cc

--- a/book/src/using_rusty/build_configuration.md
+++ b/book/src/using_rusty/build_configuration.md
@@ -4,13 +4,13 @@ In addition to the comprehensive help, `rustyc` offers a build subcommand that s
 Instead of having numerous inline arguments, using the build subcommand along with a build description file makes passing the arguments easier. </br>
 The build description file needs to be saved in the [json](https://en.wikipedia.org/wiki/JSON) format.
 
-Usage :
+Usage:
 `rustyc build`
 
 Note that if `rustyc` cannot find the `plc.json` file, it will throw an error and request the path.
 The default location for the build file is the current directory.
 
-The command for building with an additional path looks like this :
+The command for building with an additional path looks like this:
 `rustyc build src/plc.json`
 
 ## Build description file (plc.json)
@@ -22,7 +22,7 @@ All the keys used in the build description file are described in the following s
 
 The keyword `files` is the equivalent to the `input` parameter, which adds all the `ST` files that need to be compiled.
 
-The value of `files` is an array of strings, definied as follows :
+The value of `files` is an array of strings, definied as follows:
 
 ```json
 "files" : [
@@ -110,7 +110,7 @@ The `package_commands` keyword is optional.
 
 ## Build Parameters
 
-The `build` subcommand exposes the following optional parameters :
+The `build` subcommand exposes the following optional parameters:
 
 ### `--build-location`
 
@@ -128,7 +128,7 @@ This can be overriden with the `--lib-location` command line parameter.
 
 Environment variables can be used inside the build description file, the variables are evaluated before an entry is evaluated.
 
-In addition to externally defined variables, the build exports variables that can be referenced in the description file :
+In addition to externally defined variables, the build exports variables that can be referenced in the description file:
 
 ### `PROJECT_ROOT`
 
@@ -139,7 +139,7 @@ The folder containing the `plc.json` file, i.e. the root of the project.
 The target architecture currently being built, for a multi architecture build.
 The value for `ARCH` will be updated for every target.
 
-Example targets are :
+Example targets are:
 `x86_64-pc-linux-gnu`, `x86_64-pc-windows-msvc`, `aarch64-pc-linux-musl`
 
 ### `BUILD_LOCATION`


### PR DESCRIPTION
This PR contains the following changes:
1. Correctly display tables in the book, which are currently broken due to missing newlines; see https://plc-lang.github.io/rusty/arch/validation.html
2. Remove whitespace between words and colons, e.g. `Example :` becomes `Example:`
3. Add the recursive and global validators to the Validation table