### PR TITLE
Ignore `.idea/` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /target-watch
+/.idea
 **/*.rs.bk
 **/*.un~
 **/*.toml~


### PR DESCRIPTION
JetBrains related IDEs such as CLion create a `.idea/` folder which can be ignored