### PR TITLE
Update `launch.json` to reflect workspace introduction

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,10 +13,10 @@
                     "test",
                     "--no-run",
                     "--lib",
-                    "--package=rusty"
+                    "--package=plc_driver"
                 ],
                 "filter": {
-                    "name": "rusty",
+                    "name": "plc",
                     "kind": "lib"
                 }
             },
@@ -30,11 +30,11 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--bin=rustyc",
-                    "--package=rusty"
+                    "--bin=plc",
+                    "--package=plc_driver"
                 ],
                 "filter": {
-                    "name": "rustyc",
+                    "name": "plc",
                     "kind": "bin"
                 }
             },
@@ -52,11 +52,11 @@
                 "args": [
                     "test",
                     "--no-run",
-                    "--bin=rustyc",
-                    "--package=rusty"
+                    "--bin=plc",
+                    "--package=plc_driver"
                 ],
                 "filter": {
-                    "name": "rustyc",
+                    "name": "plc",
                     "kind": "bin"
                 }
             },
@@ -72,7 +72,7 @@
                     "test",
                     "--no-run",
                     "--test=tests",
-                    "--package=rusty"
+                    "--package=plc_driver"
                 ],
                 "filter": {
                     "name": "tests",
@@ -89,11 +89,11 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--bin=rustyc",
-                    "--package=rusty"
+                    "--bin=plc",
+                    "--package=plc_driver"
                 ],
                 "filter": {
-                    "name": "rustyc",
+                    "name": "plc",
                     "kind": "bin"
                 }
             },
@@ -111,10 +111,10 @@
                     "test",
                     "--no-run",
                     "--lib",
-                    "--package=rusty"
+                    "--package=plc_driver"
                 ],
                 "filter": {
-                    "name": "rusty",
+                    "name": "plc",
                     "kind": "lib"
                 }
             },

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -45,6 +45,8 @@ impl Linker {
                             return Err(LinkerError::Target(target_os.into()))
                         }
 
+                        (_, "darwin") => Box::new(CcLinker::new("clang")),
+
                         _ => Box::new(LdLinker::new()),
                     }
                 }
@@ -153,7 +155,7 @@ impl LinkerInterface for CcLinker {
     }
 
     fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-relocatable".into());
+        self.args.push("-r".into()); // --relocatable
         self.args.push("-o".into());
         self.args.push(path.into());
     }
@@ -212,7 +214,7 @@ impl LinkerInterface for LdLinker {
     }
 
     fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-relocatable".into());
+        self.args.push("-r".into()); // --relocatable
         self.args.push("-o".into());
         self.args.push(path.into());
     }

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -45,8 +45,6 @@ impl Linker {
                             return Err(LinkerError::Target(target_os.into()))
                         }
 
-                        (_, "darwin") => Box::new(CcLinker::new("clang")),
-
                         _ => Box::new(LdLinker::new()),
                     }
                 }
@@ -155,7 +153,7 @@ impl LinkerInterface for CcLinker {
     }
 
     fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-r".into()); // --relocatable
+        self.args.push("-relocatable".into());
         self.args.push("-o".into());
         self.args.push(path.into());
     }
@@ -214,7 +212,7 @@ impl LinkerInterface for LdLinker {
     }
 
     fn build_relocatable(&mut self, path: &str) {
-        self.args.push("-r".into()); // --relocatable
+        self.args.push("-relocatable".into());
         self.args.push("-o".into());
         self.args.push(path.into());
     }


### PR DESCRIPTION
Fixes issues where running a VS Code debug configuration failed due to naming issues. 

Off-topic but does anyone actually use all these configurations defined in `launch.json`? I see myself only using the `Debug source 'demo.st'` and `Debug unit test 'demo'` configuration, maybe we can remove some configuration if they're unused?