### PR TITLE
fix `string_functions.st` error when compiled to IR

### DIFF
--- a/libs/stdlib/iec61131-st/string_functions.st
+++ b/libs/stdlib/iec61131-st/string_functions.st
@@ -749,7 +749,7 @@ Return:
 ******************************************************************************)
 {external}
 FUNCTION NE <T: ANY_STRING> : BOOL
-VAR_INPUT
+VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
 END_VAR

--- a/libs/stdlib/iec61131-st/string_functions.st
+++ b/libs/stdlib/iec61131-st/string_functions.st
@@ -4,12 +4,12 @@ END_VAR
 
 (******************************************************************************
 Description: String character length
-Input: 
+Input:
     - IN:   A character string
 Return: String length
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION LEN <T: ANY_STRING> : DINT
+FUNCTION LEN < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -21,8 +21,8 @@ Input:
     - IN:   A character string
     - L:    The length of the substring
 Return: A substring consisting of the leftmost L characters of IN
-******************************************************************************)
-FUNCTION LEFT <T: ANY_STRING> : T
+***************************************************************************** *)
+FUNCTION LEFT < T : ANY_STRING > : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -32,7 +32,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION LEFT_EXT<T: ANY_STRING> : DINT
+FUNCTION LEFT_EXT < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -40,7 +40,7 @@ VAR_INPUT
     L  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: T;
+    OUT : T;
 END_VAR
 END_FUNCTION
 
@@ -73,7 +73,7 @@ VAR_INPUT
     L  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: STRING[__STRING_LENGTH];
+    OUT : STRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -86,7 +86,7 @@ VAR_INPUT
     L  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: WSTRING[__STRING_LENGTH];
+    OUT : WSTRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -96,8 +96,8 @@ Input:
     - IN:   A character string
     - L:    The length of the substring
 Return: A substring consisting of the rightmost L characters of IN
-******************************************************************************)
-FUNCTION RIGHT <T: ANY_STRING> : T
+***************************************************************************** *)
+FUNCTION RIGHT < T : ANY_STRING > : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -107,7 +107,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION RIGHT_EXT<T: ANY_STRING> : DINT
+FUNCTION RIGHT_EXT < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -115,7 +115,7 @@ VAR_INPUT
     L  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: T;
+    OUT : T;
 END_VAR
 END_FUNCTION
 
@@ -148,7 +148,7 @@ VAR_INPUT
     L  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: STRING[__STRING_LENGTH];
+    OUT : STRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -161,7 +161,7 @@ VAR_INPUT
     L  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: WSTRING[__STRING_LENGTH];
+    OUT : WSTRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -171,11 +171,11 @@ Input:
     - IN:   A character string
     - L:    The length of the substring
     - P:    The starting index position
-Return: 
-    A substring that contains L characters starting 
+Return:
+    A substring that contains L characters starting
     from position P in a string.
-******************************************************************************)
-FUNCTION MID <T: ANY_STRING> : T
+***************************************************************************** *)
+FUNCTION MID < T : ANY_STRING > : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -186,7 +186,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION MID_EXT<T: ANY_STRING> : DINT
+FUNCTION MID_EXT < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -195,7 +195,7 @@ VAR_INPUT
     P  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: T;
+    OUT : T;
 END_VAR
 END_FUNCTION
 
@@ -210,7 +210,7 @@ END_VAR
     MID_EXT(IN, L, P, MID__STRING);
 END_FUNCTION
 
-FUNCTION MID__WSTRING : WSTRING[__STRING_LENGTH] 
+FUNCTION MID__WSTRING : WSTRING[__STRING_LENGTH]
 VAR_INPUT {ref}
 	IN : WSTRING[__STRING_LENGTH];
 END_VAR
@@ -231,7 +231,7 @@ VAR_INPUT
     P  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: STRING[__STRING_LENGTH];
+    OUT : STRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -245,7 +245,7 @@ VAR_INPUT
     P  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: WSTRING[__STRING_LENGTH];
+    OUT : WSTRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -257,7 +257,7 @@ Input:
 Return:
     A string combining all given input strings in the same order
     as the given string parameters.
-******************************************************************************)
+***************************************************************************** *)
 {external}
 FUNCTION CONCAT__STRING : STRING[2048]
 VAR_INPUT {ref}
