### PR TITLE
ADR documentation (arrays, strings, structs)

### DIFF
--- a/src/tests/adr.rs
+++ b/src/tests/adr.rs
@@ -1,5 +1,8 @@
 mod annotated_ast;
+mod arrays_adr;
 /// tests for Architecture Design Records (ADR)
 mod enum_adr;
 mod pou_adr;
+mod strings_adr;
+mod structs_adr;
 mod util_macros;

--- a/src/tests/adr/arrays_adr.rs
+++ b/src/tests/adr/arrays_adr.rs
@@ -1,0 +1,131 @@
+use crate::test_utils::tests::codegen;
+
+/// # Architecture Design Record: Arrays
+/// ST supports C-like arrays
+#[test]
+fn declaring_an_array() {
+    // an array type ...
+    let src = r#"
+        TYPE Data: ARRAY[0..9] OF DINT; END_TYPE
+
+        VAR_GLOBAL
+            d : Data;
+        END_VAR
+        "#;
+
+    // ... just translates to a llvm array type
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    @d = global [10 x i32] zeroinitializer
+    "###);
+}
+
+/// Arrays can have a default value by initializing it. Variables of this
+/// type will be initialized automatically.
+#[test]
+fn initializing_an_array() {
+    // The fields of a struct can get default values ...
+    let src = r#"
+        TYPE Data: ARRAY[0..9] OF DINT := [0,1,2,3,4,5,6,7,8,9]; END_TYPE
+
+        VAR_GLOBAL
+            d : Data;
+        END_VAR
+        "#;
+
+    // ... Instances of this struct will be initialized accordingly
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    @d = global [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
+    @__Data__init = unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
+    "###);
+}
+
+/// Arrays are aggregate types. This means that passing them to functions and assigning them
+/// are expensive operations (when compared to passing ar assigning an INT). Aggregate types like
+/// structs and arrays are assigned using memcpy.
+#[test]
+fn assigning_full_arrays() {
+    // two struct instances that get assigned...
+    let src = r#"
+        TYPE Data: ARRAY[0..9] OF DINT := [0,1,2,3,4,5,6,7,8,9]; END_TYPE
+
+        PROGRAM prg
+            VAR
+                a,b : Data;
+            END_VAR
+
+             a := b;
+        END_PROGRAM
+        "#;
+
+    // ... the assignment a := b will be performed as a memcpy
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %prg = type { [10 x i32], [10 x i32] }
+
+    @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9] }
+    @__Data__init = unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
+
+    define void @prg(%prg* %0) {
+    entry:
+      %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+      %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+      %1 = bitcast [10 x i32]* %a to i8*
+      %2 = bitcast [10 x i32]* %b to i8*
+      call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %1, i8* align 1 %2, i64 ptrtoint ([10 x i32]* getelementptr ([10 x i32], [10 x i32]* null, i32 1) to i64), i1 false)
+      ret void
+    }
+
+    ; Function Attrs: argmemonly nofree nounwind willreturn
+    declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
+
+    attributes #0 = { argmemonly nofree nounwind willreturn }
+    "###);
+}
+
+/// Accessing ARRAY's members uses the LLVM GEP statement to get a pointer
+/// to its elements.
+#[test]
+fn accessing_struct_members() {
+    // two nested struct-variables that get initialized ...
+    let src = r#"
+        TYPE Data: ARRAY[0..9] OF DINT := [0,1,2,3,4,5,6,7,8,9]; END_TYPE
+
+        PROGRAM prg
+            VAR
+                a,b : Data;
+            END_VAR
+
+            a[2] := b[3];
+        END_PROGRAM       
+        "#;
+
+    // ... will be initialized directly in the variable's definition
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %prg = type { [10 x i32], [10 x i32] }
+
+    @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9] }
+    @__Data__init = unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
+
+    define void @prg(%prg* %0) {
+    entry:
+      %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+      %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+      %tmpVar = getelementptr inbounds [10 x i32], [10 x i32]* %a, i32 0, i32 2
+      %tmpVar1 = getelementptr inbounds [10 x i32], [10 x i32]* %b, i32 0, i32 3
+      %load_tmpVar = load i32, i32* %tmpVar1, align 4
+      store i32 %load_tmpVar, i32* %tmpVar, align 4
+      ret void
+    }
+    "###);
+}

