### PR TITLE
Fix linking issue on macOS

### DIFF
--- a/src/linker.rs
+++ b/src/linker.rs
@@ -45,6 +45,8 @@ impl Linker {
                             return Err(LinkerError::Target(target_os.into()))
                         }
 
+                        (_, "darwin") => Box::new(CcLinker::new("clang")),
+
                         _ => Box::new(LdLinker::new()),
                     }
                 }
@@ -153,7 +155,7 @@ impl LinkerInterface for CcLinker {
     }
 
     fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-relocatable".into());
+        self.args.push("-r".into()); // --relocatable
         self.args.push("-o".into());
         self.args.push(path.into());
     }
@@ -212,7 +214,7 @@ impl LinkerInterface for LdLinker {
     }
 
     fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-relocatable".into());
+        self.args.push("-r".into()); // --relocatable
         self.args.push("-o".into());
         self.args.push(path.into());
     }

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -16,17 +16,6 @@ pub struct Linker {
     linker: Box<dyn LinkerInterface>,
 }
 
-trait LinkerInterface {
-    fn add_obj(&mut self, path: &str);
-    fn add_lib(&mut self, path: &str);
-    fn add_lib_path(&mut self, path: &str);
-    fn add_sysroot(&mut self, path: &str);
-    fn build_shared_object(&mut self, path: &str);
-    fn build_exectuable(&mut self, path: &str);
-    fn build_relocatable(&mut self, path: &str);
-    fn finalize(&mut self) -> Result<(), LinkerError>;
-}
-
 impl Linker {
     pub fn new(target: &str, linker: Option<&str>) -> Result<Linker, LinkerError> {
         Ok(Linker {
@@ -127,37 +116,8 @@ impl CcLinker {
 }
 
 impl LinkerInterface for CcLinker {
-    fn add_obj(&mut self, path: &str) {
-        self.args.push(path.into());
-    }
-
-    fn add_lib_path(&mut self, path: &str) {
-        self.args.push(format!("-L{path}"));
-    }
-
-    fn add_lib(&mut self, path: &str) {
-        self.args.push(format!("-l{path}"));
-    }
-
-    fn add_sysroot(&mut self, path: &str) {
-        self.args.push(format!("--sysroot={path}"));
-    }
-
-    fn build_shared_object(&mut self, path: &str) {
-        self.args.push("--shared".into());
-        self.args.push("-o".into());
-        self.args.push(path.into());
-    }
-
-    fn build_exectuable(&mut self, path: &str) {
-        self.args.push("-o".into());
-        self.args.push(path.into());
-    }
-
-    fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-r".into()); // --relocatable
-        self.args.push("-o".into());
-        self.args.push(path.into());
+    fn args(&mut self) -> &mut Vec<String> {
+        &mut self.args
     }
 
     fn finalize(&mut self) -> Result<(), LinkerError> {
@@ -186,37 +146,8 @@ impl LdLinker {
 }
 
 impl LinkerInterface for LdLinker {
-    fn add_obj(&mut self, path: &str) {
-        self.args.push(path.into());
-    }
-
-    fn add_lib_path(&mut self, path: &str) {
-        self.args.push(format!("-L{path}"));
-    }
-
-    fn add_lib(&mut self, path: &str) {
-        self.args.push(format!("-l{path}"));
-    }
-
-    fn add_sysroot(&mut self, path: &str) {
-        self.args.push(format!("--sysroot={path}"));
-    }
-
-    fn build_shared_object(&mut self, path: &str) {
-        self.args.push("--shared".into());
-        self.args.push("-o".into());
-        self.args.push(path.into());
-    }
-
-    fn build_exectuable(&mut self, path: &str) {
-        self.args.push("-o".into());
-        self.args.push(path.into());
-    }
-
-    fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-r".into()); // --relocatable
-        self.args.push("-o".into());
-        self.args.push(path.into());
+    fn args(&mut self) -> &mut Vec<String> {
+        &mut self.args
     }
 
     fn finalize(&mut self) -> Result<(), LinkerError> {
@@ -224,6 +155,44 @@ impl LinkerInterface for LdLinker {
         println!("Linker arguments : {}", self.args.join(" "));
 
         lld_rs::link(lld_rs::LldFlavor::Elf, &self.args).ok().map_err(LinkerError::Link)
+    }
+}
+
+trait LinkerInterface {
+    fn args(&mut self) -> &mut Vec<String>;
+    fn finalize(&mut self) -> Result<(), LinkerError>;
+
+    fn add_obj(&mut self, path: &str) {
+        self.args().push(path.into());
+    }
+
+    fn add_lib_path(&mut self, path: &str) {
+        self.args().push(format!("-L{path}"));
+    }
+
+    fn add_lib(&mut self, path: &str) {
+        self.args().push(format!("-l{path}"));
+    }
+
+    fn add_sysroot(&mut self, path: &str) {
+        self.args().push(format!("--sysroot={path}"));
+    }
+
+    fn build_shared_object(&mut self, path: &str) {
+        self.args().push("--shared".into());
+        self.args().push("-o".into());
+        self.args().push(path.into());
+    }
+
+    fn build_exectuable(&mut self, path: &str) {
+        self.args().push("-o".into());
+        self.args().push(path.into());
+    }
+
+    fn build_relocatable(&mut self, path: &str) {
+        self.args().push("-r".into()); // equivalent to --relocatable
+        self.args().push("-o".into());
+        self.args().push(path.into());
     }
 }
 


### PR DESCRIPTION
Running `cargo b -p iec61131std` previously returned linking errors on macOS which this PR fixes by using clang as well as the `-r` flag instead of `--relocatable`. Both these flags should be equivalent although the latter isn't recognized on clang.

EDIT: Unrelated to the linking issue, I've also deduplicated some linker code by using a trait default implementation