### PR TITLE
fix: Windows compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,7 +15,3 @@ rustflags = [
     "link-arg=--target=aarch64-linux-gnu",
 ]
 linker = "clang"
-
-[target.x86_64-pc-windows-msvc]
-linker = "lld-link"
-#rustflags = ["-C", "link-arg=-fuse-ld=lld-link","-C", "link-arg=--target=aarch64-linux-gnu"]


### PR DESCRIPTION
Compiling on Windows with 
```
[target.x86_64-pc-windows-msvc]
linker = "lld-link"
```
results in the following error `note: lld-link: error: could not open 'link': no such file or directory`. Works fine without it however.