@@ -272,19 +272,19 @@ VAR_INPUT {ref}
 END_VAR
 END_FUNCTION
 
-FUNCTION CONCAT <T: ANY_STRING> : T
+FUNCTION CONCAT < T : ANY_STRING > : T
 VAR_INPUT {ref}
 	args : {sized} T...;
 END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION CONCAT_EXT<T: ANY_STRING> : DINT
+FUNCTION CONCAT_EXT < T : ANY_STRING > : DINT
 VAR_IN_OUT
-    OUT: T;
+    OUT : T;
 END_VAR
 VAR_INPUT {ref}
-    args: {sized} T...;
+    args : {sized} T...;
 END_VAR
 END_FUNCTION
 
@@ -296,28 +296,28 @@ Input:
     P:      The position at which to insert
 Return:
     A string consisting of IN2 inserted at position P into string IN1
-******************************************************************************)
-FUNCTION INSERT <T: ANY_STRING> : T
+***************************************************************************** *)
+FUNCTION INSERT < T : ANY_STRING > : T
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
 END_VAR
-VAR_INPUT    
+VAR_INPUT
     P   : DINT;
 END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION INSERT_EXT<T: ANY_STRING> : DINT
+FUNCTION INSERT_EXT < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
 END_VAR
-VAR_INPUT    
+VAR_INPUT
     P   : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: T;
+    OUT : T;
 END_VAR
 END_FUNCTION
 
@@ -326,7 +326,7 @@ VAR_INPUT {ref}
 	IN1 : STRING[__STRING_LENGTH];
     IN2 : STRING[__STRING_LENGTH];
 END_VAR
-VAR_INPUT    
+VAR_INPUT
     P   : DINT;
 END_VAR
     INSERT_EXT(IN1, IN2, P, INSERT__STRING);
@@ -337,7 +337,7 @@ VAR_INPUT {ref}
 	IN1 : WSTRING[__STRING_LENGTH];
     IN2 : WSTRING[__STRING_LENGTH];
 END_VAR
-VAR_INPUT    
+VAR_INPUT
     P   : DINT;
 END_VAR
     INSERT_EXT(IN1, IN2, P, INSERT__WSTRING);
@@ -349,11 +349,11 @@ VAR_INPUT {ref}
 	IN1 : STRING[__STRING_LENGTH];
     IN2 : STRING[__STRING_LENGTH];
 END_VAR
-VAR_INPUT    
+VAR_INPUT
     P   : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: STRING[__STRING_LENGTH];
+    OUT : STRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -363,23 +363,23 @@ VAR_INPUT {ref}
 	IN1 : WSTRING[__STRING_LENGTH];
     IN2 : WSTRING[__STRING_LENGTH];
 END_VAR
-VAR_INPUT    
+VAR_INPUT
     P   : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: WSTRING[__STRING_LENGTH];
+    OUT : WSTRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
 (******************************************************************************
 Description: Delete
-Input: 
+Input:
     IN: The string to delete characters from
     L:  The amount of characters to delete
     P:  The position at which to start deleting
 Return: A new string with L characters deleted from P onwards
-******************************************************************************)
-FUNCTION DELETE <T: ANY_STRING> : T
+***************************************************************************** *)
+FUNCTION DELETE < T : ANY_STRING > : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -390,7 +390,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION DELETE_EXT<T: ANY_STRING> : DINT
+FUNCTION DELETE_EXT < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -399,7 +399,7 @@ VAR_INPUT
     P  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: T;
+    OUT : T;
 END_VAR
 END_FUNCTION
 
@@ -414,7 +414,7 @@ END_VAR
     DELETE_EXT(IN, L, P, DELETE__STRING);
 END_FUNCTION
 
-FUNCTION DELETE__WSTRING : WSTRING[__STRING_LENGTH] 
+FUNCTION DELETE__WSTRING : WSTRING[__STRING_LENGTH]
 VAR_INPUT {ref}
 	IN : WSTRING[__STRING_LENGTH];
 END_VAR
@@ -435,7 +435,7 @@ VAR_INPUT
     P  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: STRING[__STRING_LENGTH];
