### PR TITLE
Allow assigniment of Array/Pointer/Direct Access

### DIFF
--- a/examples/lt.st
+++ b/examples/lt.st
@@ -1,0 +1,14 @@
+FUNCTION a : DINT END_FUNCTION
+        PROGRAM main
+        VAR
+            x : ARRAY[0..1] OF INT;
+            y : REF_TO INT;
+            z : REF_TO ARRAY[0..1] OF INT;
+        END_VAR
+            x[0] := 1;
+            y^ := 2;
+            y^.1 := 3;
+            z^[0] := 4;
+            z^[1].1 := 5;
+						a() := 5;
+        END_PROGRAM

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1179,7 +1179,8 @@ impl AstStatement {
             AstStatement::CastStatement { id, .. } => *id,
         }
     }
-    /// Returns true if the current statement has a return access.
+
+    /// Returns true if the current statement has a direct access.
     pub fn has_direct_access(&self) -> bool {
         if let AstStatement::QualifiedReference { elements, .. } = self {
             matches!(elements.last(), Some(AstStatement::DirectAccess { .. }))
@@ -1218,23 +1219,6 @@ impl AstStatement {
             || self.is_array_access()
             || self.is_pointer_access()
             || self.is_hardware_access()
-    }
-
-    /// Returns true if the statement is a literal
-    pub fn is_literal(&self) -> bool {
-        matches!(
-            self,
-            AstStatement::LiteralArray { .. }
-                | AstStatement::LiteralBool { .. }
-                | AstStatement::LiteralDate { .. }
-                | AstStatement::LiteralDateAndTime { .. }
-                | AstStatement::LiteralInteger { .. }
-                | AstStatement::LiteralReal { .. }
-                | AstStatement::LiteralNull { .. }
-                | AstStatement::LiteralString { .. }
-                | AstStatement::LiteralTime { .. }
-                | AstStatement::LiteralTimeOfDay { .. }
-        )
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1187,6 +1187,55 @@ impl AstStatement {
             false
         }
     }
+
+    pub fn is_reference(&self) -> bool {
+        matches!(self, AstStatement::Reference { .. })
+    }
+
+    pub fn is_hardware_access(&self) -> bool {
+        matches!(self, AstStatement::HardwareAccess { .. })
+    }
+
+    pub fn is_array_access(&self) -> bool {
+        if let AstStatement::QualifiedReference { elements, .. } = self {
+            matches!(elements.last(), Some(AstStatement::ArrayAccess { .. }))
+        } else {
+            matches!(self, AstStatement::ArrayAccess { .. })
+        }
+    }
+
+    pub fn is_pointer_access(&self) -> bool {
+        if let AstStatement::QualifiedReference { elements, .. } = self {
+            matches!(elements.last(), Some(AstStatement::PointerAccess { .. }))
+        } else {
+            matches!(self, AstStatement::PointerAccess { .. })
+        }
+    }
+
+    pub fn can_be_assigned_to(&self) -> bool {
+        self.has_direct_access()
+            || self.is_reference()
+            || self.is_array_access()
+            || self.is_pointer_access()
+            || self.is_hardware_access()
+    }
+
+    /// Returns true if the statement is a literal
+    pub fn is_literal(&self) -> bool {
+        matches!(
+            self,
+            AstStatement::LiteralArray { .. }
+                | AstStatement::LiteralBool { .. }
+                | AstStatement::LiteralDate { .. }
+                | AstStatement::LiteralDateAndTime { .. }
+                | AstStatement::LiteralInteger { .. }
+                | AstStatement::LiteralReal { .. }
+                | AstStatement::LiteralNull { .. }
+                | AstStatement::LiteralString { .. }
+                | AstStatement::LiteralTime { .. }
+                | AstStatement::LiteralTimeOfDay { .. }
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -183,6 +183,10 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
         if left_statement.has_direct_access() {
             return self.generate_direct_access_assignment(left_statement, right_statement);
         }
+        //TODO: Also hacky but for now we cannot generate assignments for hardware access
+        if matches!(left_statement, AstStatement::HardwareAccess { .. }) {
+            return Ok(());
+        }
         let exp_gen = self.create_expr_generator();
         let left = exp_gen.generate_element_pointer(left_statement)?;
         let left_type = exp_gen.get_type_hint_info_for(left_statement)?;

--- a/src/codegen/tests/expression_tests.rs
+++ b/src/codegen/tests/expression_tests.rs
@@ -447,3 +447,48 @@ fn hardware_access_codegen() {
 
     insta::assert_snapshot!(result);
 }
+
+#[test]
+fn hardware_access_assign_codegen() {
+    let result = codegen(
+        "
+        PROGRAM prg
+        VAR
+          x,y,z : BYTE;
+        END_VAR
+          %IB1.2 := 1;
+          %MB1.2 := 1;
+          %GB1.2 := 1;
+          %IX1.2 := 1;
+          %MD1.2 := 1;
+          %GW1.2 := 1;
+        END_PROGRAM
+        ",
+    );
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn allowed_assignable_types() {
+    let result = codegen(
+        r#"
+        PROGRAM main
+        VAR
+            v : INT;
+            x : ARRAY[0..1] OF INT;
+            y : REF_TO INT;
+            z : REF_TO ARRAY[0..1] OF INT;
+        END_VAR
+            v := 0;
+            x[0] := 1;
+            y^ := 2;
+            y^.1 := 3;
+            z^[0] := 4;
+            z^[1].1 := 5;
+        END_PROGRAM
+        "#,
+    );
+
+    insta::assert_snapshot!(result);
+}

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__allowed_assignable_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__allowed_assignable_types.snap
@@ -1,0 +1,39 @@
+---
+source: src/codegen/tests/expression_tests.rs
+expression: result
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%main = type { i16, [2 x i16], i16*, [2 x i16]* }
+
+@main_instance = global %main zeroinitializer
+
+define void @main(%main* %0) {
+entry:
+  %v = getelementptr inbounds %main, %main* %0, i32 0, i32 0
+  %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1
+  %y = getelementptr inbounds %main, %main* %0, i32 0, i32 2
+  %z = getelementptr inbounds %main, %main* %0, i32 0, i32 3
+  store i16 0, i16* %v, align 2
+  %tmpVar = getelementptr inbounds [2 x i16], [2 x i16]* %x, i32 0, i32 0
+  store i16 1, i16* %tmpVar, align 2
+  %deref = load i16*, i16** %y, align 8
+  store i16 2, i16* %deref, align 2
+  %deref1 = load i16*, i16** %y, align 8
+  %1 = load i16, i16* %deref1, align 2
+  %erase = and i16 %1, -3
+  %or = or i16 %erase, 6
+  store i16 %or, i16* %deref1, align 2
+  %deref2 = load [2 x i16]*, [2 x i16]** %z, align 8
+  %tmpVar3 = getelementptr inbounds [2 x i16], [2 x i16]* %deref2, i32 0, i32 0
+  store i16 4, i16* %tmpVar3, align 2
+  %deref4 = load [2 x i16]*, [2 x i16]** %z, align 8
+  %tmpVar5 = getelementptr inbounds [2 x i16], [2 x i16]* %deref4, i32 0, i32 1
+  %2 = load i16, i16* %tmpVar5, align 2
+  %erase6 = and i16 %2, -3
+  %or7 = or i16 %erase6, 10
+  store i16 %or7, i16* %tmpVar5, align 2
+  ret void
+}
+

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__assigning_of_arrays_and_pointers_allowed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__assigning_of_arrays_and_pointers_allowed.snap
@@ -1,0 +1,37 @@
+---
+source: src/codegen/tests/expression_tests.rs
+expression: result
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%main = type { [2 x i16], i16*, [2 x i16]* }
+
+@main_instance = global %main zeroinitializer
+
+define void @main(%main* %0) {
+entry:
+  %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
+  %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1
+  %z = getelementptr inbounds %main, %main* %0, i32 0, i32 2
+  %tmpVar = getelementptr inbounds [2 x i16], [2 x i16]* %x, i32 0, i32 0
+  store i16 1, i16* %tmpVar, align 2
+  %deref = load i16*, i16** %y, align 8
+  store i16 2, i16* %deref, align 2
+  %deref1 = load i16*, i16** %y, align 8
+  %1 = load i16, i16* %deref1, align 2
+  %erase = and i16 %1, -3
+  %or = or i16 %erase, 6
+  store i16 %or, i16* %deref1, align 2
+  %deref2 = load [2 x i16]*, [2 x i16]** %z, align 8
+  %tmpVar3 = getelementptr inbounds [2 x i16], [2 x i16]* %deref2, i32 0, i32 0
+  store i16 4, i16* %tmpVar3, align 2
+  %deref4 = load [2 x i16]*, [2 x i16]** %z, align 8
+  %tmpVar5 = getelementptr inbounds [2 x i16], [2 x i16]* %deref4, i32 0, i32 1
+  %2 = load i16, i16* %tmpVar5, align 2
+  %erase6 = and i16 %2, -3
+  %or7 = or i16 %erase6, 10
+  store i16 %or7, i16* %tmpVar5, align 2
+  ret void
+}
+

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_assign_codegen.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_assign_codegen.snap
@@ -1,0 +1,19 @@
+---
+source: src/codegen/tests/expression_tests.rs
+expression: result
+---
+; ModuleID = 'main'
+source_filename = "main"
+
+%prg = type { i8, i8, i8 }
+
+@prg_instance = global %prg zeroinitializer
+
+define void @prg(%prg* %0) {
+entry:
+  %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
+  %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
+  %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 2
+  ret void
+}
+

--- a/src/validation/stmt_validator.rs
+++ b/src/validation/stmt_validator.rs
@@ -191,9 +191,12 @@ impl StatementValidator {
                             statement.get_location(),
                         ));
                     }
-                } else if !matches!(left.as_ref(), AstStatement::Reference { .. }) {
-                    // we hit an assignment without a LValue to assign to
-                    self.push_diagnostic(Diagnostic::reference_expected(left.get_location()));
+                } else {
+                    // If whatever we got is not assignable, output an error
+                    if !left.can_be_assigned_to() {
+                        // we hit an assignment without a LValue to assign to
+                        self.push_diagnostic(Diagnostic::reference_expected(left.get_location()));
+                    }
                 }
             }
             AstStatement::BinaryExpression { operator, left, right, .. } => match operator {

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -1101,3 +1101,64 @@ fn assigning_to_rvalue() {
         assert_eq!(diag, &Diagnostic::reference_expected(ranges[idx].to_owned().into()))
     }
 }
+
+#[test]
+fn assigning_to_qualified_references_allowed() {
+    let diagnostics = parse_and_validate(
+        r#"
+        PROGRAM prg 
+        VAR_INPUT
+            x : INT;
+        END_VAR
+        END_PROGRAM
+    
+        PROGRAM main
+            prg.x := 1;
+        END_PROGRAM
+        "#,
+    );
+
+    assert_eq!(diagnostics.len(), 0);
+}
+
+#[test]
+fn assigning_to_rvalue_allowed_for_directaccess() {
+    let diagnostics = parse_and_validate(
+        r#"
+        PROGRAM main
+        VAR
+            x : INT;
+        END_VAR
+            %Q1 := 1;
+            %Q1 := 1;
+            x.1 := 1;
+        END_PROGRAM
+        "#,
+    );
+
+    assert_eq!(diagnostics.len(), 0);
+}
+
+#[test]
+fn allowed_assignable_types() {
+    let diagnostics = parse_and_validate(
+        r#"
+        PROGRAM main
+        VAR
+            v : INT;
+            x : ARRAY[0..1] OF INT;
+            y : REF_TO INT;
+            z : REF_TO ARRAY[0..1] OF INT;
+        END_VAR
+            v := 0;
+            x[0] := 1;
+            y^ := 2;
+            y^.1 := 3;
+            z^[0] := 4;
+            z^[1].1 := 5;
+        END_PROGRAM
+        "#,
+    );
+
+    assert_eq!(diagnostics.len(), 0);
+}


### PR DESCRIPTION
The validator for invalid assignment will now no longer trigger on Arrays/Pointers and Bitaccess

This is ideally just a temporary solution.
A better solution would include refactoring the Resolver/Annotations to separate between LValues and RValues on that level.