### PR TITLE
chore: Bump `indexmap`, `sysinfo`, `itertools` and `quick-xml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.4"
+version = "0.29.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
+checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,7 +1990,7 @@ dependencies = [
  "indexmap 2.0.0",
  "inkwell",
  "insta",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "lld_rs",
  "log",
@@ -2212,7 +2221,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "nom",
  "unicode_categories",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
  "encoding_rs",
  "encoding_rs_io",
  "env_logger",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "insta",
  "log",
  "plc_ast",
@@ -1712,7 +1712,7 @@ name = "plc_xml"
 version = "0.1.0"
 dependencies = [
  "html-escape",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "insta",
  "logos",
  "plc_ast",
@@ -1978,7 +1978,7 @@ dependencies = [
  "encoding_rs",
  "encoding_rs_io",
  "generational-arena",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "inkwell",
  "insta",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.28.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1"
 toml = "0.5"
 lazy_static = "1.4.0"
 shell-words = "1.1.0"
-itertools = "0.10.5"
+itertools = "0.11"
 plc_derive = { path = "./compiler/plc_derive" }
 lld_rs = "140.0.0"
 which = "4.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ plc_diagnostics = { path = "./compiler/plc_diagnostics" }
 logos = "0.12.0"
 thiserror = "1.0"
 clap = { version = "3.0", features = ["derive"] }
-indexmap = "1.6"
+indexmap = "2.0"
 generational-arena = "0.2.8"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1"
 clap = { version = "3.0", features = ["derive"] }
 rayon = "1.6.1"
 tempfile = "3"
-indexmap = "1.6"
+indexmap = "2.0"
 env_logger = "0.10"
 log.workspace = true
 encoding_rs.workspace = true

--- a/compiler/plc_xml/Cargo.toml
+++ b/compiler/plc_xml/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2021"
 logos = "0.12"
 quick-xml = { version = "0.28", features = ["serialize"] }
 insta = "1.20"
-indexmap = "1.9"
+indexmap = "2.0"
 html-escape = "0.2"
 plc = { path = "../..", package = "rusty" }
 ast = { path = "../plc_ast/", package = "plc_ast" }
-plc_diagnostics = { path = "../plc_diagnostics"}
-plc_source = { path = "../plc_source"}
+plc_diagnostics = { path = "../plc_diagnostics" }
+plc_source = { path = "../plc_source" }
 
 [features]
 default = []

--- a/compiler/plc_xml/Cargo.toml
+++ b/compiler/plc_xml/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 logos = "0.12"
-quick-xml = { version = "0.28", features = ["serialize"] }
+quick-xml = { version = "0.30", features = ["serialize"] }
 insta = "1.20"
 indexmap = "2.0"
 html-escape = "0.2"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,7 +11,7 @@ sql = ["dep:sqlx"]
 xshell = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sysinfo = "0.28"
+sysinfo = "0.29"
 anyhow = "1.0"
 sqlx = { version = "0.7", features = [
     "runtime-async-std",


### PR DESCRIPTION
This PR bumps the following dependencies 
- quick-xml, 0.28 -> 0.30
- itertools, 0.10.5 -> 0.11
- sysinfo, 0.28 -> 0.29
- indexmap, 1.* -> 2.0

Dependencies such as logos, clap and toml are still outdated, but given they'll need bigger changes I've left them out for now.