+    OUT : STRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 
@@ -449,7 +449,7 @@ VAR_INPUT
     P  : DINT;
 END_VAR
 VAR_IN_OUT
-    OUT: WSTRING[__STRING_LENGTH];
+    OUT : WSTRING[__STRING_LENGTH];
 END_VAR
 END_FUNCTION
 (******************************************************************************
@@ -460,8 +460,8 @@ Input:
     L:      The amount of characters to delete
     P:      The position at which to start deleting
 Return: A new string which has L characters replaced by IN2 from position P onwards
-******************************************************************************)
-FUNCTION REPLACE <T: ANY_STRING> : T
+***************************************************************************** *)
+FUNCTION REPLACE < T : ANY_STRING > : T
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
@@ -473,18 +473,18 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION REPLACE_EXT <T: ANY_STRING> : DINT
+FUNCTION REPLACE_EXT < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
     IN1 : T;
     IN2 : T;
 END_VAR
-VAR_INPUT 
+VAR_INPUT
     L   : DINT;
     P   : DINT;
 END_VAR
 VAR_IN_OUT
     OUT : T;
-END_VAR    
+END_VAR
 END_FUNCTION
 
 FUNCTION REPLACE__STRING : STRING[__STRING_LENGTH]
@@ -503,8 +503,8 @@ FUNCTION REPLACE__WSTRING : WSTRING[__STRING_LENGTH]
 VAR_INPUT {ref}
     IN1 : WSTRING[__STRING_LENGTH];
     IN2 : WSTRING[__STRING_LENGTH];
-END_VAR    
-VAR_INPUT 
+END_VAR
+VAR_INPUT
     L   : DINT;
     P   : DINT;
 END_VAR
@@ -517,13 +517,13 @@ VAR_INPUT {ref}
     IN1 : STRING[__STRING_LENGTH];
     IN2 : STRING[__STRING_LENGTH];
 END_VAR
-VAR_INPUT 
+VAR_INPUT
     L   : DINT;
     P   : DINT;
 END_VAR
 VAR_IN_OUT
     OUT : STRING[__STRING_LENGTH];
-END_VAR    
+END_VAR
 END_FUNCTION
 
 {external}
@@ -532,25 +532,25 @@ VAR_INPUT {ref}
     IN1 : WSTRING[__STRING_LENGTH];
     IN2 : WSTRING[__STRING_LENGTH];
 END_VAR
-VAR_INPUT 
+VAR_INPUT
     L   : DINT;
     P   : DINT;
 END_VAR
 VAR_IN_OUT
     OUT : WSTRING[__STRING_LENGTH];
-END_VAR    
+END_VAR
 END_FUNCTION
 
 
 (******************************************************************************
 Description: Find
-Input: 
+Input:
     IN1:    The string in which to search in
     IN2:    The substring to search for
 Return: The character index of the first match. 0 if there are no matches.
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION FIND <T: ANY_STRING> : DINT
+FUNCTION FIND < T : ANY_STRING > : DINT
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
@@ -560,68 +560,111 @@ END_FUNCTION
 (******************************************************************************
 Description: Decreasing sequence
 Input:  The strings to compare, in order. ((IN1>IN2) & (IN2>IN3) & .. & (INn-1>INn))
-Return: 
+Return:
     TRUE if codepoints are in decreasing order (alphabetical order: ZYX > YXW > XWV ..)
     FALSE otherwise
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION GT <T: ANY_STRING> : BOOL
-VAR_INPUT
+FUNCTION GT < T : ANY_STRING > : BOOL
+VAR_INPUT {ref}
 	IN1 : {sized} T...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION GT__STRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} STRING...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION GT__WSTRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} WSTRING...;
 END_VAR
 END_FUNCTION
 
 // passing strings by ref causes an error/warning. code still compiles and works correctly
 FUNCTION STRING_GREATER : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
     a, b : STRING;
 END_VAR
     STRING_GREATER := GT(a, b);
 END_FUNCTION
 
 FUNCTION WSTRING_GREATER : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
     a, b : WSTRING;
 END_VAR
     WSTRING_GREATER := GT(a, b);
 END_FUNCTION
