### PR TITLE
Add proc-macro support for custom derives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,8 +119,8 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -210,7 +210,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -235,8 +235,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "scratch",
  "syn 2.0.15",
 ]
@@ -253,8 +253,8 @@ version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -536,8 +536,8 @@ name = "inkwell_internals"
 version = "0.7.0"
 source = "git+https://github.com/TheDan64/inkwell?branch=master#aa370b54629b276f9d78802674eff494c96c8e50"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -693,8 +693,8 @@ checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
 dependencies = [
  "beef",
  "fnv",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "regex-syntax",
  "syn 1.0.109",
 ]
@@ -890,8 +890,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "version_check",
 ]
@@ -902,9 +902,18 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid",
 ]
 
 [[package]]
@@ -918,11 +927,20 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.56",
 ]
 
 [[package]]
@@ -1017,6 +1035,7 @@ dependencies = [
  "num",
  "pretty_assertions",
  "regex",
+ "rusty-derive",
  "serde",
  "serde_json",
  "serial_test",
@@ -1025,6 +1044,14 @@ dependencies = [
  "thiserror",
  "toml",
  "which",
+]
+
+[[package]]
+name = "rusty-derive"
+version = "0.1.0"
+dependencies = [
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -1066,8 +1093,8 @@ version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -1102,8 +1129,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -1142,12 +1169,23 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "unicode-ident",
 ]
 
@@ -1157,8 +1195,8 @@ version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "unicode-ident",
 ]
 
@@ -1220,8 +1258,8 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 2.0.15",
 ]
 
@@ -1258,6 +1296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,8 +1332,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
@@ -1300,7 +1344,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote",
+ "quote 1.0.26",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1310,8 +1354,8 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", feat
 thiserror = "1.0"
 clap = { version = "3.0", features = ["derive"] }
 indexmap = "1.6"
-chrono = {version = "0.4.23", default-features = false }
+chrono = { version = "0.4.23", default-features = false }
 glob = "0.3.0"
 encoding_rs = "0.8"
 encoding_rs_io = "0.1"
@@ -41,6 +41,7 @@ shell-words = "1.1.0"
 which = "4.2.5"
 tempfile = "3"
 itertools = "0.10.5"
+rusty-derive = { path = "rusty-derive" }
 
 [dev-dependencies]
 num = "0.4"
@@ -57,8 +58,5 @@ name = "rustyc"
 path = "src/main.rs"
 
 [workspace]
-members = [
-    "xtask",
-	"libs/stdlib",
-]
-default-members = [".", "libs/stdlib"]
+members = ["xtask", "libs/stdlib", "rusty-derive"]
+default-members = [".", "libs/stdlib", "rusty-derive"]

--- a/libs/stdlib/Cargo.toml
+++ b/libs/stdlib/Cargo.toml
@@ -12,7 +12,7 @@ path = "../../"
 
 
 [dev-dependencies.iec61131std]
-path= "."
+path = "."
 features = ["mock_time"]
 
 [dev-dependencies.rusty]

--- a/rusty-derive/Cargo.toml
+++ b/rusty-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rusty-derive"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = "0.15"
+quote = "0.6"
+
+[lib]
+proc-macro = true

--- a/rusty-derive/src/lib.rs
+++ b/rusty-derive/src/lib.rs
@@ -1,0 +1,26 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(Validators)]
+pub fn derive_validators_fn(input: TokenStream) -> TokenStream {
+    // parse the input stream into rust AST
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+    // build the impl which is lowered, analyzed and then generated
+    let generated = quote! {
+        impl Validators for #name {
+            fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
+                self.diagnostics.push(diagnostic);
+            }
+
+            fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
+                std::mem::take(&mut self.diagnostics)
+            }
+        }
+    };
+    // re-export generated rust code as token stream
+    TokenStream::from(generated)
+}

