### PR TITLE
fix(timers): add internal flag to track state

### DIFF
--- a/libs/stdlib/iec61131-st/timers.st
+++ b/libs/stdlib/iec61131-st/timers.st
@@ -20,6 +20,7 @@ FUNCTION_BLOCK TP
     END_VAR
     VAR
         __signal__ : BOOL; (* Value representing the internal signal *)
+        __is_running__: BOOL; (* Internal flag to track timer on/off state *)
         __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
     END_VAR
 END_FUNCTION_BLOCK
@@ -46,6 +47,7 @@ FUNCTION_BLOCK TP_TIME
     END_VAR
     VAR
       __signal__ : BOOL; (* Value representing the internal signal *)
+      __is_running__: BOOL; (* Internal flag to track timer on/off state *)
       __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
     END_VAR
 END_FUNCTION_BLOCK
@@ -72,6 +74,7 @@ FUNCTION_BLOCK TP_LTIME
     END_VAR
     VAR
         __signal__ : BOOL; (* Value representing the internal signal *)
+        __is_running__: BOOL; (* Internal flag to track timer on/off state *)
         __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
     END_VAR
 END_FUNCTION_BLOCK
@@ -98,6 +101,7 @@ VAR_OUTPUT
 END_VAR
 VAR
   __signal__ : BOOL; (* Value representing the internal signal *)
+  __is_running__: BOOL; (* Internal flag to track timer on/off state *)
   __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
 END_VAR
 END_FUNCTION_BLOCK
@@ -124,6 +128,7 @@ VAR_OUTPUT
 END_VAR
 VAR
   __signal__ : BOOL; (* Value representing the internal signal *)
+  __is_running__: BOOL; (* Internal flag to track timer on/off state *)
   __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
 END_VAR
 END_FUNCTION_BLOCK
@@ -149,7 +154,8 @@ VAR_OUTPUT
     ET: TIME;
 END_VAR
 VAR
-  __signal__ : BOOL; (* Value representing the internal signal *)
+  __signal__ : BOOL; (* Value representing the internal signal *)  
+  __is_running__: BOOL; (* Internal flag to track timer on/off state *)
   __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
 END_VAR
 END_FUNCTION_BLOCK
@@ -176,6 +182,7 @@ VAR_OUTPUT
 END_VAR
 VAR
   __signal__ : BOOL; (* Value representing the internal signal *)
+  __is_running__: BOOL; (* Internal flag to track timer on/off state *)
   __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
 END_VAR
 END_FUNCTION_BLOCK
@@ -202,6 +209,7 @@ VAR_OUTPUT
 END_VAR
 VAR
   __signal__ : BOOL; (* Value representing the internal signal *)
+  __is_running__: BOOL; (* Internal flag to track timer on/off state *)
   __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
 END_VAR
 END_FUNCTION_BLOCK
@@ -228,6 +236,7 @@ VAR_OUTPUT
 END_VAR
 VAR
   __signal__ : BOOL; (* Value representing the internal signal *)
+  __is_running__: BOOL; (* Internal flag to track timer on/off state *)
   __BUFFER__ : ARRAY[1..24] OF BYTE; (* Buffer used for internal implementation *)
 END_VAR
 END_FUNCTION_BLOCK

--- a/libs/stdlib/src/timers.rs
+++ b/libs/stdlib/src/timers.rs
@@ -20,6 +20,7 @@ pub struct TimerParams {
     output: bool,
     elapsed_time: Time,
     input_edge: Signal,
+    is_running: bool,
     start_time: Option<Instant>,
 }
 
@@ -28,16 +29,18 @@ impl TimerParams {
     /// It does not take into consideration the preset/range for the timer
     /// Only if a start time has been set.
     fn is_running(&self) -> bool {
-        self.start_time.is_some()
+        self.is_running
     }
 
     fn start(&mut self) {
         self.start_time = Some(Instant::now());
+        self.is_running = true;
         self.set_elapsed_time(0);
     }
 
     fn reset(&mut self) {
         self.start_time = None;
+        self.is_running = false;
         self.set_elapsed_time(0);
     }
 

--- a/libs/stdlib/tests/timer_tests.rs
+++ b/libs/stdlib/tests/timer_tests.rs
@@ -238,6 +238,33 @@ fn ton_returns_true_after_time_preset() {
 }
 
 #[test]
+fn ton_q_defaults_to_false() {
+    let prog = r#"
+        VAR_GLOBAL
+            ton_test: TON;
+        END_VAR
+
+        PROGRAM main
+            VAR
+                tp_out  : BOOL;
+                tp_et   : TIME;
+                tp_inst : TON;
+            END_VAR
+                ton_test(IN:=TRUE, PT:=T#2s);
+                tp_out = ton_test.Q;
+        END_PROGRAM
+    "#;
+
+    let source = add_std!(prog, "timers.st");
+    let context = CodegenContext::create();
+    let module = compile_with_native(&context, source);
+    let mut main_inst = MainType { value: true, ..MainType::default() };
+    // Value true First call -> false
+    module.run::<_, ()>("main", &mut main_inst);
+    assert!(!main_inst.tp_out);
+}
+
+#[test]
 fn ton_counts_elapsed_time_while_waiting() {
     let prog = r#"
         PROGRAM main


### PR DESCRIPTION
In our timer implementation we tracked the on/off state by checking whether or not the `start_time: Option<Instant>` field was a `Some`-Value. This led to a bug where the timer was always on, due to the `Option` value in a `Repr(C)` struct always being zero-initialized, and therefore always being a `Some` value.

I've added an internal boolean field to the timer-struct to track timer state and it seems to have fixed the issue.
Resolves #1047