+
 (******************************************************************************
 Description: Monotonic sequence
 Input:  The strings to compare, in order. ((IN1>=IN2) & (IN2>=IN3) & .. & (INn-1>=INn))
-Return: 
+Return:
     TRUE if codepoints are in decreasing order or are equal to adjacent codepoints (alphabetical order: ZYX >= ZYX >= YXW ..)
     FALSE otherwise
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION GE <T: ANY_STRING> : BOOL
-VAR_INPUT
+FUNCTION GE < T : ANY_STRING > : BOOL
+VAR_INPUT {ref}
 	IN1 : {sized} T...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION GE__STRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} STRING...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION GE__WSTRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} WSTRING...;
 END_VAR
 END_FUNCTION
 
 (******************************************************************************
 Description: Equality
 Input: The strings to compare, in order. ((IN1=IN2) & (IN2=IN3) & .. & (INn-1=INn))
-Return: 
+Return:
     TRUE if codepoints are equal to each other
     FALSE otherwise.
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION EQ <T: ANY_STRING> : BOOL
-VAR_INPUT
+FUNCTION EQ < T : ANY_STRING > : BOOL
+VAR_INPUT {ref}
 	IN1 : {sized} T...;
 END_VAR
 END_FUNCTION
 
-FUNCTION STRING_EQUAL : BOOL
+{external}
+FUNCTION EQ__STRING : BOOL
 VAR_INPUT {ref}
+	IN1 : {sized} STRING...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION EQ__WSTRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} WSTRING...;
+END_VAR
+END_FUNCTION
+
+FUNCTION STRING_EQUAL : BOOL
+VAR_INPUT
     a, b : STRING;
 END_VAR
     STRING_EQUAL := EQ(a, b);
 END_FUNCTION
 
 FUNCTION WSTRING_EQUAL : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
     a, b : WSTRING;
 END_VAR
     WSTRING_EQUAL := EQ(a, b);
@@ -630,40 +673,68 @@ END_FUNCTION
 (******************************************************************************
 Description: Monotonic sequence
 Input:  The strings to compare, in order. ((IN1<=IN2) & (IN2<=IN3) & .. & (INn-1<=INn))
-Return: 
+Return:
     TRUE if codepoints are in increasing order or are equal to adjacent codepoints (alphabetical order: ABC <= ABC <= BCD ..)
     FALSE otherwise
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION LE <T: ANY_STRING> : BOOL
-VAR_INPUT
+FUNCTION LE < T : ANY_STRING > : BOOL
+VAR_INPUT {ref}
 	IN1 : {sized} T...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION LE__STRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} STRING...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION LE__WSTRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} WSTRING...;
 END_VAR
 END_FUNCTION
 
 (******************************************************************************
 Description: Increasing sequence
 Input:  The strings to compare, in order. ((IN1<IN2) & (IN2<IN3) & .. & (INn-1<INn))
-Return: 
+Return:
     TRUE if codepoints are in increasing order (alphabetical order: ABC < BCD < CDE ..)
     FALSE otherwise
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION LT <T: ANY_STRING> : BOOL
-VAR_INPUT
+FUNCTION LT < T : ANY_STRING > : BOOL
+VAR_INPUT {ref}
 	IN1 : {sized} T...;
 END_VAR
 END_FUNCTION
 
-FUNCTION STRING_LESS : BOOL
+{external}
+FUNCTION LT__STRING : BOOL
 VAR_INPUT {ref}
+	IN1 : {sized} STRING...;
+END_VAR
+END_FUNCTION
+
+{external}
+FUNCTION LT__WSTRING : BOOL
+VAR_INPUT {ref}
+	IN1 : {sized} WSTRING...;
+END_VAR
+END_FUNCTION
+
+FUNCTION STRING_LESS : BOOL
+VAR_INPUT
     a, b : STRING;
 END_VAR
     STRING_LESS := LT(a, b);
 END_FUNCTION
 
 FUNCTION WSTRING_LESS : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
     a, b : WSTRING;
 END_VAR
     WSTRING_LESS := LT(a, b);
@@ -675,10 +746,10 @@ Input: The strings to compare. (IN1<>IN2)
 Return:
     TRUE if strings do not match
     FALSE otherwise
-******************************************************************************)
+***************************************************************************** *)
 {external}
