### PR TITLE
feat: Action support in CFC

### DIFF
--- a/compiler/plc_driver/src/runner.rs
+++ b/compiler/plc_driver/src/runner.rs
@@ -47,5 +47,6 @@ pub fn compile<T: Compilable>(context: &CodegenContext, source: T) -> GeneratedM
 pub fn compile_and_run<T, U, S: Compilable>(source: S, params: &mut T) -> U {
     let context: CodegenContext = CodegenContext::create();
     let module = compile(&context, source);
+    module.print_to_stderr();
     module.run::<T, U>("main", params)
 }

--- a/compiler/plc_xml/src/error.rs
+++ b/compiler/plc_xml/src/error.rs
@@ -60,3 +60,9 @@ impl std::fmt::Debug for Error {
         }
     }
 }
+
+impl From<quick_xml::Error> for Error {
+    fn from(value: quick_xml::Error) -> Self {
+        Error::ReadEvent(value)
+    }
+}

--- a/compiler/plc_xml/src/model/action.rs
+++ b/compiler/plc_xml/src/model/action.rs
@@ -1,21 +1,156 @@
 use std::borrow::Cow;
 
-use crate::{reader::Reader, xml_parser::Parseable};
+use quick_xml::events::Event;
+
+use crate::{
+    reader::Reader,
+    xml_parser::{get_attributes, Parseable},
+};
 
 use super::body::Body;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct Action<'xml> {
     pub name: Cow<'xml, str>,
     pub type_name: Cow<'xml, str>,
     pub body: Body<'xml>,
 }
 
-impl Parseable for Action<'_> {
+impl Action<'_> {
+    pub fn new(name: &str) -> Self {
+        Action { name: name.to_string().into(), ..Default::default() }
+    }
+}
+
+impl Parseable for Vec<Action<'_>> {
     fn visit(
-        _reader: &mut Reader,
+        reader: &mut Reader,
         _tag: Option<quick_xml::events::BytesStart>,
     ) -> Result<Self, crate::error::Error> {
-        todo!()
+        let mut res = vec![];
+        loop {
+            match reader.read_event()? {
+                Event::Start(tag) if tag.name().as_ref() == b"action" => {
+                    res.push(Action::visit(reader, Some(tag))?);
+                }
+                Event::End(tag) if tag.name().as_ref() == b"actions" => break,
+                Event::Eof => todo!(),
+                _ => {}
+            }
+        }
+
+        Ok(res)
+    }
+}
+
+impl Parseable for Action<'_> {
+    fn visit(
+        reader: &mut Reader,
+        tag: Option<quick_xml::events::BytesStart>,
+    ) -> Result<Self, crate::error::Error> {
+        let Some(tag) = tag else {
+            unreachable!()
+        };
+
+        let attributes = get_attributes(tag.attributes())?;
+        let Some(name) = attributes.get("name") else {
+            todo!()
+        };
+        let mut action = Action::new(name);
+        loop {
+            match reader.read_event()? {
+                Event::Start(tag) if tag.name().as_ref() == b"body" => {
+                    action.body = Body::visit(reader, Some(tag))?;
+                }
+                Event::End(tag) if tag.name().as_ref() == b"action" => break,
+                Event::Eof => todo!(),
+                _ => {}
+            }
+        }
+
+        Ok(action)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+
+    use crate::xml_parser;
+
+    #[test]
+    fn list_of_actions_parsed_to_model() {
+        let src = r###"
+<?xml version="1.0" encoding="UTF-8"?>
+<pou xmlns="http://www.plcopen.org/xml/tc6_0201" name="program_0" pouType="program">
+    <interface>
+        <localVars/>
+        <addData>
+            <data name="www.bachmann.at/plc/plcopenxml" handleUnknown="implementation">
+                <textDeclaration>
+                    <content>
+PROGRAM program_0
+VAR
+	a : DINT;
+END_VAR
+					</content>
+                </textDeclaration>
+            </data>
+        </addData>
+    </interface>
+    <actions>
+        <action name="newAction">
+            <body>
+                <FBD>
+                    <block localId="1" width="80" height="60" typeName="foo" executionOrderId="0">
+                        <position x="420" y="110"/>
+                        <inputVariables>
+                            <variable formalParameter="IN1" negated="false">
+                                <connectionPointIn>
+                                    <relPosition x="0" y="30"/>
+                                </connectionPointIn>
+                            </variable>
+                            <variable formalParameter="IN2" negated="false">
+                                <connectionPointIn>
+                                    <relPosition x="0" y="50"/>
+                                </connectionPointIn>
+                            </variable>
+                        </inputVariables>
+                        <inOutVariables/>
+                        <outputVariables>
+                            <variable formalParameter="OUT" negated="false">
+                                <connectionPointOut>
+                                    <relPosition x="80" y="30"/>
+                                </connectionPointOut>
+                            </variable>
+                        </outputVariables>
+                    </block>
+                </FBD>
+            </body>
+        </action>
+        <action name="newAction2">
+            <body>
+                <FBD>
+                    <inOutVariable localId="1" height="20" width="80" negatedIn="false" storageIn="none" negatedOut="false">
+                        <position x="200" y="70"/>
+                        <connectionPointIn>
+                            <relPosition x="0" y="10"/>
+                        </connectionPointIn>
+                        <connectionPointOut>
+                            <relPosition x="80" y="10"/>
+                        </connectionPointOut>
+                        <expression>a</expression>
+                    </inOutVariable>
+                </FBD>
+            </body>
+        </action>
+    </actions>
+    <body>
+        <FBD/>
+    </body>
+</pou>
+        "###;
+
+        assert_debug_snapshot!(xml_parser::visit(src).unwrap())
     }
 }

--- a/compiler/plc_xml/src/model/action.rs
+++ b/compiler/plc_xml/src/model/action.rs
@@ -4,7 +4,7 @@ use quick_xml::events::Event;
 
 use crate::{
     reader::Reader,
-    xml_parser::{get_attributes, Parseable},
+    xml_parser::{get_attributes, Parseable}, error::Error,
 };
 
 use super::body::Body;
@@ -34,7 +34,7 @@ impl Parseable for Vec<Action<'_>> {
                     res.push(Action::visit(reader, Some(tag))?);
                 }
                 Event::End(tag) if tag.name().as_ref() == b"actions" => break,
-                Event::Eof => todo!(),
+                Event::Eof => return Err(Error::UnexpectedEndOfFile(vec![b"actions"])),
                 _ => {}
             }
         }
@@ -63,7 +63,7 @@ impl Parseable for Action<'_> {
                     action.body = Body::visit(reader, Some(tag))?;
                 }
                 Event::End(tag) if tag.name().as_ref() == b"action" => break,
-                Event::Eof => todo!(),
+                Event::Eof => return Err(Error::UnexpectedEndOfFile(vec![b"actions"])),
                 _ => {}
             }
         }

--- a/compiler/plc_xml/src/model/action.rs
+++ b/compiler/plc_xml/src/model/action.rs
@@ -3,8 +3,9 @@ use std::borrow::Cow;
 use quick_xml::events::Event;
 
 use crate::{
+    error::Error,
     reader::Reader,
-    xml_parser::{get_attributes, Parseable}, error::Error,
+    xml_parser::{get_attributes, Parseable},
 };
 
 use super::body::Body;
