### PR TITLE
chore(inkwell-dependency): change inkwell dependency from master to release 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,7 +1075,8 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.2.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#5378a77fc7a14e8583709e4e21ab208f364aa37b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4fcb4a4fa0b8f7b4178e24e6317d6f8b95ab500d8e6e1bd4283b6860e369c1"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1088,7 +1089,8 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.8.0"
-source = "git+https://github.com/TheDan64/inkwell?branch=master#5378a77fc7a14e8583709e4e21ab208f364aa37b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b185e7d068d6820411502efa14d8fbf010750485399402156b72dd2a548ef8e9"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,7 @@ members = [
 default-members = [".", "compiler/plc_driver", "compiler/plc_xml"]
 
 [workspace.dependencies]
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = [
-	"llvm14-0",
-] }
+inkwell = { version = "0.2", features = ["llvm14-0"] }
 encoding_rs = "0.8"
 encoding_rs_io = "0.1"
 log = "0.4"


### PR DESCRIPTION
Since inkwell recently pushed  [breaking API-changes](https://github.com/TheDan64/inkwell/commit/d39987b58a63913612fc80b093d2b805fae805ff) to their master branch, which we currently have as a dependency, we are unable to build ruSTy on new cargo installs or after running cargo-update.

This PR changes our inkwell-dependency to their latest release version [0.2](https://github.com/TheDan64/inkwell/releases/tag/0.2.0), which already includes the contribution by @ghaith we depend on/which was the reason for our dependency on their master branch.