### PR TITLE
enum initialization in var-blocks

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -65,6 +65,7 @@ pub enum ErrNo {
     var__missing_type,
     var__assigning_to_var_input_ref,
     var__overflow,
+    var__invalid_enum_variant,
 
     //array related
     arr__invalid_array_assignment,
@@ -809,9 +810,10 @@ impl Diagnostic {
     }
 
     pub fn enum_variant_mismatch(enum_type: &str, range: SourceRange) -> Diagnostic {
-        Diagnostic::ImprovementSuggestion {
+        Diagnostic::SemanticError {
             message: format!("Assigned value is not a variant of {enum_type}"),
             range: vec![range],
+            err_no: ErrNo::var__invalid_enum_variant,
         }
     }
 }

--- a/src/validation/snapshots/rusty__validation__variable__variable_validator_tests__validate_enum_variant_initializer.snap
+++ b/src/validation/snapshots/rusty__validation__variable__variable_validator_tests__validate_enum_variant_initializer.snap
@@ -1,0 +1,10 @@
+---
+source: src/validation/variable.rs
+expression: res
+---
+SemanticError { message: "Assigned value is not a variant of main.y", range: [SourceRange { range: 196..199 }], err_no: var__invalid_enum_variant }
+SemanticError { message: "Assigned value is not a variant of main.var1", range: [SourceRange { range: 300..306 }], err_no: var__invalid_enum_variant }
+SemanticError { message: "Assigned value is not a variant of main.var2", range: [SourceRange { range: 356..360 }], err_no: var__invalid_enum_variant }
+SemanticError { message: "Assigned value is not a variant of main.var3", range: [SourceRange { range: 407..408 }], err_no: var__invalid_enum_variant }
+SemanticError { message: "Assigned value is not a variant of x", range: [SourceRange { range: 55..56 }], err_no: var__invalid_enum_variant }
+

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -552,21 +552,13 @@ fn validate_assignment<T: AnnotationMap>(
                 ));
             } else {
                 // ...enum variable where the RHS does not match its variants
-                let left_dt =
-                    context.annotations.get_type_or_void(left, context.index).get_type_information();
-                if left_dt.is_enum()
-                    && left_dt.get_name()
-                        != context
-                            .annotations
-                            .get_type_or_void(right, context.index)
-                            .get_type_information()
-                            .get_name()
-                {
-                    validator.push_diagnostic(Diagnostic::enum_variant_mismatch(
-                        qualified_name,
-                        right.get_location(),
-                    ))
-                }
+                validate_enum_variant_assignment(
+                    validator,
+                    context.annotations.get_type_or_void(left, context.index).get_type_information(),
+                    context.annotations.get_type_or_void(right, context.index).get_type_information(),
+                    qualified_name,
+                    right.get_location(),
+                );
             }
 
             // ...VAR_INPUT {ref} variable
@@ -615,6 +607,18 @@ fn validate_assignment<T: AnnotationMap>(
             // FIXME: See https://github.com/PLC-lang/rusty/issues/857
             // validate_assignment_type_sizes(validator, left_type, right_type, location, context)
         }
+    }
+}
+
+pub(crate) fn validate_enum_variant_assignment(
+    validator: &mut Validator,
+    left: &DataTypeInformation,
+    right: &DataTypeInformation,
+    qualified_name: &str,
+    location: SourceRange,
+) {
+    if left.is_enum() && left.get_name() != right.get_name() {
+        validator.push_diagnostic(Diagnostic::enum_variant_mismatch(qualified_name, location))
     }
 }
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__enum_variants_mismatch.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__enum_variants_mismatch.snap
@@ -2,8 +2,8 @@
 source: src/validation/tests/assignment_validation_tests.rs
 expression: res
 ---
-ImprovementSuggestion { message: "Assigned value is not a variant of main.color", range: [SourceRange { range: 291..294 }] }
-ImprovementSuggestion { message: "Assigned value is not a variant of main.water", range: [SourceRange { range: 334..338 }] }
-ImprovementSuggestion { message: "Assigned value is not a variant of main.color", range: [SourceRange { range: 377..386 }] }
-ImprovementSuggestion { message: "Assigned value is not a variant of main.color", range: [SourceRange { range: 420..421 }] }
+SemanticError { message: "Assigned value is not a variant of main.color", range: [SourceRange { range: 291..294 }], err_no: var__invalid_enum_variant }
+SemanticError { message: "Assigned value is not a variant of main.water", range: [SourceRange { range: 334..338 }], err_no: var__invalid_enum_variant }
+SemanticError { message: "Assigned value is not a variant of main.color", range: [SourceRange { range: 377..386 }], err_no: var__invalid_enum_variant }
+SemanticError { message: "Assigned value is not a variant of main.color", range: [SourceRange { range: 420..421 }], err_no: var__invalid_enum_variant }
 


### PR DESCRIPTION
Fixes invalid enum initializers not being validated. I've also reclassified the severity from `ImprovementSuggestion` to `SemanticError`. Consider the following example:

```
PROGRAM prog
VAR
    x : DINT := 12345;
    var3 : (a, b, c) := 7; // this should not just be a warning
END_VAR
    var3 := x; // and neither should this
END_PROGRAM
```

While we could validate against a literal initializer out of range, doing so for a reference is a different story.