### PR TITLE
Better diagnotics in codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -46,24 +46,23 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -85,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -234,9 +233,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64ct"
@@ -324,9 +323,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -334,7 +333,7 @@ dependencies = [
  "num-traits",
  "time",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -356,24 +355,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.12",
- "once_cell",
+ "clap_derive 4.4.2",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.5.0",
+ "clap_lex 0.5.1",
  "strsim",
 ]
 
@@ -392,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2 1.0.66",
@@ -413,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "codespan-reporting"
@@ -565,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.1"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.0",
@@ -628,9 +626,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -665,9 +663,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -927,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.0",
 ]
@@ -1077,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.2.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#bbe1f3d76c45fc137a125665861fc6382ab352d6"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#5378a77fc7a14e8583709e4e21ab208f364aa37b"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1090,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.8.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#bbe1f3d76c45fc137a125665861fc6382ab352d6"
+source = "git+https://github.com/TheDan64/inkwell?branch=master#5378a77fc7a14e8583709e4e21ab208f364aa37b"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -1137,7 +1135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.8",
+ "rustix 0.38.11",
  "windows-sys 0.48.0",
 ]
 
@@ -1303,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
 name = "memoffset"
@@ -1471,11 +1469,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.56"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1503,9 +1501,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.91"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",
@@ -1591,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1887,25 +1885,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1916,9 +1914,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rsa"
@@ -1958,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2058,18 +2056,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -2491,7 +2489,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall",
- "rustix 0.38.8",
+ "rustix 0.38.11",
  "windows-sys 0.48.0",
 ]
 
@@ -2651,9 +2649,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2994,7 +2992,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
- "clap 4.3.23",
+ "clap 4.4.2",
  "plc_ast",
  "plc_source",
  "rusty",

--- a/compiler/plc_diagnostics/src/diagnostician.rs
+++ b/compiler/plc_diagnostics/src/diagnostician.rs
@@ -67,7 +67,7 @@ impl Diagnostician {
 
         self.report(resolved_diagnostics.as_slice());
 
-        resolved_diagnostics.iter().fold(Severity::Info, |prev, current| prev.combine(current.severity))
+        resolved_diagnostics.iter().map(|it| it.severity).max().unwrap_or_default()
     }
 
     /// Creates a null-diagnostician that does not report diagnostics
@@ -159,12 +159,13 @@ impl DiagnosticAssessor for DefaultDiagnosticAssessor {
 }
 
 /// a diagnostics severity
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
-    Critical,
-    Error,
-    Warning,
+    #[default]
     Info,
+    Warning,
+    Error,
+    Critical,
 }
 
 impl std::fmt::Display for Severity {
@@ -176,37 +177,5 @@ impl std::fmt::Display for Severity {
             Severity::Info => "info",
         };
         write!(f, "{severity}")
-    }
-}
-
-impl PartialOrd for Severity {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Severity {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match (self, other) {
-            (Severity::Critical, Severity::Critical) => std::cmp::Ordering::Equal,
-            (Severity::Critical, _) => std::cmp::Ordering::Greater,
-            (_, Severity::Critical) => std::cmp::Ordering::Less,
-            (Severity::Error, Severity::Error) => std::cmp::Ordering::Equal,
-            (Severity::Error, _) => std::cmp::Ordering::Greater,
-            (_, Severity::Error) => std::cmp::Ordering::Less,
-            (Severity::Warning, Severity::Warning) => std::cmp::Ordering::Equal,
-            (Severity::Warning, _) => std::cmp::Ordering::Greater,
-            (_, Severity::Warning) => std::cmp::Ordering::Less,
-            (Severity::Info, Severity::Info) => std::cmp::Ordering::Equal,
-        }
-    }
-}
-
-impl Severity {
-    pub fn combine(self, other: Self) -> Self {
-        match self.cmp(&other) {
-            std::cmp::Ordering::Less => other,
-            _ => self,
-        }
     }
 }

