### PR TITLE
Update metrics workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-xtask = "run --manifest-path ./xtask/Cargo.toml --"
+xtask = "run --package xtask --"
 
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - __metrics_fix
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -22,7 +21,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        ref: __metrics_fix
+        ref: master
 
     - name: Collect metrics
       run: |

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - __metrics_fix
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -21,7 +22,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        ref: master
+        ref: __metrics_fix
 
     - name: Collect metrics
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ path = "src/main.rs"
 
 [workspace]
 members = [
-	"xtask",
+    "xtask",
 	"libs/stdlib",
 ]
-default-members = ["libs/stdlib", "xtask"]
+default-members = [".", "libs/stdlib"]

--- a/xtask/src/metrics/oscat.rs
+++ b/xtask/src/metrics/oscat.rs
@@ -5,17 +5,16 @@ pub struct Oscat;
 impl Task for Oscat {
     fn prepare(&self, sh: &Shell) -> anyhow::Result<()> {
         cmd!(sh, "git clone https://github.com/plc-lang/oscat ./benchmark/oscat").run()?;
-        sh.create_dir("./benchmark/oscat/lib").unwrap();
-        sh.create_dir("./benchmark/oscat/include").unwrap();
+        sh.create_dir("./benchmark/oscat/lib")?;
+        sh.create_dir("./benchmark/oscat/include")?;
 
         cmd!(sh, "cargo b --release").run()?;
         sh.copy_file("./target/release/rustyc", "./benchmark/oscat")?;
-        sh.copy_file("./target/release/libiec61131std.so", "./benchmark/oscat/lib").unwrap();
+        sh.copy_file("./target/release/libiec61131std.so", "./benchmark/oscat/lib")?;
 
-        sh.read_dir("libs/stdlib/iec61131-st")
-            .unwrap()
-            .iter()
-            .for_each(|f| sh.copy_file(f, "./benchmark/oscat/include").unwrap());
+        for file in sh.read_dir("libs/stdlib/iec61131-st")? {
+            sh.copy_file(file, "./benchmark/oscat/include")?;
+        }
 
         Ok(())
     }

--- a/xtask/src/metrics/oscat.rs
+++ b/xtask/src/metrics/oscat.rs
@@ -5,22 +5,17 @@ pub struct Oscat;
 impl Task for Oscat {
     fn prepare(&self, sh: &Shell) -> anyhow::Result<()> {
         cmd!(sh, "git clone https://github.com/plc-lang/oscat ./benchmark/oscat").run()?;
-        cmd!(sh, "git clone https://github.com/plc-lang/standardfunctions ./benchmark/oscat/sf").run()?;
-
-        cmd!(sh, "cargo b --release").run()?;
-        sh.copy_file("./target/release/rustyc", "./benchmark/oscat")?;
-
         sh.create_dir("./benchmark/oscat/lib").unwrap();
         sh.create_dir("./benchmark/oscat/include").unwrap();
 
-        let standardfunctions = sh.push_dir("./benchmark/oscat/sf");
         cmd!(sh, "cargo b --release").run()?;
-        std::mem::drop(standardfunctions);
+        sh.copy_file("./target/release/rustyc", "./benchmark/oscat")?;
+        sh.copy_file("./target/release/libiec61131std.so", "./benchmark/oscat/lib").unwrap();
 
-        let oscat = sh.push_dir("./benchmark/oscat");
-        sh.copy_file("sf/target/release/libiec61131std.so", "lib").unwrap();
-        sh.read_dir("sf/iec61131-st/").unwrap().iter().for_each(|f| sh.copy_file(f, "include").unwrap());
-        std::mem::drop(oscat);
+        sh.read_dir("libs/stdlib/iec61131-st")
+            .unwrap()
+            .iter()
+            .for_each(|f| sh.copy_file(f, "./benchmark/oscat/include").unwrap());
 
         Ok(())
     }


### PR DESCRIPTION
This commit does two things:
1) No longer clone https://github.com/PLC-lang/StandardFunctions for the metrics workflow, because of https://github.com/PLC-lang/rusty/pull/836
2) Add `rustyc` and remove `xtask` from the `default-members` entry