--- a/rusty-derive/tests/rusty_derive_tests.rs
+++ b/rusty-derive/tests/rusty_derive_tests.rs
@@ -1,0 +1,37 @@
+#[cfg(test)]
+mod tests {
+    use rusty_derive::Validators;
+    #[derive(PartialEq, Eq, Debug, Clone)]
+    pub enum Diagnostic {
+        SomeError,
+        SomeOtherError,
+        SomeWarning,
+    }
+    pub trait Validators {
+        fn push_diagnostic(&mut self, diagnostic: Diagnostic);
+
+        fn take_diagnostics(&mut self) -> Vec<Diagnostic>;
+    }
+
+    #[derive(Default, Validators)]
+    pub struct MockValidator {
+        pub diagnostics: Vec<Diagnostic>,
+    }
+
+    #[test]
+    fn derive_validators_implements_trait_functions_correctly() {
+        let mut validator = MockValidator::default();
+
+        validator.push_diagnostic(Diagnostic::SomeError);
+        validator.push_diagnostic(Diagnostic::SomeOtherError);
+        validator.push_diagnostic(Diagnostic::SomeWarning);
+
+        let expected = vec![Diagnostic::SomeError, Diagnostic::SomeOtherError, Diagnostic::SomeWarning];
+        assert_eq!(expected, validator.diagnostics);
+
+        let mut all_diagnostics = vec![];
+        all_diagnostics.append(&mut validator.take_diagnostics());
+
+        assert_eq!(expected, all_diagnostics);
+    }
+}

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,3 +1,5 @@
+use rusty_derive::Validators;
+
 use crate::{
     ast::{AstStatement, CompilationUnit},
     index::{Index, PouIndexEntry},
@@ -85,21 +87,12 @@ pub trait Validators {
     fn take_diagnostics(&mut self) -> Vec<Diagnostic>;
 }
 
+#[derive(Validators)]
 pub struct Validator {
     //context: ValidationContext<'s>,
     diagnostics: Vec<Diagnostic>,
     global_validator: GlobalValidator,
     recursive_validator: RecursiveValidator,
-}
-
-impl Validators for Validator {
-    fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
-        self.diagnostics.push(diagnostic);
-    }
-
-    fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
-        std::mem::take(&mut self.diagnostics)
-    }
 }
 
 impl Validator {

--- a/src/validation/global.rs
+++ b/src/validation/global.rs
@@ -14,19 +14,9 @@ use super::Validators;
 /// It performs validations including:
 ///  - naming-conflicts
 ///  - <tbc>
-#[derive(Default)]
+#[derive(Default, Validators)]
 pub struct GlobalValidator {
     diagnostics: Vec<Diagnostic>,
-}
-
-impl Validators for GlobalValidator {
-    fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
-        self.diagnostics.push(diagnostic);
-    }
-
-    fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
-        std::mem::take(&mut self.diagnostics)
-    }
 }
 
 impl GlobalValidator {

--- a/src/validation/recursive.rs
+++ b/src/validation/recursive.rs
@@ -26,19 +26,9 @@ use super::Validators;
 /// overflows the stack.
 ///
 /// [1] https://en.wikipedia.org/wiki/Depth-first_search
-#[derive(Default)]
+#[derive(Default, Validators)]
 pub struct RecursiveValidator {
     pub diagnostics: Vec<Diagnostic>,
-}
-
-impl Validators for RecursiveValidator {
-    fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
-        self.diagnostics.push(diagnostic);
-    }
-
-    fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
-        std::mem::take(&mut self.diagnostics)
-    }
 }
 
 impl RecursiveValidator {


### PR DESCRIPTION
While working on adding a Validator to the builtins, I have noticed that all the implementations for the Validators trait are exactly the same, so I've looked into proc-macro-derives. It might not be a huge improvement for this particular use-case, but considering we are planning on refactoring the visitor, AST and utilize more traits in general, I think this language feature might come in handy in future.

Feel free to leave your thoughts about this/discuss, I won't be upset if it doesn't end up being merged :)