-FUNCTION NE <T: ANY_STRING> : BOOL
-VAR_INPUT
+FUNCTION NE < T : ANY_STRING > : BOOL
+VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
 END_VAR

--- a/libs/stdlib/iec61131-st/string_functions.st
+++ b/libs/stdlib/iec61131-st/string_functions.st
@@ -7,9 +7,9 @@ Description: String character length
 Input:
     - IN:   A character string
 Return: String length
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION LEN < T : ANY_STRING > : DINT
+FUNCTION LEN <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -21,8 +21,8 @@ Input:
     - IN:   A character string
     - L:    The length of the substring
 Return: A substring consisting of the leftmost L characters of IN
-***************************************************************************** *)
-FUNCTION LEFT < T : ANY_STRING > : T
+******************************************************************************)
+FUNCTION LEFT <T: ANY_STRING> : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -32,7 +32,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION LEFT_EXT < T : ANY_STRING > : DINT
+FUNCTION LEFT_EXT <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -96,8 +96,8 @@ Input:
     - IN:   A character string
     - L:    The length of the substring
 Return: A substring consisting of the rightmost L characters of IN
-***************************************************************************** *)
-FUNCTION RIGHT < T : ANY_STRING > : T
+******************************************************************************)
+FUNCTION RIGHT <T: ANY_STRING> : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -107,7 +107,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION RIGHT_EXT < T : ANY_STRING > : DINT
+FUNCTION RIGHT_EXT <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -174,8 +174,8 @@ Input:
 Return:
     A substring that contains L characters starting
     from position P in a string.
-***************************************************************************** *)
-FUNCTION MID < T : ANY_STRING > : T
+******************************************************************************)
+FUNCTION MID <T: ANY_STRING> : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -186,7 +186,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION MID_EXT < T : ANY_STRING > : DINT
+FUNCTION MID_EXT <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -257,7 +257,7 @@ Input:
 Return:
     A string combining all given input strings in the same order
     as the given string parameters.
-***************************************************************************** *)
+******************************************************************************)
 {external}
 FUNCTION CONCAT__STRING : STRING[2048]
 VAR_INPUT {ref}
@@ -272,14 +272,14 @@ VAR_INPUT {ref}
 END_VAR
 END_FUNCTION
 
-FUNCTION CONCAT < T : ANY_STRING > : T
+FUNCTION CONCAT <T: ANY_STRING> : T
 VAR_INPUT {ref}
 	args : {sized} T...;
 END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION CONCAT_EXT < T : ANY_STRING > : DINT
+FUNCTION CONCAT_EXT <T: ANY_STRING> : DINT
 VAR_IN_OUT
     OUT : T;
 END_VAR
@@ -296,8 +296,8 @@ Input:
     P:      The position at which to insert
 Return:
     A string consisting of IN2 inserted at position P into string IN1
-***************************************************************************** *)
-FUNCTION INSERT < T : ANY_STRING > : T
+******************************************************************************)
+FUNCTION INSERT <T: ANY_STRING> : T
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
@@ -308,7 +308,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION INSERT_EXT < T : ANY_STRING > : DINT
+FUNCTION INSERT_EXT <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
@@ -378,8 +378,8 @@ Input:
     L:  The amount of characters to delete
     P:  The position at which to start deleting
 Return: A new string with L characters deleted from P onwards
-***************************************************************************** *)
-FUNCTION DELETE < T : ANY_STRING > : T
+******************************************************************************)
+FUNCTION DELETE <T: ANY_STRING> : T
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -390,7 +390,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION DELETE_EXT < T : ANY_STRING > : DINT
+FUNCTION DELETE_EXT <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
 	IN : T;
 END_VAR
@@ -460,8 +460,8 @@ Input:
     L:      The amount of characters to delete
     P:      The position at which to start deleting
 Return: A new string which has L characters replaced by IN2 from position P onwards
-***************************************************************************** *)
-FUNCTION REPLACE < T : ANY_STRING > : T
+******************************************************************************)
+FUNCTION REPLACE <T: ANY_STRING> : T
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
@@ -473,7 +473,7 @@ END_VAR
 END_FUNCTION
 
 {external}
-FUNCTION REPLACE_EXT < T : ANY_STRING > : DINT
+FUNCTION REPLACE_EXT <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
     IN1 : T;
     IN2 : T;