--- a/src/tests/adr/strings_adr.rs
+++ b/src/tests/adr/strings_adr.rs
@@ -46,9 +46,9 @@ fn strings_are_terminated_with_0byte() {
     "###);
 }
 
-/// Arrays are aggregate types. This means that passing them to functions and assigning them
-/// are expensive operations (when compared to passing ar assigning an INT). Aggregate types like
-/// structs and arrays are assigned using memcpy.
+/// Strings are aggregate types. This means that passing them to functions and assigning them
+/// are expensive operations (when compared to passing ar assigning an INT). Aggregate types
+/// are assigned using memcpy.
 #[test]
 fn assigning_strings() {
     // two strings get assigned ...

--- a/src/tests/adr/strings_adr.rs
+++ b/src/tests/adr/strings_adr.rs
@@ -1,0 +1,132 @@
+use crate::test_utils::tests::codegen;
+
+/// # Architecture Design Record: Strings
+/// ST supports two types of Strings: UTF8 and UTF16 Strings. Strings are fixed size and
+/// stored using i8-arrays for utf8 strings and i16-arrays for utf16 strings.
+#[test]
+fn declaring_a_string() {
+    // two string variables
+    let src = r#"
+        VAR_GLOBAL
+            myUtf8  : STRING[20];
+            myUtf16 : WSTRING[20];
+        END_VAR
+        "#;
+
+    // ... are stored as i8/i16 arrays and get initialized to blank (0)
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    @myUtf8 = global [21 x i8] zeroinitializer
+    @myUtf16 = global [21 x i16] zeroinitializer
+    "###);
+}
+
+/// rusty treats strings like C-strings (char arrays) so the interoperability
+/// with C-libraries is seamless.
+#[test]
+fn strings_are_terminated_with_0byte() {
+    // two strings with an initial value ...
+    let src = r#"
+        VAR_GLOBAL
+            myUtf8  : STRING[5]  := 'Hello';
+            myUtf16 : WSTRING[5] := "World";
+        END_VAR
+        "#;
+
+    // ... get stored as c-like char arrays with 0-terminators
+    // ... offer one extra entry (length 21 while only 20 were declared) for a terminator
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    @myUtf8 = global [6 x i8] c"Hello\00"
+    @myUtf16 = global [6 x i16] [i16 87, i16 111, i16 114, i16 108, i16 100, i16 0]
+    "###);
+}
+
+/// Arrays are aggregate types. This means that passing them to functions and assigning them
+/// are expensive operations (when compared to passing ar assigning an INT). Aggregate types like
+/// structs and arrays are assigned using memcpy.
+#[test]
+fn assigning_strings() {
+    // two strings get assigned ...
+    let src = r#"
+        PROGRAM prg
+            VAR
+                a,b : STRING[10];
+            END_VAR
+             a := b;
+        END_PROGRAM
+        "#;
+
+    // ... the assignments will be performed as a memcpy
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %prg = type { [11 x i8], [11 x i8] }
+
+    @prg_instance = global %prg zeroinitializer
+
+    define void @prg(%prg* %0) {
+    entry:
+      %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+      %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+      %1 = bitcast [11 x i8]* %a to i8*
+      %2 = bitcast [11 x i8]* %b to i8*
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 %2, i32 10, i1 false)
+      ret void
+    }
+
+    ; Function Attrs: argmemonly nofree nounwind willreturn
+    declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
+
+    attributes #0 = { argmemonly nofree nounwind willreturn }
+    "###);
+}
+
+/// STRING literals will be generated as global constants, so they can be used as a source of a memcpy
+/// operation
+#[test]
+fn assigning_string_literals() {
+    // two nested struct-variables that get initialized ...
+    let src = r#"
+        PROGRAM prg
+            VAR
+                a,b : STRING[10];
+            END_VAR
+             a := 'hello';
+             b := 'world';
+        END_PROGRAM
+        "#;
+
+    // ... will be initialized directly in the variable's definition
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %prg = type { [11 x i8], [11 x i8] }
+
+    @prg_instance = global %prg zeroinitializer
+    @utf08_literal_0 = unnamed_addr constant [6 x i8] c"hello\00"
+    @utf08_literal_1 = unnamed_addr constant [6 x i8] c"world\00"
+
+    define void @prg(%prg* %0) {
+    entry:
+      %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+      %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+      %1 = bitcast [11 x i8]* %a to i8*
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_0, i32 0, i32 0), i32 6, i1 false)
+      %2 = bitcast [11 x i8]* %b to i8*
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %2, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_1, i32 0, i32 0), i32 6, i1 false)
+      ret void
+    }
+
+    ; Function Attrs: argmemonly nofree nounwind willreturn
+    declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
+
+    attributes #0 = { argmemonly nofree nounwind willreturn }
+    "###);
+}