@@ -48,14 +49,10 @@ impl Parseable for Action<'_> {
         reader: &mut Reader,
         tag: Option<quick_xml::events::BytesStart>,
     ) -> Result<Self, crate::error::Error> {
-        let Some(tag) = tag else {
-            unreachable!()
-        };
+        let Some(tag) = tag else { unreachable!() };
 
         let attributes = get_attributes(tag.attributes())?;
-        let Some(name) = attributes.get("name") else {
-            todo!()
-        };
+        let Some(name) = attributes.get("name") else { todo!() };
         let mut action = Action::new(name);
         loop {
             match reader.read_event()? {

--- a/compiler/plc_xml/src/model/action.rs
+++ b/compiler/plc_xml/src/model/action.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::xml_parser::Parseable2;
+use crate::{reader::Reader, xml_parser::Parseable};
 
 use super::body::Body;
 
@@ -11,9 +11,9 @@ pub(crate) struct Action<'xml> {
     pub body: Body<'xml>,
 }
 
-impl Parseable2 for Action<'_> {
-    fn visit2(
-        _reader: &mut quick_xml::Reader<&[u8]>,
+impl Parseable for Action<'_> {
+    fn visit(
+        _reader: &mut Reader,
         _tag: Option<quick_xml::events::BytesStart>,
     ) -> Result<Self, crate::error::Error> {
         todo!()

--- a/compiler/plc_xml/src/model/action.rs
+++ b/compiler/plc_xml/src/model/action.rs
@@ -1,7 +1,21 @@
 use std::borrow::Cow;
 
+use crate::xml_parser::Parseable2;
+
+use super::body::Body;
+
 #[derive(Debug)]
 pub(crate) struct Action<'xml> {
     pub name: Cow<'xml, str>,
     pub type_name: Cow<'xml, str>,
+    pub body: Body<'xml>,
+}
+
+impl Parseable2 for Action<'_> {
+    fn visit2(
+        _reader: &mut quick_xml::Reader<&[u8]>,
+        _tag: Option<quick_xml::events::BytesStart>,
+    ) -> Result<Self, crate::error::Error> {
+        todo!()
+    }
 }

--- a/compiler/plc_xml/src/model/block.rs
+++ b/compiler/plc_xml/src/model/block.rs
@@ -34,9 +34,7 @@ impl<'xml> Block<'xml> {
 
 impl<'xml> Parseable for Block<'xml> {
     fn visit(reader: &mut Reader, tag: Option<BytesStart>) -> Result<Self, Error> {
-        let Some(tag) = tag else {
-            unreachable!()
-        };
+        let Some(tag) = tag else { unreachable!() };
         let attributes = get_attributes(tag.attributes())?;
         let mut variables = Vec::new();
         loop {

--- a/compiler/plc_xml/src/model/body.rs
+++ b/compiler/plc_xml/src/model/body.rs
@@ -5,16 +5,16 @@ use crate::{error::Error, reader::Reader, xml_parser::Parseable};
 
 #[derive(Debug, Default)]
 pub(crate) struct Body<'xml> {
-    pub function_block_diagram: Option<FunctionBlockDiagram<'xml>>,
+    pub function_block_diagram: FunctionBlockDiagram<'xml>,
 }
 
 impl<'xml> Body<'xml> {
-    fn new(fbd: Option<FunctionBlockDiagram<'xml>>) -> Result<Self, Error> {
+    fn new(fbd: FunctionBlockDiagram<'xml>) -> Result<Self, Error> {
         Ok(Self { function_block_diagram: fbd })
     }
 
     fn empty() -> Result<Self, Error> {
-        Ok(Self { function_block_diagram: None })
+        Ok(Self { function_block_diagram: FunctionBlockDiagram::default() })
     }
 }
 
@@ -24,7 +24,7 @@ impl<'xml> Parseable for Body<'xml> {
         loop {
             match reader.read_event().map_err(Error::ReadEvent)? {
                 Event::Start(tag) if tag.name().as_ref() == b"FBD" => {
-                    body.function_block_diagram = Some(FunctionBlockDiagram::visit(reader, Some(tag))?)
+                    body.function_block_diagram = FunctionBlockDiagram::visit(reader, Some(tag))?
                 }
                 Event::End(tag) if tag.name().as_ref() == b"body" => break,
                 Event::Eof => return Err(Error::UnexpectedEndOfFile(vec![b"body"])),

--- a/compiler/plc_xml/src/model/connector.rs
+++ b/compiler/plc_xml/src/model/connector.rs
@@ -38,9 +38,7 @@ pub(crate) enum ConnectorKind {
 
 impl<'xml> Parseable for Connector<'xml> {
     fn visit(reader: &mut Reader, tag: Option<quick_xml::events::BytesStart>) -> Result<Self, Error> {
-        let Some(tag) = tag else {
-            unreachable!()
-        };
+        let Some(tag) = tag else { unreachable!() };
 
         let kind = match tag.name().as_ref() {
             b"connector" => ConnectorKind::Source,

--- a/compiler/plc_xml/src/model/control.rs
+++ b/compiler/plc_xml/src/model/control.rs
@@ -54,9 +54,7 @@ impl FromStr for ControlKind {
 
 impl<'xml> Parseable for Control<'xml> {
     fn visit(reader: &mut Reader, tag: Option<quick_xml::events::BytesStart>) -> Result<Self, Error> {
-        let Some(tag) = tag else {
-            unreachable!()
-        };
+        let Some(tag) = tag else { unreachable!() };
 
         let kind = ControlKind::from_str(&tag.name().try_to_string()?)?;
         let mut attributes = get_attributes(tag.attributes())?;

--- a/compiler/plc_xml/src/model/fbd.rs
+++ b/compiler/plc_xml/src/model/fbd.rs
@@ -392,7 +392,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         model.desugar(&source_location_factory).unwrap();
@@ -451,7 +451,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         model.desugar(&source_location_factory).unwrap();
@@ -531,7 +531,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         model.desugar(&source_location_factory).unwrap();
@@ -610,7 +610,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         model.desugar(&source_location_factory).unwrap();
@@ -659,7 +659,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         model.desugar(&source_location_factory).unwrap();
@@ -708,7 +708,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
         //With diagnostic
 
@@ -789,7 +789,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         let err = model.desugar(&source_location_factory).unwrap_err();
@@ -849,7 +849,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         let err = model.desugar(&source_location_factory).unwrap_err();
@@ -952,7 +952,7 @@ mod tests {
             ]
             .into(),
         };
-        pou.body.function_block_diagram = Some(fbd);
+        pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
 
         model.desugar(&source_location_factory).unwrap();

--- a/compiler/plc_xml/src/model/interface.rs
+++ b/compiler/plc_xml/src/model/interface.rs
@@ -1,10 +1,10 @@
 use std::borrow::Borrow;
 
 use quick_xml::events::{BytesStart, Event};
-use quick_xml::Reader;
 
 use crate::error::Error;
-use crate::xml_parser::Parseable2;
+use crate::reader::Reader;
+use crate::xml_parser::Parseable;
 
 use super::pou::PouType;
 
@@ -43,8 +43,8 @@ impl Interface {
     }
 }
 
-impl Parseable2 for Interface {
-    fn visit2(reader: &mut Reader<&[u8]>, _tag: Option<BytesStart>) -> Result<Self, Error> {
+impl Parseable for Interface {
+    fn visit(reader: &mut Reader, _tag: Option<BytesStart>) -> Result<Self, Error> {
         let mut interface = Interface { add_data: None };
         loop {
             match reader.read_event().map_err(Error::ReadEvent)? {

--- a/compiler/plc_xml/src/model/pou.rs
+++ b/compiler/plc_xml/src/model/pou.rs
@@ -36,30 +36,24 @@ impl<'xml> Pou<'xml> {
         &mut self,
         source_location_factory: &plc_source::source_location::SourceLocationFactory,
     ) -> Result<(), Vec<Diagnostic>> {
-        if let Some(ref mut fbd) = self.body.function_block_diagram {
-            fbd.desugar(source_location_factory)
-        } else {
-            Ok(())
-        }
+        self.body.function_block_diagram.desugar(source_location_factory)
     }
 }
 
 impl<'xml> Parseable for Pou<'xml> {
     fn visit(reader: &mut Reader, tag: Option<BytesStart>) -> Result<Self, Error> {
-        let Some(tag) = tag else {
-            unreachable!()
-        };
+        let Some(tag) = tag else { unreachable!() };
         let attributes = get_attributes(tag.attributes())?;
         let mut pou = Pou::default().with_attributes(attributes)?;
         loop {
             match reader.read_event()? {
+                // XXX: this is very specific to our own xml schema, but does not adhere to the plc open standard
                 Event::Start(tag) if tag.name().as_ref() == b"interface" => {
-                    // XXX: this is very specific to our own xml schema, but does not adhere to the plc open standard
                     pou.interface =
-                        Some(Interface::visit(reader, Some(tag))?.append_end_keyword(&pou.pou_type));
+                        Some(Interface::visit(reader, Some(tag))?.append_end_keyword(&pou.pou_type))
                 }
                 Event::Start(tag) if tag.name().as_ref() == b"body" => {
-                    pou.body = Body::visit(reader, Some(tag))?;
+                    pou.body = Body::visit(reader, Some(tag))?
                 }
                 Event::Start(tag) if tag.name().as_ref() == b"actions" => {
                     let actions: Vec<Action<'_>> = Parseable::visit(reader, Some(tag))?;

--- a/compiler/plc_xml/src/model/pou.rs
+++ b/compiler/plc_xml/src/model/pou.rs
@@ -69,6 +69,10 @@ impl<'xml> Parseable for Pou<'xml> {
                 Event::Start(tag) if tag.name().as_ref() == b"body" => {
                     pou.body = Body::visit(reader, Some(tag))?;
                 }
+                Event::Start(tag) if tag.name().as_ref() == b"actions" => {
+                    let actions: Vec<Action<'_>> = Parseable::visit(reader, Some(tag))?;
+                    pou.actions.extend(actions)
+                }
                 Event::End(tag) if tag.name().as_ref() == b"pou" => break,
                 Event::Eof => return Err(Error::UnexpectedEndOfFile(vec![b"pou"])),
 

--- a/compiler/plc_xml/src/model/project.rs
+++ b/compiler/plc_xml/src/model/project.rs
@@ -1,6 +1,6 @@
 use plc_diagnostics::diagnostics::Diagnostic;
 
-use crate::xml_parser::Parseable;
+use crate::{reader::Reader, xml_parser::Parseable};
 
 use super::pou::Pou;
 
@@ -19,19 +19,16 @@ pub(crate) struct Project<'xml> {
     */
 }
 
-impl<'xml> Parseable for Project<'xml> {
-    type Item = Self;
-
-    fn visit(_reader: &mut crate::reader::PeekableReader) -> Result<Self::Item, crate::error::Error> {
+impl Parseable for Project<'_> {
+    fn visit(
+        _reader: &mut Reader,
+        _tag: Option<quick_xml::events::BytesStart>,
+    ) -> Result<Self, crate::error::Error> {
         unimplemented!()
     }
 }
 
 impl<'xml> Project<'xml> {
-    pub fn pou_entry(reader: &mut crate::reader::PeekableReader) -> Result<Self, crate::error::Error> {
-        Ok(Project { pous: vec![Pou::visit(reader)?] })
-    }
-
     pub(crate) fn desugar(
         &mut self,
         source_location_factory: &plc_source::source_location::SourceLocationFactory,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__action__tests__list_of_actions_parsed_to_model.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__action__tests__list_of_actions_parsed_to_model.snap
@@ -1,0 +1,93 @@
+---
+source: compiler/plc_xml/src/model/action.rs
+expression: "xml_parser::visit(src).unwrap()"
+---
+Project {
+    pous: [
+        Pou {
+            name: "program_0",
+            pou_type: Program,
+            body: Body {
+                function_block_diagram: Some(
+                    FunctionBlockDiagram {
+                        nodes: {},
+                    },
+                ),
+            },
+            actions: [
+                Action {
+                    name: "newAction",
+                    type_name: "",
+                    body: Body {
+                        function_block_diagram: Some(
+                            FunctionBlockDiagram {
+                                nodes: {
+                                    1: Block(
+                                        Block {
+                                            local_id: 1,
+                                            type_name: "foo",
+                                            instance_name: None,
+                                            execution_order_id: Some(
+                                                0,
+                                            ),
+                                            variables: [
+                                                BlockVariable {
+                                                    kind: Input,
+                                                    formal_parameter: "IN1",
+                                                    negated: false,
+                                                    ref_local_id: None,
+                                                    edge: None,
+                                                    storage: None,
+                                                    enable: None,
+                                                },
+                                                BlockVariable {
+                                                    kind: Input,
+                                                    formal_parameter: "IN2",
+                                                    negated: false,
+                                                    ref_local_id: None,
+                                                    edge: None,
+                                                    storage: None,
+                                                    enable: None,
+                                                },
+                                                BlockVariable {
+                                                    kind: Output,
+                                                    formal_parameter: "OUT",
+                                                    negated: false,
+                                                    ref_local_id: None,
+                                                    edge: None,
+                                                    storage: None,
+                                                    enable: None,
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            },
+                        ),
+                    },
+                },
+                Action {
+                    name: "newAction2",
+                    type_name: "",
+                    body: Body {
+                        function_block_diagram: Some(
+                            FunctionBlockDiagram {
+                                nodes: {},
+                            },
+                        ),
+                    },
+                },
+            ],
+            interface: Some(
+                Interface {
+                    add_data: Some(
+                        Data {
+                            content: "PROGRAM program_0\nVAR\n\ta : DINT;\nEND_VAR\nEND_PROGRAM",
+                            handle: Implementation,
+                        },
+                    ),
+                },
+            ),
+        },
+    ],
+}

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__action__tests__list_of_actions_parsed_to_model.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__action__tests__list_of_actions_parsed_to_model.snap
@@ -8,73 +8,67 @@ Project {
             name: "program_0",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {},
-                    },
-                ),
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {},
+                },
             },
             actions: [
                 Action {
                     name: "newAction",
                     type_name: "program_0",
                     body: Body {
-                        function_block_diagram: Some(
-                            FunctionBlockDiagram {
-                                nodes: {
-                                    1: Block(
-                                        Block {
-                                            local_id: 1,
-                                            type_name: "foo",
-                                            instance_name: None,
-                                            execution_order_id: Some(
-                                                0,
-                                            ),
-                                            variables: [
-                                                BlockVariable {
-                                                    kind: Input,
-                                                    formal_parameter: "IN1",
-                                                    negated: false,
-                                                    ref_local_id: None,
-                                                    edge: None,
-                                                    storage: None,
-                                                    enable: None,
-                                                },
-                                                BlockVariable {
-                                                    kind: Input,
-                                                    formal_parameter: "IN2",
-                                                    negated: false,
-                                                    ref_local_id: None,
-                                                    edge: None,
-                                                    storage: None,
-                                                    enable: None,
-                                                },
-                                                BlockVariable {
-                                                    kind: Output,
-                                                    formal_parameter: "OUT",
-                                                    negated: false,
-                                                    ref_local_id: None,
-                                                    edge: None,
-                                                    storage: None,
-                                                    enable: None,
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
+                        function_block_diagram: FunctionBlockDiagram {
+                            nodes: {
+                                1: Block(
+                                    Block {
+                                        local_id: 1,
+                                        type_name: "foo",
+                                        instance_name: None,
+                                        execution_order_id: Some(
+                                            0,
+                                        ),
+                                        variables: [
+                                            BlockVariable {
+                                                kind: Input,
+                                                formal_parameter: "IN1",
+                                                negated: false,
+                                                ref_local_id: None,
+                                                edge: None,
+                                                storage: None,
+                                                enable: None,
+                                            },
+                                            BlockVariable {
+                                                kind: Input,
+                                                formal_parameter: "IN2",
+                                                negated: false,
+                                                ref_local_id: None,
+                                                edge: None,
+                                                storage: None,
+                                                enable: None,
+                                            },
+                                            BlockVariable {
+                                                kind: Output,
+                                                formal_parameter: "OUT",
+                                                negated: false,
+                                                ref_local_id: None,
+                                                edge: None,
+                                                storage: None,
+                                                enable: None,
+                                            },
+                                        ],
+                                    },
+                                ),
                             },
-                        ),
+                        },
                     },
                 },
                 Action {
                     name: "newAction2",
                     type_name: "program_0",
                     body: Body {
-                        function_block_diagram: Some(
-                            FunctionBlockDiagram {
-                                nodes: {},
-                            },
-                        ),
+                        function_block_diagram: FunctionBlockDiagram {
+                            nodes: {},
+                        },
                     },
                 },
             ],

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__action__tests__list_of_actions_parsed_to_model.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__action__tests__list_of_actions_parsed_to_model.snap
@@ -17,7 +17,7 @@ Project {
             actions: [
                 Action {
                     name: "newAction",
-                    type_name: "",
+                    type_name: "program_0",
                     body: Body {
                         function_block_diagram: Some(
                             FunctionBlockDiagram {
@@ -68,7 +68,7 @@ Project {
                 },
                 Action {
                     name: "newAction2",
-                    type_name: "",
+                    type_name: "program_0",
                     body: Body {
                         function_block_diagram: Some(
                             FunctionBlockDiagram {

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__body__tests__empty.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__body__tests__empty.snap
@@ -3,5 +3,9 @@ source: compiler/plc_xml/src/model/body.rs
 expression: "Body::visit(&mut reader).unwrap()"
 ---
 Body {
-    function_block_diagram: None,
+    function_block_diagram: Some(
+        FunctionBlockDiagram {
+            nodes: {},
+        },
+    ),
 }

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__body__tests__empty.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__body__tests__empty.snap
@@ -1,11 +1,9 @@
 ---
 source: compiler/plc_xml/src/model/body.rs
-expression: "Body::visit(&mut reader).unwrap()"
+expression: "Body::visit(&mut reader, None).unwrap()"
 ---
 Body {
-    function_block_diagram: Some(
-        FunctionBlockDiagram {
-            nodes: {},
-        },
-    ),
+    function_block_diagram: FunctionBlockDiagram {
+        nodes: {},
+    },
 }

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__body__tests__fbd_with_add_block.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__body__tests__fbd_with_add_block.snap
@@ -1,55 +1,53 @@
 ---
 source: compiler/plc_xml/src/model/body.rs
-expression: "Body::visit(&mut reader).unwrap()"
+expression: "Body::visit(&mut reader, tag).unwrap()"
 ---
 Body {
-    function_block_diagram: Some(
-        FunctionBlockDiagram {
-            nodes: {
-                1: Block(
-                    Block {
-                        local_id: 1,
-                        type_name: "ADD",
-                        instance_name: None,
-                        execution_order_id: Some(
-                            0,
-                        ),
-                        variables: [
-                            BlockVariable {
-                                kind: Input,
-                                formal_parameter: "a",
-                                negated: false,
-                                ref_local_id: Some(
-                                    1,
-                                ),
-                                edge: None,
-                                storage: None,
-                                enable: None,
-                            },
-                            BlockVariable {
-                                kind: Input,
-                                formal_parameter: "b",
-                                negated: false,
-                                ref_local_id: Some(
-                                    2,
-                                ),
-                                edge: None,
-                                storage: None,
-                                enable: None,
-                            },
-                            BlockVariable {
-                                kind: Output,
-                                formal_parameter: "c",
-                                negated: false,
-                                ref_local_id: None,
-                                edge: None,
-                                storage: None,
-                                enable: None,
-                            },
-                        ],
-                    },
-                ),
-            },
+    function_block_diagram: FunctionBlockDiagram {
+        nodes: {
+            1: Block(
+                Block {
+                    local_id: 1,
+                    type_name: "ADD",
+                    instance_name: None,
+                    execution_order_id: Some(
+                        0,
+                    ),
+                    variables: [
+                        BlockVariable {
+                            kind: Input,
+                            formal_parameter: "a",
+                            negated: false,
+                            ref_local_id: Some(
+                                1,
+                            ),
+                            edge: None,
+                            storage: None,
+                            enable: None,
+                        },
+                        BlockVariable {
+                            kind: Input,
+                            formal_parameter: "b",
+                            negated: false,
+                            ref_local_id: Some(
+                                2,
+                            ),
+                            edge: None,
+                            storage: None,
+                            enable: None,
+                        },
+                        BlockVariable {
+                            kind: Output,
+                            formal_parameter: "c",
+                            negated: false,
+                            ref_local_id: None,
+                            edge: None,
+                            storage: None,
+                            enable: None,
+                        },
+                    ],
+                },
+            ),
         },
-    ),
+    },
 }

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__model_with_no_source_sink_unchanged.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__model_with_no_source_sink_unchanged.snap
@@ -8,36 +8,34 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__multiple_sink_are_ok_and_duplicate_sources_instances_are_reported.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__multiple_sink_are_ok_and_duplicate_sources_instances_are_reported.snap
@@ -8,56 +8,54 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            3: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 3,
-                                    negated: false,
-                                    expression: "c",
-                                    execution_order_id: None,
-                                    ref_local_id: Some(
-                                        2,
-                                    ),
-                                },
-                            ),
-                            4: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 4,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: Some(
-                                        2,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        3: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 3,
+                                negated: false,
+                                expression: "c",
+                                execution_order_id: None,
+                                ref_local_id: Some(
+                                    2,
+                                ),
+                            },
+                        ),
+                        4: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 4,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: Some(
+                                    2,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__recursive_sink_source_connections_are_an_error-2.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__recursive_sink_source_connections_are_an_error-2.snap
@@ -8,34 +8,32 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: None,
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: None,
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__source_sink_chain_converted_to_connection.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__source_sink_chain_converted_to_connection.snap
@@ -8,36 +8,34 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__source_to_sink_converted_to_connection.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__source_to_sink_converted_to_connection.snap
@@ -8,36 +8,34 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__two_sinks_for_single_source_converted_to_connections.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__two_sinks_for_single_source_converted_to_connections.snap
@@ -8,50 +8,48 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            6: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 6,
-                                    negated: false,
-                                    expression: "c",
-                                    execution_order_id: Some(
-                                        2,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
+                        6: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 6,
+                                negated: false,
+                                expression: "c",
+                                execution_order_id: Some(
+                                    2,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__unassociated_sink_removed_from_model_with_error-2.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__unassociated_sink_removed_from_model_with_error-2.snap
@@ -8,34 +8,32 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: None,
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: None,
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__unassociated_source_remains_in_model.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__unassociated_source_remains_in_model.snap
@@ -8,34 +8,32 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: None,
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: None,
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__unconnected_source_has_no_effect-2.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__fbd__tests__unconnected_source_has_no_effect-2.snap
@@ -8,34 +8,32 @@ Project {
             name: "TestProg",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: None,
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: None,
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__empty.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__empty.snap
@@ -9,11 +9,9 @@ Ok(
                 name: "foo",
                 pou_type: Program,
                 body: Body {
-                    function_block_diagram: Some(
-                        FunctionBlockDiagram {
-                            nodes: {},
-                        },
-                    ),
+                    function_block_diagram: FunctionBlockDiagram {
+                        nodes: {},
+                    },
                 },
                 actions: [],
                 interface: Some(

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__empty.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__empty.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler/plc_xml/src/model/pou.rs
-expression: "Project::pou_entry(&mut reader)"
+expression: "xml_parser::visit(&content)"
 ---
 Ok(
     Project {
@@ -20,7 +20,7 @@ Ok(
                     Interface {
                         add_data: Some(
                             Data {
-                                content: "\nPROGRAM foo\nVAR\n\nEND_VAR\n                    \nEND_PROGRAM",
+                                content: "PROGRAM foo\nVAR\n\nEND_VAR\nEND_PROGRAM",
                                 handle: Implementation,
                             },
                         ),

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__empty.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__empty.snap
@@ -9,7 +9,11 @@ Ok(
                 name: "foo",
                 pou_type: Program,
                 body: Body {
-                    function_block_diagram: None,
+                    function_block_diagram: Some(
+                        FunctionBlockDiagram {
+                            nodes: {},
+                        },
+                    ),
                 },
                 actions: [],
                 interface: Some(

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__poutype_function.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__poutype_function.snap
@@ -1,13 +1,15 @@
 ---
 source: compiler/plc_xml/src/model/pou.rs
-expression: "Pou::visit(&mut reader)"
+expression: "Pou::visit(&mut reader, tag)"
 ---
 Ok(
     Pou {
         name: "foo",
         pou_type: Function,
         body: Body {
-            function_block_diagram: None,
+            function_block_diagram: FunctionBlockDiagram {
+                nodes: {},
+            },
         },
         actions: [],
         interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__poutype_function_block.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__poutype_function_block.snap
@@ -1,13 +1,15 @@
 ---
 source: compiler/plc_xml/src/model/pou.rs
-expression: "Pou::visit(&mut reader)"
+expression: "Pou::visit(&mut reader, tag)"
 ---
 Ok(
     Pou {
         name: "foo",
         pou_type: FunctionBlock,
         body: Body {
-            function_block_diagram: None,
+            function_block_diagram: FunctionBlockDiagram {
+                nodes: {},
+            },
         },
         actions: [],
         interface: None,

--- a/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__poutype_program.snap
+++ b/compiler/plc_xml/src/model/snapshots/plc_xml__model__pou__tests__poutype_program.snap
@@ -1,13 +1,15 @@
 ---
 source: compiler/plc_xml/src/model/pou.rs
-expression: "Pou::visit(&mut reader)"
+expression: "Pou::visit(&mut reader, tag)"
 ---
 Ok(
     Pou {
         name: "foo",
         pou_type: Program,
         body: Body {
-            function_block_diagram: None,
+            function_block_diagram: FunctionBlockDiagram {
+                nodes: {},
+            },
         },
         actions: [],
         interface: None,

--- a/compiler/plc_xml/src/model/variables.rs
+++ b/compiler/plc_xml/src/model/variables.rs
@@ -133,9 +133,7 @@ impl FromStr for Storage {
 
 impl<'xml> Parseable for FunctionBlockVariable<'xml> {
     fn visit(reader: &mut Reader, tag: Option<quick_xml::events::BytesStart>) -> Result<Self, Error> {
-        let Some(tag) = tag else {
-            unreachable!()
-        };
+        let Some(tag) = tag else { unreachable!() };
         let kind = tag.name().as_ref().try_into()?;
         let mut attributes = get_attributes(tag.attributes())?;
 
@@ -166,9 +164,7 @@ impl<'xml> Parseable for FunctionBlockVariable<'xml> {
 
 impl Parseable for Vec<BlockVariable> {
     fn visit(reader: &mut Reader, tag: Option<BytesStart>) -> Result<Self, Error> {
-        let Some(tag) = tag else {
-                        unreachable!()
-                    };
+        let Some(tag) = tag else { unreachable!() };
 
         let mut variables = vec![];
         let kind = VariableKind::try_from(tag.name().as_ref())?;
@@ -202,9 +198,7 @@ impl Parseable for Vec<BlockVariable> {
 
 impl Parseable for BlockVariable {
     fn visit(reader: &mut Reader, tag: Option<quick_xml::events::BytesStart>) -> Result<Self, Error> {
-        let Some(tag) = tag else {
-            unreachable!()
-        };
+        let Some(tag) = tag else { unreachable!() };
 
         let mut attributes = get_attributes(tag.attributes())?;
         loop {

--- a/compiler/plc_xml/src/reader.rs
+++ b/compiler/plc_xml/src/reader.rs
@@ -1,130 +1,32 @@
-use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 
-use quick_xml::{events::Event, name::QName, Reader};
-
-use crate::{error::Error, extensions::TryToString};
-
-pub(crate) struct PeekableReader<'xml> {
-    reader: Reader<&'xml [u8]>,
-    peeked: Option<Event<'xml>>,
+pub struct Reader<'xml>(quick_xml::Reader<&'xml [u8]>);
+impl<'xml> Deref for Reader<'xml> {
+    type Target = quick_xml::Reader<&'xml [u8]>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
-impl<'xml> PeekableReader<'xml> {
+impl<'xml> DerefMut for Reader<'xml> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'xml> Reader<'xml> {
     pub fn new(content: &'xml str) -> Self {
-        PeekableReader {
-            reader: {
-                let mut reader = Reader::from_str(content);
-                reader.trim_text(true).expand_empty_elements(true);
-                reader
-            },
-            peeked: None,
-        }
-    }
-
-    pub fn next(&mut self) -> Result<Event<'xml>, Error> {
-        if let Some(event) = self.peeked.take() {
-            return Ok(event);
-        }
-
-        self.reader.read_event().map_err(Error::ReadEvent)
-    }
-
-    pub fn peek(&mut self) -> Result<&Event<'xml>, Error> {
-        if self.peeked.is_none() {
-            self.peeked = Some(self.reader.read_event().map_err(Error::ReadEvent)?);
-        }
-
-        match self.peeked.as_ref() {
-            Some(val) => Ok(val),
-            None => unreachable!(),
-        }
-    }
-
-    // Advances the reader until it sees one of the defined token and stops after consuming it
-    pub fn consume_until(&mut self, tokens: Vec<&'static [u8]>) -> Result<(), Error> {
-        loop {
-            match self.next()? {
-                Event::End(tag) if tokens.contains(&tag.name().as_ref()) => break,
-                Event::Eof => return Err(Error::UnexpectedEndOfFile(tokens)),
-                _ => continue,
-            }
-        }
-
-        Ok(())
-    }
-
-    // Advances the reader until it sees the defined token and stops without consuming it
-    pub fn consume_until_start(&mut self, token: &'static [u8]) -> Result<(), Error> {
-        loop {
-            match self.peek()? {
-                Event::Start(tag) if token == tag.name().as_ref() => break,
-                Event::Eof => return Err(Error::UnexpectedEndOfFile(vec![token])),
-                _ => self.consume()?,
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Advances the reader consuming the event without returning it.
-    pub fn consume(&mut self) -> Result<(), Error> {
-        self.next()?;
-        Ok(())
-    }
-
-    /// Advances the reader, consuming the event returning its attributes.
-    pub fn attributes(&mut self) -> Result<HashMap<String, String>, Error> {
-        let tag = match self.next()? {
-            Event::Start(tag) | Event::Empty(tag) => tag,
-            _ => todo!(),
-        };
-
-        let mut hm = HashMap::new();
-        for it in tag.attributes().flatten() {
-            hm.insert(it.key.try_to_string()?, it.value.try_to_string()?);
-        }
-
-        Ok(hm)
-    }
-
-    pub fn read_text(&mut self, name: QName) -> Result<String, Error> {
-        Ok(self.reader.read_text(name).map_err(Error::ReadEvent)?.to_string())
+        let mut reader = quick_xml::Reader::from_str(content);
+        reader.expand_empty_elements(true).trim_text(true);
+        Reader(reader)
     }
 }
 
-#[test]
-fn peek() {
-    const CONTENT: &str = r#"
-        <body>
-            <FBD>
-                <block localId="5" width="82" height="60" typeName="MyAdd" instanceName="local_add" executionOrderId="0">
-                    <inputVariables>
-                        <variable formalParameter="a" negated="false">
-                            <connectionPointIn>
-                                <relPosition x="0" y="30" />
-                                <connection refLocalId="6" />
-                            </connectionPointIn>
-                        </variable>
-                        <variable formalParameter="b" negated="false">
-                            <connectionPointIn>
-                                <relPosition x="0" y="50" />
-                                <connection refLocalId="7" />
-                            </connectionPointIn>
-                        </variable>
-                    </inputVariables>
-                </block>
-                <inVariable localId="6" height="20" width="82" negated="false">
-                    <position x="340" y="170" />
-                    <connectionPointOut>
-                        <relPosition x="82" y="10" />
-                    </connectionPointOut>
-                    <expression>local_a</expression>
-                </inVariable>
-            <FBD>
-        </body>
-    "#;
-
-    let mut temp = PeekableReader::new(CONTENT);
-    assert_eq!(temp.peek().unwrap(), &Event::Start(quick_xml::events::BytesStart::new("body")));
-    assert_eq!(temp.next().unwrap(), Event::Start(quick_xml::events::BytesStart::new("body")));
+#[cfg(test)]
+pub fn get_start_tag(event: quick_xml::events::Event) -> Option<quick_xml::events::BytesStart> {
+    if let quick_xml::events::Event::Start(tag) = event {
+        Some(tag)
+    } else {
+        None
+    }
 }

--- a/compiler/plc_xml/src/reader.rs
+++ b/compiler/plc_xml/src/reader.rs
@@ -14,7 +14,7 @@ impl<'xml> PeekableReader<'xml> {
         PeekableReader {
             reader: {
                 let mut reader = Reader::from_str(content);
-                reader.trim_text(true);
+                reader.trim_text(true).expand_empty_elements(true);
                 reader
             },
             peeked: None,

--- a/compiler/plc_xml/src/xml_parser.rs
+++ b/compiler/plc_xml/src/xml_parser.rs
@@ -56,7 +56,9 @@ pub(crate) fn visit(content: &str) -> Result<Project, Error> {
             Event::Start(tag) if tag.name().as_ref() == b"pou" => {
                 project.pous.push(Pou::visit(&mut reader, Some(tag))?)
             }
-            Event::Start(tag) if tag.name().as_ref() == b"project" || tag.name().as_ref() == b"pous" => {todo!("Project support comming in #977")}
+            Event::Start(tag) if tag.name().as_ref() == b"project" || tag.name().as_ref() == b"pous" => {
+                todo!("Project support comming in #977")
+            }
             Event::End(tag) if tag.name().as_ref() == b"project" || tag.name().as_ref() == b"pous" => break,
             Event::Eof => break,
             _ => {}

--- a/compiler/plc_xml/src/xml_parser.rs
+++ b/compiler/plc_xml/src/xml_parser.rs
@@ -167,7 +167,9 @@ impl<'parse, 'xml> ParseSession<'parse, 'xml> {
             // transform body
             implementations.push(pou.build_implementation(&mut self));
             // transform actions
-            pou.actions.iter().for_each(|action| implementations.push(action.build_implementation(&self)));
+            pou.actions
+                .iter()
+                .for_each(|action| implementations.push(action.build_implementation(&mut self)));
         }
 
         (implementations, self.diagnostics)

--- a/compiler/plc_xml/src/xml_parser.rs
+++ b/compiler/plc_xml/src/xml_parser.rs
@@ -56,7 +56,7 @@ pub(crate) fn visit(content: &str) -> Result<Project, Error> {
             Event::Start(tag) if tag.name().as_ref() == b"pou" => {
                 project.pous.push(Pou::visit(&mut reader, Some(tag))?)
             }
-            Event::Start(tag) if tag.name().as_ref() == b"project" || tag.name().as_ref() == b"pous" => {} //TODO: Handle some attributes
+            Event::Start(tag) if tag.name().as_ref() == b"project" || tag.name().as_ref() == b"pous" => {todo!("Project support comming in #977")}
             Event::End(tag) if tag.name().as_ref() == b"project" || tag.name().as_ref() == b"pous" => break,
             Event::Eof => break,
             _ => {}

--- a/compiler/plc_xml/src/xml_parser/action.rs
+++ b/compiler/plc_xml/src/xml_parser/action.rs
@@ -5,15 +5,27 @@ use crate::model::action::Action;
 use super::ParseSession;
 
 impl<'xml> Action<'xml> {
-    pub(crate) fn transform(&self, _session: &ParseSession) -> Vec<AstNode> {
-        todo!()
+    pub(crate) fn transform(&self, session: &mut ParseSession) -> Vec<AstNode> {
+        let Some(fbd) = &self.body.function_block_diagram else {
+            // empty body
+            return vec![];
+        };
+
+        if cfg!(feature = "debug") {
+            let statements = fbd.transform(session);
+            println!("{statements:#?}");
+
+            return statements;
+        }
+
+        fbd.transform(session)
     }
 
-    pub(crate) fn build_implementation(&self, session: &ParseSession) -> Implementation {
+    pub(crate) fn build_implementation(&self, session: &mut ParseSession) -> Implementation {
         let statements = self.transform(session);
 
         Implementation {
-            name: self.name.to_string(),
+            name: format!("{}.{}", self.type_name, self.name),
             type_name: self.type_name.to_string(),
             linkage: session.linkage,
             pou_type: AstPouType::Action,

--- a/compiler/plc_xml/src/xml_parser/action.rs
+++ b/compiler/plc_xml/src/xml_parser/action.rs
@@ -6,10 +6,7 @@ use super::ParseSession;
 
 impl<'xml> Action<'xml> {
     pub(crate) fn transform(&self, session: &mut ParseSession) -> Vec<AstNode> {
-        let Some(fbd) = &self.body.function_block_diagram else {
-            // empty body
-            return vec![];
-        };
+        let fbd = &self.body.function_block_diagram;
 
         if cfg!(feature = "debug") {
             let statements = fbd.transform(session);

--- a/compiler/plc_xml/src/xml_parser/control.rs
+++ b/compiler/plc_xml/src/xml_parser/control.rs
@@ -101,7 +101,7 @@ mod tests {
 
     use crate::{
         model::control::Control,
-        reader::PeekableReader,
+        reader::{get_start_tag, Reader},
         serializer::{XAddData, XConnectionPointIn, XJump, XLabel, XReturn},
         xml_parser::{self, Parseable},
     };
@@ -115,8 +115,9 @@ mod tests {
             .with_add_data(XAddData::negated(false))
             .serialize();
 
-        let reader = &mut PeekableReader::new(&content);
-        assert_debug_snapshot!(Control::visit(reader).unwrap());
+        let reader = &mut Reader::new(&content);
+        let tag = get_start_tag(reader.read_event().unwrap());
+        assert_debug_snapshot!(Control::visit(reader, tag).unwrap());
     }
 
     #[test]
@@ -128,8 +129,9 @@ mod tests {
             .with_add_data(XAddData::negated(true))
             .serialize();
 
-        let reader = &mut PeekableReader::new(&content);
-        assert_debug_snapshot!(Control::visit(reader).unwrap());
+        let reader = &mut Reader::new(&content);
+        let tag = get_start_tag(reader.read_event().unwrap());
+        assert_debug_snapshot!(Control::visit(reader, tag).unwrap());
     }
 
     #[test]
@@ -203,8 +205,9 @@ mod tests {
     fn unconnected_jump_to_label() {
         let content = XJump::new().with_local_id("1").with_execution_order_id("2").serialize();
 
-        let reader = &mut PeekableReader::new(&content);
-        assert_debug_snapshot!(Control::visit(reader).unwrap());
+        let mut reader = Reader::new(&content);
+        let tag = get_start_tag(reader.read_event().unwrap());
+        assert_debug_snapshot!(Control::visit(&mut reader, tag).unwrap());
     }
 
     #[test]
@@ -278,8 +281,9 @@ mod tests {
     fn label_parsed() {
         let content = XLabel::new().with_local_id("1").with_execution_order_id("2").serialize();
 
-        let reader = &mut PeekableReader::new(&content);
-        assert_debug_snapshot!(Control::visit(reader).unwrap());
+        let mut reader = Reader::new(&content);
+        let tag = get_start_tag(reader.read_event().unwrap());
+        assert_debug_snapshot!(Control::visit(&mut reader, tag).unwrap());
     }
 
     #[test]

--- a/compiler/plc_xml/src/xml_parser/pou.rs
+++ b/compiler/plc_xml/src/xml_parser/pou.rs
@@ -6,10 +6,7 @@ use super::ParseSession;
 
 impl<'xml> Pou<'xml> {
     fn transform(&self, session: &mut ParseSession) -> Vec<AstNode> {
-        let Some(fbd) = &self.body.function_block_diagram else {
-            // empty body
-            return vec![];
-        };
+        let fbd = &self.body.function_block_diagram;
 
         if cfg!(feature = "debug") {
             let statements = fbd.transform(session);

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__jump_to_label.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__jump_to_label.snap
@@ -85,7 +85,7 @@ Ok(
                     Interface {
                         add_data: Some(
                             Data {
-                                content: "\n                                    PROGRAM program_0\n                                    VAR&#xd;\n                                        x: BOOL := 0;&#xd;\n                                    END_VAR\n                                \nEND_PROGRAM",
+                                content: "PROGRAM program_0\n                                    VAR\r\n                                        x: BOOL := 0;\r\n                                    END_VAR\nEND_PROGRAM",
                                 handle: Implementation,
                             },
                         ),

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__jump_to_label.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__jump_to_label.snap
@@ -9,76 +9,74 @@ Ok(
                 name: "program_0",
                 pou_type: Program,
                 body: Body {
-                    function_block_diagram: Some(
-                        FunctionBlockDiagram {
-                            nodes: {
-                                0: FunctionBlockVariable(
-                                    FunctionBlockVariable {
-                                        kind: Input,
-                                        local_id: 0,
-                                        negated: false,
-                                        expression: "x",
-                                        execution_order_id: None,
-                                        ref_local_id: None,
-                                    },
-                                ),
-                                4: FunctionBlockVariable(
-                                    FunctionBlockVariable {
-                                        kind: Input,
-                                        local_id: 4,
-                                        negated: false,
-                                        expression: "FALSE",
-                                        execution_order_id: None,
-                                        ref_local_id: None,
-                                    },
-                                ),
-                                1: Control(
-                                    Control {
-                                        kind: Label,
-                                        name: Some(
-                                            "lbl",
-                                        ),
-                                        local_id: 1,
-                                        ref_local_id: None,
-                                        execution_order_id: Some(
-                                            0,
-                                        ),
-                                        negated: false,
-                                    },
-                                ),
-                                2: Control(
-                                    Control {
-                                        kind: Jump,
-                                        name: Some(
-                                            "lbl",
-                                        ),
-                                        local_id: 2,
-                                        ref_local_id: Some(
-                                            0,
-                                        ),
-                                        execution_order_id: Some(
-                                            1,
-                                        ),
-                                        negated: false,
-                                    },
-                                ),
-                                3: FunctionBlockVariable(
-                                    FunctionBlockVariable {
-                                        kind: Output,
-                                        local_id: 3,
-                                        negated: false,
-                                        expression: "x",
-                                        execution_order_id: Some(
-                                            2,
-                                        ),
-                                        ref_local_id: Some(
-                                            4,
-                                        ),
-                                    },
-                                ),
-                            },
+                    function_block_diagram: FunctionBlockDiagram {
+                        nodes: {
+                            0: FunctionBlockVariable(
+                                FunctionBlockVariable {
+                                    kind: Input,
+                                    local_id: 0,
+                                    negated: false,
+                                    expression: "x",
+                                    execution_order_id: None,
+                                    ref_local_id: None,
+                                },
+                            ),
+                            4: FunctionBlockVariable(
+                                FunctionBlockVariable {
+                                    kind: Input,
+                                    local_id: 4,
+                                    negated: false,
+                                    expression: "FALSE",
+                                    execution_order_id: None,
+                                    ref_local_id: None,
+                                },
+                            ),
+                            1: Control(
+                                Control {
+                                    kind: Label,
+                                    name: Some(
+                                        "lbl",
+                                    ),
+                                    local_id: 1,
+                                    ref_local_id: None,
+                                    execution_order_id: Some(
+                                        0,
+                                    ),
+                                    negated: false,
+                                },
+                            ),
+                            2: Control(
+                                Control {
+                                    kind: Jump,
+                                    name: Some(
+                                        "lbl",
+                                    ),
+                                    local_id: 2,
+                                    ref_local_id: Some(
+                                        0,
+                                    ),
+                                    execution_order_id: Some(
+                                        1,
+                                    ),
+                                    negated: false,
+                                },
+                            ),
+                            3: FunctionBlockVariable(
+                                FunctionBlockVariable {
+                                    kind: Output,
+                                    local_id: 3,
+                                    negated: false,
+                                    expression: "x",
+                                    execution_order_id: Some(
+                                        2,
+                                    ),
+                                    ref_local_id: Some(
+                                        4,
+                                    ),
+                                },
+                            ),
                         },
-                    ),
+                    },
                 },
                 actions: [],
                 interface: Some(

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__negated_jump.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__negated_jump.snap
@@ -9,76 +9,74 @@ Ok(
                 name: "program_0",
                 pou_type: Program,
                 body: Body {
-                    function_block_diagram: Some(
-                        FunctionBlockDiagram {
-                            nodes: {
-                                0: FunctionBlockVariable(
-                                    FunctionBlockVariable {
-                                        kind: Input,
-                                        local_id: 0,
-                                        negated: false,
-                                        expression: "x",
-                                        execution_order_id: None,
-                                        ref_local_id: None,
-                                    },
-                                ),
-                                4: FunctionBlockVariable(
-                                    FunctionBlockVariable {
-                                        kind: Input,
-                                        local_id: 4,
-                                        negated: false,
-                                        expression: "FALSE",
-                                        execution_order_id: None,
-                                        ref_local_id: None,
-                                    },
-                                ),
-                                1: Control(
-                                    Control {
-                                        kind: Label,
-                                        name: Some(
-                                            "lbl",
-                                        ),
-                                        local_id: 1,
-                                        ref_local_id: None,
-                                        execution_order_id: Some(
-                                            0,
-                                        ),
-                                        negated: false,
-                                    },
-                                ),
-                                2: Control(
-                                    Control {
-                                        kind: Jump,
-                                        name: Some(
-                                            "lbl",
-                                        ),
-                                        local_id: 2,
-                                        ref_local_id: Some(
-                                            0,
-                                        ),
-                                        execution_order_id: Some(
-                                            1,
-                                        ),
-                                        negated: true,
-                                    },
-                                ),
-                                3: FunctionBlockVariable(
-                                    FunctionBlockVariable {
-                                        kind: Output,
-                                        local_id: 3,
-                                        negated: false,
-                                        expression: "x",
-                                        execution_order_id: Some(
-                                            2,
-                                        ),
-                                        ref_local_id: Some(
-                                            4,
-                                        ),
-                                    },
-                                ),
-                            },
+                    function_block_diagram: FunctionBlockDiagram {
+                        nodes: {
+                            0: FunctionBlockVariable(
+                                FunctionBlockVariable {
+                                    kind: Input,
+                                    local_id: 0,
+                                    negated: false,
+                                    expression: "x",
+                                    execution_order_id: None,
+                                    ref_local_id: None,
+                                },
+                            ),
+                            4: FunctionBlockVariable(
+                                FunctionBlockVariable {
+                                    kind: Input,
+                                    local_id: 4,
+                                    negated: false,
+                                    expression: "FALSE",
+                                    execution_order_id: None,
+                                    ref_local_id: None,
+                                },
+                            ),
+                            1: Control(
+                                Control {
+                                    kind: Label,
+                                    name: Some(
+                                        "lbl",
+                                    ),
+                                    local_id: 1,
+                                    ref_local_id: None,
+                                    execution_order_id: Some(
+                                        0,
+                                    ),
+                                    negated: false,
+                                },
+                            ),
+                            2: Control(
+                                Control {
+                                    kind: Jump,
+                                    name: Some(
+                                        "lbl",
+                                    ),
+                                    local_id: 2,
+                                    ref_local_id: Some(
+                                        0,
+                                    ),
+                                    execution_order_id: Some(
+                                        1,
+                                    ),
+                                    negated: true,
+                                },
+                            ),
+                            3: FunctionBlockVariable(
+                                FunctionBlockVariable {
+                                    kind: Output,
+                                    local_id: 3,
+                                    negated: false,
+                                    expression: "x",
+                                    execution_order_id: Some(
+                                        2,
+                                    ),
+                                    ref_local_id: Some(
+                                        4,
+                                    ),
+                                },
+                            ),
                         },
-                    ),
+                    },
                 },
                 actions: [],
                 interface: Some(

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__negated_jump.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__negated_jump.snap
@@ -85,7 +85,7 @@ Ok(
                     Interface {
                         add_data: Some(
                             Data {
-                                content: "\n                                    PROGRAM program_0\n                                    VAR&#xd;\n                                        x: BOOL := 0;&#xd;\n                                    END_VAR\n                                \nEND_PROGRAM",
+                                content: "PROGRAM program_0\n                                    VAR\r\n                                        x: BOOL := 0;\r\n                                    END_VAR\nEND_PROGRAM",
                                 handle: Implementation,
                             },
                         ),

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__actions_generated_correctly.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__actions_generated_correctly.snap
@@ -1,0 +1,153 @@
+---
+source: compiler/plc_xml/src/xml_parser/tests.rs
+expression: units.implementations
+---
+[
+    Implementation {
+        name: "program_0",
+        type_name: "program_0",
+        linkage: Internal,
+        pou_type: Program,
+        statements: [
+            CallStatement {
+                operator: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "newAction",
+                        },
+                    ),
+                    base: None,
+                },
+                parameters: Some(
+                    ExpressionList {
+                        expressions: [],
+                    },
+                ),
+            },
+            CallStatement {
+                operator: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "newAction2",
+                        },
+                    ),
+                    base: None,
+                },
+                parameters: Some(
+                    ExpressionList {
+                        expressions: [],
+                    },
+                ),
+            },
+        ],
+        location: SourceLocation {
+            span: None,
+            file: Some(
+                "<internal>.cfc",
+            ),
+        },
+        name_location: SourceLocation {
+            span: None,
+            file: Some(
+                "<internal>.cfc",
+            ),
+        },
+        overriding: false,
+        generic: false,
+        access: None,
+    },
+    Implementation {
+        name: "program_0.newAction",
+        type_name: "program_0",
+        linkage: Internal,
+        pou_type: Action,
+        statements: [
+            Assignment {
+                left: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "a",
+                        },
+                    ),
+                    base: None,
+                },
+                right: BinaryExpression {
+                    operator: Plus,
+                    left: ReferenceExpr {
+                        kind: Member(
+                            Identifier {
+                                name: "a",
+                            },
+                        ),
+                        base: None,
+                    },
+                    right: LiteralInteger {
+                        value: 1,
+                    },
+                },
+            },
+        ],
+        location: SourceLocation {
+            span: None,
+            file: Some(
+                "<internal>.cfc",
+            ),
+        },
+        name_location: SourceLocation {
+            span: None,
+            file: Some(
+                "<internal>.cfc",
+            ),
+        },
+        overriding: false,
+        generic: false,
+        access: None,
+    },
+    Implementation {
+        name: "program_0.newAction2",
+        type_name: "program_0",
+        linkage: Internal,
+        pou_type: Action,
+        statements: [
+            Assignment {
+                left: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "b",
+                        },
+                    ),
+                    base: None,
+                },
+                right: BinaryExpression {
+                    operator: Plus,
+                    left: ReferenceExpr {
+                        kind: Member(
+                            Identifier {
+                                name: "b",
+                            },
+                        ),
+                        base: None,
+                    },
+                    right: LiteralInteger {
+                        value: 1,
+                    },
+                },
+            },
+        ],
+        location: SourceLocation {
+            span: None,
+            file: Some(
+                "<internal>.cfc",
+            ),
+        },
+        name_location: SourceLocation {
+            span: None,
+            file: Some(
+                "<internal>.cfc",
+            ),
+        },
+        overriding: false,
+        generic: false,
+        access: None,
+    },
+]

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__direct_connection_of_sink_to_other_source_generates_correct_model.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__direct_connection_of_sink_to_other_source_generates_correct_model.snap
@@ -8,36 +8,34 @@ Project {
             name: "myConnection",
             pou_type: Function,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            16: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 16,
-                                    negated: false,
-                                    expression: "x",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            4: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 4,
-                                    negated: false,
-                                    expression: "myConnection",
-                                    execution_order_id: Some(
-                                        3,
-                                    ),
-                                    ref_local_id: Some(
-                                        16,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        16: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 16,
+                                negated: false,
+                                expression: "x",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        4: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 4,
+                                negated: false,
+                                expression: "myConnection",
+                                execution_order_id: Some(
+                                    3,
+                                ),
+                                ref_local_id: Some(
+                                    16,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: Some(

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__direct_connection_of_sink_to_other_source_generates_correct_model.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__direct_connection_of_sink_to_other_source_generates_correct_model.snap
@@ -44,7 +44,7 @@ Project {
                 Interface {
                     add_data: Some(
                         Data {
-                            content: "\n    FUNCTION myConnection : DINT\n    VAR_INPUT\n        x: DINT;\n    END_VAR\n                \nEND_FUNCTION",
+                            content: "FUNCTION myConnection : DINT\n    VAR_INPUT\n        x: DINT;\n    END_VAR\nEND_FUNCTION",
                             handle: Implementation,
                         },
                     ),

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__function_returns.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__function_returns.snap
@@ -8,36 +8,34 @@ Project {
             name: "FuncyReturn",
             pou_type: Function,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "FuncyReturn",
-                                    execution_order_id: Some(
-                                        0,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "FuncyReturn",
+                                execution_order_id: Some(
+                                    0,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: Some(

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__model_is_sorted_by_execution_order.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__model_is_sorted_by_execution_order.snap
@@ -72,7 +72,7 @@ Project {
                 Interface {
                     add_data: Some(
                         Data {
-                            content: "\n    PROGRAM thistimereallyeasy\n    VAR\n        a, b, c, d : DINT;\n    END_VAR\n                        \nEND_PROGRAM",
+                            content: "PROGRAM thistimereallyeasy\n    VAR\n        a, b, c, d : DINT;\n    END_VAR\nEND_PROGRAM",
                             handle: Implementation,
                         },
                     ),

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__model_is_sorted_by_execution_order.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__model_is_sorted_by_execution_order.snap
@@ -8,64 +8,62 @@ Project {
             name: "thistimereallyeasy",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            3: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 3,
-                                    negated: false,
-                                    expression: "c",
-                                    execution_order_id: Some(
-                                        0,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            4: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 4,
-                                    negated: false,
-                                    expression: "d",
-                                    execution_order_id: Some(
-                                        1,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        2,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        3: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 3,
+                                negated: false,
+                                expression: "c",
+                                execution_order_id: Some(
+                                    0,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
+                        4: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 4,
+                                negated: false,
+                                expression: "d",
+                                execution_order_id: Some(
+                                    1,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    2,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: Some(

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__variable_assignment.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__variable_assignment.snap
@@ -8,36 +8,34 @@ Project {
             name: "thistimereallyeasy",
             pou_type: Program,
             body: Body {
-                function_block_diagram: Some(
-                    FunctionBlockDiagram {
-                        nodes: {
-                            1: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Input,
-                                    local_id: 1,
-                                    negated: false,
-                                    expression: "a",
-                                    execution_order_id: None,
-                                    ref_local_id: None,
-                                },
-                            ),
-                            2: FunctionBlockVariable(
-                                FunctionBlockVariable {
-                                    kind: Output,
-                                    local_id: 2,
-                                    negated: false,
-                                    expression: "b",
-                                    execution_order_id: Some(
-                                        0,
-                                    ),
-                                    ref_local_id: Some(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        },
+                function_block_diagram: FunctionBlockDiagram {
+                    nodes: {
+                        1: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Input,
+                                local_id: 1,
+                                negated: false,
+                                expression: "a",
+                                execution_order_id: None,
+                                ref_local_id: None,
+                            },
+                        ),
+                        2: FunctionBlockVariable(
+                            FunctionBlockVariable {
+                                kind: Output,
+                                local_id: 2,
+                                negated: false,
+                                expression: "b",
+                                execution_order_id: Some(
+                                    0,
+                                ),
+                                ref_local_id: Some(
+                                    1,
+                                ),
+                            },
+                        ),
                     },
-                ),
+                },
             },
             actions: [],
             interface: Some(

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__variable_assignment.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__tests__variable_assignment.snap
@@ -44,7 +44,7 @@ Project {
                 Interface {
                     add_data: Some(
                         Data {
-                            content: "\n        PROGRAM thistimereallyeasy\n        VAR\n            a, b : DINT;\n        END_VAR\n                            \nEND_PROGRAM",
+                            content: "PROGRAM thistimereallyeasy\n        VAR\n            a, b : DINT;\n        END_VAR\nEND_PROGRAM",
                             handle: Implementation,
                         },
                     ),

--- a/compiler/plc_xml/src/xml_parser/tests.rs
+++ b/compiler/plc_xml/src/xml_parser/tests.rs
@@ -201,6 +201,15 @@ fn ast_generates_locations() {
 }
 
 #[test]
+fn actions_generated_correctly() {
+    let source = SourceCode::new(content::ACTION_TEST, "<internal>.cfc");
+    let (units, diagnostics) = xml_parser::parse(&source, LinkageType::Internal, IdProvider::default());
+
+    assert_debug_snapshot!(units.implementations);
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
 #[ignore = "Validation is not implemented on CFC tests yet, we need to be able to change parsers on the test utils level"]
 fn ast_diagnostic_locations() {
     let source_code = SourceCode::new(content::ASSIGNMENT_TO_UNRESOLVED_REFERENCE, "<internal>.cfc");
@@ -1179,4 +1188,83 @@ mod content {
     </pou>
     
     "#;
+
+    pub(super) const ACTION_TEST: &str = r###"
+<?xml version="1.0" encoding="UTF-8"?>
+<pou xmlns="http://www.plcopen.org/xml/tc6_0201" name="program_0" pouType="program">
+    <interface>
+        <localVars/>
+        <addData>
+            <data name="www.bachmann.at/plc/plcopenxml" handleUnknown="implementation">
+                <textDeclaration>
+                    <content>PROGRAM program_0
+VAR
+	a,b : DINT;
+END_VAR</content>
+                </textDeclaration>
+            </data>
+        </addData>
+    </interface>
+    <actions>
+        <action name="newAction">
+            <body>
+                <FBD>
+                    <outVariable localId="1" height="20" width="80" executionOrderId="0" negated="false" storage="none">
+                        <position x="570" y="100"/>
+                        <connectionPointIn>
+                            <relPosition x="0" y="10"/>
+                            <connection refLocalId="2"/>
+                        </connectionPointIn>
+                        <expression>a</expression>
+                    </outVariable>
+                    <inVariable localId="2" height="20" width="80" negated="false">
+                        <position x="420" y="100"/>
+                        <connectionPointOut>
+                            <relPosition x="80" y="10"/>
+                        </connectionPointOut>
+                        <expression>a +  1</expression>
+                    </inVariable>
+                </FBD>
+            </body>
+        </action>
+        <action name="newAction2">
+            <body>
+                <FBD>
+                    <inVariable localId="1" height="20" width="80" negated="false">
+                        <position x="240" y="120"/>
+                        <connectionPointOut>
+                            <relPosition x="80" y="10"/>
+                        </connectionPointOut>
+                        <expression>b +  1</expression>
+                    </inVariable>
+                    <outVariable localId="2" height="20" width="80" executionOrderId="0" negated="false" storage="none">
+                        <position x="390" y="120"/>
+                        <connectionPointIn>
+                            <relPosition x="0" y="10"/>
+                            <connection refLocalId="1"/>
+                        </connectionPointIn>
+                        <expression>b</expression>
+                    </outVariable>
+                </FBD>
+            </body>
+        </action>
+    </actions>
+    <body>
+        <FBD>
+            <block localId="1" width="100" height="40" typeName="newAction" executionOrderId="0">
+                <position x="220" y="170"/>
+                <inputVariables/>
+                <inOutVariables/>
+                <outputVariables/>
+            </block>
+            <block localId="2" width="110" height="40" typeName="newAction2" executionOrderId="1">
+                <position x="220" y="230"/>
+                <inputVariables/>
+                <inOutVariables/>
+                <outputVariables/>
+            </block>
+        </FBD>
+    </body>
+</pou>
+    "###;
 }

--- a/compiler/plc_xml/src/xml_parser/tests.rs
+++ b/compiler/plc_xml/src/xml_parser/tests.rs
@@ -15,7 +15,7 @@ use crate::{
         with_header, XBody, XConnection, XConnectionPointIn, XExpression, XFbd, XInVariable, XOutVariable,
         XPou, XRelPosition,
     },
-    xml_parser::{self},
+    xml_parser,
 };
 
 fn parse(content: &str) -> (CompilationUnit, Vec<Diagnostic>) {

--- a/examples/actions.st
+++ b/examples/actions.st
@@ -1,0 +1,18 @@
+PROGRAM main
+VAR
+	a,b : DINT;
+END_VAr
+
+action1();
+action2();
+
+END_PROGRAM
+
+ACTIONS
+	ACTION action1
+		a := a + 1;
+	END_ACTION
+	ACTION action2
+		b := b + 2;
+	END_ACTION
+END_ACTIONS

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -149,14 +149,17 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             }
             AstStatement::JumpStatement(JumpStatement { condition, .. }) => {
                 //Find the label to jump to
-                let Some(then_block) = self.annotations.get(statement).and_then(
-                        |label| if let StatementAnnotation::Label { name } = label {
-                            self.function_context.blocks.get(name)
-                        } else {
-                            None
-                        })
-                else {
-                    return Err(Diagnostic::codegen_error("Could not find label for {statement:?}", statement.get_location()));
+                let Some(then_block) = self.annotations.get(statement).and_then(|label| {
+                    if let StatementAnnotation::Label { name } = label {
+                        self.function_context.blocks.get(name)
+                    } else {
+                        None
+                    }
+                }) else {
+                    return Err(Diagnostic::codegen_error(
+                        "Could not find label for {statement:?}",
+                        statement.get_location(),
+                    ));
                 };
                 //Set current location as else block
                 let current_block = self.llvm.builder.get_insert_block().expect(INTERNAL_LLVM_ERROR);

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -4305,17 +4305,23 @@ fn action_called_from_other_action_resolved() {
     let annotations = annotate_with_ids(&unit, &mut index, id_provider);
 
     //Actions are annotated corretly
-    let AstStatement::CallStatement(CallStatement { operator, .. }) = unit.implementations[0].statements[0].get_stmt() else {
+    let AstStatement::CallStatement(CallStatement { operator, .. }) =
+        unit.implementations[0].statements[0].get_stmt()
+    else {
         unreachable!()
     };
     assert_eq!(annotations.get_call_name(operator).unwrap(), "mainProg.act1");
 
-    let AstStatement::CallStatement(CallStatement { operator, .. }) = unit.implementations[1].statements[0].get_stmt() else {
+    let AstStatement::CallStatement(CallStatement { operator, .. }) =
+        unit.implementations[1].statements[0].get_stmt()
+    else {
         unreachable!()
     };
     assert_eq!(annotations.get_call_name(operator).unwrap(), "mainProg.act2");
 
-    let AstStatement::CallStatement(CallStatement { operator, .. }) = unit.implementations[2].statements[0].get_stmt() else {
+    let AstStatement::CallStatement(CallStatement { operator, .. }) =
+        unit.implementations[2].statements[0].get_stmt()
+    else {
         unreachable!()
     };
     assert_eq!(annotations.get_call_name(operator).unwrap(), "mainProg.act1");

--- a/tests/integration/cfc.rs
+++ b/tests/integration/cfc.rs
@@ -179,6 +179,24 @@ fn jump_to_label_with_false() {
     assert_eq!(res, 5);
 }
 
+#[test]
+fn actions_called_correctly() {
+    #[derive(Default)]
+    #[repr(C)]
+    struct MainType {
+        a: i32,
+        b: i32,
+    }
+
+    let mut main = MainType::default();
+
+    let file = get_test_file("cfc/actions.cfc");
+    let _: i32 = compile_and_run(vec![file], &mut main);
+
+    assert_eq!(main.a, 1);
+    assert_eq!(main.b, 2);
+}
+
 // TODO(volsa): Remove this once our `test_utils.rs` file has been polished to also support CFC.
 // More specifically transform the following tests into simple codegen ones.
 #[cfg(test)]

--- a/tests/integration/cfc.rs
+++ b/tests/integration/cfc.rs
@@ -237,7 +237,6 @@ mod ir {
         let cfc_file = get_test_file("cfc/connection_var_source_multi_sink.cfc");
 
         let res = generate_to_string("plc", vec![st_file, cfc_file]).unwrap();
-
         // We truncate the first 3 lines of the snapshot file because they contain file-metadata that changes
         // with each run. This is due to working with temporary files (i.e. tempfile::NamedTempFile::new())
         let output_file_content_without_headers = res.lines().skip(3).collect::<Vec<&str>>().join(NEWLINE);

--- a/tests/integration/cfc/resolver_tests.rs
+++ b/tests/integration/cfc/resolver_tests.rs
@@ -1,6 +1,6 @@
 use driver::parse_and_annotate;
 use insta::assert_debug_snapshot;
-use plc_ast::ast::{Assignment, AstStatement, CallStatement};
+use plc_ast::ast::{Assignment, AstStatement};
 use plc_source::SourceContainer;
 use rusty::resolver::AnnotationMap;
 

--- a/tests/integration/cfc/resolver_tests.rs
+++ b/tests/integration/cfc/resolver_tests.rs
@@ -1,5 +1,6 @@
 use driver::parse_and_annotate;
 use insta::assert_debug_snapshot;
+use plc_ast::ast::{Assignment, AstStatement, CallStatement};
 use plc_source::SourceContainer;
 use rusty::resolver::AnnotationMap;
 
@@ -44,4 +45,32 @@ fn unbound_jumps_not_annotated() {
     // Get the jump
     let jump = &unit.implementations[0].statements[1];
     assert!(annotations.get(jump).is_none())
+}
+
+#[test]
+fn action_variables_annotated() {
+    let cfc_file = get_test_file("cfc/actions.cfc");
+    let mut cfc_file = cfc_file.load_source(None).unwrap();
+    //Remove the path
+    cfc_file.path.replace("<internal>.cfc".into());
+
+    let annotated_project = parse_and_annotate("plc", vec![cfc_file]).unwrap();
+    let annotations = &annotated_project.annotations;
+    let (unit, ..) = &annotated_project.units[0];
+
+    //Action 1 and 2 calls annotated
+    let act1 = &unit.implementations[0].statements[1];
+    assert_debug_snapshot!(annotations.get(act1));
+    let act2 = &unit.implementations[0].statements[2];
+    assert_debug_snapshot!(annotations.get(act2));
+    //In action 1 a is annotated
+    let AstStatement::Assignment(Assignment { left, .. }) =  &unit.implementations[1].statements[0].get_stmt() else {
+        unreachable!("Statement must be an assingment");
+    };
+    assert_debug_snapshot!(annotations.get(left));
+    //In action 2 b is annotated
+    let AstStatement::Assignment(Assignment { left, .. }) =  &unit.implementations[2].statements[0].get_stmt() else {
+        unreachable!("Statement must be an assingment");
+    };
+    assert_debug_snapshot!(annotations.get(left));
 }

--- a/tests/integration/cfc/resolver_tests.rs
+++ b/tests/integration/cfc/resolver_tests.rs
@@ -64,12 +64,14 @@ fn action_variables_annotated() {
     let act2 = &unit.implementations[0].statements[2];
     assert_debug_snapshot!(annotations.get(act2));
     //In action 1 a is annotated
-    let AstStatement::Assignment(Assignment { left, .. }) =  &unit.implementations[1].statements[0].get_stmt() else {
+    let AstStatement::Assignment(Assignment { left, .. }) = &unit.implementations[1].statements[0].get_stmt()
+    else {
         unreachable!("Statement must be an assingment");
     };
     assert_debug_snapshot!(annotations.get(left));
     //In action 2 b is annotated
-    let AstStatement::Assignment(Assignment { left, .. }) =  &unit.implementations[2].statements[0].get_stmt() else {
+    let AstStatement::Assignment(Assignment { left, .. }) = &unit.implementations[2].statements[0].get_stmt()
+    else {
         unreachable!("Statement must be an assingment");
     };
     assert_debug_snapshot!(annotations.get(left));

--- a/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated-2.snap
+++ b/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated-2.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/cfc/resolver_tests.rs
+expression: annotations.get(act2)
+---
+Some(
+    Program {
+        qualified_name: "main.newAction2",
+    },
+)

--- a/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated-3.snap
+++ b/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated-3.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration/cfc/resolver_tests.rs
+expression: annotations.get(left)
+---
+Some(
+    Variable {
+        resulting_type: "DINT",
+        qualified_name: "main.a",
+        constant: false,
+        argument_type: ByVal(
+            Local,
+        ),
+        is_auto_deref: false,
+    },
+)

--- a/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated-4.snap
+++ b/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated-4.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration/cfc/resolver_tests.rs
+expression: annotations.get(left)
+---
+Some(
+    Variable {
+        resulting_type: "DINT",
+        qualified_name: "main.b",
+        constant: false,
+        argument_type: ByVal(
+            Local,
+        ),
+        is_auto_deref: false,
+    },
+)

--- a/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated.snap
+++ b/tests/integration/cfc/snapshots/tests__integration__cfc__resolver_tests__action_variables_annotated.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/cfc/resolver_tests.rs
+expression: annotations.get(act1)
+---
+Some(
+    Program {
+        qualified_name: "main.newAction",
+    },
+)

--- a/tests/integration/data/cfc/actions.cfc
+++ b/tests/integration/data/cfc/actions.cfc
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pou xmlns="http://www.plcopen.org/xml/tc6_0201" name="main" pouType="program">
+    <interface>
+        <localVars/>
+        <addData>
+            <data name="www.bachmann.at/plc/plcopenxml" handleUnknown="implementation">
+                <textDeclaration>
+                    <content>PROGRAM main
+VAR
+	a,b : DINT;
+END_VAR</content>
+                </textDeclaration>
+            </data>
+        </addData>
+    </interface>
+    <actions>
+        <action name="newAction">
+            <body>
+                <FBD>
+                    <outVariable localId="1" height="20" width="80" executionOrderId="0" negated="false" storage="none">
+                        <position x="570" y="100"/>
+                        <connectionPointIn>
+                            <relPosition x="0" y="10"/>
+                            <connection refLocalId="2"/>
+                        </connectionPointIn>
+                        <expression>a</expression>
+                    </outVariable>
+                    <inVariable localId="2" height="20" width="80" negated="false">
+                        <position x="420" y="100"/>
+                        <connectionPointOut>
+                            <relPosition x="80" y="10"/>
+                        </connectionPointOut>
+                        <expression>a +  1</expression>
+                    </inVariable>
+                </FBD>
+            </body>
+        </action>
+        <action name="newAction2">
+            <body>
+                <FBD>
+                    <inVariable localId="1" height="20" width="80" negated="false">
+                        <position x="240" y="120"/>
+                        <connectionPointOut>
+                            <relPosition x="80" y="10"/>
+                        </connectionPointOut>
+                        <expression>b +  2</expression>
+                    </inVariable>
+                    <outVariable localId="2" height="20" width="80" executionOrderId="0" negated="false" storage="none">
+                        <position x="390" y="120"/>
+                        <connectionPointIn>
+                            <relPosition x="0" y="10"/>
+                            <connection refLocalId="1"/>
+                        </connectionPointIn>
+                        <expression>b</expression>
+                    </outVariable>
+                </FBD>
+            </body>
+        </action>
+    </actions>
+    <body>
+        <FBD>
+						<outVariable localId="3" height="20" width="80" executionOrderId="0" negated="false" storage="none">
+								<position x="570" y="100"/>
+								<connectionPointIn>
+										<relPosition x="0" y="10"/>
+										<connection refLocalId="4"/>
+								</connectionPointIn>
+								<expression>a</expression>
+						</outVariable>
+						<inVariable localId="4" height="20" width="80" negated="false">
+								<position x="420" y="100"/>
+								<connectionPointOut>
+										<relPosition x="80" y="10"/>
+								</connectionPointOut>
+								<expression>0</expression>
+						</inVariable>
+            <block localId="1" width="100" height="40" typeName="newAction" executionOrderId="1">
+                <position x="220" y="170"/>
+                <inputVariables/>
+                <inOutVariables/>
+                <outputVariables/>
+            </block>
+            <block localId="2" width="110" height="40" typeName="newAction2" executionOrderId="2">
+                <position x="220" y="230"/>
+                <inputVariables/>
+                <inOutVariables/>
+                <outputVariables/>
+            </block>
+        </FBD>
+    </body>
+</pou>


### PR DESCRIPTION
Actions can now be parsed in the XML and generated as implementations
I replaced the peeking reader with a standard reader.