### PR TITLE
Give a warning when trying to access bits without using the %X operator

### DIFF
--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -230,18 +230,13 @@ fn validate_qualified_reference<T: AnnotationMap>(
             ))
         }
     } else {
-        let Some((reference, other)) = access else {
+        let Some((reference, _)) = access else {
             return
         };
         if !context.annotations.has_type_annotation(reference) {
             let AstStatement::Reference { name, location, .. } = reference else {
                 return
             };
-
-            let other_type = context.annotations.get_type(other, context.index);
-            if other_type.is_some_and(|it| it.is_struct()) || other_type.is_none() {
-                return;
-            }
 
             validator.push_diagnostic(Diagnostic::ImprovementSuggestion {
                 message: format!("If you meant to access a bit, use %X{name} instead.",),

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -230,13 +230,17 @@ fn validate_qualified_reference<T: AnnotationMap>(
             ))
         }
     } else {
-        let Some((reference, _)) = access else {
+        let Some((reference, accessed)) = access else {
             return
         };
         if !context.annotations.has_type_annotation(reference) {
             let AstStatement::Reference { name, location, .. } = reference else {
                 return
             };
+
+            if context.annotations.get_type(accessed, context.index).is_none() {
+                return;
+            }
 
             validator.push_diagnostic(Diagnostic::ImprovementSuggestion {
                 message: format!("If you meant to access a bit, use %X{name} instead.",),

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resole_struct_member_access.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resole_struct_member_access.snap
@@ -1,11 +1,17 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: make_readable(&diagnostics)
+expression: res
 ---
 SyntaxError { message: "Could not resolve reference to field10", range: [SourceRange { range: 694..701 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xfield10 instead.", range: [SourceRange { range: 694..701 }] }
 SyntaxError { message: "Could not resolve reference to field20", range: [SourceRange { range: 721..728 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xfield20 instead.", range: [SourceRange { range: 721..728 }] }
 SyntaxError { message: "Could not resolve reference to field30", range: [SourceRange { range: 748..755 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xfield30 instead.", range: [SourceRange { range: 748..755 }] }
 SyntaxError { message: "Could not resolve reference to subfield10", range: [SourceRange { range: 955..965 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xsubfield10 instead.", range: [SourceRange { range: 955..965 }] }
 SyntaxError { message: "Could not resolve reference to subfield20", range: [SourceRange { range: 989..999 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xsubfield20 instead.", range: [SourceRange { range: 989..999 }] }
 SyntaxError { message: "Could not resolve reference to subfield30", range: [SourceRange { range: 1023..1033 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xsubfield30 instead.", range: [SourceRange { range: 1023..1033 }] }
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_in_structs_and_field_access.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_in_structs_and_field_access.snap
@@ -4,11 +4,8 @@ expression: res
 ---
 SyntaxError { message: "Could not resolve reference to fb3", range: [SourceRange { range: 650..653 }], err_no: reference__unresolved }
 SyntaxError { message: "Could not resolve reference to a", range: [SourceRange { range: 654..655 }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to access a bit, use %Xa instead.", range: [SourceRange { range: 654..655 }] }
 SyntaxError { message: "Could not resolve reference to fb3", range: [SourceRange { range: 664..667 }], err_no: reference__unresolved }
 SyntaxError { message: "Could not resolve reference to b", range: [SourceRange { range: 668..669 }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to access a bit, use %Xb instead.", range: [SourceRange { range: 668..669 }] }
 SyntaxError { message: "Could not resolve reference to fb3", range: [SourceRange { range: 678..681 }], err_no: reference__unresolved }
 SyntaxError { message: "Could not resolve reference to c", range: [SourceRange { range: 682..683 }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to access a bit, use %Xc instead.", range: [SourceRange { range: 682..683 }] }
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_in_structs_and_field_access.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_in_structs_and_field_access.snap
@@ -1,11 +1,14 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: make_readable(&diagnostics)
+expression: res
 ---
 SyntaxError { message: "Could not resolve reference to fb3", range: [SourceRange { range: 650..653 }], err_no: reference__unresolved }
 SyntaxError { message: "Could not resolve reference to a", range: [SourceRange { range: 654..655 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xa instead.", range: [SourceRange { range: 654..655 }] }
 SyntaxError { message: "Could not resolve reference to fb3", range: [SourceRange { range: 664..667 }], err_no: reference__unresolved }
 SyntaxError { message: "Could not resolve reference to b", range: [SourceRange { range: 668..669 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xb instead.", range: [SourceRange { range: 668..669 }] }
 SyntaxError { message: "Could not resolve reference to fb3", range: [SourceRange { range: 678..681 }], err_no: reference__unresolved }
 SyntaxError { message: "Could not resolve reference to c", range: [SourceRange { range: 682..683 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xc instead.", range: [SourceRange { range: 682..683 }] }
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_members_via_qualifier.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_members_via_qualifier.snap
@@ -3,9 +3,6 @@ source: src/validation/tests/reference_resolve_tests.rs
 expression: res
 ---
 SyntaxError { message: "Could not resolve reference to a", range: [SourceRange { range: 181..182 }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to access a bit, use %Xa instead.", range: [SourceRange { range: 181..182 }] }
 SyntaxError { message: "Could not resolve reference to b", range: [SourceRange { range: 217..218 }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to access a bit, use %Xb instead.", range: [SourceRange { range: 217..218 }] }
 SyntaxError { message: "Could not resolve reference to c", range: [SourceRange { range: 253..254 }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to access a bit, use %Xc instead.", range: [SourceRange { range: 253..254 }] }
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_members_via_qualifier.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_members_via_qualifier.snap
@@ -1,8 +1,11 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: make_readable(&diagnostics)
+expression: res
 ---
 SyntaxError { message: "Could not resolve reference to a", range: [SourceRange { range: 181..182 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xa instead.", range: [SourceRange { range: 181..182 }] }
 SyntaxError { message: "Could not resolve reference to b", range: [SourceRange { range: 217..218 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xb instead.", range: [SourceRange { range: 217..218 }] }
 SyntaxError { message: "Could not resolve reference to c", range: [SourceRange { range: 253..254 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xc instead.", range: [SourceRange { range: 253..254 }] }
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
@@ -6,4 +6,5 @@ SyntaxError { message: "Could not resolve reference to n1", range: [SourceRange 
 ImprovementSuggestion { message: "If you meant to access a bit, use %Xn1 instead.", range: [SourceRange { range: 287..289 }] }
 SyntaxError { message: "Could not resolve reference to access", range: [SourceRange { range: 376..382 }], err_no: reference__unresolved }
 SyntaxError { message: "Could not resolve reference to var1", range: [SourceRange { range: 383..387 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xvar1 instead.", range: [SourceRange { range: 383..387 }] }
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
@@ -1,0 +1,9 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: res
+---
+SyntaxError { message: "Could not resolve reference to n1", range: [SourceRange { range: 287..289 }], err_no: reference__unresolved }
+ImprovementSuggestion { message: "If you meant to access a bit, use %Xn1 instead.", range: [SourceRange { range: 287..289 }] }
+SyntaxError { message: "Could not resolve reference to access", range: [SourceRange { range: 376..382 }], err_no: reference__unresolved }
+SyntaxError { message: "Could not resolve reference to var1", range: [SourceRange { range: 383..387 }], err_no: reference__unresolved }
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
@@ -4,7 +4,4 @@ expression: res
 ---
 SyntaxError { message: "Could not resolve reference to n1", range: [SourceRange { range: 287..289 }], err_no: reference__unresolved }
 ImprovementSuggestion { message: "If you meant to access a bit, use %Xn1 instead.", range: [SourceRange { range: 287..289 }] }
-SyntaxError { message: "Could not resolve reference to access", range: [SourceRange { range: 376..382 }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to var1", range: [SourceRange { range: 383..387 }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to access a bit, use %Xvar1 instead.", range: [SourceRange { range: 383..387 }] }
 

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -1297,7 +1297,6 @@ fn bit_access_with_incorrect_operator_causes_warning() {
         END_VAR
             Output.var1.%Wn1.%Bn1.%Xn1 := Input.var1; // OK
             Output.var1.n1             := Input.var1; // bitaccess without %X -> Warning
-            Output.var1.access.var1    := Input.var1; // qualified bitaccess without %X -> Warning
         END_PROGRAM
         
         TYPE STRUCT1 :

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -1281,3 +1281,44 @@ fn passing_compatible_numeric_types_to_functions_is_allowed() {
 
     assert_eq!(diagnostics, vec![]);
 }
+
+#[test]
+fn bit_access_with_incorrect_operator_causes_warning() {
+    let diagnostics = parse_and_validate(
+        "PROGRAM mainProg
+        VAR_INPUT
+            Input : STRUCT1;
+        END_VAR
+        VAR
+            access : STRUCT2;
+        END_VAR
+        VAR_OUTPUT
+            Output : STRUCT1;
+        END_VAR
+            Output.var1.%Wn1.%Bn1.%Xn1 := Input.var1; // OK
+            Output.var1.n1             := Input.var1; // bitaccess without %X -> Warning
+            Output.var1.access.var1    := Input.var1; // qualified bitaccess without %X -> Warning
+        END_PROGRAM
+        
+        TYPE STRUCT1 :
+        STRUCT
+            var1 : DWORD;
+        END_STRUCT
+        END_TYPE
+        
+        TYPE ENUM1 :
+        (
+            n1 := 1,
+            n2 := 2
+        );
+        END_TYPE
+        
+        TYPE STRUCT2 :
+        STRUCT
+            var1 : BOOL;
+        END_STRUCT
+        END_TYPE",
+    );
+
+    assert_validation_snapshot!(diagnostics);
+}


### PR DESCRIPTION
This PR introduces a warning when a bit-access is attempted with the `.`-operator. If the type that is bit-accessed does not have a type annotation (i.e. POUs, unresolved refs), no warning will be given.

This will not hint at attempts to use bit-access with qualified variables as indices.
E.g. `prog.baz.var1.prog.baz.var2`, will just result in unresolved reference warnings. Here a hint to the user allowed would be helpful, but it is not trivial to know what the user attempts here - everything after `.var1` will be unresolved.