### PR TITLE
Fix cargo rebuilding issue

### DIFF
--- a/libs/stdlib/build.rs
+++ b/libs/stdlib/build.rs
@@ -32,7 +32,7 @@ fn main() {
     //link the object file
     println!("cargo:rustc-link-search=native={out_dir}");
     println!("cargo:rustc-link-lib=static=st");
-    println!("cargo:rerun-if-changed=iec61131-st/*");
+    println!("cargo:rerun-if-changed=iec61131-st/");
 
     //We can link against the st lib gernerated, but this will only be reflected in static libs.
     // The shared lib still has to be generated later.


### PR DESCRIPTION
This should fix the issue where cargo is rebuilding the standard library even without any changes. Found the issue via https://doc.rust-lang.org/cargo/faq.html#why-is-cargo-rebuilding-my-code. Specifically when running `cargo build` with `CARGO_LOG=cargo::core::compiler::fingerprint=info cargo build` we previously got the following log message
```
[2023-06-20T11:51:52Z INFO  cargo::core::compiler::fingerprint]     dirty: FsStatusOutdated(StaleItem(MissingFile("/home/volkan/Desktop/rusty/libs/stdlib/iec61131-st/*")))
```
Removing the `*` from the path seems to fix it on my machine(TM)