### PR TITLE
cast-if-needed convenience macro

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -164,15 +164,7 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             return Ok(v)
         };
         let actual_type = self.annotations.get_type_or_void(expression, self.index);
-        Ok(cast_if_needed(
-            self.llvm,
-            self.index,
-            self.llvm_index,
-            target_type,
-            actual_type,
-            v,
-            self.annotations.get(expression),
-        ))
+        Ok(cast_if_needed!(self, target_type, actual_type, v, self.annotations.get(expression)))
     }
 
     fn register_debug_location(&self, statement: &AstStatement) {
@@ -384,16 +376,9 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             //being accessed.
             //The reason is that llvm expects a shift operation to happen on the same type, and
             //this is what the direct access will eventually end up in.
-            let reference = cast_if_needed(
-                self.llvm,
-                self.index,
-                self.llvm_index,
-                target_type,
-                self.get_type_hint_for(index)?,
-                reference,
-                None,
-            )
-            .into_int_value();
+            let reference =
+                cast_if_needed!(self, target_type, self.get_type_hint_for(index)?, reference, None)
+                    .into_int_value();
             // let reference = reference.into_int_value();
             //Multiply by the bitwitdh
             if access.get_bit_width() > 1 {
@@ -901,14 +886,12 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
                 // XXX: Calling `cast_if_needed` will result in an `alloca` call for EVERY function call.
                 // LLVM might be able to optimize it away but ideally we find a solution for this at some
                 // point? For a more in-depth description see the `pass` function in `vla_adr.rs`
-                return Ok(cast_if_needed(
-                    self.llvm,
-                    self.index,
-                    self.llvm_index,
+                return Ok(cast_if_needed!(
+                    self,
                     hint,
                     actual_type,
                     value.into(),
-                    self.annotations.get(argument),
+                    self.annotations.get(argument)
                 ));
             };
 
@@ -1451,14 +1434,12 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             access_value.into_int_value()
         };
         //turn it into i32 immediately
-        Ok(cast_if_needed(
-            self.llvm,
-            self.index,
-            self.llvm_index,
+        Ok(cast_if_needed!(
+            self,
             self.index.get_type(DINT_TYPE)?,
             self.get_type_hint_for(access_expression)?,
             result.as_basic_value_enum(),
-            None,
+            None
         ))
     }
 

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -294,16 +294,7 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
                 //Generate an expression for the right size
                 let right = exp_gen.generate_expression(right_statement)?;
                 //Cast the right side to the left side type
-                let lhs = cast_if_needed(
-                    self.llvm,
-                    self.index,
-                    self.llvm_index,
-                    left_type,
-                    right_type,
-                    right,
-                    None,
-                )
-                .into_int_value();
+                let lhs = cast_if_needed!(self, left_type, right_type, right, None).into_int_value();
                 //Shift left by the direct access
                 let value = self.llvm.builder.build_left_shift(lhs, rhs, "value");
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -99,7 +99,7 @@ pub fn generate_global_variable<'ctx, 'b>(
             let value = expr_generator.generate_expression(initializer)?;
             let target_type = global_index.get_effective_type_or_void_by_name(type_name);
             let value_type = annotations.get_type_or_void(initializer, global_index);
-            Some(cast_if_needed(llvm, global_index, index, target_type, value_type, value, None))
+            Some(cast_if_needed!(expr_generator, target_type, value_type, value, None))
         }
     } else {
         None


### PR DESCRIPTION
Adds a convenience macro for the cast_if_needed function which allows calling it with fewer parameters.