### PR TITLE
Add unsigned integers to string conversion

### DIFF
--- a/libs/stdlib/iec61131-st/extra_functions.st
+++ b/libs/stdlib/iec61131-st/extra_functions.st
@@ -1048,3 +1048,51 @@ END_FUNCTION
 ******************************************************************************)
 {external}
 FUNCTION TIME : TIME END_FUNCTION
+
+(******************************************************************************
+*
+* Converts USINT to STRING.
+*
+******************************************************************************)
+FUNCTION USINT_TO_STRING : STRING[__STRING_LENGTH]
+VAR_INPUT
+    IN : USINT;
+END_VAR
+    LWORD_TO_STRING_EXT(IN, USINT_TO_STRING);
+END_FUNCTION
+
+(******************************************************************************
+*
+* Converts UINT to STRING.
+*
+******************************************************************************)
+FUNCTION UINT_TO_STRING : STRING[__STRING_LENGTH]
+VAR_INPUT
+    IN : UINT;
+END_VAR
+    LWORD_TO_STRING_EXT(IN, UINT_TO_STRING);
+END_FUNCTION
+
+(******************************************************************************
+*
+* Converts UDINT to STRING.
+*
+******************************************************************************)
+FUNCTION UDINT_TO_STRING : STRING[__STRING_LENGTH]
+VAR_INPUT
+    IN : UDINT;
+END_VAR
+    LWORD_TO_STRING_EXT(IN, UDINT_TO_STRING);
+END_FUNCTION
+
+(******************************************************************************
+*
+* Converts ULINT to STRING.
+*
+******************************************************************************)
+FUNCTION ULINT_TO_STRING : STRING[__STRING_LENGTH]
+VAR_INPUT
+    IN : ULINT;
+END_VAR
+    LWORD_TO_STRING_EXT(IN, ULINT_TO_STRING);
+END_FUNCTION

--- a/libs/stdlib/tests/extra_function_tests.rs
+++ b/libs/stdlib/tests/extra_function_tests.rs
@@ -276,6 +276,110 @@ fn dint_to_wstring_conversion() {
 }
 
 #[test]
+fn usint_to_string_conversion() {
+    let mut maintype = MainType { s: [0_u8; STR_SIZE] };
+    let src = r#"
+    FUNCTION main : STRING
+    VAR
+        in: USINT := 255;
+    END_VAR
+        main := USINT_TO_STRING(in);
+    END_FUNCTION
+    "#;
+
+    let sources = add_std!(
+        src,
+        "string_functions.st",
+        "string_conversion.st",
+        "extra_functions.st",
+        "numerical_functions.st"
+    );
+
+    let expected = format!("{}", 255);
+    let _: i32 = compile_and_run(sources, &mut maintype);
+    let res = unsafe { std::str::from_utf8_unchecked(&maintype.s) }.trim_end_matches('\0');
+    assert_eq!(expected, res);
+}
+
+#[test]
+fn uint_to_string_conversion() {
+    let mut maintype = MainType { s: [0_u8; STR_SIZE] };
+    let src = r#"
+    FUNCTION main : STRING
+    VAR
+        in: UINT := 65_535;
+    END_VAR
+        main := UINT_TO_STRING(in);
+    END_FUNCTION
+    "#;
+
+    let sources = add_std!(
+        src,
+        "string_functions.st",
+        "string_conversion.st",
+        "extra_functions.st",
+        "numerical_functions.st"
+    );
+
+    let expected = format!("{}", 65_535);
+    let _: i32 = compile_and_run(sources, &mut maintype);
+    let res = unsafe { std::str::from_utf8_unchecked(&maintype.s) }.trim_end_matches('\0');
+    assert_eq!(expected, res);
+}
+
+#[test]
+fn udint_to_string_conversion() {
+    let mut maintype = MainType { s: [0_u8; STR_SIZE] };
+    let src = r#"
+    FUNCTION main : STRING
+    VAR
+        in: UDINT := 4_294_967_295;
+    END_VAR
+        main := UDINT_TO_STRING(in);
+    END_FUNCTION
+    "#;
+
+    let sources = add_std!(
+        src,
+        "string_functions.st",
+        "string_conversion.st",
+        "extra_functions.st",
+        "numerical_functions.st"
+    );
+
+    let expected = format!("{}", 4_294_967_295_u32);
+    let _: i32 = compile_and_run(sources, &mut maintype);
+    let res = unsafe { std::str::from_utf8_unchecked(&maintype.s) }.trim_end_matches('\0');
+    assert_eq!(expected, res);
+}
+
+#[test]
+fn ulint_to_string_conversion() {
+    let mut maintype = MainType { s: [0_u8; STR_SIZE] };
+    let src = r#"
+    FUNCTION main : STRING
+    VAR
+        in: ULINT := 18_446_744_073_709_551_615;
+    END_VAR
+        main := ULINT_TO_STRING(in);
+    END_FUNCTION
+    "#;
+
+    let sources = add_std!(
+        src,
+        "string_functions.st",
+        "string_conversion.st",
+        "extra_functions.st",
+        "numerical_functions.st"
+    );
+
+    let expected = format!("{}", 18_446_744_073_709_551_615u64);
+    let _: i32 = compile_and_run(sources, &mut maintype);
+    let res = unsafe { std::str::from_utf8_unchecked(&maintype.s) }.trim_end_matches('\0');
+    assert_eq!(expected, res);
+}
+
+#[test]
 fn lreal_to_string_conversion() {
     let mut maintype = MainType { s: [0_u8; STR_SIZE] };
     let src = r#"


### PR DESCRIPTION
This PR introduces the following stdlib functions 
- `USINT_TO_STRING`
- `UINT_TO_STRING`
- `UDINT_TO_STRING`
- `ULINT_TO_STRING`