### PR TITLE
Make LLD the default linker for Linux x86_64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [alias]
 xtask = "run --manifest-path ./xtask/Cargo.toml --"
 
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
 [target.aarch64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]


### PR DESCRIPTION
MacOS still has some issues when specifiying lld as the default linker. Might create another PR for that specifically if I find a fix, but compiling under M1 is currently fast enough.