### PR TITLE
Update metrics CI

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -3,7 +3,7 @@ name: Metrics
 on:
   push:
     branches:
-    - master
+    - __ci
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        ref: master
+        ref: __ci
 
     - name: Collect metrics
       run: |

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -3,7 +3,7 @@ name: Metrics
 on:
   push:
     branches:
-    - __ci
+    - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        ref: __ci
+        ref: master
 
     - name: Collect metrics
       run: |

--- a/xtask/src/metrics/oscat.rs
+++ b/xtask/src/metrics/oscat.rs
@@ -8,7 +8,7 @@ impl Task for Oscat {
         sh.create_dir("./benchmark/oscat/lib")?;
         sh.create_dir("./benchmark/oscat/include")?;
 
-        cmd!(sh, "cargo b --release").run()?;
+        cmd!(sh, "cargo b --release --workspace").run()?;
         sh.copy_file("./target/release/rustyc", "./benchmark/oscat")?;
         sh.copy_file("./target/release/libiec61131std.so", "./benchmark/oscat/lib")?;
 


### PR DESCRIPTION
Should fix the current issue with the metrics CI; 

I feel like we should trigger the metrics workflow on pull requests also, but don't append to the database / json file just so we can actually check whether any changes will break the CI as this has happened at least twice in the last few months. Any thoughts?