--- a/src/tests/adr/structs_adr.rs
+++ b/src/tests/adr/structs_adr.rs
@@ -1,0 +1,220 @@
+use crate::test_utils::tests::codegen;
+
+/// # Architecture Design Record: Structs
+/// ST supports C-like structures.
+///
+#[test]
+fn declaring_a_struct() {
+    // a struct type ...
+    let src = r#"
+        TYPE Person:
+        STRUCT
+            firstName   : STRING;
+            lastName    : STRING;
+            yearOfBirth : INT;
+            isLoggedIn  : BOOL;
+        END_STRUCT
+        END_TYPE
+        "#;
+
+    // ... just translates to a llvm struct type
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %Person = type { [81 x i8], [81 x i8], i16, i8 }
+
+    @__Person__init = unnamed_addr constant %Person zeroinitializer
+    "###);
+}
+
+/// Structs can have a default value by initializing its fields.
+#[test]
+fn default_values_of_a_struct() {
+    // The fields of a struct can get default values ...
+    let src = r#"
+        TYPE Person:
+        STRUCT
+            firstName   : STRING[5] := 'Jane';
+            lastName    : STRING[5] := 'Row';
+            yearOfBirth : INT    := 1988;
+            isLoggedIn  : BOOL   := FALSE;
+        END_STRUCT
+        END_TYPE
+
+        VAR_GLOBAL
+            p : Person;
+        END_VAR
+        "#;
+
+    // ... instances of this struct-type will be initialized accordingly
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %Person = type { [6 x i8], [6 x i8], i16, i8 }
+
+    @p = global %Person { [6 x i8] c"Jane\00\00", [6 x i8] c"Row\00\00\00", i16 1988, i8 0 }
+    @__Person__init = unnamed_addr constant %Person { [6 x i8] c"Jane\00\00", [6 x i8] c"Row\00\00\00", i16 1988, i8 0 }
+    "###);
+}
+
+/// a Struct can also be assigned a struct-literal.
+#[test]
+fn initializing_a_struct() {
+    // two nested struct-variables that get initialized ...
+    let src = r#"
+        TYPE Point:
+        STRUCT
+            x, y   : INT;
+        END_STRUCT
+        END_TYPE
+
+        TYPE Rect:
+        STRUCT
+            topLeft, bottomRight   : Point;
+        END_STRUCT
+        END_TYPE
+
+        PROGRAM prg
+            VAR
+                rect1  : Rect := (
+                            topLeft := (x := 1, y := 5),
+                            bottomRight := (x := 10, y := 15));
+                rect2  : Rect := (
+                            topLeft := (x := 4, y := 6),
+                            bottomRight := (x := 16, y := 22));
+            END_VAR
+        END_PROGRAM
+        "#;
+
+    // ... will be initialized directly in the variable's definition
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %prg = type { %Rect, %Rect }
+    %Rect = type { %Point, %Point }
+    %Point = type { i16, i16 }
+
+    @prg_instance = global %prg { %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }, %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } } }
+    @__Point__init = unnamed_addr constant %Point zeroinitializer
+    @__Rect__init = unnamed_addr constant %Rect zeroinitializer
+    @__prg.rect1__init = unnamed_addr constant %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }
+    @__prg.rect2__init = unnamed_addr constant %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } }
+
+    define void @prg(%prg* %0) {
+    entry:
+      %rect1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+      %rect2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+      ret void
+    }
+    "###);
+}
+
+/// Structs are aggregate types. This means that passing them to functions and assigning them
+/// are expensive operations (when compared to passing ar assigning an INT). Aggregate types like
+/// structs and arrays are assigned using memcpy.
+#[test]
+fn assigning_structs() {
+    // two struct instances that get assigned and passed to a function ...
+    let src = r#"
+        TYPE Point:
+        STRUCT
+            x, y   : INT;
+        END_STRUCT
+        END_TYPE
+
+        PROGRAM prg
+            VAR
+                p1  : Point;
+                p2  : Point;
+            END_VAR
+
+            p1 := p2;
+        END_PROGRAM
+        "#;
+
+    // ... the assignment p1 := p2 will be performed as a memcpy
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %prg = type { %Point, %Point }
+    %Point = type { i16, i16 }
+
+    @prg_instance = global %prg zeroinitializer
+    @__Point__init = unnamed_addr constant %Point zeroinitializer
+
+    define void @prg(%prg* %0) {
+    entry:
+      %p1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+      %p2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+      %1 = bitcast %Point* %p1 to i8*
+      %2 = bitcast %Point* %p2 to i8*
+      call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %1, i8* align 1 %2, i64 ptrtoint (%Point* getelementptr (%Point, %Point* null, i32 1) to i64), i1 false)
+      ret void
+    }
+
+    ; Function Attrs: argmemonly nofree nounwind willreturn
+    declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
+
+    attributes #0 = { argmemonly nofree nounwind willreturn }
+    "###);
+}
+
+/// Accessing STRUCT's members uses the LLVM GEP statement to get a pointer
+/// to the struct's elements.
+#[test]
+fn accessing_struct_members() {
+    // two nested struct-variables that get initialized ...
+    let src = r#"
+        TYPE Point:
+        STRUCT
+            x, y   : INT;
+        END_STRUCT
+        END_TYPE
+
+        TYPE Rect:
+        STRUCT
+            topLeft, bottomRight   : Point;
+        END_STRUCT
+        END_TYPE
+
+        PROGRAM prg
+            VAR
+                rect1  : Rect;
+                rect2  : Rect;
+            END_VAR
+
+            rect1.topLeft.x := rect2.bottomRight.x;
+        END_PROGRAM
+        "#;
+
+    // ... will be initialized directly in the variable's definition
+    insta::assert_snapshot!(codegen(src), @r###"
+    ; ModuleID = 'main'
+    source_filename = "main"
+
+    %prg = type { %Rect, %Rect }
+    %Rect = type { %Point, %Point }
+    %Point = type { i16, i16 }
+
+    @prg_instance = global %prg zeroinitializer
+    @__Point__init = unnamed_addr constant %Point zeroinitializer
+    @__Rect__init = unnamed_addr constant %Rect zeroinitializer
+
+    define void @prg(%prg* %0) {
+    entry:
+      %rect1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+      %rect2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+      %topLeft = getelementptr inbounds %Rect, %Rect* %rect1, i32 0, i32 0
+      %x = getelementptr inbounds %Point, %Point* %topLeft, i32 0, i32 0
+      %bottomRight = getelementptr inbounds %Rect, %Rect* %rect2, i32 0, i32 1
+      %x1 = getelementptr inbounds %Point, %Point* %bottomRight, i32 0, i32 0
+      %load_ = load i16, i16* %x1, align 2
+      store i16 %load_, i16* %x, align 2
+      ret void
+    }
+    "###);
+}


### PR DESCRIPTION
introduce the architecture design records for aggreate datatypes