@@ -548,9 +548,9 @@ Input:
     IN1:    The string in which to search in
     IN2:    The substring to search for
 Return: The character index of the first match. 0 if there are no matches.
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION FIND < T : ANY_STRING > : DINT
+FUNCTION FIND <T: ANY_STRING> : DINT
 VAR_INPUT {ref}
 	IN1 : T;
     IN2 : T;
@@ -563,9 +563,9 @@ Input:  The strings to compare, in order. ((IN1>IN2) & (IN2>IN3) & .. & (INn-1>I
 Return:
     TRUE if codepoints are in decreasing order (alphabetical order: ZYX > YXW > XWV ..)
     FALSE otherwise
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION GT < T : ANY_STRING > : BOOL
+FUNCTION GT <T: ANY_STRING> : BOOL
 VAR_INPUT {ref}
 	IN1 : {sized} T...;
 END_VAR
@@ -606,9 +606,9 @@ Input:  The strings to compare, in order. ((IN1>=IN2) & (IN2>=IN3) & .. & (INn-1
 Return:
     TRUE if codepoints are in decreasing order or are equal to adjacent codepoints (alphabetical order: ZYX >= ZYX >= YXW ..)
     FALSE otherwise
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION GE < T : ANY_STRING > : BOOL
+FUNCTION GE <T: ANY_STRING> : BOOL
 VAR_INPUT {ref}
 	IN1 : {sized} T...;
 END_VAR
@@ -634,9 +634,9 @@ Input: The strings to compare, in order. ((IN1=IN2) & (IN2=IN3) & .. & (INn-1=IN
 Return:
     TRUE if codepoints are equal to each other
     FALSE otherwise.
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION EQ < T : ANY_STRING > : BOOL
+FUNCTION EQ <T: ANY_STRING> : BOOL
 VAR_INPUT {ref}
 	IN1 : {sized} T...;
 END_VAR
@@ -676,9 +676,9 @@ Input:  The strings to compare, in order. ((IN1<=IN2) & (IN2<=IN3) & .. & (INn-1
 Return:
     TRUE if codepoints are in increasing order or are equal to adjacent codepoints (alphabetical order: ABC <= ABC <= BCD ..)
     FALSE otherwise
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION LE < T : ANY_STRING > : BOOL
+FUNCTION LE <T: ANY_STRING> : BOOL
 VAR_INPUT {ref}
 	IN1 : {sized} T...;
 END_VAR
@@ -704,9 +704,9 @@ Input:  The strings to compare, in order. ((IN1<IN2) & (IN2<IN3) & .. & (INn-1<I
 Return:
     TRUE if codepoints are in increasing order (alphabetical order: ABC < BCD < CDE ..)
     FALSE otherwise
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION LT < T : ANY_STRING > : BOOL
+FUNCTION LT <T: ANY_STRING> : BOOL
 VAR_INPUT {ref}
 	IN1 : {sized} T...;
 END_VAR
@@ -746,10 +746,10 @@ Input: The strings to compare. (IN1<>IN2)
 Return:
     TRUE if strings do not match
     FALSE otherwise
-***************************************************************************** *)
+******************************************************************************)
 {external}
-FUNCTION NE < T : ANY_STRING > : BOOL
-VAR_INPUT {ref}
+FUNCTION NE <T: ANY_STRING> : BOOL
+VAR_INPUT
 	IN1 : T;
     IN2 : T;
 END_VAR

--- a/libs/stdlib/iec61131-st/string_functions.st
+++ b/libs/stdlib/iec61131-st/string_functions.st
@@ -566,21 +566,21 @@ Return:
 ******************************************************************************)
 {external}
 FUNCTION GT <T: ANY_STRING> : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
 	IN1 : {sized} T...;
 END_VAR
 END_FUNCTION
 
 // passing strings by ref causes an error/warning. code still compiles and works correctly
 FUNCTION STRING_GREATER : BOOL
-VAR_INPUT 
+VAR_INPUT {ref}
     a, b : STRING;
 END_VAR
     STRING_GREATER := GT(a, b);
 END_FUNCTION
 
 FUNCTION WSTRING_GREATER : BOOL
-VAR_INPUT
+VAR_INPUT {ref}
     a, b : WSTRING;
 END_VAR
     WSTRING_GREATER := GT(a, b);
@@ -594,7 +594,7 @@ Return:
 ******************************************************************************)
 {external}
 FUNCTION GE <T: ANY_STRING> : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
 	IN1 : {sized} T...;
 END_VAR
 END_FUNCTION
@@ -608,20 +608,20 @@ Return:
 ******************************************************************************)
 {external}
 FUNCTION EQ <T: ANY_STRING> : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
 	IN1 : {sized} T...;
 END_VAR
 END_FUNCTION
 
 FUNCTION STRING_EQUAL : BOOL
-VAR_INPUT
+VAR_INPUT {ref}
     a, b : STRING;
 END_VAR
     STRING_EQUAL := EQ(a, b);
 END_FUNCTION
 
 FUNCTION WSTRING_EQUAL : BOOL
-VAR_INPUT
+VAR_INPUT {ref}
     a, b : WSTRING;
 END_VAR
     WSTRING_EQUAL := EQ(a, b);
@@ -636,7 +636,7 @@ Return:
 ******************************************************************************)
 {external}
 FUNCTION LE <T: ANY_STRING> : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
 	IN1 : {sized} T...;
 END_VAR
 END_FUNCTION
@@ -650,20 +650,20 @@ Return:
 ******************************************************************************)
 {external}
 FUNCTION LT <T: ANY_STRING> : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
 	IN1 : {sized} T...;
 END_VAR
 END_FUNCTION
 
 FUNCTION STRING_LESS : BOOL
-VAR_INPUT
+VAR_INPUT {ref}
     a, b : STRING;
 END_VAR
     STRING_LESS := LT(a, b);
 END_FUNCTION
 
 FUNCTION WSTRING_LESS : BOOL
-VAR_INPUT
+VAR_INPUT {ref}
     a, b : WSTRING;
 END_VAR
     WSTRING_LESS := LT(a, b);
@@ -678,7 +678,7 @@ Return:
 ******************************************************************************)
 {external}
 FUNCTION NE <T: ANY_STRING> : BOOL
-VAR_INPUT {ref}
+VAR_INPUT
 	IN1 : T;
     IN2 : T;
 END_VAR

--- a/libs/stdlib/src/string_functions.rs
+++ b/libs/stdlib/src/string_functions.rs
@@ -15,7 +15,7 @@ use num::PrimInt;
 /// Works on raw pointers, inherently unsafe.
 /// May return an incorrect value if passed an
 /// array filled with (non-zero) garbage values.
-pub unsafe fn get_null_terminated_len<T: num::PrimInt>(src: *const T) -> usize {
+pub unsafe fn get_null_terminated_len<T: PrimInt>(src: *const T) -> usize {
     if src.is_null() {
         return 0;
     }
@@ -32,7 +32,7 @@ pub unsafe fn get_null_terminated_len<T: num::PrimInt>(src: *const T) -> usize {
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-pub unsafe fn ptr_to_slice<'a, T: num::PrimInt>(src: *const T) -> &'a [T] {
+pub unsafe fn ptr_to_slice<'a, T: PrimInt>(src: *const T) -> &'a [T] {
     let nbytes = get_null_terminated_len(src);
     std::slice::from_raw_parts(src, nbytes)
 }

--- a/tests/integration/command_line_compile.rs
+++ b/tests/integration/command_line_compile.rs
@@ -61,3 +61,21 @@ fn hardware_conf_full_pass_toml() {
     //clean up
     let _foo = fs::remove_file("toml");
 }
+
+#[test]
+fn stdlib_string_function_headers_compile_to_ir() {
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("libs");
+    path.push("stdlib");
+    path.push("iec61131-st");
+    path.push("string_functions.st");
+    let file = path.display().to_string();
+
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    let path = temp_file.path().to_string_lossy();
+    assert_eq!(
+        compile(&["plc", file.as_str(), "-o", &path, "--ir"]),
+        Ok(()),
+        "Expected file to compile without errors"
+    )
+}


### PR DESCRIPTION
fixes #920

String equality comparison functions were missing resolved-type header implementations (e.g. GT__STRING) with the proper variadic signature.