--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, ops::Range};
+use std::{error::Error, fmt::Display, ops::Range};
 
 use plc_ast::ast::{AstStatement, DataTypeDeclaration, DiagnosticInfo, PouType};
 use plc_source::source_location::SourceLocation;
@@ -14,6 +14,18 @@ pub enum Diagnostic {
     GeneralError { message: String, err_no: ErrNo },
     ImprovementSuggestion { message: String, range: Vec<SourceLocation> },
     CombinedDiagnostic { message: String, inner_diagnostics: Vec<Diagnostic>, err_no: ErrNo },
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.get_type(), self.get_message())?;
+        let location = self.get_location();
+        if !location.is_undefined() {
+            write!(f, " at: {location}")
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<T: Error> From<T> for Diagnostic {

--- a/compiler/plc_diagnostics/src/errno.rs
+++ b/compiler/plc_diagnostics/src/errno.rs
@@ -1,9 +1,12 @@
+use std::fmt::Display;
+
 #[allow(non_camel_case_types)]
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum ErrNo {
     undefined,
 
     //general
+    general__err,
     general__io_err,
     general__param_err,
     duplicate_symbol,
@@ -84,4 +87,18 @@ pub enum ErrNo {
     case__duplicate_condition,
     case__case_condition_outside_case_statement,
     case__invalid_case_condition,
+}
+
+impl Display for ErrNo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = match self {
+            Self::general__err => "General Error".into(),
+            Self::codegen__general => "Codegen Error".into(),
+            Self::codegen__missing_compare_function => "Codegen Error: No compare function".into(),
+            Self::codegen__missing_function => "Codegen Error: Missing Function".into(),
+            _ => format!("{self:#?}"),
+        };
+
+        write!(f, "{desc}")
+    }
 }

--- a/compiler/plc_diagnostics/src/reporter/codespan.rs
+++ b/compiler/plc_diagnostics/src/reporter/codespan.rs
@@ -100,9 +100,9 @@ impl DiagnosticReporter for CodeSpanDiagnosticReporter {
     fn report(&mut self, diagnostics: &[ResolvedDiagnostics]) {
         for d in diagnostics {
             let diagnostic_factory = match d.severity {
-                Severity::Error => codespan_reporting::diagnostic::Diagnostic::error(),
+                Severity::Critical | Severity::Error => codespan_reporting::diagnostic::Diagnostic::error(),
                 Severity::Warning => codespan_reporting::diagnostic::Diagnostic::warning(),
-                Severity::_Info => codespan_reporting::diagnostic::Diagnostic::note(),
+                Severity::Info => codespan_reporting::diagnostic::Diagnostic::note(),
             };
 
             let mut labels = vec![];

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -206,7 +206,7 @@ impl AnnotatedProject {
             validator.visit_unit(&self.annotations, &self.index, unit);
             // log errors
             let diagnostics = validator.diagnostics();
-            severity = severity.combine(diagnostician.handle(&diagnostics));
+            severity = severity.max(diagnostician.handle(&diagnostics));
         });
         if severity == Severity::Critical {
             Err(Diagnostic::GeneralError {

--- a/compiler/plc_source/src/source_location.rs
+++ b/compiler/plc_source/src/source_location.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::{Debug, Formatter},
+    fmt::{Debug, Display, Formatter},
     ops::Range,
 };
 
@@ -81,6 +81,28 @@ pub enum CodeSpan {
     None,
 }
 
+impl Display for CodeSpan {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CodeSpan::Block { .. } => write!(f, "Block {}", self.get_line()),
+            CodeSpan::Combined(spans) => {
+                write!(f, "{}", spans.iter().map(|it| it.to_string()).collect::<String>())
+            }
+            CodeSpan::Range(range) => write!(
+                f,
+                "{}:{}:{{{}:{}-{}:{}}}: ",
+                range.start.line,
+                range.start.column,
+                range.start.line,
+                range.start.column,
+                range.end.line,
+                range.end.column,
+            ),
+            CodeSpan::None => Ok(()),
+        }
+    }
+}
+
 impl CodeSpan {
     /// Creates a codespan from line, column and range info
     pub fn from_text_info(start: TextLocation, end: TextLocation) -> Self {
@@ -133,6 +155,15 @@ impl Debug for SourceLocation {
             f.field("file", &self.file);
         }
         f.finish()
+    }
+}
+
+impl Display for SourceLocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.file.filter(|name| *name != "<internal>").is_some() {
+            write!(f, "{}", self.get_file_name().unwrap())?;
+        }
+        write!(f, ":{}", self.span)
     }
 }
 

--- a/compiler/plc_xml/src/xml_parser.rs
+++ b/compiler/plc_xml/src/xml_parser.rs
@@ -51,7 +51,7 @@ pub fn parse_file(
     let (unit, errors) = parse(&source, linkage, id_provider);
     //Register the source file with the diagnostician
     diagnostician.register_file(source.get_location_str().to_string(), source.source.to_string());
-    diagnostician.handle(errors);
+    diagnostician.handle(&errors);
     unit
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,7 +51,7 @@ pub fn parse_file(
     //Register the source file with the diagnostician
     //TODO: We should reduce the clone here
     diagnostician.register_file(source.get_location_str().to_string(), source.source);
-    diagnostician.handle(errors);
+    diagnostician.handle(&errors);
     unit
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -58,7 +58,7 @@ pub mod tests {
         let mut reporter = Diagnostician::buffered();
         reporter.register_file("<internal>".to_string(), src.to_string());
         let (unit, diagnostics) = parse(src);
-        reporter.handle(diagnostics);
+        reporter.handle(&diagnostics);
         (unit, reporter.buffer().unwrap_or_default())
     }
 
@@ -72,7 +72,7 @@ pub mod tests {
             "test.st",
         );
         pre_process(&mut unit, id_provider);
-        reporter.handle(diagnostic);
+        reporter.handle(&diagnostic);
 
         (unit, reporter.buffer().unwrap_or_default())
     }
@@ -132,7 +132,7 @@ pub mod tests {
         let mut reporter = Diagnostician::buffered();
 
         reporter.register_file("<internal>".to_string(), src.to_string());
-        reporter.handle(diagnostics);
+        reporter.handle(&diagnostics);
 
         reporter.buffer().expect(
             "This should be unreachable, otherwise somethings wrong with the buffered codespan reporter",
@@ -167,7 +167,7 @@ pub mod tests {
         reporter.register_file("<internal>".to_string(), src.to_string());
         let mut id_provider = IdProvider::default();
         let (unit, index, diagnostics) = do_index(src, id_provider.clone());
-        reporter.handle(diagnostics);
+        reporter.handle(&diagnostics);
 
         let (mut index, ..) = evaluate_constants(index);
         let (mut annotations, dependencies, literals) =
@@ -187,7 +187,7 @@ pub mod tests {
         let llvm_index = code_generator
             .generate_llvm_index(&context, &annotations, &literals, &dependencies, &index)
             .map_err(|err| {
-                reporter.handle(vec![err]);
+                reporter.handle(&[err]);
                 reporter.buffer().unwrap()
             })?;
 
@@ -195,7 +195,7 @@ pub mod tests {
             .generate(&context, &unit, &annotations, &index, &llvm_index)
             .map(|module| module.persist_to_string())
             .map_err(|err| {
-                reporter.handle(vec![err]);
+                reporter.handle(&[err]);
                 reporter.buffer().unwrap()
             })
     }

--- a/tests/integration/linking.rs
+++ b/tests/integration/linking.rs
@@ -138,7 +138,7 @@ fn link_missing_file() {
                 .into_diagnostic()
                 .unwrap()
                 .get_message()
-                .contains("lld: error: undefined symbol: func2"));
+                .contains("Compilation aborted due to previous errors"));
         }
         _ => panic!("Expected link failure"),
     }


### PR DESCRIPTION
When outputing errors from codegen, we now report them the same way as normal errors.
We also can now abort on critical errors.