### PR TITLE
fix:  validations when out of source now use bin location

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,11 @@ jobs:
 
       - uses: actions/upload-artifact@master
         with:
+          name: schema
+          path: compiler/plc_project/schema
+
+      - uses: actions/upload-artifact@master
+        with:
           name: stdlib
           path: output
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,13 @@ num = "0.4"
 insta = "1.31.0"
 pretty_assertions = "1.3.0"
 driver = { path = "./compiler/plc_driver/", package = "plc_driver" }
-project = { path = "./compiler/plc_project/", package = "plc_project" }
+project = { path = "./compiler/plc_project/", package = "plc_project", features = ["integration"]}
 plc_xml = { path = "./compiler/plc_xml" }
 serial_test = "*"
 tempfile = "3"
 encoding_rs.workspace = true
 encoding_rs_io.workspace = true
+
 
 [lib]
 name = "rusty"

--- a/book/src/using_rusty/build_configuration.md
+++ b/book/src/using_rusty/build_configuration.md
@@ -168,3 +168,9 @@ To reference an environment variable in the description file, reference the vari
  ]
 }
 ```
+
+## Validation
+
+The build description file uses a [Json Schema](https://json-schema.org/) file located at `compiler/plc_project/schema/plc-json.schema` to validate the build description before build.
+In order for the schema to be used, it has to be either in that location for source builds or copied next to the build binaries.
+If the schema is not found, the schema based validation will be skipped.

--- a/compiler/plc_project/Cargo.toml
+++ b/compiler/plc_project/Cargo.toml
@@ -19,3 +19,6 @@ glob = "*"
 
 [dev-dependencies]
 insta = "1.31.0"
+
+[features]
+integration = []

--- a/compiler/plc_project/src/build_config.rs
+++ b/compiler/plc_project/src/build_config.rs
@@ -86,8 +86,35 @@ impl ProjectConfig {
         Ok(project)
     }
 
+    fn get_schema() -> Result<PathBuf, Diagnostic> {
+        let current_exe_dir =
+            std::env::current_exe()?.parent().map(|it| it.to_path_buf()).unwrap_or_default();
+        let schema_dir = current_exe_dir.join("schema");
+        #[cfg(feature = "integration")]
+        //Fallback to the build location
+        let schema_dir = if !&schema_dir.exists() {
+            let project_dir: PathBuf = env!("CARGO_MANIFEST_DIR").into();
+            project_dir.join("schema")
+        } else {
+            schema_dir
+        };
+        let path = schema_dir.join("plc-json.schema");
+        if !path.exists() {
+            Err(Diagnostic::io_read_error(&path.to_string_lossy(), "File not found"))
+        } else {
+            Ok(path)
+        }
+    }
+
     fn validate(&self) -> Result<(), Diagnostic> {
-        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(Path::new("schema/plc-json.schema"));
+        let schema_path = match Self::get_schema() {
+            Ok(path) => path,
+            Err(error) => {
+                eprintln!("Could not find schema, validation skipped. Original error: {error:?}");
+                //Skip validation but do not fail
+                return Ok(());
+            }
+        };
         let schema = fs::read_to_string(schema_path).map_err(Diagnostic::from)?;
         let schema_obj = serde_json::from_str(&schema).expect("A valid schema");
         let compiled = JSONSchema::compile(&schema_obj).expect("A valid schema");

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1773,7 +1773,10 @@ fn parenthesized_expression_span() {
     let src = "PROGRAM prg [(1 + 2)] END_PROGRAM";
 
     let (result, _) = parse(src);
-    let AstStatement::Literal(AstLiteral::Array(array)) = result.implementations[0].statements[0].get_stmt() else { panic!() };
+    let AstStatement::Literal(AstLiteral::Array(array)) = result.implementations[0].statements[0].get_stmt()
+    else {
+        panic!()
+    };
     let range = array.elements().unwrap().get_location().get_span().to_range().unwrap();
     assert_eq!(&src[range.start..range.end], "(1 + 2)");
 }

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -547,13 +547,13 @@ fn parenthesized_expression_assignment() {
     let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
 
     let one = &unit.implementations[0].statements[0];
-    let AstStatement::Assignment(Assignment {right, ..}) = &one.stmt else { panic!() };
+    let AstStatement::Assignment(Assignment { right, .. }) = &one.stmt else { panic!() };
     assert!(&right.is_paren());
     assert_eq!(annotations.get_type(right, &index).unwrap().name, "DINT");
     assert_eq!(annotations.get_type_hint(right, &index).unwrap().name, "DINT");
 
     let two = &unit.implementations[0].statements[1];
-    let AstStatement::Assignment(Assignment {right, ..}) = &two.stmt else { panic!() };
+    let AstStatement::Assignment(Assignment { right, .. }) = &two.stmt else { panic!() };
     assert!(&right.is_paren());
     assert_eq!(annotations.get_type(right, &index).unwrap().name, "DINT");
     assert_eq!(annotations.get_type_hint(right, &index).unwrap().name, "SINT");
@@ -4071,7 +4071,11 @@ fn array_with_parenthesized_expression() {
     let AstStatement::Literal(AstLiteral::Array(Array { elements })) = index
         .get_const_expressions()
         .maybe_get_constant_statement(&members[0].initial_value)
-        .map(AstNode::get_stmt).unwrap() else { panic!() };
+        .map(AstNode::get_stmt)
+        .unwrap()
+    else {
+        panic!()
+    };
 
     let AstStatement::ExpressionList(expressions) = elements.as_ref().unwrap().get_stmt() else { panic!() };
 
@@ -4120,7 +4124,10 @@ fn array_of_struct_with_initial_values_annotated_correctly() {
         .get_const_expressions()
         .maybe_get_constant_statement(&members[0].initial_value)
         .map(|it| it.get_stmt())
-        .unwrap() else { panic!() };
+        .unwrap()
+    else {
+        panic!()
+    };
     let AstStatement::ExpressionList(expressions) = array.elements().unwrap().get_stmt() else { panic!() };
 
     // we initialized the array with 2 structs


### PR DESCRIPTION
Schema validation now happens from the current binary location. In tests, it still uses the source location.
If no schema is found, validation is skipped.