### PR TITLE
Make shared and PIC the same, add no-pic option

### DIFF
--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -33,6 +33,9 @@ pub struct CompileParameters {
     #[clap(long = "pic", group = "format", global = true, help = "Equivalent to --shared")]
     pub output_pic_obj: bool,
 
+    #[clap(long = "no-pic", group = "format", global = true, help = "Emit a no PIC shared object")]
+    pub output_no_pic_obj: bool,
+
     #[clap(long = "static", group = "format", global = true, help = "Emit an object as output")]
     pub output_obj_code: bool,
 
@@ -267,6 +270,8 @@ impl CompileParameters {
             Some(FormatOption::PIC)
         } else if self.output_shared_obj {
             Some(FormatOption::Shared)
+        } else if self.output_no_pic_obj {
+            Some(FormatOption::NoPIC)
         } else if self.compile_only {
             Some(FormatOption::Object)
         } else if self.output_obj_code {

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -487,7 +487,7 @@ impl GeneratedProject<'_> {
 
                 match link_options.format {
                     FormatOption::Static => linker.build_exectuable(output_location).map_err(Into::into),
-                    FormatOption::Shared | FormatOption::PIC => {
+                    FormatOption::Shared | FormatOption::PIC | FormatOption::NoPIC => {
                         linker.build_shared_obj(output_location).map_err(Into::into)
                     }
                     FormatOption::Object | FormatOption::Relocatable => {

--- a/compiler/plc_project/src/project.rs
+++ b/compiler/plc_project/src/project.rs
@@ -270,8 +270,8 @@ impl<S: SourceContainer> Project<S> {
             let input = self.get_name();
             match self.format {
                 FormatOption::Object | FormatOption::Relocatable => format!("{input}.o"),
-                FormatOption::Static => input.to_string(),
-                FormatOption::Shared | FormatOption::PIC => format!("{input}.so"),
+                FormatOption::Static => format!("{input}.out"),
+                FormatOption::Shared | FormatOption::PIC | FormatOption::NoPIC => format!("{input}.so"),
                 FormatOption::Bitcode => format!("{input}.bc"),
                 FormatOption::IR => format!("{input}.ll"),
             }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-
 use std::{
     cell::RefCell,
     ops::Deref,
@@ -270,10 +269,10 @@ impl<'ink> GeneratedModule<'ink> {
             FormatOption::Object | FormatOption::Relocatable => {
                 self.persist_as_static_obj(output, target, optimization_level)
             }
-            FormatOption::PIC | FormatOption::Static => {
+            FormatOption::PIC | FormatOption::Shared | FormatOption::Static => {
                 self.persist_to_shared_pic_object(output, target, optimization_level)
             }
-            FormatOption::Shared => self.persist_to_shared_object(output, target, optimization_level),
+            FormatOption::NoPIC => self.persist_to_shared_object(output, target, optimization_level),
             FormatOption::Bitcode => self.persist_to_bitcode(output),
             FormatOption::IR => self.persist_to_ir(output),
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -11,6 +11,8 @@ pub enum FormatOption {
     PIC,
     /// Indicates that the linked object will be shared and position independent
     Shared,
+    /// Indicates that the compiled object will be a DynamicNoPIC object
+    NoPIC,
     /// Indicates that the compiled object will be relocatable (e.g. Combinable into multiple objects)
     Relocatable,
     /// Indicates that the compile result will be LLVM Bitcode
@@ -23,7 +25,11 @@ impl FormatOption {
     pub fn should_link(self) -> bool {
         matches!(
             self,
-            FormatOption::Static | FormatOption::Shared | FormatOption::PIC | FormatOption::Relocatable
+            FormatOption::Static
+                | FormatOption::Shared
+                | FormatOption::PIC
+                | FormatOption::NoPIC
+                | FormatOption::Relocatable
         )
     }
 }


### PR DESCRIPTION
Also fixed an issue with the default name overwriting the input, the output name is now <input>.out if not specified

Fixes #792 and #936