### PR TITLE
Add `launch.json` debug entries

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,30 +47,6 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'rustyc'",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=rustyc",
-                    "--package=rusty"
-                ],
-                "filter": {
-                    "name": "rustyc",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "-c",
-                "./examples/hw.st",
-                "-o",
-                "/tmp/comp.ll",
-                "--config=test.xml"
-            ],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
             "name": "Debug unit tests in executable 'rustyc'",
             "cargo": {
                 "args": [
@@ -122,7 +98,7 @@
                 }
             },
             "args": [
-                "demo.st"
+                "target/demo.st"
             ],
             "cwd": "${workspaceFolder}"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,6 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-
         {
             "type": "lldb",
             "request": "launch",
@@ -39,7 +38,10 @@
                     "kind": "bin"
                 }
             },
-            "args": ["build", "..\\..\\build_commands_tests\\test_proj\\plc.json"],
+            "args": [
+                "build",
+                "..\\..\\build_commands_tests\\test_proj\\plc.json"
+            ],
             "cwd": "${workspaceFolder}"
         },
         {
@@ -57,7 +59,13 @@
                     "kind": "bin"
                 }
             },
-            "args": ["-c", "./examples/hw.st", "-o", "/tmp/comp.ll", "--config=test.xml"],
+            "args": [
+                "-c",
+                "./examples/hw.st",
+                "-o",
+                "/tmp/comp.ll",
+                "--config=test.xml"
+            ],
             "cwd": "${workspaceFolder}"
         },
         {
@@ -97,6 +105,47 @@
             },
             "args": [],
             "cwd": "${workspaceFolder}"
-        }
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug source 'demo.st'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=rustyc",
+                    "--package=rusty"
+                ],
+                "filter": {
+                    "name": "rustyc",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "demo.st"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit test 'demo'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=rusty"
+                ],
+                "filter": {
+                    "name": "rusty",
+                    "kind": "lib"
+                }
+            },
+            "args": [
+                "demo"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
     ]
 }


### PR DESCRIPTION
(Nit of mine) Adds entries to the `launch.json` file allowing us to debug a unit test and/or a ST file called `demo` and `demo.st` respectively with a simple button click.