### PR TITLE
fix: Force parentheses for structs within array initializers

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -653,6 +653,14 @@ impl Diagnostic {
         }
     }
 
+    pub fn struct_inside_array_assignment(range: SourceLocation) -> Diagnostic {
+        Diagnostic::SyntaxError {
+            message: "Structs within arrays must be surrounded with `()`".to_string(),
+            range: vec![range],
+            err_no: ErrNo::arr__invalid_array_assignment, // TODO:
+        }
+    }
+
     pub fn array_size(name: &str, len_lhs: usize, len_rhs: usize, range: SourceLocation) -> Diagnostic {
         Diagnostic::SemanticError {
             message: format!("Array {name} has a size of {len_lhs}, but {len_rhs} elements were provided"),

--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -661,6 +661,14 @@ impl Diagnostic {
         }
     }
 
+    pub fn struct_inside_array_assignment(range: SourceLocation) -> Diagnostic {
+        Diagnostic::SyntaxError {
+            message: "Structs within arrays must be surrounded by `()`".to_string(),
+            range: vec![range],
+            err_no: ErrNo::arr__invalid_array_assignment,
+        }
+    }
+
     pub fn recursive_datastructure(path: &str, range: Vec<SourceLocation>) -> Diagnostic {
         Diagnostic::SemanticError {
             message: format!("Recursive data structure `{path}` has infinite size"),

--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -653,14 +653,6 @@ impl Diagnostic {
         }
     }
 
-    pub fn struct_inside_array_assignment(range: SourceLocation) -> Diagnostic {
-        Diagnostic::SyntaxError {
-            message: "Structs within arrays must be surrounded with `()`".to_string(),
-            range: vec![range],
-            err_no: ErrNo::arr__invalid_array_assignment, // TODO:
-        }
-    }
-
     pub fn array_size(name: &str, len_lhs: usize, len_rhs: usize, range: SourceLocation) -> Diagnostic {
         Diagnostic::SemanticError {
             message: format!("Array {name} has a size of {len_lhs}, but {len_rhs} elements were provided"),

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -257,11 +257,7 @@ fn parse_atomic_leaf_expression(lexer: &mut ParseSession<'_>) -> Result<AstNode,
         KeywordParensOpen => {
             parse_any_in_region(lexer, vec![KeywordParensClose], |lexer| {
                 lexer.advance(); // eat KeywordParensOpen
-                Ok(AstFactory::create_expression_list(
-                    vec![parse_expression(lexer)],
-                    lexer.last_location(),
-                    lexer.next_id(),
-                ))
+                Ok(parse_expression(lexer))
             })
         }
         Identifier => Ok(parse_identifier(lexer)),

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -257,7 +257,11 @@ fn parse_atomic_leaf_expression(lexer: &mut ParseSession<'_>) -> Result<AstNode,
         KeywordParensOpen => {
             parse_any_in_region(lexer, vec![KeywordParensClose], |lexer| {
                 lexer.advance(); // eat KeywordParensOpen
-                Ok(parse_expression(lexer))
+                Ok(AstFactory::create_expression_list(
+                    vec![parse_expression(lexer)],
+                    lexer.last_location(),
+                    lexer.next_id(),
+                ))
             })
         }
         Identifier => Ok(parse_identifier(lexer)),

--- a/src/validation/array.rs
+++ b/src/validation/array.rs
@@ -15,6 +15,7 @@ use plc_ast::{
 };
 use plc_diagnostics::diagnostics::Diagnostic;
 
+use crate::typesystem::DataTypeInformationProvider;
 use crate::{resolver::AnnotationMap, typesystem::DataTypeInformation};
 
 use super::{ValidationContext, Validator, Validators};
@@ -42,6 +43,21 @@ pub(super) fn validate_array_assignment<T>(
     if !(stmt_rhs.is_literal_array() || stmt_rhs.is_reference()) {
         validator.push_diagnostic(Diagnostic::array_assignment(stmt_rhs.get_location()));
         return; // Return here, because array size validation is error-prone with incorrect assignments
+    }
+
+    let AstStatement::Literal(AstLiteral::Array(array)) = &stmt_rhs.stmt else {
+        todo!()
+    };
+
+    let ty = dti_lhs.get_inner_array_type_name().and_then(|it| context.index.find_effective_type_info(it));
+    if ty.is_some_and(|it| it.is_struct()) {
+        if let Some(AstStatement::ExpressionList(expressions)) = array.elements().map(|it| it.get_stmt()) {
+            for expr in expressions {
+                if !dbg!(expr).is_expression_list() {
+                    validator.push_diagnostic(Diagnostic::struct_inside_array_assignment(expr.get_location()))
+                }
+            }
+        }
     }
 
     let len_lhs = dti_lhs.get_array_length(context.index).unwrap_or(0);
@@ -72,7 +88,7 @@ fn statement_to_array_length(statement: &AstNode) -> usize {
         // Any literal other than an array can be counted as 1
         AstStatement::Literal { .. } => 1,
 
-        _any => {
+        _ => {
             // XXX: Not sure what else could be in here
             log::warn!("Array size-counting for {statement:?} not covered; validation _might_ be wrong");
             0

--- a/src/validation/tests/array_validation_test.rs
+++ b/src/validation/tests/array_validation_test.rs
@@ -296,3 +296,24 @@ fn assignment_multiplied_statement() {
 
     assert_snapshot!(diagnostics);
 }
+
+#[test]
+fn demo() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE foo : STRUCT
+            id      : DINT;
+            arr     : ARRAY[1..3] OF DINT;
+        END_STRUCT END_TYPE
+
+        FUNCTION main : DINT
+            VAR
+                arr_correct : ARRAY[1..1] OF foo := [(id := 0, arr := [1, 2, 3])];
+                arr_incorrect : ARRAY[1..1] OF foo := [id := 0, arr := [1, 2, 3]];
+            END_VAR
+        END_FUNCTION
+        ",
+    );
+
+    assert_snapshot!(diagnostics);
+}

--- a/src/validation/tests/array_validation_test.rs
+++ b/src/validation/tests/array_validation_test.rs
@@ -296,3 +296,27 @@ fn assignment_multiplied_statement() {
 
     assert_snapshot!(diagnostics);
 }
+
+#[test]
+fn demo() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE foo : STRUCT
+            id      : DINT;
+            arr     : ARRAY[1..2] OF DINT;
+        END_STRUCT END_TYPE
+
+        FUNCTION main : DINT
+            VAR
+				// Valid
+				arr_one : ARRAY[1..2] OF foo := [(id := 0, arr := [1, 2])];
+
+				// Invalid, because the second argument isn't surrounded by `()`
+				arr_two : ARRAY[1..2] OF foo := [(id := 0, arr := [1, 2]), id := 1, arr := [1, 2]];
+            END_VAR
+        END_FUNCTION
+        ",
+    );
+
+    assert_snapshot!(diagnostics);
+}

--- a/src/validation/tests/array_validation_test.rs
+++ b/src/validation/tests/array_validation_test.rs
@@ -296,24 +296,3 @@ fn assignment_multiplied_statement() {
 
     assert_snapshot!(diagnostics);
 }
-
-#[test]
-fn demo() {
-    let diagnostics = parse_and_validate_buffered(
-        "
-        TYPE foo : STRUCT
-            id      : DINT;
-            arr     : ARRAY[1..3] OF DINT;
-        END_STRUCT END_TYPE
-
-        FUNCTION main : DINT
-            VAR
-                arr_correct : ARRAY[1..1] OF foo := [(id := 0, arr := [1, 2, 3])];
-                arr_incorrect : ARRAY[1..1] OF foo := [id := 0, arr := [1, 2, 3]];
-            END_VAR
-        END_FUNCTION
-        ",
-    );
-
-    assert_snapshot!(diagnostics);
-}

--- a/src/validation/tests/snapshots/rusty__validation__tests__array_validation_test__structs_within_array_initializers.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__array_validation_test__structs_within_array_initializers.snap
@@ -1,0 +1,17 @@
+---
+source: src/validation/tests/array_validation_test.rs
+expression: diagnostics
+---
+error: Structs within arrays must be surrounded by `()`
+   ┌─ <internal>:13:64
+   │
+13 │         arr_two : ARRAY[1..2] OF foo := [(id := 0, arr := [1, 2]), id := 1, arr := [1, 2]];
+   │                                                                    ^^^^^^^ Structs within arrays must be surrounded by `()`
+
+error: Structs within arrays must be surrounded by `()`
+   ┌─ <internal>:13:73
+   │
+13 │         arr_two : ARRAY[1..2] OF foo := [(id := 0, arr := [1, 2]), id := 1, arr := [1, 2]];
+   │                                                                             ^^^^^^^^^^^^^ Structs within arrays must be surrounded by `()`
+
+


### PR DESCRIPTION
As defined in the grammar, structs within array initializers have to be surrounded by parentheses. For example this is currently valid `arr : ARRAY[1..1] OF foo := [id := 0, value := "bar"]`, according to the official grammar however this is invalid and instead should have been `arr : ARRAY[1..1] OF foo := [(id := 0, value := "bar")]`. Furthermore while there are no real QOL changes for small arrays, for larger arrays this make initialization more clear and structured (no pun intended).

Fixes #965