### PR TITLE
Simplify snapshot assertion

### DIFF
--- a/src/validation/tests.rs
+++ b/src/validation/tests.rs
@@ -1,5 +1,3 @@
-use crate::diagnostics::Diagnostic;
-
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 mod array_validation_test;
 mod assignment_validation_tests;
@@ -13,10 +11,14 @@ mod reference_resolve_tests;
 mod statement_validation_tests;
 mod variable_validation_tests;
 
-pub fn make_readable(diagnostics: &Vec<Diagnostic>) -> String {
-    let mut res = String::new();
-    for ele in diagnostics {
-        res.push_str(&format!("{:?}\n", ele));
-    }
-    res
+#[macro_export]
+macro_rules! assert_validation_snapshot {
+    ($diagnostics:expr) => {{
+        let mut res = String::new();
+        for ele in $diagnostics {
+            res.push_str(&format!("{:?}\n", ele));
+        }
+
+        insta::assert_snapshot!(res);
+    }};
 }

--- a/src/validation/tests/array_validation_test.rs
+++ b/src/validation/tests/array_validation_test.rs
@@ -1,7 +1,5 @@
-use insta::assert_snapshot;
-
+use crate::assert_validation_snapshot;
 use crate::test_utils::tests::parse_and_validate;
-use crate::validation::tests::make_readable;
 
 #[test]
 fn array_access_validation() {
@@ -46,7 +44,7 @@ fn array_access_validation() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -78,5 +76,5 @@ fn array_initialization_validation() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/assignment_validation_tests.rs
+++ b/src/validation/tests/assignment_validation_tests.rs
@@ -1,7 +1,5 @@
-use insta::assert_snapshot;
-
+use crate::assert_validation_snapshot;
 use crate::test_utils::tests::parse_and_validate;
-use crate::validation::tests::make_readable;
 
 #[test]
 fn constant_assignment_validation() {
@@ -18,7 +16,7 @@ fn constant_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -77,7 +75,7 @@ fn real_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -161,7 +159,7 @@ fn int_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -220,7 +218,7 @@ fn duration_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -279,7 +277,7 @@ fn bit_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -343,7 +341,7 @@ fn string_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -411,7 +409,7 @@ fn char_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -470,7 +468,7 @@ fn date_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -528,7 +526,7 @@ fn pointer_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -590,7 +588,7 @@ fn array_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -673,7 +671,7 @@ fn struct_assignment_validation() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -715,7 +713,7 @@ fn invalid_action_call_assignments_are_validated() {
         "#,
     );
     assert_eq!(diagnostics.len(), 4);
-    assert_snapshot!(make_readable(&diagnostics))
+    assert_validation_snapshot!(&diagnostics)
 }
 
 #[test]
@@ -749,7 +747,7 @@ fn implicit_invalid_action_call_assignments_are_validated() {
         "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics))
+    assert_validation_snapshot!(&diagnostics)
 }
 
 #[test]
@@ -781,5 +779,5 @@ fn invalid_method_call_assignments_are_validated() {
         "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics))
+    assert_validation_snapshot!(&diagnostics)
 }

--- a/src/validation/tests/bitaccess_validation_test.rs
+++ b/src/validation/tests/bitaccess_validation_test.rs
@@ -1,6 +1,4 @@
-use insta::assert_snapshot;
-
-use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable};
+use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
 #[test]
 fn bitaccess_only_on_bit_types() {
@@ -25,7 +23,7 @@ fn bitaccess_only_on_bit_types() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -48,7 +46,7 @@ fn byteaccess_only_on_bigger_sizes() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -71,7 +69,7 @@ fn wordaccess_only_on_bigger_sizes() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -94,7 +92,7 @@ fn dwordaccess_only_on_bigger_sizes() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -113,7 +111,7 @@ fn bitaccess_range_test() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -131,7 +129,7 @@ fn byteaccess_range_test() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -148,7 +146,7 @@ fn wordaccess_range_test() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -164,7 +162,7 @@ fn dwordaccess_range_test() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -182,5 +180,5 @@ fn reference_direct_access_only_with_ints() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/duplicates_validation_test.rs
+++ b/src/validation/tests/duplicates_validation_test.rs
@@ -1,6 +1,7 @@
 use insta::assert_snapshot;
 
 use crate::{
+    assert_validation_snapshot,
     ast::{self, CompilationUnit, SourceRangeFactory},
     index::{visitor, Index},
     lexer::{self, IdProvider},
@@ -8,7 +9,7 @@ use crate::{
     resolver::TypeAnnotator,
     test_utils::tests::{compile_to_string, parse_and_validate},
     typesystem,
-    validation::{tests::make_readable, Validator},
+    validation::Validator,
     DebugLevel, SourceCode,
 };
 
@@ -26,7 +27,7 @@ fn duplicate_pous_validation() {
     "#,
     );
     // THEN there should be 3 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -40,7 +41,7 @@ fn duplicate_pous_and_types_validation() {
     "#,
     );
     // THEN there should be 3 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -76,7 +77,7 @@ fn duplicate_global_variables() {
         "#,
     );
     // THEN there should be 0 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -98,7 +99,7 @@ fn duplicate_variables_in_same_pou() {
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -137,7 +138,7 @@ fn duplicate_fb_inst_and_function() {
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -150,7 +151,7 @@ fn duplicate_enum_variables() {
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -173,7 +174,7 @@ fn duplicate_global_and_program() {
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -206,7 +207,7 @@ fn duplicate_action_should_be_a_problem() {
     );
 
     // THEN there should be 2 duplication diagnostics
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]

--- a/src/validation/tests/generic_validation_tests.rs
+++ b/src/validation/tests/generic_validation_tests.rs
@@ -1,6 +1,4 @@
-use insta::assert_snapshot;
-
-use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable};
+use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
 #[test]
 fn any_allows_all_natures() {
@@ -46,7 +44,7 @@ fn any_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -57,7 +55,7 @@ fn non_resolved_generics_reported() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_MAGNITUDE    ##########
@@ -117,7 +115,7 @@ fn any_magnitude_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -129,7 +127,7 @@ fn any_magnitude_does_not_allow_strings() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -141,7 +139,7 @@ fn any_magnitude_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -156,7 +154,7 @@ fn any_magnitude_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -182,7 +180,7 @@ fn any_magnitude_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_NUMBER    ##########
@@ -227,7 +225,7 @@ fn any_num_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -242,7 +240,7 @@ fn any_num_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -254,7 +252,7 @@ fn any_num_does_not_allow_strings() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -266,7 +264,7 @@ fn any_num_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -281,7 +279,7 @@ fn any_num_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -307,7 +305,7 @@ fn any_num_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_REAL    ##########
@@ -354,7 +352,7 @@ fn any_real_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -369,7 +367,7 @@ fn any_real_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -381,7 +379,7 @@ fn any_real_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -393,7 +391,7 @@ fn any_real_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -408,7 +406,7 @@ fn any_real_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -434,7 +432,7 @@ fn any_real_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_INT    ##########
@@ -448,7 +446,7 @@ fn any_int_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -480,7 +478,7 @@ fn any_int_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -495,7 +493,7 @@ fn any_int_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -507,7 +505,7 @@ fn any_int_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -519,7 +517,7 @@ fn any_int_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -534,7 +532,7 @@ fn any_int_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -560,7 +558,7 @@ fn any_int_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_UNSIGNED    ##########
@@ -574,7 +572,7 @@ fn any_unsigned_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -602,7 +600,7 @@ fn any_unsigned_does_not_allow_signed_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -614,7 +612,7 @@ fn any_unsigned_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -629,7 +627,7 @@ fn any_unsigned_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -641,7 +639,7 @@ fn any_unsigned_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -653,7 +651,7 @@ fn any_unsigned_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -668,7 +666,7 @@ fn any_unsigned_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -694,7 +692,7 @@ fn any_unsigned_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_SIGNED    ##########
@@ -708,7 +706,7 @@ fn any_signed_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -736,7 +734,7 @@ fn any_signed_does_not_allow_unsigned_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -748,7 +746,7 @@ fn any_signed_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -763,7 +761,7 @@ fn any_signed_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -775,7 +773,7 @@ fn any_signed_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -787,7 +785,7 @@ fn any_signed_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -802,7 +800,7 @@ fn any_signed_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -828,7 +826,7 @@ fn any_signed_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_DURATION    ##########
@@ -842,7 +840,7 @@ fn any_duration_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -862,7 +860,7 @@ fn any_duration_does_not_allow_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -889,7 +887,7 @@ fn any_duration_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -901,7 +899,7 @@ fn any_duration_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -913,7 +911,7 @@ fn any_duration_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -928,7 +926,7 @@ fn any_duration_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -954,7 +952,7 @@ fn any_duration_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_BIT    ##########
@@ -968,7 +966,7 @@ fn any_bit_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -988,7 +986,7 @@ fn any_bit_does_not_allow_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1000,7 +998,7 @@ fn any_bit_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1041,7 +1039,7 @@ fn any_bit_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1053,7 +1051,7 @@ fn any_bit_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1068,7 +1066,7 @@ fn any_bit_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1094,7 +1092,7 @@ fn any_bit_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_CHARS    ##########
@@ -1108,7 +1106,7 @@ fn any_chars_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1128,7 +1126,7 @@ fn any_chars_does_not_allow_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1140,7 +1138,7 @@ fn any_chars_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1155,7 +1153,7 @@ fn any_chars_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1194,7 +1192,7 @@ fn any_chars_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1220,7 +1218,7 @@ fn any_chars_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_STRING    ##########
@@ -1234,7 +1232,7 @@ fn any_string_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1254,7 +1252,7 @@ fn any_string_does_not_allow_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1266,7 +1264,7 @@ fn any_string_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1281,7 +1279,7 @@ fn any_string_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1293,7 +1291,7 @@ fn any_string_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1320,7 +1318,7 @@ fn any_string_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1346,7 +1344,7 @@ fn any_string_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_CHAR    ##########
@@ -1360,7 +1358,7 @@ fn any_char_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1380,7 +1378,7 @@ fn any_char_does_not_allow_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1392,7 +1390,7 @@ fn any_char_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1407,7 +1405,7 @@ fn any_char_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1431,7 +1429,7 @@ fn any_char_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1446,7 +1444,7 @@ fn any_char_does_not_allow_date() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1472,7 +1470,7 @@ fn any_char_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_DATE    ##########
@@ -1486,7 +1484,7 @@ fn any_date_does_not_allow_reals() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1506,7 +1504,7 @@ fn any_date_does_not_allow_ints() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1518,7 +1516,7 @@ fn any_date_does_not_allow_time() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1533,7 +1531,7 @@ fn any_date_does_not_allow_bits() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1545,7 +1543,7 @@ fn any_date_does_not_allow_chars() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1557,7 +1555,7 @@ fn any_date_does_not_allow_string() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1598,5 +1596,5 @@ fn any_date_multiple_parameters() {
     ";
 
     let diagnostics = parse_and_validate(src);
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/literals_validation_tests.rs
+++ b/src/validation/tests/literals_validation_tests.rs
@@ -1,6 +1,4 @@
-use insta::assert_snapshot;
-
-use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable, Diagnostic};
+use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate, Diagnostic};
 
 #[test]
 fn int_literal_casts_max_values_are_validated() {
@@ -22,7 +20,7 @@ fn int_literal_casts_max_values_are_validated() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -41,7 +39,7 @@ fn bool_literal_casts_are_validated() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -67,7 +65,7 @@ fn string_literal_casts_are_validated() {
        "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -92,7 +90,7 @@ fn real_literal_casts_are_validated() {
        "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -102,7 +100,7 @@ fn literal_cast_with_non_literal() {
             INT#[x]; 
         END_PROGRAM",
     );
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -145,7 +143,7 @@ fn date_literal_casts_are_validated() {
        "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -164,5 +162,5 @@ fn char_cast_validate() {
        "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/pou_validation_tests.rs
+++ b/src/validation/tests/pou_validation_tests.rs
@@ -1,6 +1,4 @@
-use insta::assert_snapshot;
-
-use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable};
+use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
 #[test]
 fn function_no_return_unsupported() {
@@ -8,7 +6,7 @@ fn function_no_return_unsupported() {
     // WHEN parse_and_validate is done
     let diagnostics = parse_and_validate("FUNCTION foo VAR_INPUT END_VAR END_FUNCTION");
     // THEN there should be one diagnostic -> missing return type
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -17,5 +15,5 @@ fn actions_container_no_name() {
     // WHEN parse_and_validate is done
     let diagnostics = parse_and_validate("ACTIONS ACTION myAction END_ACTION END_ACTIONS");
     // THEN there should be one diagnostic -> missing action container name
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/recursive_validation_tests.rs
+++ b/src/validation/tests/recursive_validation_tests.rs
@@ -102,9 +102,7 @@ mod edgecases {
 }
 
 mod structs {
-    use insta::assert_snapshot;
-
-    use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable};
+    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
     #[test]
     fn one_cycle_abca() {
@@ -129,7 +127,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -142,7 +140,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -157,7 +155,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -174,7 +172,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -195,7 +193,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -214,7 +212,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -232,7 +230,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -258,7 +256,7 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -300,14 +298,13 @@ mod structs {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 }
 
 mod arrays {
-    use insta::assert_snapshot;
 
-    use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable};
+    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
     #[test]
     fn two_cycles_aa_and_aba() {
@@ -324,7 +321,7 @@ mod arrays {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -345,7 +342,7 @@ mod arrays {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -364,7 +361,7 @@ mod arrays {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -383,7 +380,7 @@ mod arrays {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -402,7 +399,7 @@ mod arrays {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -452,14 +449,12 @@ mod arrays {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 }
 
 mod functionblocks {
-    use insta::assert_snapshot;
-
-    use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable};
+    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
     #[test]
     fn one_cycle_aba_var() {
@@ -480,7 +475,7 @@ mod functionblocks {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -502,7 +497,7 @@ mod functionblocks {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -524,7 +519,7 @@ mod functionblocks {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -605,14 +600,13 @@ mod functionblocks {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 }
 
 mod mixed_structs_and_functionblocks {
-    use insta::assert_snapshot;
 
-    use crate::{test_utils::tests::parse_and_validate, validation::tests::make_readable};
+    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
     #[test]
     fn one_cycle_aba_output() {
@@ -630,7 +624,7 @@ mod mixed_structs_and_functionblocks {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -649,7 +643,7 @@ mod mixed_structs_and_functionblocks {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 
     #[test]
@@ -699,6 +693,6 @@ mod mixed_structs_and_functionblocks {
             ",
         );
 
-        assert_snapshot!(make_readable(&diagnostics));
+        assert_validation_snapshot!(&diagnostics);
     }
 }

--- a/src/validation/tests/reference_resolve_tests.rs
+++ b/src/validation/tests/reference_resolve_tests.rs
@@ -1,7 +1,5 @@
-use insta::assert_snapshot;
-
+use crate::assert_validation_snapshot;
 use crate::test_utils::tests::parse_and_validate;
-use crate::validation::tests::make_readable;
 
 /// tests wheter simple local and global variables can be resolved and
 /// errors are reported properly
@@ -25,7 +23,7 @@ fn resolve_simple_variable_references() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 /// tests wheter functions and function parameters can be resolved and
@@ -49,7 +47,7 @@ fn resolve_function_calls_and_parameters() {
         ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 /// tests wheter structs and struct member variables can be resolved and
@@ -101,7 +99,7 @@ fn resole_struct_member_access() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 /// tests wheter function_block members can be resolved and
@@ -169,7 +167,7 @@ fn resolve_function_block_calls_in_structs_and_field_access() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 /// tests wheter function's members cannot be access using the function's name as a qualifier
@@ -195,7 +193,7 @@ fn resolve_function_members_via_qualifier() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 /// tests whether references to privater variables do resolve, but end up in an validation problem
@@ -215,7 +213,7 @@ fn reference_to_private_variable_is_illegal() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 /// tests whether an intermediate access like: `a.priv.b` (where priv is a var_local)
@@ -251,7 +249,7 @@ fn reference_to_private_variable_in_intermediate_fb() {
 
     // THEN we get a validtion-error for accessing fb1.f, but no follow-up errors for
     // the access of fb2 which is legit
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -1,8 +1,5 @@
-use insta::assert_snapshot;
-
 use crate::test_utils::tests::parse_and_validate;
-use crate::validation::tests::make_readable;
-use crate::Diagnostic;
+use crate::{assert_validation_snapshot, Diagnostic};
 
 #[test]
 fn assign_pointer_to_too_small_type_result_in_an_error() {
@@ -23,7 +20,7 @@ fn assign_pointer_to_too_small_type_result_in_an_error() {
     );
 
     //THEN assignment with different type sizes are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -45,7 +42,7 @@ fn assign_too_small_type_to_pointer_result_in_an_error() {
     );
 
     //THEN assignment with different type sizes are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -102,7 +99,7 @@ fn assignment_to_constants_result_in_an_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -130,7 +127,7 @@ fn assignment_to_enum_literals_results_in_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -176,7 +173,7 @@ fn invalid_char_assignments() {
     );
 
     // THEN every assignment should be reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -197,7 +194,7 @@ fn missing_string_compare_function_causes_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -240,7 +237,7 @@ fn string_compare_function_with_wrong_signature_causes_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -261,7 +258,7 @@ fn missing_wstring_compare_function_causes_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -362,7 +359,7 @@ fn switch_case_duplicate_integer_non_const_var_reference() {
     );
 
     // THEN the non constant variables are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -399,7 +396,7 @@ fn switch_case_duplicate_integer() {
     );
 
     // THEN the non constant variables are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -427,7 +424,7 @@ fn switch_case_invalid_case_conditions() {
     );
 
     // THEN
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -448,7 +445,7 @@ fn case_condition_used_outside_case_statement() {
     );
 
     // THEN
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -563,7 +560,7 @@ fn program_missing_inout_assignment() {
 		",
     );
     // THEN
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -604,7 +601,7 @@ fn function_call_parameter_validation() {
     );
 
     // THEN
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -645,7 +642,7 @@ fn program_call_parameter_validation() {
     );
 
     // THEN
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -713,7 +710,7 @@ fn reference_to_reference_assignments_in_function_arguments() {
     "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -750,7 +747,7 @@ fn address_of_operations() {
         ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -799,7 +796,7 @@ fn validate_call_by_ref() {
         ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -828,7 +825,7 @@ fn validate_array_elements_passed_to_functions_by_ref() {
         ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -878,7 +875,7 @@ fn validate_arrays_passed_to_functions() {
         ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -902,7 +899,7 @@ fn assigning_to_rvalue() {
         "#,
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]

--- a/src/validation/tests/variable_validation_tests.rs
+++ b/src/validation/tests/variable_validation_tests.rs
@@ -1,7 +1,4 @@
-use insta::assert_snapshot;
-
-use crate::test_utils::tests::parse_and_validate;
-use crate::validation::tests::make_readable;
+use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 
 #[test]
 fn uninitialized_constants_fall_back_to_the_default() {
@@ -63,7 +60,7 @@ fn unresolvable_variables_are_reported() {
        ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -112,7 +109,7 @@ fn constant_on_illegal_var_blocks_cause_validation_issue() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -141,7 +138,7 @@ fn constant_fb_instances_are_illegal() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -159,5 +156,5 @@ fn sized_varargs_require_type() {
       ",
     );
 
-    assert_snapshot!(make_readable(&diagnostics));
+    assert_validation_snapshot!(&diagnostics);
 }


### PR DESCRIPTION
Refactored `assert_snapshot!(make_readable(&diagnostics))` to `assert_validation_snapshot!(&diagnostics)`