### PR TITLE
Make sure cargo works on nightly with junit

### DIFF
--- a/libs/stdlib/scripts/build.sh
+++ b/libs/stdlib/scripts/build.sh
@@ -123,6 +123,8 @@ function run_test() {
 	CARGO_OPTIONS=$(set_cargo_options)
 	log "Running cargo test"
 	if [[ $junit -ne 0 ]]; then
+		# Switch to nightly
+		rustup default nightly
 		#Delete the test results if they exist
 		rm -rf "$project_location/test_results"
 		make_dir "$project_location/test_results"
@@ -133,6 +135,8 @@ function run_test() {
 		 -Zunstable-options | tail -n +2 | \
 		 split -l1 - "$project_location"/test_results/std_integration_tests \
 		 -d --additional-suffix=.xml
+		# Switch to stable
+		rustup default stable
 	else
 		cargo test $CARGO_OPTIONS
 	fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,6 +108,8 @@ function run_test() {
 	CARGO_OPTIONS=$(set_cargo_options)
 	log "Running cargo test"
 	if [[ $junit -ne 0 ]]; then
+		# Switch to nightly
+		rustup default nightly
 		#Delete the test results if they exist
 		rm -rf "$project_location/test_results"
 		make_dir "$project_location/test_results"
@@ -121,6 +123,8 @@ function run_test() {
 		 -Zunstable-options  \
 		 | split -l1 - "$project_location"/test_results/integration_tests \
 		 -d --additional-suffix=.xml
+		# Switch back to stable
+		rustup default stable
 	else
 		cargo test $CARGO_OPTIONS
 	fi

--- a/tests/correctness/pointers.rs
+++ b/tests/correctness/pointers.rs
@@ -81,6 +81,7 @@ END_FUNCTION
 #[test]
 fn binary_expressions_for_pointers() {
     #[derive(Default)]
+    #[repr(C)]
     struct Main {
         a: u8,
         b: u8,
@@ -192,10 +193,22 @@ fn binary_expressions_for_pointers_with_function_return() {
 
 #[test]
 fn value_behind_function_block_pointer_is_assigned_to_correctly() {
+    #[repr(C)]
     #[derive(Default)]
     struct MainType {
         a: bool,
         b: bool,
+        file: FileT,
+        file_open: Option<&'static FileT>,
+    }
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct FileT {
+        var1: bool,
+        var2: bool,
+        out1: bool,
+        out2: bool,
     }
 
     let src = r#"


### PR DESCRIPTION
Rust nightly is required for the junit test format option, this was not failing previously for some reason
I also fixed a test that fails with nightly.