### PR TITLE
refactor: use the buffered validator

### DIFF
--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__enums_with_inline_initializer_do_not_report_errors.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__enums_with_inline_initializer_do_not_report_errors.snap
@@ -1,0 +1,5 @@
+---
+source: src/codegen/tests/initialization_test/type_initializers.rs
+expression: diagnostics
+---
+

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__partly_uninitialized_const_struct_will_not_report_errors.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__partly_uninitialized_const_struct_will_not_report_errors.snap
@@ -1,0 +1,5 @@
+---
+source: src/codegen/tests/initialization_test/type_initializers.rs
+expression: diagnostics
+---
+

--- a/src/codegen/tests/initialization_test/type_initializers.rs
+++ b/src/codegen/tests/initialization_test/type_initializers.rs
@@ -1,7 +1,9 @@
 use insta::assert_snapshot;
 
 use crate::{
-    test_utils::tests::{codegen, codegen_debug_without_unwrap, codegen_without_unwrap, parse_and_validate},
+    test_utils::tests::{
+        codegen, codegen_debug_without_unwrap, codegen_without_unwrap, parse_and_validate_buffered,
+    },
     DebugLevel,
 };
 
@@ -538,7 +540,7 @@ fn partly_uninitialized_const_struct_will_get_default_values() {
 
 #[test]
 fn partly_uninitialized_const_struct_will_not_report_errors() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             TYPE MyOtherDINT : DINT := 2 ; END_TYPE
             TYPE MyDINT      : MyOtherDINT; END_TYPE
@@ -556,12 +558,12 @@ fn partly_uninitialized_const_struct_will_not_report_errors() {
             END_VAR
         "#,
     );
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn enums_with_inline_initializer_do_not_report_errors() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         VAR_GLOBAL
               x : (red, yellow, green) := red;
@@ -579,7 +581,7 @@ fn enums_with_inline_initializer_do_not_report_errors() {
         END_FUNCTION
         "#,
     );
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]

--- a/src/validation/tests/assignment_validation_tests.rs
+++ b/src/validation/tests/assignment_validation_tests.rs
@@ -1,9 +1,10 @@
-use crate::assert_validation_snapshot;
-use crate::test_utils::tests::{parse_and_validate, parse_and_validate_buffered};
+use insta::assert_snapshot;
+
+use crate::test_utils::tests::parse_and_validate_buffered;
 
 #[test]
 fn constant_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     VAR_GLOBAL CONSTANT
         v_global : BOOL;
@@ -16,12 +17,12 @@ fn constant_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn real_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -75,12 +76,12 @@ fn real_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn int_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -159,12 +160,12 @@ fn int_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn duration_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -218,12 +219,12 @@ fn duration_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn bit_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -277,12 +278,12 @@ fn bit_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn string_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -341,12 +342,12 @@ fn string_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn char_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -409,12 +410,12 @@ fn char_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn date_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -468,12 +469,12 @@ fn date_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn pointer_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -526,12 +527,12 @@ fn pointer_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn array_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     FUNCTION main : DINT
     VAR
@@ -588,12 +589,12 @@ fn array_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn struct_assignment_validation() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         TYPE STRUCT1 :
         STRUCT
@@ -671,12 +672,12 @@ fn struct_assignment_validation() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn assigning_literal_with_incompatible_encoding_to_char_is_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION main : DINT
         VAR
@@ -688,7 +689,7 @@ fn assigning_literal_with_incompatible_encoding_to_char_is_validated() {
         END_FUNCTION"#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -775,7 +776,7 @@ fn action_call_parameters_are_only_validated_outside_of_parent_pou_contexts() {
 
 #[test]
 fn implicit_invalid_action_call_assignments_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION_BLOCK fb_t
         VAR
@@ -804,12 +805,12 @@ fn implicit_invalid_action_call_assignments_are_validated() {
         "#,
     );
 
-    assert_validation_snapshot!(&diagnostics)
+    assert_snapshot!(&diagnostics)
 }
 
 #[test]
 fn invalid_method_call_assignments_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         CLASS cl_t
         VAR
@@ -836,12 +837,12 @@ fn invalid_method_call_assignments_are_validated() {
         "#,
     );
 
-    assert_validation_snapshot!(&diagnostics)
+    assert_snapshot!(&diagnostics)
 }
 
 #[test]
 fn invalid_function_block_instantiation_is_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION_BLOCK fb_t
         VAR_INPUT
@@ -861,12 +862,12 @@ fn invalid_function_block_instantiation_is_validated() {
         END_PROGRAM"#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn implicit_action_downcasts_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION_BLOCK fb_t
         VAR
@@ -897,12 +898,12 @@ fn implicit_action_downcasts_are_validated() {
         "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn assigning_to_input_by_ref_should_deliver_improvment_suggestion() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION fn : DINT
                 VAR_INPUT
@@ -937,12 +938,12 @@ fn assigning_to_input_by_ref_should_deliver_improvment_suggestion() {
             ",
         );
 
-    assert_validation_snapshot!(diagnostics);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn enum_variants_mismatch() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         TYPE Animal: (Dog, Cat, Horse); END_TYPE
 
@@ -960,12 +961,12 @@ fn enum_variants_mismatch() {
         END_PROGRAM",
     );
 
-    assert_validation_snapshot!(diagnostics);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn string_type_alias_assignment_can_be_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         TYPE MY_STR : STRING; END_TYPE
         TYPE MY_OTHER_STR: STRING[256]; END_TYPE
@@ -982,5 +983,5 @@ fn string_type_alias_assignment_can_be_validated() {
         ",
     );
 
-    assert_validation_snapshot!(diagnostics);
+    assert_snapshot!(diagnostics);
 }

--- a/src/validation/tests/bitaccess_validation_test.rs
+++ b/src/validation/tests/bitaccess_validation_test.rs
@@ -1,8 +1,9 @@
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+use crate::test_utils::tests::parse_and_validate_buffered;
+use insta::assert_snapshot;
 
 #[test]
 fn bitaccess_only_on_bit_types() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -23,12 +24,12 @@ fn bitaccess_only_on_bit_types() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn byteaccess_only_on_bigger_sizes() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -46,12 +47,12 @@ fn byteaccess_only_on_bigger_sizes() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn wordaccess_only_on_bigger_sizes() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -69,12 +70,12 @@ fn wordaccess_only_on_bigger_sizes() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn dwordaccess_only_on_bigger_sizes() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -92,12 +93,12 @@ fn dwordaccess_only_on_bigger_sizes() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn bitaccess_range_test() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -111,12 +112,12 @@ fn bitaccess_range_test() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn byteaccess_range_test() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -129,12 +130,12 @@ fn byteaccess_range_test() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn wordaccess_range_test() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -146,12 +147,12 @@ fn wordaccess_range_test() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn dwordaccess_range_test() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -162,12 +163,12 @@ fn dwordaccess_range_test() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn reference_direct_access_only_with_ints() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
             VAR
@@ -180,5 +181,5 @@ fn reference_direct_access_only_with_ints() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/builtin_validation_tests.rs
+++ b/src/validation/tests/builtin_validation_tests.rs
@@ -1,8 +1,9 @@
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+use crate::test_utils::tests::parse_and_validate_buffered;
+use insta::assert_snapshot;
 
 #[test]
 fn arithmetic_builtins_allow_mixing_of_fp_and_int_params() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION main : LINT
         VAR
@@ -25,7 +26,7 @@ fn arithmetic_builtins_allow_mixing_of_fp_and_int_params() {
 #[test]
 #[ignore = "FIXME: no validation for incompatible types for arithmetic operations"]
 fn arithmetic_builtins_called_with_incompatible_types() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION main : DINT
         VAR
@@ -40,12 +41,12 @@ fn arithmetic_builtins_called_with_incompatible_types() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn arithmetic_builtins_called_with_invalid_param_count() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION main : DINT
         VAR
@@ -60,13 +61,13 @@ fn arithmetic_builtins_called_with_invalid_param_count() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 #[ignore = "FIXME: no validation for incompatible type comparisons"]
 fn comparison_builtins_called_with_incompatible_types() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION main : DINT
         VAR
@@ -81,12 +82,12 @@ fn comparison_builtins_called_with_incompatible_types() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn comparison_builtins_called_with_invalid_param_count() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION main : DINT
         VAR
@@ -101,5 +102,5 @@ fn comparison_builtins_called_with_invalid_param_count() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/duplicates_validation_test.rs
+++ b/src/validation/tests/duplicates_validation_test.rs
@@ -1,3 +1,4 @@
+use insta::assert_snapshot;
 use plc_ast::{
     ast::{pre_process, CompilationUnit, LinkageType},
     provider::IdProvider,
@@ -7,11 +8,10 @@ use plc_source::source_location::SourceLocationFactory;
 use plc_source::SourceCode;
 
 use crate::{
-    assert_validation_snapshot,
     index::{visitor, Index},
     lexer, parser,
     resolver::TypeAnnotator,
-    test_utils::tests::parse_and_validate,
+    test_utils::tests::parse_and_validate_buffered,
     typesystem,
     validation::Validator,
 };
@@ -20,7 +20,7 @@ use crate::{
 fn duplicate_pous_validation() {
     // GIVEN two POUs witht he same name
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION        foo : INT  END_FUNCTION
 
@@ -30,42 +30,42 @@ fn duplicate_pous_validation() {
     "#,
     );
     // THEN there should be 3 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_pous_and_types_validation() {
     // GIVEN a POU and a Type with the same name
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION_BLOCK  foo  END_FUNCTION_BLOCK
         TYPE foo : INT; END_TYPE
     "#,
     );
     // THEN there should be 3 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_function_and_type_is_no_issue() {
     // GIVEN a Function and a Type with the same name
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION  foo: INT  END_FUNCTION
         TYPE foo : INT; END_TYPE
     "#,
     );
     // THEN there should be 0 duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn duplicate_global_variables() {
     // GIVEN some duplicate global variables
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         VAR_GLOBAL
             a: INT;
@@ -80,14 +80,14 @@ fn duplicate_global_variables() {
         "#,
     );
     // THEN there should be 0 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_variables_in_same_pou() {
     // GIVEN a POU with a duplicate variable
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prg
         VAR
@@ -102,28 +102,28 @@ fn duplicate_variables_in_same_pou() {
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_enum_members_in_different_types_is_no_issue() {
     // GIVEN a two enums with the same elements
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             TYPE enum1 : (red, green, yellow); END_TYPE
             TYPE enum2 : (red, green, yellow); END_TYPE
         "#,
     );
     // THEN there should be no issues
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn duplicate_fb_inst_and_function() {
     // GIVEN a global fb-instance called foo and a function called foo
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             FUNCTION_BLOCK FooFB
                 VAR x : INT; END_VAR
@@ -141,27 +141,27 @@ fn duplicate_fb_inst_and_function() {
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_enum_variables() {
     // GIVEN an enum with two identical elements
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             TYPE enum1 : (red, green, yellow, red); END_TYPE
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_global_and_program() {
     // GIVEN a global variable `prg` and a Program `prg`
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             VAR_GLOBAL
                 a: INT;
@@ -177,14 +177,14 @@ fn duplicate_global_and_program() {
         "#,
     );
     // THEN there should be 2 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_action_should_be_a_problem() {
     // GIVEN a program with two actions with the same name
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             PROGRAM prg
                 VAR_INPUT
@@ -210,14 +210,14 @@ fn duplicate_action_should_be_a_problem() {
     );
 
     // THEN there should be 2 duplication diagnostics
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn duplicate_actions_in_different_pous_are_no_issue() {
     // GIVEN two POUs with actions with the same name
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             PROGRAM prg
             END_PROGRAM
@@ -236,14 +236,14 @@ fn duplicate_actions_in_different_pous_are_no_issue() {
     );
 
     // THEN there should be no duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn automatically_generated_ptr_types_dont_cause_duplication_issues() {
     // GIVEN some code that automatically generates a pointer type
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             PROGRAM prg
             VAR
@@ -258,14 +258,14 @@ fn automatically_generated_ptr_types_dont_cause_duplication_issues() {
     );
 
     // THEN there should be no duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn automatically_generated_string_types_dont_cause_duplication_issues() {
     // GIVEN some code that automatically generates a pointer type
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             PROGRAM prg
             VAR
@@ -279,14 +279,14 @@ fn automatically_generated_string_types_dont_cause_duplication_issues() {
     );
 
     // THEN there should be no duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn automatically_generated_byref_types_dont_cause_duplication_issues() {
     // GIVEN some code that automatically generates a ref-types
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             FUNCTION foo : INT
                 VAR_INPUT {ref}
@@ -298,14 +298,14 @@ fn automatically_generated_byref_types_dont_cause_duplication_issues() {
     );
 
     // THEN there should be no duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn automatically_generated_inout_types_dont_cause_duplication_issues() {
     // GIVEN some code that automatically generates a ptr-types
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             FUNCTION foo : INT
                 VAR_IN_OUT
@@ -317,14 +317,14 @@ fn automatically_generated_inout_types_dont_cause_duplication_issues() {
     );
 
     // THEN there should be no duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn automatically_generated_output_types_dont_cause_duplication_issues() {
     // GIVEN some code that automatically generates a ptr-types
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             FUNCTION foo : INT
                 VAR_OUTPUT
@@ -336,7 +336,7 @@ fn automatically_generated_output_types_dont_cause_duplication_issues() {
     );
 
     // THEN there should be no duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
@@ -510,7 +510,7 @@ fn generics_with_duplicate_symbol_dont_err() {
     // END_FUNCTION
 
     // WHEN it is indexed and validated with other generic functions with the same name
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
             FUNCTION ADD < T1: ANY, T2: ANY >: T1
             VAR_INPUT
@@ -529,7 +529,7 @@ fn generics_with_duplicate_symbol_dont_err() {
     );
 
     // THEN there should be no duplication diagnostics
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 // #[test]

--- a/src/validation/tests/generic_validation_tests.rs
+++ b/src/validation/tests/generic_validation_tests.rs
@@ -1,4 +1,6 @@
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+use insta::assert_snapshot;
+
+use crate::test_utils::tests::parse_and_validate_buffered;
 
 #[test]
 fn any_allows_all_natures() {
@@ -17,8 +19,8 @@ fn any_allows_all_natures() {
         FUNCTION func10  : INT VAR x : str; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -43,8 +45,8 @@ fn any_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -54,8 +56,8 @@ fn non_resolved_generics_reported() {
         FUNCTION func  : INT  test(); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_MAGNITUDE    ##########
@@ -68,8 +70,8 @@ fn any_magnitude_allows_reals() {
         FUNCTION func2  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -87,8 +89,8 @@ fn any_magnitude_allows_ints() {
         FUNCTION func8  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -99,8 +101,8 @@ fn any_magnitude_allows_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -114,8 +116,8 @@ fn any_magnitude_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -126,8 +128,8 @@ fn any_magnitude_does_not_allow_strings() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -138,8 +140,8 @@ fn any_magnitude_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -153,8 +155,8 @@ fn any_magnitude_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -179,8 +181,8 @@ fn any_magnitude_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_NUMBER    ##########
@@ -193,8 +195,8 @@ fn any_num_allows_reals() {
         FUNCTION func2  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -212,8 +214,8 @@ fn any_num_allows_ints() {
         FUNCTION func8  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -224,8 +226,8 @@ fn any_num_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -239,8 +241,8 @@ fn any_num_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -251,8 +253,8 @@ fn any_num_does_not_allow_strings() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -263,8 +265,8 @@ fn any_num_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -278,8 +280,8 @@ fn any_num_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -304,8 +306,8 @@ fn any_num_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_REAL    ##########
@@ -318,8 +320,8 @@ fn any_real_allows_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -339,8 +341,8 @@ fn any_real_allows_ints() {
         FUNCTION func8  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -351,8 +353,8 @@ fn any_real_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -366,8 +368,8 @@ fn any_real_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -378,8 +380,8 @@ fn any_real_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -390,8 +392,8 @@ fn any_real_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -405,8 +407,8 @@ fn any_real_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -431,8 +433,8 @@ fn any_real_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_INT    ##########
@@ -445,8 +447,8 @@ fn any_int_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -465,8 +467,8 @@ fn any_int_allows_ints() {
         FUNCTION func8  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -477,8 +479,8 @@ fn any_int_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -492,8 +494,8 @@ fn any_int_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -504,8 +506,8 @@ fn any_int_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -516,8 +518,8 @@ fn any_int_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -531,8 +533,8 @@ fn any_int_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -557,8 +559,8 @@ fn any_int_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_UNSIGNED    ##########
@@ -571,8 +573,8 @@ fn any_unsigned_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -585,8 +587,8 @@ fn any_unsigned_allows_unsigned_ints() {
         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -599,8 +601,8 @@ fn any_unsigned_does_not_allow_signed_ints() {
         FUNCTION func4  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -611,8 +613,8 @@ fn any_unsigned_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -626,8 +628,8 @@ fn any_unsigned_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -638,8 +640,8 @@ fn any_unsigned_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -650,8 +652,8 @@ fn any_unsigned_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -665,8 +667,8 @@ fn any_unsigned_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -691,8 +693,8 @@ fn any_unsigned_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_SIGNED    ##########
@@ -705,8 +707,8 @@ fn any_signed_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -719,8 +721,8 @@ fn any_signed_allows_signed_ints() {
         FUNCTION func4  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -733,8 +735,8 @@ fn any_signed_does_not_allow_unsigned_ints() {
         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -745,8 +747,8 @@ fn any_signed_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -760,8 +762,8 @@ fn any_signed_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -772,8 +774,8 @@ fn any_signed_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -784,8 +786,8 @@ fn any_signed_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -799,8 +801,8 @@ fn any_signed_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -825,8 +827,8 @@ fn any_signed_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_DURATION    ##########
@@ -839,8 +841,8 @@ fn any_duration_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -859,8 +861,8 @@ fn any_duration_does_not_allow_ints() {
         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -871,8 +873,8 @@ fn any_duration_allows_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -886,8 +888,8 @@ fn any_duration_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -898,8 +900,8 @@ fn any_duration_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -910,8 +912,8 @@ fn any_duration_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -925,8 +927,8 @@ fn any_duration_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -951,8 +953,8 @@ fn any_duration_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_BIT    ##########
@@ -965,8 +967,8 @@ fn any_bit_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -985,8 +987,8 @@ fn any_bit_does_not_allow_ints() {
         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -997,8 +999,8 @@ fn any_bit_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1026,8 +1028,8 @@ fn any_bit_allows_bits() {
         END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -1038,8 +1040,8 @@ fn any_bit_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1050,8 +1052,8 @@ fn any_bit_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1065,8 +1067,8 @@ fn any_bit_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1091,8 +1093,8 @@ fn any_bit_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_CHARS    ##########
@@ -1105,8 +1107,8 @@ fn any_chars_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1125,8 +1127,8 @@ fn any_chars_does_not_allow_ints() {
         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1137,8 +1139,8 @@ fn any_chars_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1152,8 +1154,8 @@ fn any_chars_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1164,8 +1166,8 @@ fn any_chars_allows_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -1176,8 +1178,8 @@ fn any_chars_allows_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -1191,8 +1193,8 @@ fn any_chars_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1217,8 +1219,8 @@ fn any_chars_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_STRING    ##########
@@ -1231,8 +1233,8 @@ fn any_string_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1251,8 +1253,8 @@ fn any_string_does_not_allow_ints() {
         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1263,8 +1265,8 @@ fn any_string_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1278,8 +1280,8 @@ fn any_string_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1290,8 +1292,8 @@ fn any_string_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1302,8 +1304,8 @@ fn any_string_allows_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -1317,8 +1319,8 @@ fn any_string_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1343,8 +1345,8 @@ fn any_string_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_CHAR    ##########
@@ -1357,8 +1359,8 @@ fn any_char_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1377,8 +1379,8 @@ fn any_char_does_not_allow_ints() {
         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1389,8 +1391,8 @@ fn any_char_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1404,8 +1406,8 @@ fn any_char_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1416,8 +1418,8 @@ fn any_char_allows_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -1428,8 +1430,8 @@ fn any_char_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1443,8 +1445,8 @@ fn any_char_does_not_allow_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1469,8 +1471,8 @@ fn any_char_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 // ##########    ANY_DATE    ##########
@@ -1483,8 +1485,8 @@ fn any_date_does_not_allow_reals() {
         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1503,8 +1505,8 @@ fn any_date_does_not_allow_ints() {
         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1515,8 +1517,8 @@ fn any_date_does_not_allow_time() {
         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1530,8 +1532,8 @@ fn any_date_does_not_allow_bits() {
         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1542,8 +1544,8 @@ fn any_date_does_not_allow_chars() {
         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1554,8 +1556,8 @@ fn any_date_does_not_allow_string() {
         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -1569,8 +1571,8 @@ fn any_date_allows_date() {
         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_eq!(diagnostics, vec![]);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -1595,6 +1597,6 @@ fn any_date_multiple_parameters() {
     END_FUNCTION
     ";
 
-    let diagnostics = parse_and_validate(src);
-    assert_validation_snapshot!(&diagnostics);
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/literals_validation_tests.rs
+++ b/src/validation/tests/literals_validation_tests.rs
@@ -1,10 +1,10 @@
-use plc_diagnostics::diagnostics::Diagnostic;
+use insta::assert_snapshot;
 
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+use crate::test_utils::tests::parse_and_validate_buffered;
 
 #[test]
 fn int_literal_casts_max_values_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
                 BYTE#255;
@@ -22,12 +22,12 @@ fn int_literal_casts_max_values_are_validated() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn bool_literal_casts_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM prg
             BOOL#TRUE;
@@ -41,12 +41,12 @@ fn bool_literal_casts_are_validated() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn string_literal_casts_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prg
 
@@ -67,12 +67,12 @@ fn string_literal_casts_are_validated() {
        "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn real_literal_casts_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prg
 
@@ -92,24 +92,24 @@ fn real_literal_casts_are_validated() {
        "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn literal_cast_with_non_literal() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "PROGRAM exp
             INT#[x];
         END_PROGRAM
 
         VAR_GLOBAL x : INT; END_VAR",
     );
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn literal_enum_elements_validate_without_errors() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         TYPE Animal: (Dog, Cat, Horse); END_TYPE
         TYPE Color: (Red, Yellow, Green); END_TYPE
@@ -120,13 +120,12 @@ fn literal_enum_elements_validate_without_errors() {
         END_PROGRAM",
     );
 
-    let empty: Vec<Diagnostic> = Vec::new();
-    assert_eq!(empty, diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn date_literal_casts_are_validated() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prg
             LINT#DT#1989-06-15-13:56:14.77;
@@ -147,12 +146,12 @@ fn date_literal_casts_are_validated() {
        "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn char_cast_validate() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prg
 
@@ -166,5 +165,5 @@ fn char_cast_validate() {
        "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }

--- a/src/validation/tests/naming_validation_test.rs
+++ b/src/validation/tests/naming_validation_test.rs
@@ -1,4 +1,5 @@
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+use crate::test_utils::tests::parse_and_validate_buffered;
+use insta::assert_snapshot;
 
 macro_rules! assert_with_type_name {
     ($name:ident) => {
@@ -6,8 +7,9 @@ macro_rules! assert_with_type_name {
         #[allow(non_snake_case)]
         fn $name() {
             let name = stringify!($name);
-            let result = parse_and_validate(&format!("TYPE {name} : STRUCT x : DINT; END_STRUCT END_TYPE"));
-            assert_validation_snapshot!(&result)
+            let result =
+                parse_and_validate_buffered(&format!("TYPE {name} : STRUCT x : DINT; END_STRUCT END_TYPE"));
+            assert_snapshot!(&result)
         }
     };
 }

--- a/src/validation/tests/pou_validation_tests.rs
+++ b/src/validation/tests/pou_validation_tests.rs
@@ -1,28 +1,29 @@
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+use crate::test_utils::tests::parse_and_validate_buffered;
+use insta::assert_snapshot;
 
 #[test]
 fn function_no_return_unsupported() {
     // GIVEN FUNCTION with no return type
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate("FUNCTION foo VAR_INPUT END_VAR END_FUNCTION");
+    let diagnostics = parse_and_validate_buffered("FUNCTION foo VAR_INPUT END_VAR END_FUNCTION");
     // THEN there should be one diagnostic -> missing return type
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn actions_container_no_name() {
     // GIVEN ACTIONS without a name
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate("ACTIONS ACTION myAction END_ACTION END_ACTIONS");
+    let diagnostics = parse_and_validate_buffered("ACTIONS ACTION myAction END_ACTION END_ACTIONS");
     // THEN there should be one diagnostic -> missing action container name
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn class_has_implementation() {
     // GIVEN CLASS with an implementation
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS myCLASS
         VAR
@@ -33,14 +34,14 @@ fn class_has_implementation() {
     ",
     );
     // THEN there should be one diagnostic -> Class cannot have implementation
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn program_has_super_class() {
     // GIVEN PROGRAM with a super class
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS cls
         END_CLASS
@@ -50,14 +51,14 @@ fn program_has_super_class() {
     ",
     );
     // THEN there should be one diagnostic -> Program cannot have super class
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn function_has_super_class() {
     // GIVEN FUNCTION with a super class
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS cls
         END_CLASS
@@ -67,28 +68,28 @@ fn function_has_super_class() {
     ",
     );
     // THEN there should be one diagnostic -> Function cannot have super class
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn class_with_return_type() {
     // GIVEN class with a return type
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS cls : INT
         END_CLASS
     ",
     );
     // THEN there should be one diagnostic -> Class cannot have a return type
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn in_out_variable_not_allowed_in_class() {
     // GIVEN class with a VAR_IN_OUT
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS cls
         VAR_IN_OUT
@@ -98,14 +99,14 @@ fn in_out_variable_not_allowed_in_class() {
     ",
     );
     // THEN there should be one diagnostic -> Class cannot have a var in/out/inout block
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn input_variable_not_allowed_in_class() {
     // GIVEN class with a VAR_INPUT
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS cls
         VAR_INPUT
@@ -115,14 +116,14 @@ fn input_variable_not_allowed_in_class() {
     ",
     );
     // THEN there should be one diagnostic -> Class cannot have a var in/out/inout block
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn output_variable_not_allowed_in_class() {
     // GIVEN class with a VAR_OUTPUT
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS cls
         VAR_OUTPUT
@@ -132,14 +133,14 @@ fn output_variable_not_allowed_in_class() {
     ",
     );
     // THEN there should be one diagnostic -> Class cannot have a var in/out/inout block
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn local_variable_allowed_in_class() {
     // GIVEN class with a VAR
     // WHEN parse_and_validate is done
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         CLASS cls
         VAR
@@ -149,7 +150,7 @@ fn local_variable_allowed_in_class() {
     ",
     );
     // THEN there should be no diagnostic -> Class can have local var block
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
@@ -158,7 +159,7 @@ fn do_not_validate_external() {
     // for this kind of assignment our validator would report
     // potential loss of information (assigning bigger to smaller type)
     // WHEN ...
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
     PROGRAM main
     END_PROGRAM
@@ -179,7 +180,7 @@ fn do_not_validate_external() {
 
 #[test]
 fn in_out_variable_out_of_order() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
     PROGRAM mainProg
     VAR
@@ -220,5 +221,5 @@ fn in_out_variable_out_of_order() {
     ",
     );
 
-    assert_validation_snapshot!(diagnostics);
+    assert_snapshot!(diagnostics);
 }

--- a/src/validation/tests/recursive_validation_tests.rs
+++ b/src/validation/tests/recursive_validation_tests.rs
@@ -1,9 +1,11 @@
 mod edgecases {
-    use crate::test_utils::tests::parse_and_validate;
+    use insta::assert_snapshot;
+
+    use crate::test_utils::tests::parse_and_validate_buffered;
 
     #[test]
     fn pointers_should_not_be_considered_as_cycle() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -15,7 +17,7 @@ mod edgecases {
             ",
         );
 
-        assert_eq!(diagnostics.len(), 0);
+        assert_snapshot!(diagnostics)
     }
 
     // From https://github.com/PLC-lang/rusty/pull/748:
@@ -26,7 +28,7 @@ mod edgecases {
     // This test covers the above edge-case
     #[test]
     fn external_function_should_not_trigger() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             {external}
             FUNCTION TIME : TIME
@@ -40,12 +42,12 @@ mod edgecases {
             ",
         );
 
-        assert_eq!(diagnostics.len(), 0);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn struct_and_function_with_same_name() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION TM : TM
             END_FUNCTION
@@ -57,12 +59,12 @@ mod edgecases {
             ",
         );
 
-        assert_eq!(diagnostics.len(), 0);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn struct_and_function_with_same_name_2() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION TM : DINT
                 VAR_INPUT
@@ -77,12 +79,12 @@ mod edgecases {
             ",
         );
 
-        assert_eq!(diagnostics.len(), 0);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn struct_and_function_with_same_name_3() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION TM : DINT
                 VAR_INPUT
@@ -97,16 +99,17 @@ mod edgecases {
             ",
         );
 
-        assert_eq!(diagnostics.len(), 0);
+        assert_snapshot!(diagnostics);
     }
 }
 
 mod structs {
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn one_cycle_abca() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -127,12 +130,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_self_a() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 a : A;
@@ -140,12 +143,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_multiple_self_a() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 a1 : A;
@@ -155,12 +158,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_aba() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -172,12 +175,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_bcb() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -193,12 +196,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_with_multiple_identical_members_aba() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b1 : B;
@@ -212,12 +215,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn two_cycles_aa_and_aba() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 a : A;
@@ -230,12 +233,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn two_cycles_branch_cc_and_cec() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -256,12 +259,12 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn two_cycles_with_branch() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -298,17 +301,17 @@ mod structs {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 }
 
 mod arrays {
-
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn two_cycles_aa_and_aba() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 a : ARRAY[0..1] OF A;
@@ -321,12 +324,12 @@ mod arrays {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_bcb() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : ARRAY[0..1] OF B;
@@ -342,12 +345,12 @@ mod arrays {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_with_multiple_identical_members_aba() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b1 : ARRAY[0..1] OF B;
@@ -361,12 +364,12 @@ mod arrays {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_aba_output() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : ARRAY [0..1] OF B;
@@ -380,12 +383,12 @@ mod arrays {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_aba_input() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : ARRAY [0..1] OF B;
@@ -399,12 +402,12 @@ mod arrays {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn two_cycles_with_branch_input() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION_BLOCK A
                 VAR_INPUT
@@ -449,16 +452,17 @@ mod arrays {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 }
 
 mod functionblocks {
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn one_cycle_aba_var() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION_BLOCK A
                 VAR
@@ -475,12 +479,12 @@ mod functionblocks {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_aba_input() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION_BLOCK A
                 VAR_INPUT
@@ -497,12 +501,12 @@ mod functionblocks {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_aba_output() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION_BLOCK A
                 VAR_OUTPUT
@@ -519,12 +523,12 @@ mod functionblocks {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_aba_inout() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION_BLOCK A
                 VAR_IN_OUT
@@ -542,12 +546,12 @@ mod functionblocks {
         );
 
         // No recursion because VAR_IN_OUT are treated as pointers
-        assert_eq!(diagnostics.len(), 0);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn two_cycles_with_branch_input() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION_BLOCK A
                 VAR_INPUT
@@ -600,17 +604,18 @@ mod functionblocks {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 }
 
 mod mixed_structs_and_functionblocks {
 
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn one_cycle_aba_output() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -624,12 +629,12 @@ mod mixed_structs_and_functionblocks {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn one_cycle_aba_input() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             TYPE A : STRUCT
                 b : B;
@@ -643,12 +648,12 @@ mod mixed_structs_and_functionblocks {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 
     #[test]
     fn two_cycles_with_branch_input() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION_BLOCK A
                 VAR_INPUT
@@ -693,6 +698,6 @@ mod mixed_structs_and_functionblocks {
             ",
         );
 
-        assert_validation_snapshot!(&diagnostics);
+        assert_snapshot!(&diagnostics);
     }
 }

--- a/src/validation/tests/reference_resolve_tests.rs
+++ b/src/validation/tests/reference_resolve_tests.rs
@@ -1,11 +1,11 @@
-use crate::assert_validation_snapshot;
-use crate::test_utils::tests::parse_and_validate;
+use crate::test_utils::tests::parse_and_validate_buffered;
+use insta::assert_snapshot;
 
 /// tests wheter simple local and global variables can be resolved and
 /// errors are reported properly
 #[test]
 fn resolve_simple_variable_references() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             VAR_GLOBAL
                 ga : INT;
@@ -23,14 +23,14 @@ fn resolve_simple_variable_references() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(diagnostics);
 }
 
 /// tests wheter functions and function parameters can be resolved and
 /// errors are reported properly
 #[test]
 fn resolve_function_calls_and_parameters() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
            PROGRAM prg
                 VAR a : INT; END_VAR
@@ -47,14 +47,14 @@ fn resolve_function_calls_and_parameters() {
         ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 /// tests wheter structs and struct member variables can be resolved and
 /// errors are reported properly
 #[test]
 fn resole_struct_member_access() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             TYPE MySubStruct: STRUCT
                 subfield1: INT;
@@ -99,14 +99,14 @@ fn resole_struct_member_access() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 /// tests wheter function_block members can be resolved and
 /// errors are reported properly
 #[test]
 fn resolve_function_block_calls_field_access() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             FUNCTION_BLOCK FB
                 VAR_INPUT
@@ -130,14 +130,14 @@ fn resolve_function_block_calls_field_access() {
        ",
     );
 
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 /// tests wheter function_block types and member variables can be resolved and
 /// errors are reported properly
 #[test]
 fn resolve_function_block_calls_in_structs_and_field_access() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             FUNCTION_BLOCK FB
                 VAR_INPUT
@@ -167,13 +167,13 @@ fn resolve_function_block_calls_in_structs_and_field_access() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 /// tests wheter function's members cannot be access using the function's name as a qualifier
 #[test]
 fn resolve_function_members_via_qualifier() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
                 VAR
@@ -193,13 +193,13 @@ fn resolve_function_members_via_qualifier() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 /// tests whether references to privater variables do resolve, but end up in an validation problem
 #[test]
 fn reference_to_private_variable_is_illegal() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
                 VAR
@@ -213,7 +213,7 @@ fn reference_to_private_variable_is_illegal() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 /// tests whether an intermediate access like: `a.priv.b` (where priv is a var_local)
@@ -223,7 +223,7 @@ fn reference_to_private_variable_in_intermediate_fb() {
     // GIVEN a qualified reference prg.a.f.x where f is a
     // private member of a functionblock (VAR)
     // WHEN this is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             FUNCTION_BLOCK fb1
                 VAR
@@ -249,12 +249,12 @@ fn reference_to_private_variable_in_intermediate_fb() {
 
     // THEN we get a validtion-error for accessing fb1.f, but no follow-up errors for
     // the access of fb2 which is legit
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn program_vars_are_allowed_in_their_actions() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
             PROGRAM prg
                 VAR
@@ -269,12 +269,12 @@ fn program_vars_are_allowed_in_their_actions() {
        ",
     );
 
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn fb_pointer_access_call_statement_resolves_without_validation_errors() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM main
         VAR
@@ -296,12 +296,12 @@ fn fb_pointer_access_call_statement_resolves_without_validation_errors() {
        ",
     );
 
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn resolve_array_of_struct_as_member_of_another_struct_initializer() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM mainProg
         VAR
@@ -327,12 +327,12 @@ fn resolve_array_of_struct_as_member_of_another_struct_initializer() {
        ",
     );
 
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initialized() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM mainProg
         VAR
@@ -359,5 +359,5 @@ fn array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initi
        ",
     );
 
-    assert!(diagnostics.is_empty());
+    assert_snapshot!(diagnostics);
 }

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__array_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__array_assignment_validation.snap
@@ -1,22 +1,107 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..8] OF STRING[1256]' to 'ARRAY[0..3] OF STRING[256]'", range: [SourceLocation { span: Range(TextLocation { line: 29, column: 4, offset: 729 }..TextLocation { line: 29, column: 45, offset: 770 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..2] OF INT' to 'ARRAY[0..3] OF INT'", range: [SourceLocation { span: Range(TextLocation { line: 30, column: 4, offset: 787 }..TextLocation { line: 30, column: 30, offset: 813 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..4] OF INT' to 'ARRAY[0..3] OF INT'", range: [SourceLocation { span: Range(TextLocation { line: 32, column: 4, offset: 871 }..TextLocation { line: 32, column: 30, offset: 897 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..3] OF REAL' to 'ARRAY[0..3] OF INT'", range: [SourceLocation { span: Range(TextLocation { line: 33, column: 4, offset: 914 }..TextLocation { line: 33, column: 31, offset: 941 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..3] OF STRING' to 'ARRAY[0..3] OF INT'", range: [SourceLocation { span: Range(TextLocation { line: 34, column: 4, offset: 958 }..TextLocation { line: 34, column: 33, offset: 987 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..3] OF CHAR' to 'ARRAY[0..3] OF INT'", range: [SourceLocation { span: Range(TextLocation { line: 35, column: 4, offset: 1004 }..TextLocation { line: 35, column: 31, offset: 1031 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Array assignments must be surrounded with `[]`", range: [SourceLocation { span: Range(TextLocation { line: 36, column: 19, offset: 1063 }..TextLocation { line: 36, column: 20, offset: 1064 }) }], err_no: arr__invalid_array_assignment }
-SyntaxError { message: "Array assignments must be surrounded with `[]`", range: [SourceLocation { span: Range(TextLocation { line: 37, column: 20, offset: 1106 }..TextLocation { line: 37, column: 30, offset: 1116 }) }], err_no: arr__invalid_array_assignment }
-SyntaxError { message: "Array assignments must be surrounded with `[]`", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 20, offset: 1148 }..TextLocation { line: 38, column: 36, offset: 1164 }) }], err_no: arr__invalid_array_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 43, column: 4, offset: 1352 }..TextLocation { line: 43, column: 30, offset: 1378 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 44, column: 4, offset: 1395 }..TextLocation { line: 44, column: 37, offset: 1428 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 45, column: 4, offset: 1445 }..TextLocation { line: 45, column: 30, offset: 1471 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 1488 }..TextLocation { line: 46, column: 28, offset: 1512 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 47, column: 4, offset: 1529 }..TextLocation { line: 47, column: 30, offset: 1555 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 49, column: 4, offset: 1615 }..TextLocation { line: 49, column: 35, offset: 1646 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'ARRAY[0..3] OF INT'", range: [SourceLocation { span: Range(TextLocation { line: 50, column: 4, offset: 1663 }..TextLocation { line: 50, column: 25, offset: 1684 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..3] OF INT' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 51, column: 4, offset: 1701 }..TextLocation { line: 51, column: 25, offset: 1722 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[0..8] OF STRING[1256]' to 'ARRAY[0..3] OF STRING[256]'
+   ┌─ <internal>:30:5
+   │
+30 │     v_arr_sized_string := v_arr_sized_string2; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..8] OF STRING[1256]' to 'ARRAY[0..3] OF STRING[256]'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..2] OF INT' to 'ARRAY[0..3] OF INT'
+   ┌─ <internal>:31:5
+   │
+31 │     v_arr_int_3 := v_arr_int_2; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..2] OF INT' to 'ARRAY[0..3] OF INT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..4] OF INT' to 'ARRAY[0..3] OF INT'
+   ┌─ <internal>:33:5
+   │
+33 │     v_arr_int_3 := v_arr_int_4; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..4] OF INT' to 'ARRAY[0..3] OF INT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..3] OF REAL' to 'ARRAY[0..3] OF INT'
+   ┌─ <internal>:34:5
+   │
+34 │     v_arr_int_3 := v_arr_real_3; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..3] OF REAL' to 'ARRAY[0..3] OF INT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..3] OF STRING' to 'ARRAY[0..3] OF INT'
+   ┌─ <internal>:35:5
+   │
+35 │     v_arr_int_3 := v_arr_string_3; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..3] OF STRING' to 'ARRAY[0..3] OF INT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..3] OF CHAR' to 'ARRAY[0..3] OF INT'
+   ┌─ <internal>:36:5
+   │
+36 │     v_arr_int_3 := v_arr_char_3; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..3] OF CHAR' to 'ARRAY[0..3] OF INT'
+
+error: Array assignments must be surrounded with `[]`
+   ┌─ <internal>:37:20
+   │
+37 │     v_arr_int_3 := 1, 2, 3, 4; // INVALID
+   │                    ^ Array assignments must be surrounded with `[]`
+
+error: Array assignments must be surrounded with `[]`
+   ┌─ <internal>:38:21
+   │
+38 │     v_arr_int_3 := (1, 2, 3, 4); // valid
+   │                     ^^^^^^^^^^ Array assignments must be surrounded with `[]`
+
+error: Array assignments must be surrounded with `[]`
+   ┌─ <internal>:39:21
+   │
+39 │     v_arr_int_3 := (1, 2, 3, 4, 5, 6); // INVALID -> missing
+   │                     ^^^^^^^^^^^^^^^^ Array assignments must be surrounded with `[]`
+
+error: Invalid assignment: cannot assign 'STRING' to 'INT'
+   ┌─ <internal>:44:5
+   │
+44 │     v_arr_int_3[0] := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'INT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'INT'
+   ┌─ <internal>:45:5
+   │
+45 │     v_arr_int_3[0] := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'INT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'INT'
+   ┌─ <internal>:46:5
+   │
+46 │     v_arr_int_3[0] := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'INT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'INT'
+   ┌─ <internal>:47:5
+   │
+47 │     v_arr_int_3[0] := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'INT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'INT'
+   ┌─ <internal>:48:5
+   │
+48 │     v_arr_int_3[0] := CHAR#'a'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'INT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'INT'
+   ┌─ <internal>:50:5
+   │
+50 │     v_arr_int_3[0] := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'INT'
+
+error: Invalid assignment: cannot assign 'DINT' to 'ARRAY[0..3] OF INT'
+   ┌─ <internal>:51:5
+   │
+51 │     v_arr_int_3 := v_dint; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'ARRAY[0..3] OF INT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..3] OF INT' to 'DINT'
+   ┌─ <internal>:52:5
+   │
+52 │     v_dint := v_arr_int_3; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..3] OF INT' to 'DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__assigning_literal_with_incompatible_encoding_to_char_is_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__assigning_literal_with_incompatible_encoding_to_char_is_validated.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 115 }..TextLocation { line: 6, column: 20, offset: 123 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'WCHAR'", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 137 }..TextLocation { line: 7, column: 20, offset: 145 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'WSTRING' to 'CHAR'
+  ┌─ <internal>:7:13
+  │
+7 │             x := "A";
+  │             ^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'WCHAR'
+  ┌─ <internal>:8:13
+  │
+8 │             y := 'B';
+  │             ^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'WCHAR'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__assigning_to_input_by_ref_should_deliver_improvment_suggestion.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__assigning_to_input_by_ref_should_deliver_improvment_suggestion.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-ImprovementSuggestion { message: "VAR_INPUT {ref} variables are mutable and changes to them will also affect the referenced variable. For increased clarity use VAR_IN_OUT instead.", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 16, offset: 353 }..TextLocation { line: 16, column: 24, offset: 361 }) }] }
+warning: VAR_INPUT {ref} variables are mutable and changes to them will also affect the referenced variable. For increased clarity use VAR_IN_OUT instead.
+   ┌─ <internal>:17:17
+   │
+17 │                 b := 1.0;   // This should trigger an improvment suggestion, because we are assigning a value
+   │                 ^^^^^^^^ VAR_INPUT {ref} variables are mutable and changes to them will also affect the referenced variable. For increased clarity use VAR_IN_OUT instead.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__bit_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__bit_assignment_validation.snap
@@ -1,12 +1,47 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 4, offset: 775 }..TextLocation { line: 38, column: 22, offset: 793 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 4, offset: 810 }..TextLocation { line: 39, column: 29, offset: 835 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 40, column: 4, offset: 852 }..TextLocation { line: 40, column: 22, offset: 870 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 41, column: 4, offset: 887 }..TextLocation { line: 41, column: 20, offset: 903 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 42, column: 4, offset: 920 }..TextLocation { line: 42, column: 22, offset: 938 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 1057 }..TextLocation { line: 46, column: 27, offset: 1080 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 48, column: 4, offset: 1136 }..TextLocation { line: 48, column: 31, offset: 1163 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'BYTE'
+   ┌─ <internal>:39:5
+   │
+39 │     v_byte := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'BYTE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'BYTE'
+   ┌─ <internal>:40:5
+   │
+40 │     v_byte := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'BYTE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'BYTE'
+   ┌─ <internal>:41:5
+   │
+41 │     v_byte := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'BYTE'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'BYTE'
+   ┌─ <internal>:42:5
+   │
+42 │     v_byte := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'BYTE'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'BYTE'
+   ┌─ <internal>:43:5
+   │
+43 │     v_byte := CHAR#'c'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'BYTE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'BYTE'
+   ┌─ <internal>:47:5
+   │
+47 │     v_byte := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'BYTE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'BYTE'
+   ┌─ <internal>:49:5
+   │
+49 │     v_byte := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'BYTE'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__char_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__char_assignment_validation.snap
@@ -1,30 +1,155 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'LREAL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 31, column: 4, offset: 531 }..TextLocation { line: 31, column: 21, offset: 548 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 32, column: 4, offset: 565 }..TextLocation { line: 32, column: 22, offset: 583 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 33, column: 4, offset: 600 }..TextLocation { line: 33, column: 21, offset: 617 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 34, column: 4, offset: 634 }..TextLocation { line: 34, column: 22, offset: 652 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 35, column: 4, offset: 669 }..TextLocation { line: 35, column: 20, offset: 685 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 36, column: 4, offset: 702 }..TextLocation { line: 36, column: 21, offset: 719 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 37, column: 4, offset: 736 }..TextLocation { line: 37, column: 20, offset: 752 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 4, offset: 769 }..TextLocation { line: 38, column: 28, offset: 793 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 4, offset: 810 }..TextLocation { line: 39, column: 20, offset: 826 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 40, column: 4, offset: 843 }..TextLocation { line: 40, column: 26, offset: 865 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING[1]' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 41, column: 4, offset: 882 }..TextLocation { line: 41, column: 23, offset: 901 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 42, column: 4, offset: 933 }..TextLocation { line: 42, column: 24, offset: 953 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 44, column: 4, offset: 1013 }..TextLocation { line: 44, column: 17, offset: 1026 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 45, column: 4, offset: 1043 }..TextLocation { line: 45, column: 22, offset: 1061 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 1078 }..TextLocation { line: 46, column: 29, offset: 1103 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Value: 'string' exceeds length for type: CHAR", range: [SourceLocation { span: Range(TextLocation { line: 47, column: 4, offset: 1120 }..TextLocation { line: 47, column: 22, offset: 1138 }) }], err_no: syntax__generic_error }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 47, column: 4, offset: 1120 }..TextLocation { line: 47, column: 22, offset: 1138 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 50, column: 4, offset: 1219 }..TextLocation { line: 50, column: 21, offset: 1236 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 51, column: 4, offset: 1253 }..TextLocation { line: 51, column: 23, offset: 1272 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 52, column: 4, offset: 1289 }..TextLocation { line: 52, column: 19, offset: 1304 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 53, column: 4, offset: 1321 }..TextLocation { line: 53, column: 26, offset: 1343 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 54, column: 4, offset: 1360 }..TextLocation { line: 54, column: 24, offset: 1380 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 55, column: 4, offset: 1397 }..TextLocation { line: 55, column: 27, offset: 1420 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 56, column: 4, offset: 1437 }..TextLocation { line: 56, column: 28, offset: 1461 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 57, column: 4, offset: 1478 }..TextLocation { line: 57, column: 31, offset: 1505 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'LREAL' to 'CHAR'
+   ┌─ <internal>:32:5
+   │
+32 │     v_char := v_lreal; // INVALID
+   │     ^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'LREAL' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'REAL' to 'CHAR'
+   ┌─ <internal>:33:5
+   │
+33 │     v_char := REAL#2.0; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REAL' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+   ┌─ <internal>:34:5
+   │
+34 │     v_char := v_udint; // INVALID
+   │     ^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+   ┌─ <internal>:35:5
+   │
+35 │     v_char := UDINT#10; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'DINT' to 'CHAR'
+   ┌─ <internal>:36:5
+   │
+36 │     v_char := v_dint; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'DINT' to 'CHAR'
+   ┌─ <internal>:37:5
+   │
+37 │     v_char := DINT#20; // INVALID
+   │     ^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'TIME' to 'CHAR'
+   ┌─ <internal>:38:5
+   │
+38 │     v_char := v_time; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'TIME' to 'CHAR'
+   ┌─ <internal>:39:5
+   │
+39 │     v_char := TIME#10h20m30s; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'WORD' to 'CHAR'
+   ┌─ <internal>:40:5
+   │
+40 │     v_char := v_word; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WORD' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'WORD' to 'CHAR'
+   ┌─ <internal>:41:5
+   │
+41 │     v_char := WORD#16#ffff; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WORD' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING[1]' to 'CHAR'
+   ┌─ <internal>:42:5
+   │
+42 │     v_char := v_string1; // INVALID -> should work
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING[1]' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:43:5
+   │
+43 │     v_char := STRING#'a'; // INVALID -> should work
+   │     ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'CHAR'
+   ┌─ <internal>:45:5
+   │
+45 │     v_char := "a"; // INVALID
+   │     ^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:46:5
+   │
+46 │     v_char := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:47:5
+   │
+47 │     v_char := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Value: 'string' exceeds length for type: CHAR
+   ┌─ <internal>:48:5
+   │
+48 │     v_char := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Value: 'string' exceeds length for type: CHAR
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:48:5
+   │
+48 │     v_char := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'CHAR'
+   ┌─ <internal>:51:5
+   │
+51 │     v_char := v_wchar; // INVALID
+   │     ^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WCHAR' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'CHAR'
+   ┌─ <internal>:52:5
+   │
+52 │     v_char := WCHAR#"c"; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WCHAR' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+   ┌─ <internal>:53:5
+   │
+53 │     v_char := v_tod; // INVALID
+   │     ^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+   ┌─ <internal>:54:5
+   │
+54 │     v_char := TOD#15:36:30; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'INT' to 'CHAR'
+   ┌─ <internal>:55:5
+   │
+55 │     v_char := v_ptr_int^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:56:5
+   │
+56 │     v_char := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'INT' to 'CHAR'
+   ┌─ <internal>:57:5
+   │
+57 │     v_char := v_arr_int_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:58:5
+   │
+58 │     v_char := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__constant_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__constant_assignment_validation.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Cannot assign to CONSTANT 'v_global'", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 4, offset: 119 }..TextLocation { line: 7, column: 12, offset: 127 }) }], err_no: var__cannot_assign_to_const }
+error: Cannot assign to CONSTANT 'v_global'
+  ┌─ <internal>:8:5
+  │
+8 │     v_global := TRUE; // INVALID
+  │     ^^^^^^^^ Cannot assign to CONSTANT 'v_global'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__date_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__date_assignment_validation.snap
@@ -1,12 +1,47 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 4, offset: 776 }..TextLocation { line: 38, column: 22, offset: 794 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 4, offset: 811 }..TextLocation { line: 39, column: 29, offset: 836 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 40, column: 4, offset: 853 }..TextLocation { line: 40, column: 22, offset: 871 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 41, column: 4, offset: 888 }..TextLocation { line: 41, column: 20, offset: 904 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 42, column: 4, offset: 921 }..TextLocation { line: 42, column: 22, offset: 939 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 1058 }..TextLocation { line: 46, column: 27, offset: 1081 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 48, column: 4, offset: 1137 }..TextLocation { line: 48, column: 31, offset: 1164 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+   ┌─ <internal>:39:5
+   │
+39 │     v_date := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+   ┌─ <internal>:40:5
+   │
+40 │     v_date := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+   ┌─ <internal>:41:5
+   │
+41 │     v_date := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DATE'
+   ┌─ <internal>:42:5
+   │
+42 │     v_date := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DATE'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DATE'
+   ┌─ <internal>:43:5
+   │
+43 │     v_date := CHAR#'c'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DATE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+   ┌─ <internal>:47:5
+   │
+47 │     v_date := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+   ┌─ <internal>:49:5
+   │
+49 │     v_date := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__duration_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__duration_assignment_validation.snap
@@ -1,12 +1,47 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 4, offset: 780 }..TextLocation { line: 38, column: 22, offset: 798 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 4, offset: 815 }..TextLocation { line: 39, column: 29, offset: 840 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 40, column: 4, offset: 857 }..TextLocation { line: 40, column: 22, offset: 875 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 41, column: 4, offset: 892 }..TextLocation { line: 41, column: 20, offset: 908 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 42, column: 4, offset: 925 }..TextLocation { line: 42, column: 22, offset: 943 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 1062 }..TextLocation { line: 46, column: 27, offset: 1085 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 48, column: 4, offset: 1141 }..TextLocation { line: 48, column: 31, offset: 1168 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+   ┌─ <internal>:39:5
+   │
+39 │     v_time := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+   ┌─ <internal>:40:5
+   │
+40 │     v_time := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+   ┌─ <internal>:41:5
+   │
+41 │     v_time := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'TIME'
+   ┌─ <internal>:42:5
+   │
+42 │     v_time := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'TIME'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'TIME'
+   ┌─ <internal>:43:5
+   │
+43 │     v_time := CHAR#'c'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'TIME'
+
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+   ┌─ <internal>:47:5
+   │
+47 │     v_time := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+   ┌─ <internal>:49:5
+   │
+49 │     v_time := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__enum_variants_mismatch.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__enum_variants_mismatch.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "Assigned value is not a variant of main.color", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 21, offset: 283 }..TextLocation { line: 10, column: 24, offset: 286 }) }], err_no: var__invalid_enum_variant }
-SemanticError { message: "Assigned value is not a variant of main.water", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 21, offset: 326 }..TextLocation { line: 11, column: 25, offset: 330 }) }], err_no: var__invalid_enum_variant }
-SemanticError { message: "Assigned value is not a variant of main.color", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 21, offset: 369 }..TextLocation { line: 12, column: 30, offset: 378 }) }], err_no: var__invalid_enum_variant }
-SemanticError { message: "Assigned value is not a variant of main.color", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 21, offset: 412 }..TextLocation { line: 13, column: 22, offset: 413 }) }], err_no: var__invalid_enum_variant }
+error: Assigned value is not a variant of main.color
+   ┌─ <internal>:11:22
+   │
+11 │             color := Dog;       // warning
+   │                      ^^^ Assigned value is not a variant of main.color
+
+error: Assigned value is not a variant of main.water
+   ┌─ <internal>:12:22
+   │
+12 │             water := blue;      // warning
+   │                      ^^^^ Assigned value is not a variant of main.water
+
+error: Assigned value is not a variant of main.color
+   ┌─ <internal>:13:22
+   │
+13 │             color := sparkling; // warning
+   │                      ^^^^^^^^^ Assigned value is not a variant of main.color
+
+error: Assigned value is not a variant of main.color
+   ┌─ <internal>:14:22
+   │
+14 │             color := 2;         // warning
+   │                      ^ Assigned value is not a variant of main.color
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__implicit_action_downcasts_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__implicit_action_downcasts_are_validated.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 25, column: 31, offset: 548 }..TextLocation { line: 25, column: 35, offset: 552 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'BYTE'
+   ┌─ <internal>:26:32
+   │
+26 │             fb.foo(var1, var2, var3);
+   │                                ^^^^ Invalid assignment: cannot assign 'STRING' to 'BYTE'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__implicit_invalid_action_call_assignments_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__implicit_invalid_action_call_assignments_are_validated.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 23, column: 19, offset: 516 }..TextLocation { line: 23, column: 22, offset: 519 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 23, column: 24, offset: 521 }..TextLocation { line: 23, column: 27, offset: 524 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'DINT'
+   ┌─ <internal>:24:20
+   │
+24 │             fb.foo(arr, arr); // invalid
+   │                    ^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'STRING'
+   ┌─ <internal>:24:25
+   │
+24 │             fb.foo(arr, arr); // invalid
+   │                         ^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__int_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__int_assignment_validation.snap
@@ -1,19 +1,89 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 40, column: 4, offset: 840 }..TextLocation { line: 40, column: 23, offset: 859 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 41, column: 4, offset: 876 }..TextLocation { line: 41, column: 30, offset: 902 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 42, column: 4, offset: 919 }..TextLocation { line: 42, column: 23, offset: 938 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 43, column: 4, offset: 955 }..TextLocation { line: 43, column: 21, offset: 972 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 44, column: 4, offset: 989 }..TextLocation { line: 44, column: 23, offset: 1008 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 48, column: 4, offset: 1130 }..TextLocation { line: 48, column: 28, offset: 1154 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 50, column: 4, offset: 1211 }..TextLocation { line: 50, column: 32, offset: 1239 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 63, column: 4, offset: 1602 }..TextLocation { line: 63, column: 22, offset: 1620 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 64, column: 4, offset: 1637 }..TextLocation { line: 64, column: 29, offset: 1662 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 65, column: 4, offset: 1679 }..TextLocation { line: 65, column: 22, offset: 1697 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 66, column: 4, offset: 1714 }..TextLocation { line: 66, column: 20, offset: 1730 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 67, column: 4, offset: 1747 }..TextLocation { line: 67, column: 22, offset: 1765 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 71, column: 4, offset: 1884 }..TextLocation { line: 71, column: 27, offset: 1907 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 73, column: 4, offset: 1963 }..TextLocation { line: 73, column: 31, offset: 1990 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'UDINT'
+   ┌─ <internal>:41:5
+   │
+41 │     v_udint := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'UDINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'UDINT'
+   ┌─ <internal>:42:5
+   │
+42 │     v_udint := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'UDINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'UDINT'
+   ┌─ <internal>:43:5
+   │
+43 │     v_udint := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'UDINT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'UDINT'
+   ┌─ <internal>:44:5
+   │
+44 │     v_udint := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'UDINT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'UDINT'
+   ┌─ <internal>:45:5
+   │
+45 │     v_udint := CHAR#'c'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'UDINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'UDINT'
+   ┌─ <internal>:49:5
+   │
+49 │     v_udint := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'UDINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'UDINT'
+   ┌─ <internal>:51:5
+   │
+51 │     v_udint := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'UDINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:64:5
+   │
+64 │     v_dint := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:65:5
+   │
+65 │     v_dint := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:66:5
+   │
+66 │     v_dint := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DINT'
+   ┌─ <internal>:67:5
+   │
+67 │     v_dint := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DINT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DINT'
+   ┌─ <internal>:68:5
+   │
+68 │     v_dint := CHAR#'c'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:72:5
+   │
+72 │     v_dint := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:74:5
+   │
+74 │     v_dint := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__invalid_function_block_instantiation_is_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__invalid_function_block_instantiation_is_validated.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'WSTRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 15, offset: 319 }..TextLocation { line: 14, column: 22, offset: 326 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 24, offset: 328 }..TextLocation { line: 14, column: 40, offset: 344 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'WSTRING'", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 15, offset: 382 }..TextLocation { line: 15, column: 16, offset: 383 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 18, offset: 385 }..TextLocation { line: 15, column: 24, offset: 391 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'WSTRING'
+   ┌─ <internal>:15:16
+   │
+15 │             fb(ws := s, arr_32 := arr_64); // invalid explicit
+   │                ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'WSTRING'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:15:25
+   │
+15 │             fb(ws := s, arr_32 := arr_64); // invalid explicit
+   │                         ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'WSTRING'
+   ┌─ <internal>:16:16
+   │
+16 │             fb(s, arr_64); // invalid implicit
+   │                ^ Invalid assignment: cannot assign 'STRING' to 'WSTRING'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:16:19
+   │
+16 │             fb(s, arr_64); // invalid implicit
+   │                   ^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__invalid_method_call_assignments_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__invalid_method_call_assignments_are_validated.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 19, offset: 425 }..TextLocation { line: 21, column: 22, offset: 428 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 24, offset: 430 }..TextLocation { line: 21, column: 27, offset: 433 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'DINT'
+   ┌─ <internal>:22:20
+   │
+22 │             cl.foo(arr, arr); // invalid
+   │                    ^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'STRING'
+   ┌─ <internal>:22:25
+   │
+22 │             cl.foo(arr, arr); // invalid
+   │                         ^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF WSTRING' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__pointer_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__pointer_assignment_validation.snap
@@ -1,14 +1,59 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "The type DINT 32 is too small to hold a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 27, column: 4, offset: 412 }..TextLocation { line: 27, column: 23, offset: 431 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'REF_TO INT' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 27, column: 4, offset: 412 }..TextLocation { line: 27, column: 23, offset: 431 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "The type WORD 16 is too small to hold a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 28, column: 4, offset: 448 }..TextLocation { line: 28, column: 23, offset: 467 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'REF_TO INT' to 'WORD'", range: [SourceLocation { span: Range(TextLocation { line: 28, column: 4, offset: 448 }..TextLocation { line: 28, column: 23, offset: 467 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO INT'", range: [SourceLocation { span: Range(TextLocation { line: 30, column: 4, offset: 519 }..TextLocation { line: 30, column: 24, offset: 539 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO INT'", range: [SourceLocation { span: Range(TextLocation { line: 40, column: 4, offset: 898 }..TextLocation { line: 40, column: 26, offset: 920 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 41, column: 4, offset: 937 }..TextLocation { line: 41, column: 26, offset: 959 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 43, column: 4, offset: 1041 }..TextLocation { line: 43, column: 24, offset: 1061 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 47, column: 4, offset: 1191 }..TextLocation { line: 47, column: 35, offset: 1222 }) }], err_no: var__invalid_assignment }
+error: The type DINT 32 is too small to hold a Pointer
+   ┌─ <internal>:28:5
+   │
+28 │     v_dint := v_ptr_int; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ The type DINT 32 is too small to hold a Pointer
+
+error: Invalid assignment: cannot assign 'REF_TO INT' to 'DINT'
+   ┌─ <internal>:28:5
+   │
+28 │     v_dint := v_ptr_int; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REF_TO INT' to 'DINT'
+
+error: The type WORD 16 is too small to hold a Pointer
+   ┌─ <internal>:29:5
+   │
+29 │     v_word := v_ptr_int; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ The type WORD 16 is too small to hold a Pointer
+
+error: Invalid assignment: cannot assign 'REF_TO INT' to 'WORD'
+   ┌─ <internal>:29:5
+   │
+29 │     v_word := v_ptr_int; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REF_TO INT' to 'WORD'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO INT'
+   ┌─ <internal>:31:5
+   │
+31 │     v_ptr_int := &v_real; // INVALID -> TODO: should be valid
+   │     ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO INT'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO INT'
+   ┌─ <internal>:41:5
+   │
+41 │     v_ptr_int := &v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO INT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'INT'
+   ┌─ <internal>:42:5
+   │
+42 │     v_ptr_int^ := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'INT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'INT'
+   ┌─ <internal>:44:5
+   │
+44 │     v_ptr_int^ := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'INT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'INT'
+   ┌─ <internal>:48:5
+   │
+48 │     v_ptr_int^ := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'INT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__real_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__real_assignment_validation.snap
@@ -1,12 +1,47 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 4, offset: 776 }..TextLocation { line: 38, column: 22, offset: 794 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 4, offset: 811 }..TextLocation { line: 39, column: 29, offset: 836 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 40, column: 4, offset: 853 }..TextLocation { line: 40, column: 22, offset: 871 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 41, column: 4, offset: 888 }..TextLocation { line: 41, column: 20, offset: 904 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 42, column: 4, offset: 921 }..TextLocation { line: 42, column: 22, offset: 939 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 1058 }..TextLocation { line: 46, column: 27, offset: 1081 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 48, column: 4, offset: 1137 }..TextLocation { line: 48, column: 31, offset: 1164 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+   ┌─ <internal>:39:5
+   │
+39 │     v_real := v_string; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+   ┌─ <internal>:40:5
+   │
+40 │     v_real := STRING#'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+   ┌─ <internal>:41:5
+   │
+41 │     v_real := 'string'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'REAL'
+   ┌─ <internal>:42:5
+   │
+42 │     v_real := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'REAL'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'REAL'
+   ┌─ <internal>:43:5
+   │
+43 │     v_real := CHAR#'c'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'REAL'
+
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+   ┌─ <internal>:47:5
+   │
+47 │     v_real := v_ptr_string^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+   ┌─ <internal>:49:5
+   │
+49 │     v_real := v_arr_string_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__string_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__string_assignment_validation.snap
@@ -1,24 +1,119 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'LREAL' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 30, column: 4, offset: 508 }..TextLocation { line: 30, column: 23, offset: 527 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 31, column: 4, offset: 544 }..TextLocation { line: 31, column: 24, offset: 564 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 32, column: 4, offset: 581 }..TextLocation { line: 32, column: 23, offset: 600 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 33, column: 4, offset: 617 }..TextLocation { line: 33, column: 24, offset: 637 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 34, column: 4, offset: 654 }..TextLocation { line: 34, column: 22, offset: 672 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 35, column: 4, offset: 689 }..TextLocation { line: 35, column: 23, offset: 708 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 36, column: 4, offset: 725 }..TextLocation { line: 36, column: 22, offset: 743 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 37, column: 4, offset: 760 }..TextLocation { line: 37, column: 30, offset: 786 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WORD' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 4, offset: 803 }..TextLocation { line: 38, column: 22, offset: 821 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WORD' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 4, offset: 838 }..TextLocation { line: 39, column: 28, offset: 862 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 43, column: 4, offset: 988 }..TextLocation { line: 43, column: 25, offset: 1009 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 44, column: 4, offset: 1026 }..TextLocation { line: 44, column: 33, offset: 1055 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 45, column: 4, offset: 1072 }..TextLocation { line: 45, column: 25, offset: 1093 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 1110 }..TextLocation { line: 46, column: 22, offset: 1128 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 47, column: 4, offset: 1145 }..TextLocation { line: 47, column: 24, offset: 1165 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 48, column: 4, offset: 1182 }..TextLocation { line: 48, column: 21, offset: 1199 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 49, column: 4, offset: 1216 }..TextLocation { line: 49, column: 28, offset: 1240 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 50, column: 4, offset: 1257 }..TextLocation { line: 50, column: 26, offset: 1279 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 52, column: 4, offset: 1336 }..TextLocation { line: 52, column: 30, offset: 1362 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'LREAL' to 'STRING'
+   ┌─ <internal>:31:5
+   │
+31 │     v_string := v_lreal; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'LREAL' to 'STRING'
+
+error: Invalid assignment: cannot assign 'REAL' to 'STRING'
+   ┌─ <internal>:32:5
+   │
+32 │     v_string := REAL#2.0; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REAL' to 'STRING'
+
+error: Invalid assignment: cannot assign 'UDINT' to 'STRING'
+   ┌─ <internal>:33:5
+   │
+33 │     v_string := v_udint; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'UDINT' to 'STRING'
+
+error: Invalid assignment: cannot assign 'UDINT' to 'STRING'
+   ┌─ <internal>:34:5
+   │
+34 │     v_string := UDINT#10; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'UDINT' to 'STRING'
+
+error: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:35:5
+   │
+35 │     v_string := v_dint; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:36:5
+   │
+36 │     v_string := DINT#20; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error: Invalid assignment: cannot assign 'TIME' to 'STRING'
+   ┌─ <internal>:37:5
+   │
+37 │     v_string := v_time; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'STRING'
+
+error: Invalid assignment: cannot assign 'TIME' to 'STRING'
+   ┌─ <internal>:38:5
+   │
+38 │     v_string := TIME#10h20m30s; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'STRING'
+
+error: Invalid assignment: cannot assign 'WORD' to 'STRING'
+   ┌─ <internal>:39:5
+   │
+39 │     v_string := v_word; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WORD' to 'STRING'
+
+error: Invalid assignment: cannot assign 'WORD' to 'STRING'
+   ┌─ <internal>:40:5
+   │
+40 │     v_string := WORD#16#ffff; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WORD' to 'STRING'
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+   ┌─ <internal>:44:5
+   │
+44 │     v_string := v_wstring; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+   ┌─ <internal>:45:5
+   │
+45 │     v_string := WSTRING#"wstring"; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+   ┌─ <internal>:46:5
+   │
+46 │     v_string := "wstring"; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'STRING'
+   ┌─ <internal>:47:5
+   │
+47 │     v_string := v_char; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'STRING'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'STRING'
+   ┌─ <internal>:48:5
+   │
+48 │     v_string := CHAR#'c'; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'STRING'
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+   ┌─ <internal>:49:5
+   │
+49 │     v_string := v_tod; // INVALID
+   │     ^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+   ┌─ <internal>:50:5
+   │
+50 │     v_string := TOD#15:36:30; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+
+error: Invalid assignment: cannot assign 'INT' to 'STRING'
+   ┌─ <internal>:51:5
+   │
+51 │     v_string := v_ptr_int^; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'STRING'
+
+error: Invalid assignment: cannot assign 'INT' to 'STRING'
+   ┌─ <internal>:53:5
+   │
+53 │     v_string := v_arr_int_3[0]; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__string_type_alias_assignment_can_be_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__string_type_alias_assignment_can_be_validated.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 12, offset: 241 }..TextLocation { line: 10, column: 23, offset: 252 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'MY_OTHER_STR'", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 12, offset: 266 }..TextLocation { line: 11, column: 29, offset: 283 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'INT' to 'STRING'
+   ┌─ <internal>:11:13
+   │
+11 │             my_str := i;
+   │             ^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'STRING'
+
+error: Invalid assignment: cannot assign 'INT' to 'MY_OTHER_STR'
+   ┌─ <internal>:12:13
+   │
+12 │             my_other_str := i;
+   │             ^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'MY_OTHER_STR'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__struct_assignment_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__assignment_validation_tests__struct_assignment_validation.snap
@@ -1,16 +1,71 @@
 ---
 source: src/validation/tests/assignment_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRUCT1' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 45, column: 4, offset: 754 }..TextLocation { line: 45, column: 23, offset: 773 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 4, offset: 790 }..TextLocation { line: 46, column: 23, offset: 809 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 49, column: 4, offset: 866 }..TextLocation { line: 49, column: 26, offset: 888 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 52, column: 18, offset: 974 }..TextLocation { line: 52, column: 42, offset: 998 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 55, column: 9, offset: 1073 }..TextLocation { line: 55, column: 39, offset: 1103 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 66, column: 4, offset: 1410 }..TextLocation { line: 66, column: 35, offset: 1441 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 67, column: 4, offset: 1458 }..TextLocation { line: 67, column: 37, offset: 1491 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_CHAR' to 'REF_TO STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 68, column: 4, offset: 1508 }..TextLocation { line: 68, column: 35, offset: 1539 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 70, column: 4, offset: 1557 }..TextLocation { line: 70, column: 33, offset: 1586 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 71, column: 4, offset: 1603 }..TextLocation { line: 71, column: 35, offset: 1634 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_CHAR' to 'REF_TO STRUCT1'", range: [SourceLocation { span: Range(TextLocation { line: 72, column: 4, offset: 1651 }..TextLocation { line: 72, column: 33, offset: 1680 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRUCT1' to 'REAL'
+   ┌─ <internal>:46:5
+   │
+46 │     v_real := v_struct1; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRUCT1' to 'REAL'
+
+error: Invalid assignment: cannot assign 'REAL' to 'STRUCT1'
+   ┌─ <internal>:47:5
+   │
+47 │     v_struct1 := v_real; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REAL' to 'STRUCT1'
+
+error: Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'
+   ┌─ <internal>:50:5
+   │
+50 │     v_struct1 := v_struct2; // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'
+
+error: Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'
+   ┌─ <internal>:53:19
+   │
+53 │     v_struct3 := (var_struct1 := v_struct2); // INVALID
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'
+
+error: Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'
+   ┌─ <internal>:56:10
+   │
+56 │     myFB(var_inout_struct1 := v_struct2); // INVALID
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRUCT2' to 'STRUCT1'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT1'
+   ┌─ <internal>:67:5
+   │
+67 │     v_ref_to_struct1 := REF(v_real); // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT1'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT1'
+   ┌─ <internal>:68:5
+   │
+68 │     v_ref_to_struct1 := REF(v_string); // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT1'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_CHAR' to 'REF_TO STRUCT1'
+   ┌─ <internal>:69:5
+   │
+69 │     v_ref_to_struct1 := REF(v_char); // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_CHAR' to 'REF_TO STRUCT1'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT1'
+   ┌─ <internal>:71:5
+   │
+71 │     v_ref_to_struct1 := &(v_real); // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT1'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT1'
+   ┌─ <internal>:72:5
+   │
+72 │     v_ref_to_struct1 := &(v_string); // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT1'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_CHAR' to 'REF_TO STRUCT1'
+   ┌─ <internal>:73:5
+   │
+73 │     v_ref_to_struct1 := &(v_char); // INVALID
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_CHAR' to 'REF_TO STRUCT1'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__bitaccess_only_on_bit_types.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__bitaccess_only_on_bit_types.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Bit-Wise access requires a Numerical type larger than 1 bits", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 20, offset: 222 }..TextLocation { line: 10, column: 21, offset: 223 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "Bit-Wise access requires a Numerical type larger than 1 bits", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 21, offset: 246 }..TextLocation { line: 11, column: 22, offset: 247 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "Bit-Wise access requires a Numerical type larger than 1 bits", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 20, offset: 269 }..TextLocation { line: 12, column: 21, offset: 270 }) }], err_no: type__incompatible_directaccess }
+error: Bit-Wise access requires a Numerical type larger than 1 bits
+   ┌─ <internal>:11:21
+   │
+11 │             invalid.1;
+   │                     ^ Bit-Wise access requires a Numerical type larger than 1 bits
+
+error: Bit-Wise access requires a Numerical type larger than 1 bits
+   ┌─ <internal>:12:22
+   │
+12 │             invalid2.1;
+   │                      ^ Bit-Wise access requires a Numerical type larger than 1 bits
+
+error: Bit-Wise access requires a Numerical type larger than 1 bits
+   ┌─ <internal>:13:21
+   │
+13 │             valid.1.2; (*Invalid*)
+   │                     ^ Bit-Wise access requires a Numerical type larger than 1 bits
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__bitaccess_range_test.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__bitaccess_range_test.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Bit-Wise access for type BYTE must be in the range 0..7", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 18, offset: 137 }..TextLocation { line: 5, column: 19, offset: 138 }) }], err_no: type__incompatible_directaccess_range }
-SyntaxError { message: "Bit-Wise access for type WORD must be in the range 0..15", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 18, offset: 158 }..TextLocation { line: 6, column: 20, offset: 160 }) }], err_no: type__incompatible_directaccess_range }
-SyntaxError { message: "Bit-Wise access for type DWORD must be in the range 0..31", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 18, offset: 180 }..TextLocation { line: 7, column: 20, offset: 182 }) }], err_no: type__incompatible_directaccess_range }
-SyntaxError { message: "Bit-Wise access for type LWORD must be in the range 0..63", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 18, offset: 202 }..TextLocation { line: 8, column: 20, offset: 204 }) }], err_no: type__incompatible_directaccess_range }
+error: Bit-Wise access for type BYTE must be in the range 0..7
+  ┌─ <internal>:6:19
+  │
+6 │                 a.8;
+  │                   ^ Bit-Wise access for type BYTE must be in the range 0..7
+
+error: Bit-Wise access for type WORD must be in the range 0..15
+  ┌─ <internal>:7:19
+  │
+7 │                 b.16;
+  │                   ^^ Bit-Wise access for type WORD must be in the range 0..15
+
+error: Bit-Wise access for type DWORD must be in the range 0..31
+  ┌─ <internal>:8:19
+  │
+8 │                 c.32;
+  │                   ^^ Bit-Wise access for type DWORD must be in the range 0..31
+
+error: Bit-Wise access for type LWORD must be in the range 0..63
+  ┌─ <internal>:9:19
+  │
+9 │                 d.64;
+  │                   ^^ Bit-Wise access for type LWORD must be in the range 0..63
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__byteaccess_only_on_bigger_sizes.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__byteaccess_only_on_bigger_sizes.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Byte-Wise access requires a Numerical type larger than 8 bits", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 20, offset: 194 }..TextLocation { line: 9, column: 23, offset: 197 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "Byte-Wise access requires a Numerical type larger than 8 bits", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 21, offset: 220 }..TextLocation { line: 10, column: 24, offset: 223 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "Byte-Wise access requires a Numerical type larger than 8 bits", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 21, offset: 246 }..TextLocation { line: 11, column: 24, offset: 249 }) }], err_no: type__incompatible_directaccess }
+error: Byte-Wise access requires a Numerical type larger than 8 bits
+   ┌─ <internal>:10:21
+   │
+10 │             invalid.%B1;
+   │                     ^^^ Byte-Wise access requires a Numerical type larger than 8 bits
+
+error: Byte-Wise access requires a Numerical type larger than 8 bits
+   ┌─ <internal>:11:22
+   │
+11 │             invalid2.%B1;
+   │                      ^^^ Byte-Wise access requires a Numerical type larger than 8 bits
+
+error: Byte-Wise access requires a Numerical type larger than 8 bits
+   ┌─ <internal>:12:22
+   │
+12 │             invalid3.%B1;
+   │                      ^^^ Byte-Wise access requires a Numerical type larger than 8 bits
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__byteaccess_range_test.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__byteaccess_range_test.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Byte-Wise access for type WORD must be in the range 0..1", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 18, offset: 127 }..TextLocation { line: 5, column: 21, offset: 130 }) }], err_no: type__incompatible_directaccess_range }
-SyntaxError { message: "Byte-Wise access for type DWORD must be in the range 0..3", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 18, offset: 150 }..TextLocation { line: 6, column: 21, offset: 153 }) }], err_no: type__incompatible_directaccess_range }
-SyntaxError { message: "Byte-Wise access for type LWORD must be in the range 0..7", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 18, offset: 173 }..TextLocation { line: 7, column: 21, offset: 176 }) }], err_no: type__incompatible_directaccess_range }
+error: Byte-Wise access for type WORD must be in the range 0..1
+  ┌─ <internal>:6:19
+  │
+6 │                 b.%B2;
+  │                   ^^^ Byte-Wise access for type WORD must be in the range 0..1
+
+error: Byte-Wise access for type DWORD must be in the range 0..3
+  ┌─ <internal>:7:19
+  │
+7 │                 c.%B4;
+  │                   ^^^ Byte-Wise access for type DWORD must be in the range 0..3
+
+error: Byte-Wise access for type LWORD must be in the range 0..7
+  ┌─ <internal>:8:19
+  │
+8 │                 d.%B8;
+  │                   ^^^ Byte-Wise access for type LWORD must be in the range 0..7
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__dwordaccess_only_on_bigger_sizes.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__dwordaccess_only_on_bigger_sizes.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "DWord-Wise access requires a Numerical type larger than 32 bits", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 20, offset: 196 }..TextLocation { line: 9, column: 23, offset: 199 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "DWord-Wise access requires a Numerical type larger than 32 bits", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 21, offset: 222 }..TextLocation { line: 10, column: 24, offset: 225 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "DWord-Wise access requires a Numerical type larger than 32 bits", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 21, offset: 248 }..TextLocation { line: 11, column: 24, offset: 251 }) }], err_no: type__incompatible_directaccess }
+error: DWord-Wise access requires a Numerical type larger than 32 bits
+   ┌─ <internal>:10:21
+   │
+10 │             invalid.%D1;
+   │                     ^^^ DWord-Wise access requires a Numerical type larger than 32 bits
+
+error: DWord-Wise access requires a Numerical type larger than 32 bits
+   ┌─ <internal>:11:22
+   │
+11 │             invalid2.%D1;
+   │                      ^^^ DWord-Wise access requires a Numerical type larger than 32 bits
+
+error: DWord-Wise access requires a Numerical type larger than 32 bits
+   ┌─ <internal>:12:22
+   │
+12 │             invalid3.%D1;
+   │                      ^^^ DWord-Wise access requires a Numerical type larger than 32 bits
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__dwordaccess_range_test.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__dwordaccess_range_test.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "DWord-Wise access for type LWORD must be in the range 0..1", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 18, offset: 106 }..TextLocation { line: 5, column: 21, offset: 109 }) }], err_no: type__incompatible_directaccess_range }
+error: DWord-Wise access for type LWORD must be in the range 0..1
+  ┌─ <internal>:6:19
+  │
+6 │                 d.%D2;
+  │                   ^^^ DWord-Wise access for type LWORD must be in the range 0..1
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__reference_direct_access_only_with_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__reference_direct_access_only_with_ints.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type LREAL for direct variable access. Only variables of Integer types are allowed", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 18, offset: 159 }..TextLocation { line: 6, column: 21, offset: 162 }) }], err_no: type__incompatible_directaccess_variable }
-SyntaxError { message: "Invalid type REAL for direct variable access. Only variables of Integer types are allowed", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 18, offset: 182 }..TextLocation { line: 7, column: 21, offset: 185 }) }], err_no: type__incompatible_directaccess_variable }
+error: Invalid type LREAL for direct variable access. Only variables of Integer types are allowed
+  ┌─ <internal>:7:19
+  │
+7 │                 c.%Xe;
+  │                   ^^^ Invalid type LREAL for direct variable access. Only variables of Integer types are allowed
+
+error: Invalid type REAL for direct variable access. Only variables of Integer types are allowed
+  ┌─ <internal>:8:19
+  │
+8 │                 c.%Xf;
+  │                   ^^^ Invalid type REAL for direct variable access. Only variables of Integer types are allowed
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__wordaccess_only_on_bigger_sizes.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__wordaccess_only_on_bigger_sizes.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Word-Wise access requires a Numerical type larger than 16 bits", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 20, offset: 193 }..TextLocation { line: 9, column: 23, offset: 196 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "Word-Wise access requires a Numerical type larger than 16 bits", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 21, offset: 219 }..TextLocation { line: 10, column: 24, offset: 222 }) }], err_no: type__incompatible_directaccess }
-SyntaxError { message: "Word-Wise access requires a Numerical type larger than 16 bits", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 21, offset: 245 }..TextLocation { line: 11, column: 24, offset: 248 }) }], err_no: type__incompatible_directaccess }
+error: Word-Wise access requires a Numerical type larger than 16 bits
+   ┌─ <internal>:10:21
+   │
+10 │             invalid.%W1;
+   │                     ^^^ Word-Wise access requires a Numerical type larger than 16 bits
+
+error: Word-Wise access requires a Numerical type larger than 16 bits
+   ┌─ <internal>:11:22
+   │
+11 │             invalid2.%W1;
+   │                      ^^^ Word-Wise access requires a Numerical type larger than 16 bits
+
+error: Word-Wise access requires a Numerical type larger than 16 bits
+   ┌─ <internal>:12:22
+   │
+12 │             invalid3.%W1;
+   │                      ^^^ Word-Wise access requires a Numerical type larger than 16 bits
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__wordaccess_range_test.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__bitaccess_validation_test__wordaccess_range_test.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/bitaccess_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Word-Wise access for type DWORD must be in the range 0..1", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 18, offset: 117 }..TextLocation { line: 5, column: 21, offset: 120 }) }], err_no: type__incompatible_directaccess_range }
-SyntaxError { message: "Word-Wise access for type LWORD must be in the range 0..3", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 18, offset: 140 }..TextLocation { line: 6, column: 21, offset: 143 }) }], err_no: type__incompatible_directaccess_range }
+error: Word-Wise access for type DWORD must be in the range 0..1
+  ┌─ <internal>:6:19
+  │
+6 │                 c.%W2;
+  │                   ^^^ Word-Wise access for type DWORD must be in the range 0..1
+
+error: Word-Wise access for type LWORD must be in the range 0..3
+  ┌─ <internal>:7:19
+  │
+7 │                 d.%W4;
+  │                   ^^^ Word-Wise access for type LWORD must be in the range 0..3
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__builtin_validation_tests__arithmetic_builtins_called_with_invalid_param_count.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__builtin_validation_tests__arithmetic_builtins_called_with_invalid_param_count.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/builtin_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid parameter count. Received 0 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 116 }..TextLocation { line: 6, column: 15, offset: 119 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Could not resolve generic type T with nature Num", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 116 }..TextLocation { line: 6, column: 18, offset: 122 }) }], err_no: type__unresolved_generic }
-SyntaxError { message: "Invalid parameter count. Received 1 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 135 }..TextLocation { line: 7, column: 15, offset: 138 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 4 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 156 }..TextLocation { line: 8, column: 15, offset: 159 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 4 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 12, offset: 223 }..TextLocation { line: 9, column: 15, offset: 226 }) }], err_no: call__invalid_parameter_count }
+error: Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+  ┌─ <internal>:7:13
+  │
+7 │             ADD();
+  │             ^^^ Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+
+error: Could not resolve generic type T with nature Num
+  ┌─ <internal>:7:13
+  │
+7 │             ADD();
+  │             ^^^^^^ Could not resolve generic type T with nature Num
+
+error: Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+  ┌─ <internal>:8:13
+  │
+8 │             MUL(x1);
+  │             ^^^ Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+  ┌─ <internal>:9:13
+  │
+9 │             DIV(x2, x2, x1, x2); // DIV and SUB are not extensible
+  │             ^^^ Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+   ┌─ <internal>:10:13
+   │
+10 │             SUB(x2, x2, x1, x2);
+   │             ^^^ Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__builtin_validation_tests__comparison_builtins_called_with_invalid_param_count.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__builtin_validation_tests__comparison_builtins_called_with_invalid_param_count.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/builtin_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid parameter count. Received 0 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 116 }..TextLocation { line: 6, column: 14, offset: 118 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 1 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 134 }..TextLocation { line: 7, column: 14, offset: 136 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 4 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 12, offset: 192 }..TextLocation { line: 9, column: 14, offset: 194 }) }], err_no: call__invalid_parameter_count }
+error: Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+  ┌─ <internal>:7:13
+  │
+7 │             EQ();
+  │             ^^ Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+  ┌─ <internal>:8:13
+  │
+8 │             GT(x1);
+  │             ^^ Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+   ┌─ <internal>:10:13
+   │
+10 │             NE(x2, x2, x1, x2); // NE is not extensible
+   │             ^^ Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_byref_types_dont_cause_duplication_issues.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_byref_types_dont_cause_duplication_issues.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_inout_types_dont_cause_duplication_issues.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_inout_types_dont_cause_duplication_issues.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_output_types_dont_cause_duplication_issues.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_output_types_dont_cause_duplication_issues.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_ptr_types_dont_cause_duplication_issues.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_ptr_types_dont_cause_duplication_issues.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_string_types_dont_cause_duplication_issues.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__automatically_generated_string_types_dont_cause_duplication_issues.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_action_should_be_a_problem.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_action_should_be_a_problem.snap
@@ -1,7 +1,23 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "prg.foo: Ambiguous callable symbol.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 19, offset: 167 }..TextLocation { line: 8, column: 22, offset: 170 }) }, SourceLocation { span: Range(TextLocation { line: 16, column: 19, offset: 309 }..TextLocation { line: 16, column: 22, offset: 312 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "prg.foo: Ambiguous callable symbol.", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 19, offset: 309 }..TextLocation { line: 16, column: 22, offset: 312 }) }, SourceLocation { span: Range(TextLocation { line: 8, column: 19, offset: 167 }..TextLocation { line: 8, column: 22, offset: 170 }) }], err_no: duplicate_symbol }
+error: prg.foo: Ambiguous callable symbol.
+   ┌─ <internal>:9:20
+   │
+ 9 │             ACTION foo
+   │                    ^^^ prg.foo: Ambiguous callable symbol.
+   ·
+17 │             ACTION foo
+   │                    --- see also
+
+error: prg.foo: Ambiguous callable symbol.
+   ┌─ <internal>:17:20
+   │
+ 9 │             ACTION foo
+   │                    --- see also
+   ·
+17 │             ACTION foo
+   │                    ^^^ prg.foo: Ambiguous callable symbol.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_actions_in_different_pous_are_no_issue.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_actions_in_different_pous_are_no_issue.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_enum_members_in_different_types_is_no_issue.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_enum_members_in_different_types_is_no_issue.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_enum_variables.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_enum_variables.snap
@@ -1,7 +1,21 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "enum1.red: Duplicate symbol.", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 26, offset: 27 }..TextLocation { line: 1, column: 29, offset: 30 }) }, SourceLocation { span: Range(TextLocation { line: 1, column: 46, offset: 47 }..TextLocation { line: 1, column: 49, offset: 50 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "enum1.red: Duplicate symbol.", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 46, offset: 47 }..TextLocation { line: 1, column: 49, offset: 50 }) }, SourceLocation { span: Range(TextLocation { line: 1, column: 26, offset: 27 }..TextLocation { line: 1, column: 29, offset: 30 }) }], err_no: duplicate_symbol }
+error: enum1.red: Duplicate symbol.
+  ┌─ <internal>:2:27
+  │
+2 │             TYPE enum1 : (red, green, yellow, red); END_TYPE
+  │                           ^^^                 --- see also
+  │                           │                    
+  │                           enum1.red: Duplicate symbol.
+
+error: enum1.red: Duplicate symbol.
+  ┌─ <internal>:2:47
+  │
+2 │             TYPE enum1 : (red, green, yellow, red); END_TYPE
+  │                           ---                 ^^^ enum1.red: Duplicate symbol.
+  │                           │                    
+  │                           see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_fb_inst_and_function.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_fb_inst_and_function.snap
@@ -1,7 +1,23 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "foo: Ambiguous callable symbol.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 16, offset: 142 }..TextLocation { line: 6, column: 19, offset: 145 }) }, SourceLocation { span: Range(TextLocation { line: 9, column: 21, offset: 196 }..TextLocation { line: 9, column: 24, offset: 199 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "foo: Ambiguous callable symbol.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 21, offset: 196 }..TextLocation { line: 9, column: 24, offset: 199 }) }, SourceLocation { span: Range(TextLocation { line: 6, column: 16, offset: 142 }..TextLocation { line: 6, column: 19, offset: 145 }) }], err_no: duplicate_symbol }
+error: foo: Ambiguous callable symbol.
+   ┌─ <internal>:7:17
+   │
+ 7 │                 foo: FooFB;
+   │                 ^^^ foo: Ambiguous callable symbol.
+   ·
+10 │             FUNCTION foo: INT
+   │                      --- see also
+
+error: foo: Ambiguous callable symbol.
+   ┌─ <internal>:10:22
+   │
+ 7 │                 foo: FooFB;
+   │                 --- see also
+   ·
+10 │             FUNCTION foo: INT
+   │                      ^^^ foo: Ambiguous callable symbol.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_function_and_type_is_no_issue.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_function_and_type_is_no_issue.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_global_and_program.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_global_and_program.snap
@@ -1,7 +1,23 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "prg: Ambiguous global variable.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 16, offset: 64 }..TextLocation { line: 3, column: 19, offset: 67 }) }, SourceLocation { span: Range(TextLocation { line: 7, column: 20, offset: 139 }..TextLocation { line: 7, column: 23, offset: 142 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "prg: Ambiguous global variable.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 20, offset: 139 }..TextLocation { line: 7, column: 23, offset: 142 }) }, SourceLocation { span: Range(TextLocation { line: 3, column: 16, offset: 64 }..TextLocation { line: 3, column: 19, offset: 67 }) }], err_no: duplicate_symbol }
+error: prg: Ambiguous global variable.
+  ┌─ <internal>:4:17
+  │
+4 │                 prg: INT;
+  │                 ^^^ prg: Ambiguous global variable.
+  ·
+8 │             PROGRAM prg
+  │                     --- see also
+
+error: prg: Ambiguous global variable.
+  ┌─ <internal>:8:21
+  │
+4 │                 prg: INT;
+  │                 --- see also
+  ·
+8 │             PROGRAM prg
+  │                     ^^^ prg: Ambiguous global variable.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_global_variables.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_global_variables.snap
@@ -1,7 +1,23 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "a: Ambiguous global variable.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 12, offset: 32 }..TextLocation { line: 2, column: 13, offset: 33 }) }, SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 128 }..TextLocation { line: 8, column: 13, offset: 129 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "a: Ambiguous global variable.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 128 }..TextLocation { line: 8, column: 13, offset: 129 }) }, SourceLocation { span: Range(TextLocation { line: 2, column: 12, offset: 32 }..TextLocation { line: 2, column: 13, offset: 33 }) }], err_no: duplicate_symbol }
+error: a: Ambiguous global variable.
+  ┌─ <internal>:3:13
+  │
+3 │             a: INT;
+  │             ^ a: Ambiguous global variable.
+  ·
+9 │             a: BOOL;
+  │             - see also
+
+error: a: Ambiguous global variable.
+  ┌─ <internal>:9:13
+  │
+3 │             a: INT;
+  │             - see also
+  ·
+9 │             a: BOOL;
+  │             ^ a: Ambiguous global variable.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_pous_and_types_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_pous_and_types_validation.snap
@@ -1,7 +1,21 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "foo: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 13, offset: 62 }..TextLocation { line: 2, column: 16, offset: 65 }) }, SourceLocation { span: Range(TextLocation { line: 1, column: 24, offset: 25 }..TextLocation { line: 1, column: 27, offset: 28 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "foo: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 24, offset: 25 }..TextLocation { line: 1, column: 27, offset: 28 }) }, SourceLocation { span: Range(TextLocation { line: 2, column: 13, offset: 62 }..TextLocation { line: 2, column: 16, offset: 65 }) }], err_no: duplicate_symbol }
+error: foo: Ambiguous datatype.
+  ┌─ <internal>:3:14
+  │
+2 │         FUNCTION_BLOCK  foo  END_FUNCTION_BLOCK
+  │                         --- see also
+3 │         TYPE foo : INT; END_TYPE
+  │              ^^^ foo: Ambiguous datatype.
+
+error: foo: Ambiguous datatype.
+  ┌─ <internal>:2:25
+  │
+2 │         FUNCTION_BLOCK  foo  END_FUNCTION_BLOCK
+  │                         ^^^ foo: Ambiguous datatype.
+3 │         TYPE foo : INT; END_TYPE
+  │              --- see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_pous_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_pous_validation.snap
@@ -1,10 +1,59 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "foo: Ambiguous callable symbol.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 24, offset: 74 }..TextLocation { line: 3, column: 27, offset: 77 }) }, SourceLocation { span: Range(TextLocation { line: 1, column: 24, offset: 25 }..TextLocation { line: 1, column: 27, offset: 28 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "foo: Ambiguous callable symbol.", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 24, offset: 25 }..TextLocation { line: 1, column: 27, offset: 28 }) }, SourceLocation { span: Range(TextLocation { line: 3, column: 24, offset: 74 }..TextLocation { line: 3, column: 27, offset: 77 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "foo: Duplicate symbol.", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 24, offset: 25 }..TextLocation { line: 1, column: 27, offset: 28 }) }, SourceLocation { span: Range(TextLocation { line: 3, column: 24, offset: 74 }..TextLocation { line: 3, column: 27, offset: 77 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 24, offset: 116 }..TextLocation { line: 5, column: 27, offset: 119 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "foo: Duplicate symbol.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 24, offset: 74 }..TextLocation { line: 3, column: 27, offset: 77 }) }, SourceLocation { span: Range(TextLocation { line: 1, column: 24, offset: 25 }..TextLocation { line: 1, column: 27, offset: 28 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 24, offset: 116 }..TextLocation { line: 5, column: 27, offset: 119 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "foo: Duplicate symbol.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 24, offset: 116 }..TextLocation { line: 5, column: 27, offset: 119 }) }, SourceLocation { span: Range(TextLocation { line: 1, column: 24, offset: 25 }..TextLocation { line: 1, column: 27, offset: 28 }) }, SourceLocation { span: Range(TextLocation { line: 3, column: 24, offset: 74 }..TextLocation { line: 3, column: 27, offset: 77 }) }], err_no: duplicate_symbol }
+error: foo: Ambiguous callable symbol.
+  ┌─ <internal>:4:25
+  │
+2 │         FUNCTION        foo : INT  END_FUNCTION
+  │                         --- see also
+3 │ 
+4 │         PROGRAM         foo  END_PROGRAM
+  │                         ^^^ foo: Ambiguous callable symbol.
+
+error: foo: Ambiguous callable symbol.
+  ┌─ <internal>:2:25
+  │
+2 │         FUNCTION        foo : INT  END_FUNCTION
+  │                         ^^^ foo: Ambiguous callable symbol.
+3 │ 
+4 │         PROGRAM         foo  END_PROGRAM
+  │                         --- see also
+
+error: foo: Duplicate symbol.
+  ┌─ <internal>:2:25
+  │
+2 │         FUNCTION        foo : INT  END_FUNCTION
+  │                         ^^^ foo: Duplicate symbol.
+3 │ 
+4 │         PROGRAM         foo  END_PROGRAM
+  │                         --- see also
+5 │ 
+6 │         FUNCTION_BLOCK  foo  END_FUNCTION_BLOCK
+  │                         --- see also
+
+error: foo: Duplicate symbol.
+  ┌─ <internal>:4:25
+  │
+2 │         FUNCTION        foo : INT  END_FUNCTION
+  │                         --- see also
+3 │ 
+4 │         PROGRAM         foo  END_PROGRAM
+  │                         ^^^ foo: Duplicate symbol.
+5 │ 
+6 │         FUNCTION_BLOCK  foo  END_FUNCTION_BLOCK
+  │                         --- see also
+
+error: foo: Duplicate symbol.
+  ┌─ <internal>:6:25
+  │
+2 │         FUNCTION        foo : INT  END_FUNCTION
+  │                         --- see also
+3 │ 
+4 │         PROGRAM         foo  END_PROGRAM
+  │                         --- see also
+5 │ 
+6 │         FUNCTION_BLOCK  foo  END_FUNCTION_BLOCK
+  │                         ^^^ foo: Duplicate symbol.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_variables_in_same_pou.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__duplicate_variables_in_same_pou.snap
@@ -1,7 +1,23 @@
 ---
 source: src/validation/tests/duplicates_validation_test.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "prg.b: Duplicate symbol.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 12, offset: 65 }..TextLocation { line: 4, column: 13, offset: 66 }) }, SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 133 }..TextLocation { line: 8, column: 13, offset: 134 }) }], err_no: duplicate_symbol }
-SyntaxError { message: "prg.b: Duplicate symbol.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 133 }..TextLocation { line: 8, column: 13, offset: 134 }) }, SourceLocation { span: Range(TextLocation { line: 4, column: 12, offset: 65 }..TextLocation { line: 4, column: 13, offset: 66 }) }], err_no: duplicate_symbol }
+error: prg.b: Duplicate symbol.
+  ┌─ <internal>:5:13
+  │
+5 │             b: INT;
+  │             ^ prg.b: Duplicate symbol.
+  ·
+9 │             b: BOOL;
+  │             - see also
+
+error: prg.b: Duplicate symbol.
+  ┌─ <internal>:9:13
+  │
+5 │             b: INT;
+  │             - see also
+  ·
+9 │             b: BOOL;
+  │             ^ prg.b: Duplicate symbol.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__generics_with_duplicate_symbol_dont_err.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__duplicates_validation_test__generics_with_duplicate_symbol_dont_err.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/duplicates_validation_test.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_allows_all_natures.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_allows_all_natures.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_allows_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_allows_bits.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'BOOL'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'BOOL'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'BOOL'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'BOOL'
+
+error: Invalid type nature for generic argument. CHAR is no Bit.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Bit.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'BOOL'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'BOOL'
+
+error: Invalid type nature for generic argument. WCHAR is no Bit.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Bit.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 135 }..TextLocation { line: 2, column: 56, offset: 136 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 208 }..TextLocation { line: 3, column: 57, offset: 209 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 282 }..TextLocation { line: 4, column: 58, offset: 283 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 355 }..TextLocation { line: 5, column: 57, offset: 356 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 429 }..TextLocation { line: 6, column: 58, offset: 430 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Bit.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Bit.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Bit.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Bit.
+
+error: Invalid type nature for generic argument. DATE is no Bit.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Bit.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Bit.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Bit.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Bit.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Bit.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_ints.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. USINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 139 }..TextLocation { line: 3, column: 59, offset: 140 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 213 }..TextLocation { line: 4, column: 58, offset: 214 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 288 }..TextLocation { line: 5, column: 59, offset: 289 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. ULINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 363 }..TextLocation { line: 6, column: 59, offset: 364 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. SINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 438 }..TextLocation { line: 8, column: 58, offset: 439 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. INT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 511 }..TextLocation { line: 9, column: 57, offset: 512 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 585 }..TextLocation { line: 10, column: 58, offset: 586 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 659 }..TextLocation { line: 11, column: 58, offset: 660 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. USINT is no Bit.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. USINT is no Bit.
+
+error: Invalid type nature for generic argument. UINT is no Bit.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. UINT is no Bit.
+
+error: Invalid type nature for generic argument. UDINT is no Bit.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. UDINT is no Bit.
+
+error: Invalid type nature for generic argument. ULINT is no Bit.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. ULINT is no Bit.
+
+error: Invalid type nature for generic argument. SINT is no Bit.
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. SINT is no Bit.
+
+error: Invalid type nature for generic argument. INT is no Bit.
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid type nature for generic argument. INT is no Bit.
+
+error: Invalid type nature for generic argument. DINT is no Bit.
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. DINT is no Bit.
+
+error: Invalid type nature for generic argument. LINT is no Bit.
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. LINT is no Bit.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_reals.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 136 }..TextLocation { line: 2, column: 57, offset: 137 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 211 }..TextLocation { line: 3, column: 59, offset: 212 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Bit.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Bit.
+
+error: Invalid type nature for generic argument. LREAL is no Bit.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Bit.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BOOL'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 140 }..TextLocation { line: 2, column: 61, offset: 141 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 140 }..TextLocation { line: 2, column: 61, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'BOOL'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 217 }..TextLocation { line: 3, column: 61, offset: 218 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 217 }..TextLocation { line: 3, column: 61, offset: 218 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'BOOL'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'BOOL'
+
+error: Invalid type nature for generic argument. STRING is no Bit.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Bit.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'BOOL'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'BOOL'
+
+error: Invalid type nature for generic argument. WSTRING is no Bit.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Bit.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_does_not_allow_time.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Bit.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Bit.
+
+error: Invalid type nature for generic argument. TIME is no Bit.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Bit.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_bit_multiple_parameters.snap
@@ -1,14 +1,59 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 429 }..TextLocation { line: 14, column: 21, offset: 437 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 439 }..TextLocation { line: 14, column: 35, offset: 451 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 453 }..TextLocation { line: 14, column: 47, offset: 463 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 465 }..TextLocation { line: 14, column: 57, offset: 473 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 485 }..TextLocation { line: 14, column: 76, offset: 492 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 485 }..TextLocation { line: 14, column: 76, offset: 492 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'BYTE'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 494 }..TextLocation { line: 14, column: 86, offset: 502 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 494 }..TextLocation { line: 14, column: 86, offset: 502 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Bit.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 504 }..TextLocation { line: 14, column: 96, offset: 512 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Bit.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Bit.
+
+error: Invalid type nature for generic argument. UDINT is no Bit.
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid type nature for generic argument. UDINT is no Bit.
+
+error: Invalid type nature for generic argument. DINT is no Bit.
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid type nature for generic argument. DINT is no Bit.
+
+error: Invalid type nature for generic argument. TIME is no Bit.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Bit.
+
+error: Invalid assignment: cannot assign 'STRING' to 'BYTE'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'BYTE'
+
+error: Invalid type nature for generic argument. STRING is no Bit.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Bit.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'BYTE'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'BYTE'
+
+error: Invalid type nature for generic argument. CHAR is no Bit.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Bit.
+
+error: Invalid type nature for generic argument. DATE is no Bit.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Bit.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_allows_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_allows_chars.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_bits.snap
@@ -1,15 +1,65 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'BOOL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'BYTE' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 212 }..TextLocation { line: 3, column: 58, offset: 213 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 212 }..TextLocation { line: 3, column: 58, offset: 213 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 286 }..TextLocation { line: 4, column: 58, offset: 287 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 286 }..TextLocation { line: 4, column: 58, offset: 287 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DWORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 361 }..TextLocation { line: 5, column: 59, offset: 362 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 361 }..TextLocation { line: 5, column: 59, offset: 362 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LWORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 436 }..TextLocation { line: 6, column: 59, offset: 437 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 436 }..TextLocation { line: 6, column: 59, offset: 437 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'BOOL' to 'CHAR'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'BOOL' to 'CHAR'
+
+error: Invalid type nature for generic argument. BOOL is no Char.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Char.
+
+error: Invalid assignment: cannot assign 'BYTE' to 'CHAR'
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'BYTE' to 'CHAR'
+
+error: Invalid type nature for generic argument. BYTE is no Char.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Char.
+
+error: Invalid assignment: cannot assign 'WORD' to 'CHAR'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'WORD' to 'CHAR'
+
+error: Invalid type nature for generic argument. WORD is no Char.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Char.
+
+error: Invalid assignment: cannot assign 'DWORD' to 'CHAR'
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'DWORD' to 'CHAR'
+
+error: Invalid type nature for generic argument. DWORD is no Char.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Char.
+
+error: Invalid assignment: cannot assign 'LWORD' to 'CHAR'
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'LWORD' to 'CHAR'
+
+error: Invalid type nature for generic argument. LWORD is no Char.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Char.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_date.snap
@@ -1,15 +1,65 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 136 }..TextLocation { line: 2, column: 56, offset: 137 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 136 }..TextLocation { line: 2, column: 56, offset: 137 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 209 }..TextLocation { line: 3, column: 57, offset: 210 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 209 }..TextLocation { line: 3, column: 57, offset: 210 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 283 }..TextLocation { line: 4, column: 58, offset: 284 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 283 }..TextLocation { line: 4, column: 58, offset: 284 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 356 }..TextLocation { line: 5, column: 57, offset: 357 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 356 }..TextLocation { line: 5, column: 57, offset: 357 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 430 }..TextLocation { line: 6, column: 58, offset: 431 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 430 }..TextLocation { line: 6, column: 58, offset: 431 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Char.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Char.
+
+error: Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Char.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Char.
+
+error: Invalid assignment: cannot assign 'DATE' to 'CHAR'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'DATE' to 'CHAR'
+
+error: Invalid type nature for generic argument. DATE is no Char.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Char.
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Char.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Char.
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Char.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Char.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_ints.snap
@@ -1,21 +1,101 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'USINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 140 }..TextLocation { line: 3, column: 59, offset: 141 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. USINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 140 }..TextLocation { line: 3, column: 59, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 214 }..TextLocation { line: 4, column: 58, offset: 215 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 214 }..TextLocation { line: 4, column: 58, offset: 215 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 289 }..TextLocation { line: 5, column: 59, offset: 290 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 289 }..TextLocation { line: 5, column: 59, offset: 290 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'ULINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 364 }..TextLocation { line: 6, column: 59, offset: 365 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. ULINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 364 }..TextLocation { line: 6, column: 59, offset: 365 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'SINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 439 }..TextLocation { line: 8, column: 58, offset: 440 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. SINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 439 }..TextLocation { line: 8, column: 58, offset: 440 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 512 }..TextLocation { line: 9, column: 57, offset: 513 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. INT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 512 }..TextLocation { line: 9, column: 57, offset: 513 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 586 }..TextLocation { line: 10, column: 58, offset: 587 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 586 }..TextLocation { line: 10, column: 58, offset: 587 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 660 }..TextLocation { line: 11, column: 58, offset: 661 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 660 }..TextLocation { line: 11, column: 58, offset: 661 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'USINT' to 'CHAR'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'USINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. USINT is no Char.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. USINT is no Char.
+
+error: Invalid assignment: cannot assign 'UINT' to 'CHAR'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'UINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. UINT is no Char.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. UINT is no Char.
+
+error: Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. UDINT is no Char.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. UDINT is no Char.
+
+error: Invalid assignment: cannot assign 'ULINT' to 'CHAR'
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'ULINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. ULINT is no Char.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. ULINT is no Char.
+
+error: Invalid assignment: cannot assign 'SINT' to 'CHAR'
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'SINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. SINT is no Char.
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. SINT is no Char.
+
+error: Invalid assignment: cannot assign 'INT' to 'CHAR'
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid assignment: cannot assign 'INT' to 'CHAR'
+
+error: Invalid type nature for generic argument. INT is no Char.
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid type nature for generic argument. INT is no Char.
+
+error: Invalid assignment: cannot assign 'DINT' to 'CHAR'
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid assignment: cannot assign 'DINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. DINT is no Char.
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. DINT is no Char.
+
+error: Invalid assignment: cannot assign 'LINT' to 'CHAR'
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid assignment: cannot assign 'LINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. LINT is no Char.
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. LINT is no Char.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_reals.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 137 }..TextLocation { line: 2, column: 57, offset: 138 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 137 }..TextLocation { line: 2, column: 57, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LREAL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'REAL' to 'CHAR'
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'REAL' to 'CHAR'
+
+error: Invalid type nature for generic argument. REAL is no Char.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Char.
+
+error: Invalid assignment: cannot assign 'LREAL' to 'CHAR'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'LREAL' to 'CHAR'
+
+error: Invalid type nature for generic argument. LREAL is no Char.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Char.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 141 }..TextLocation { line: 2, column: 61, offset: 142 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 141 }..TextLocation { line: 2, column: 61, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 218 }..TextLocation { line: 3, column: 61, offset: 219 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 218 }..TextLocation { line: 3, column: 61, offset: 219 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Invalid type nature for generic argument. STRING is no Char.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Char.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'CHAR'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'CHAR'
+
+error: Invalid type nature for generic argument. WSTRING is no Char.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Char.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_does_not_allow_time.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'TIME' to 'CHAR'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME is no Char.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Char.
+
+error: Invalid assignment: cannot assign 'TIME' to 'CHAR'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME is no Char.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Char.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_char_multiple_parameters.snap
@@ -1,19 +1,89 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 430 }..TextLocation { line: 14, column: 21, offset: 438 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 430 }..TextLocation { line: 14, column: 21, offset: 438 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 440 }..TextLocation { line: 14, column: 35, offset: 452 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 440 }..TextLocation { line: 14, column: 35, offset: 452 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 454 }..TextLocation { line: 14, column: 47, offset: 464 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 454 }..TextLocation { line: 14, column: 47, offset: 464 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 466 }..TextLocation { line: 14, column: 57, offset: 474 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 466 }..TextLocation { line: 14, column: 57, offset: 474 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'BYTE' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 476 }..TextLocation { line: 14, column: 67, offset: 484 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 476 }..TextLocation { line: 14, column: 67, offset: 484 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 486 }..TextLocation { line: 14, column: 76, offset: 493 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 486 }..TextLocation { line: 14, column: 76, offset: 493 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 505 }..TextLocation { line: 14, column: 96, offset: 513 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Char.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 505 }..TextLocation { line: 14, column: 96, offset: 513 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'REAL' to 'CHAR'
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid assignment: cannot assign 'REAL' to 'CHAR'
+
+error: Invalid type nature for generic argument. REAL is no Char.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Char.
+
+error: Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. UDINT is no Char.
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid type nature for generic argument. UDINT is no Char.
+
+error: Invalid assignment: cannot assign 'DINT' to 'CHAR'
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. DINT is no Char.
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid type nature for generic argument. DINT is no Char.
+
+error: Invalid assignment: cannot assign 'TIME' to 'CHAR'
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME is no Char.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Char.
+
+error: Invalid assignment: cannot assign 'BYTE' to 'CHAR'
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid assignment: cannot assign 'BYTE' to 'CHAR'
+
+error: Invalid type nature for generic argument. BYTE is no Char.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Char.
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Invalid type nature for generic argument. STRING is no Char.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Char.
+
+error: Invalid assignment: cannot assign 'DATE' to 'CHAR'
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid assignment: cannot assign 'DATE' to 'CHAR'
+
+error: Invalid type nature for generic argument. DATE is no Char.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Char.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_allows_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_allows_chars.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_allows_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_allows_string.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_bits.snap
@@ -1,15 +1,65 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'BOOL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 139 }..TextLocation { line: 2, column: 58, offset: 140 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 139 }..TextLocation { line: 2, column: 58, offset: 140 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'BYTE' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 213 }..TextLocation { line: 3, column: 58, offset: 214 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 213 }..TextLocation { line: 3, column: 58, offset: 214 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 287 }..TextLocation { line: 4, column: 58, offset: 288 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 287 }..TextLocation { line: 4, column: 58, offset: 288 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DWORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 362 }..TextLocation { line: 5, column: 59, offset: 363 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 362 }..TextLocation { line: 5, column: 59, offset: 363 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LWORD' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 437 }..TextLocation { line: 6, column: 59, offset: 438 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 437 }..TextLocation { line: 6, column: 59, offset: 438 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'BOOL' to 'CHAR'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'BOOL' to 'CHAR'
+
+error: Invalid type nature for generic argument. BOOL is no Chars.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Chars.
+
+error: Invalid assignment: cannot assign 'BYTE' to 'CHAR'
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'BYTE' to 'CHAR'
+
+error: Invalid type nature for generic argument. BYTE is no Chars.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Chars.
+
+error: Invalid assignment: cannot assign 'WORD' to 'CHAR'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'WORD' to 'CHAR'
+
+error: Invalid type nature for generic argument. WORD is no Chars.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Chars.
+
+error: Invalid assignment: cannot assign 'DWORD' to 'CHAR'
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'DWORD' to 'CHAR'
+
+error: Invalid type nature for generic argument. DWORD is no Chars.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Chars.
+
+error: Invalid assignment: cannot assign 'LWORD' to 'CHAR'
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'LWORD' to 'CHAR'
+
+error: Invalid type nature for generic argument. LWORD is no Chars.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Chars.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_date.snap
@@ -1,15 +1,65 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 137 }..TextLocation { line: 2, column: 56, offset: 138 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 137 }..TextLocation { line: 2, column: 56, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 210 }..TextLocation { line: 3, column: 57, offset: 211 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 210 }..TextLocation { line: 3, column: 57, offset: 211 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 284 }..TextLocation { line: 4, column: 58, offset: 285 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 284 }..TextLocation { line: 4, column: 58, offset: 285 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 357 }..TextLocation { line: 5, column: 57, offset: 358 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 357 }..TextLocation { line: 5, column: 57, offset: 358 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 431 }..TextLocation { line: 6, column: 58, offset: 432 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 431 }..TextLocation { line: 6, column: 58, offset: 432 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Chars.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Chars.
+
+error: Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'DATE_AND_TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Chars.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Chars.
+
+error: Invalid assignment: cannot assign 'DATE' to 'CHAR'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'DATE' to 'CHAR'
+
+error: Invalid type nature for generic argument. DATE is no Chars.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Chars.
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Chars.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Chars.
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Chars.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Chars.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_ints.snap
@@ -1,21 +1,101 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'USINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 141 }..TextLocation { line: 3, column: 59, offset: 142 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. USINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 141 }..TextLocation { line: 3, column: 59, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 215 }..TextLocation { line: 4, column: 58, offset: 216 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 215 }..TextLocation { line: 4, column: 58, offset: 216 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 290 }..TextLocation { line: 5, column: 59, offset: 291 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 290 }..TextLocation { line: 5, column: 59, offset: 291 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'ULINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 365 }..TextLocation { line: 6, column: 59, offset: 366 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. ULINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 365 }..TextLocation { line: 6, column: 59, offset: 366 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'SINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 440 }..TextLocation { line: 8, column: 58, offset: 441 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. SINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 440 }..TextLocation { line: 8, column: 58, offset: 441 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 513 }..TextLocation { line: 9, column: 57, offset: 514 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. INT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 513 }..TextLocation { line: 9, column: 57, offset: 514 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 587 }..TextLocation { line: 10, column: 58, offset: 588 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 587 }..TextLocation { line: 10, column: 58, offset: 588 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 661 }..TextLocation { line: 11, column: 58, offset: 662 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 661 }..TextLocation { line: 11, column: 58, offset: 662 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'USINT' to 'CHAR'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'USINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. USINT is no Chars.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. USINT is no Chars.
+
+error: Invalid assignment: cannot assign 'UINT' to 'CHAR'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'UINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. UINT is no Chars.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. UINT is no Chars.
+
+error: Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'UDINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. UDINT is no Chars.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. UDINT is no Chars.
+
+error: Invalid assignment: cannot assign 'ULINT' to 'CHAR'
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'ULINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. ULINT is no Chars.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. ULINT is no Chars.
+
+error: Invalid assignment: cannot assign 'SINT' to 'CHAR'
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'SINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. SINT is no Chars.
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. SINT is no Chars.
+
+error: Invalid assignment: cannot assign 'INT' to 'CHAR'
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid assignment: cannot assign 'INT' to 'CHAR'
+
+error: Invalid type nature for generic argument. INT is no Chars.
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid type nature for generic argument. INT is no Chars.
+
+error: Invalid assignment: cannot assign 'DINT' to 'CHAR'
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid assignment: cannot assign 'DINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. DINT is no Chars.
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. DINT is no Chars.
+
+error: Invalid assignment: cannot assign 'LINT' to 'CHAR'
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid assignment: cannot assign 'LINT' to 'CHAR'
+
+error: Invalid type nature for generic argument. LINT is no Chars.
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. LINT is no Chars.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_reals.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 138 }..TextLocation { line: 2, column: 57, offset: 139 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 138 }..TextLocation { line: 2, column: 57, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LREAL' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'REAL' to 'CHAR'
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'REAL' to 'CHAR'
+
+error: Invalid type nature for generic argument. REAL is no Chars.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Chars.
+
+error: Invalid assignment: cannot assign 'LREAL' to 'CHAR'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'LREAL' to 'CHAR'
+
+error: Invalid type nature for generic argument. LREAL is no Chars.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Chars.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_does_not_allow_time.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 139 }..TextLocation { line: 2, column: 58, offset: 140 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 139 }..TextLocation { line: 2, column: 58, offset: 140 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 214 }..TextLocation { line: 3, column: 59, offset: 215 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 214 }..TextLocation { line: 3, column: 59, offset: 215 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'TIME' to 'CHAR'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME is no Chars.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Chars.
+
+error: Invalid assignment: cannot assign 'TIME' to 'CHAR'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'TIME' to 'CHAR'
+
+error: Invalid type nature for generic argument. TIME is no Chars.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Chars.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_chars_multiple_parameters.snap
@@ -1,18 +1,83 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 431 }..TextLocation { line: 14, column: 21, offset: 439 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 431 }..TextLocation { line: 14, column: 21, offset: 439 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 441 }..TextLocation { line: 14, column: 35, offset: 453 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 441 }..TextLocation { line: 14, column: 35, offset: 453 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 455 }..TextLocation { line: 14, column: 47, offset: 465 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 455 }..TextLocation { line: 14, column: 47, offset: 465 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 467 }..TextLocation { line: 14, column: 57, offset: 475 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 467 }..TextLocation { line: 14, column: 57, offset: 475 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'BYTE' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 477 }..TextLocation { line: 14, column: 67, offset: 485 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 477 }..TextLocation { line: 14, column: 67, offset: 485 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 496 }..TextLocation { line: 14, column: 86, offset: 504 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 506 }..TextLocation { line: 14, column: 96, offset: 514 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Chars.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 506 }..TextLocation { line: 14, column: 96, offset: 514 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'REAL' to 'STRING'
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid assignment: cannot assign 'REAL' to 'STRING'
+
+error: Invalid type nature for generic argument. REAL is no Chars.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Chars.
+
+error: Invalid assignment: cannot assign 'UDINT' to 'STRING'
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid assignment: cannot assign 'UDINT' to 'STRING'
+
+error: Invalid type nature for generic argument. UDINT is no Chars.
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid type nature for generic argument. UDINT is no Chars.
+
+error: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error: Invalid type nature for generic argument. DINT is no Chars.
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid type nature for generic argument. DINT is no Chars.
+
+error: Invalid assignment: cannot assign 'TIME' to 'STRING'
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'STRING'
+
+error: Invalid type nature for generic argument. TIME is no Chars.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Chars.
+
+error: Invalid assignment: cannot assign 'BYTE' to 'STRING'
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid assignment: cannot assign 'BYTE' to 'STRING'
+
+error: Invalid type nature for generic argument. BYTE is no Chars.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Chars.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'STRING'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'STRING'
+
+error: Invalid assignment: cannot assign 'DATE' to 'STRING'
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid assignment: cannot assign 'DATE' to 'STRING'
+
+error: Invalid type nature for generic argument. DATE is no Chars.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Chars.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_allows_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_allows_date.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 212 }..TextLocation { line: 3, column: 58, offset: 213 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 286 }..TextLocation { line: 4, column: 58, offset: 287 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 361 }..TextLocation { line: 5, column: 59, offset: 362 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 436 }..TextLocation { line: 6, column: 59, offset: 437 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Date.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Date.
+
+error: Invalid type nature for generic argument. BYTE is no Date.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Date.
+
+error: Invalid type nature for generic argument. WORD is no Date.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Date.
+
+error: Invalid type nature for generic argument. DWORD is no Date.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Date.
+
+error: Invalid type nature for generic argument. LWORD is no Date.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Date.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'DATE'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'DATE'
+
+error: Invalid type nature for generic argument. CHAR is no Date.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Date.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'DATE'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'DATE'
+
+error: Invalid type nature for generic argument. WCHAR is no Date.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Date.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_ints.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. USINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 140 }..TextLocation { line: 3, column: 59, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 214 }..TextLocation { line: 4, column: 58, offset: 215 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 289 }..TextLocation { line: 5, column: 59, offset: 290 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. ULINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 364 }..TextLocation { line: 6, column: 59, offset: 365 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. SINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 439 }..TextLocation { line: 8, column: 58, offset: 440 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. INT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 512 }..TextLocation { line: 9, column: 57, offset: 513 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 586 }..TextLocation { line: 10, column: 58, offset: 587 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 660 }..TextLocation { line: 11, column: 58, offset: 661 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. USINT is no Date.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. USINT is no Date.
+
+error: Invalid type nature for generic argument. UINT is no Date.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. UINT is no Date.
+
+error: Invalid type nature for generic argument. UDINT is no Date.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. UDINT is no Date.
+
+error: Invalid type nature for generic argument. ULINT is no Date.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. ULINT is no Date.
+
+error: Invalid type nature for generic argument. SINT is no Date.
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. SINT is no Date.
+
+error: Invalid type nature for generic argument. INT is no Date.
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid type nature for generic argument. INT is no Date.
+
+error: Invalid type nature for generic argument. DINT is no Date.
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. DINT is no Date.
+
+error: Invalid type nature for generic argument. LINT is no Date.
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. LINT is no Date.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_reals.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 137 }..TextLocation { line: 2, column: 57, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Date.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Date.
+
+error: Invalid type nature for generic argument. LREAL is no Date.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Date.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 141 }..TextLocation { line: 2, column: 61, offset: 142 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 141 }..TextLocation { line: 2, column: 61, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 218 }..TextLocation { line: 3, column: 61, offset: 219 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 218 }..TextLocation { line: 3, column: 61, offset: 219 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
+error: Invalid type nature for generic argument. STRING is no Date.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Date.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'DATE'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'DATE'
+
+error: Invalid type nature for generic argument. WSTRING is no Date.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Date.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_does_not_allow_time.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Date.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Date.
+
+error: Invalid type nature for generic argument. TIME is no Date.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Date.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_date_multiple_parameters.snap
@@ -1,14 +1,59 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 430 }..TextLocation { line: 14, column: 21, offset: 438 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 440 }..TextLocation { line: 14, column: 35, offset: 452 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 454 }..TextLocation { line: 14, column: 47, offset: 464 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 466 }..TextLocation { line: 14, column: 57, offset: 474 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 476 }..TextLocation { line: 14, column: 67, offset: 484 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 486 }..TextLocation { line: 14, column: 76, offset: 493 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 486 }..TextLocation { line: 14, column: 76, offset: 493 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 495 }..TextLocation { line: 14, column: 86, offset: 503 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Date.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 495 }..TextLocation { line: 14, column: 86, offset: 503 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Date.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Date.
+
+error: Invalid type nature for generic argument. UDINT is no Date.
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid type nature for generic argument. UDINT is no Date.
+
+error: Invalid type nature for generic argument. DINT is no Date.
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid type nature for generic argument. DINT is no Date.
+
+error: Invalid type nature for generic argument. TIME is no Date.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Date.
+
+error: Invalid type nature for generic argument. BYTE is no Date.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Date.
+
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
+error: Invalid type nature for generic argument. STRING is no Date.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Date.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DATE'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DATE'
+
+error: Invalid type nature for generic argument. CHAR is no Date.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Date.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_allows_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_allows_time.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 216 }..TextLocation { line: 3, column: 58, offset: 217 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 290 }..TextLocation { line: 4, column: 58, offset: 291 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 365 }..TextLocation { line: 5, column: 59, offset: 366 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 440 }..TextLocation { line: 6, column: 59, offset: 441 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Duration.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Duration.
+
+error: Invalid type nature for generic argument. BYTE is no Duration.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Duration.
+
+error: Invalid type nature for generic argument. WORD is no Duration.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Duration.
+
+error: Invalid type nature for generic argument. DWORD is no Duration.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Duration.
+
+error: Invalid type nature for generic argument. LWORD is no Duration.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Duration.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 217 }..TextLocation { line: 3, column: 59, offset: 218 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 217 }..TextLocation { line: 3, column: 59, offset: 218 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'TIME'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'TIME'
+
+error: Invalid type nature for generic argument. CHAR is no Duration.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Duration.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'TIME'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'TIME'
+
+error: Invalid type nature for generic argument. WCHAR is no Duration.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Duration.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 140 }..TextLocation { line: 2, column: 56, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 213 }..TextLocation { line: 3, column: 57, offset: 214 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 287 }..TextLocation { line: 4, column: 58, offset: 288 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 360 }..TextLocation { line: 5, column: 57, offset: 361 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 434 }..TextLocation { line: 6, column: 58, offset: 435 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Duration.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Duration.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Duration.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Duration.
+
+error: Invalid type nature for generic argument. DATE is no Duration.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Duration.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Duration.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Duration.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Duration.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Duration.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_ints.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. USINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 144 }..TextLocation { line: 3, column: 59, offset: 145 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 218 }..TextLocation { line: 4, column: 58, offset: 219 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 293 }..TextLocation { line: 5, column: 59, offset: 294 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. ULINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 368 }..TextLocation { line: 6, column: 59, offset: 369 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. SINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 443 }..TextLocation { line: 8, column: 58, offset: 444 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. INT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 516 }..TextLocation { line: 9, column: 57, offset: 517 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 590 }..TextLocation { line: 10, column: 58, offset: 591 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 664 }..TextLocation { line: 11, column: 58, offset: 665 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. USINT is no Duration.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. USINT is no Duration.
+
+error: Invalid type nature for generic argument. UINT is no Duration.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. UINT is no Duration.
+
+error: Invalid type nature for generic argument. UDINT is no Duration.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. UDINT is no Duration.
+
+error: Invalid type nature for generic argument. ULINT is no Duration.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. ULINT is no Duration.
+
+error: Invalid type nature for generic argument. SINT is no Duration.
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. SINT is no Duration.
+
+error: Invalid type nature for generic argument. INT is no Duration.
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid type nature for generic argument. INT is no Duration.
+
+error: Invalid type nature for generic argument. DINT is no Duration.
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. DINT is no Duration.
+
+error: Invalid type nature for generic argument. LINT is no Duration.
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. LINT is no Duration.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_reals.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 141 }..TextLocation { line: 2, column: 57, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 216 }..TextLocation { line: 3, column: 59, offset: 217 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Duration.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Duration.
+
+error: Invalid type nature for generic argument. LREAL is no Duration.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Duration.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 145 }..TextLocation { line: 2, column: 61, offset: 146 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 145 }..TextLocation { line: 2, column: 61, offset: 146 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 222 }..TextLocation { line: 3, column: 61, offset: 223 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 222 }..TextLocation { line: 3, column: 61, offset: 223 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
+error: Invalid type nature for generic argument. STRING is no Duration.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Duration.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'TIME'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'TIME'
+
+error: Invalid type nature for generic argument. WSTRING is no Duration.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Duration.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_duration_multiple_parameters.snap
@@ -1,14 +1,59 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 434 }..TextLocation { line: 14, column: 21, offset: 442 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 444 }..TextLocation { line: 14, column: 35, offset: 456 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 458 }..TextLocation { line: 14, column: 47, offset: 468 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 480 }..TextLocation { line: 14, column: 67, offset: 488 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 490 }..TextLocation { line: 14, column: 76, offset: 497 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 490 }..TextLocation { line: 14, column: 76, offset: 497 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 499 }..TextLocation { line: 14, column: 86, offset: 507 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 499 }..TextLocation { line: 14, column: 86, offset: 507 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Duration.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 509 }..TextLocation { line: 14, column: 96, offset: 517 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Duration.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Duration.
+
+error: Invalid type nature for generic argument. UDINT is no Duration.
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid type nature for generic argument. UDINT is no Duration.
+
+error: Invalid type nature for generic argument. DINT is no Duration.
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid type nature for generic argument. DINT is no Duration.
+
+error: Invalid type nature for generic argument. BYTE is no Duration.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Duration.
+
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
+error: Invalid type nature for generic argument. STRING is no Duration.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Duration.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'TIME'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'TIME'
+
+error: Invalid type nature for generic argument. CHAR is no Duration.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Duration.
+
+error: Invalid type nature for generic argument. DATE is no Duration.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Duration.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_allows_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_allows_ints.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 211 }..TextLocation { line: 3, column: 58, offset: 212 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 285 }..TextLocation { line: 4, column: 58, offset: 286 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 360 }..TextLocation { line: 5, column: 59, offset: 361 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 435 }..TextLocation { line: 6, column: 59, offset: 436 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Int.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Int.
+
+error: Invalid type nature for generic argument. BYTE is no Int.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Int.
+
+error: Invalid type nature for generic argument. WORD is no Int.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Int.
+
+error: Invalid type nature for generic argument. DWORD is no Int.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Int.
+
+error: Invalid type nature for generic argument. LWORD is no Int.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Int.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'USINT'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. CHAR is no Int.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Int.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. WCHAR is no Int.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Int.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 135 }..TextLocation { line: 2, column: 56, offset: 136 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 208 }..TextLocation { line: 3, column: 57, offset: 209 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 282 }..TextLocation { line: 4, column: 58, offset: 283 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 355 }..TextLocation { line: 5, column: 57, offset: 356 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 429 }..TextLocation { line: 6, column: 58, offset: 430 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Int.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Int.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Int.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Int.
+
+error: Invalid type nature for generic argument. DATE is no Int.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Int.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Int.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Int.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Int.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Int.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_reals.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 136 }..TextLocation { line: 2, column: 57, offset: 137 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 211 }..TextLocation { line: 3, column: 59, offset: 212 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Int.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Int.
+
+error: Invalid type nature for generic argument. LREAL is no Int.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Int.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 140 }..TextLocation { line: 2, column: 61, offset: 141 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 140 }..TextLocation { line: 2, column: 61, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 217 }..TextLocation { line: 3, column: 61, offset: 218 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 217 }..TextLocation { line: 3, column: 61, offset: 218 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'USINT'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'USINT'
+
+error: Invalid type nature for generic argument. STRING is no Int.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Int.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+
+error: Invalid type nature for generic argument. WSTRING is no Int.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Int.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_does_not_allow_time.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Int.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Int.
+
+error: Invalid type nature for generic argument. TIME is no Int.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Int.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_int_multiple_parameters.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 429 }..TextLocation { line: 14, column: 21, offset: 437 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 465 }..TextLocation { line: 14, column: 57, offset: 473 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 475 }..TextLocation { line: 14, column: 67, offset: 483 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 485 }..TextLocation { line: 14, column: 76, offset: 492 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 485 }..TextLocation { line: 14, column: 76, offset: 492 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 494 }..TextLocation { line: 14, column: 86, offset: 502 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 494 }..TextLocation { line: 14, column: 86, offset: 502 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 504 }..TextLocation { line: 14, column: 96, offset: 512 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Int.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Int.
+
+error: Invalid type nature for generic argument. TIME is no Int.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Int.
+
+error: Invalid type nature for generic argument. BYTE is no Int.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Int.
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: Invalid type nature for generic argument. STRING is no Int.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Int.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DINT'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DINT'
+
+error: Invalid type nature for generic argument. CHAR is no Int.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Int.
+
+error: Invalid type nature for generic argument. DATE is no Int.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Int.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_allows_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_allows_ints.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_allows_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_allows_reals.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_allows_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_allows_time.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 143 }..TextLocation { line: 2, column: 58, offset: 144 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 217 }..TextLocation { line: 3, column: 58, offset: 218 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 291 }..TextLocation { line: 4, column: 58, offset: 292 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 366 }..TextLocation { line: 5, column: 59, offset: 367 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 441 }..TextLocation { line: 6, column: 59, offset: 442 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Magnitude.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Magnitude.
+
+error: Invalid type nature for generic argument. BYTE is no Magnitude.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Magnitude.
+
+error: Invalid type nature for generic argument. WORD is no Magnitude.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Magnitude.
+
+error: Invalid type nature for generic argument. DWORD is no Magnitude.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Magnitude.
+
+error: Invalid type nature for generic argument. LWORD is no Magnitude.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Magnitude.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 143 }..TextLocation { line: 2, column: 58, offset: 144 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 143 }..TextLocation { line: 2, column: 58, offset: 144 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 218 }..TextLocation { line: 3, column: 59, offset: 219 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 218 }..TextLocation { line: 3, column: 59, offset: 219 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'USINT'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. CHAR is no Magnitude.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Magnitude.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. WCHAR is no Magnitude.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Magnitude.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 141 }..TextLocation { line: 2, column: 56, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 214 }..TextLocation { line: 3, column: 57, offset: 215 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 288 }..TextLocation { line: 4, column: 58, offset: 289 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 361 }..TextLocation { line: 5, column: 57, offset: 362 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 435 }..TextLocation { line: 6, column: 58, offset: 436 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Magnitude.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Magnitude.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Magnitude.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Magnitude.
+
+error: Invalid type nature for generic argument. DATE is no Magnitude.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Magnitude.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Magnitude.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Magnitude.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Magnitude.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Magnitude.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_strings.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_does_not_allow_strings.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 59, offset: 145 }..TextLocation { line: 2, column: 60, offset: 146 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 59, offset: 145 }..TextLocation { line: 2, column: 60, offset: 146 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 222 }..TextLocation { line: 3, column: 61, offset: 223 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 222 }..TextLocation { line: 3, column: 61, offset: 223 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'USINT'
+  ┌─ <internal>:3:60
+  │
+3 │         FUNCTION func1  : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                            ^ Invalid assignment: cannot assign 'STRING' to 'USINT'
+
+error: Invalid type nature for generic argument. STRING is no Magnitude.
+  ┌─ <internal>:3:60
+  │
+3 │         FUNCTION func1  : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                            ^ Invalid type nature for generic argument. STRING is no Magnitude.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+
+error: Invalid type nature for generic argument. WSTRING is no Magnitude.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Magnitude.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_magnitude_multiple_parameters.snap
@@ -1,11 +1,41 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 481 }..TextLocation { line: 14, column: 67, offset: 489 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 491 }..TextLocation { line: 14, column: 76, offset: 498 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 491 }..TextLocation { line: 14, column: 76, offset: 498 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'TIME'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 500 }..TextLocation { line: 14, column: 86, offset: 508 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 500 }..TextLocation { line: 14, column: 86, offset: 508 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Magnitude.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 510 }..TextLocation { line: 14, column: 96, offset: 518 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BYTE is no Magnitude.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Magnitude.
+
+error: Invalid assignment: cannot assign 'STRING' to 'TIME'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'TIME'
+
+error: Invalid type nature for generic argument. STRING is no Magnitude.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Magnitude.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'TIME'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'TIME'
+
+error: Invalid type nature for generic argument. CHAR is no Magnitude.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Magnitude.
+
+error: Invalid type nature for generic argument. DATE is no Magnitude.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Magnitude.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_multiple_parameters.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 481 }..TextLocation { line: 14, column: 76, offset: 488 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DATE'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 490 }..TextLocation { line: 14, column: 86, offset: 498 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'STRING' to 'DATE'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DATE'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DATE'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DATE'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_allows_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_allows_ints.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_allows_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_allows_reals.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 211 }..TextLocation { line: 3, column: 58, offset: 212 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 285 }..TextLocation { line: 4, column: 58, offset: 286 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 360 }..TextLocation { line: 5, column: 59, offset: 361 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 435 }..TextLocation { line: 6, column: 59, offset: 436 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Num.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Num.
+
+error: Invalid type nature for generic argument. BYTE is no Num.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Num.
+
+error: Invalid type nature for generic argument. WORD is no Num.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Num.
+
+error: Invalid type nature for generic argument. DWORD is no Num.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Num.
+
+error: Invalid type nature for generic argument. LWORD is no Num.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Num.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'USINT'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. CHAR is no Num.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Num.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. WCHAR is no Num.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Num.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 135 }..TextLocation { line: 2, column: 56, offset: 136 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 208 }..TextLocation { line: 3, column: 57, offset: 209 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 282 }..TextLocation { line: 4, column: 58, offset: 283 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 355 }..TextLocation { line: 5, column: 57, offset: 356 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 429 }..TextLocation { line: 6, column: 58, offset: 430 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Num.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Num.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Num.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Num.
+
+error: Invalid type nature for generic argument. DATE is no Num.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Num.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Num.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Num.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Num.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Num.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_strings.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_strings.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 59, offset: 139 }..TextLocation { line: 2, column: 60, offset: 140 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 59, offset: 139 }..TextLocation { line: 2, column: 60, offset: 140 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 216 }..TextLocation { line: 3, column: 61, offset: 217 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 216 }..TextLocation { line: 3, column: 61, offset: 217 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'USINT'
+  ┌─ <internal>:3:60
+  │
+3 │         FUNCTION func1  : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                            ^ Invalid assignment: cannot assign 'STRING' to 'USINT'
+
+error: Invalid type nature for generic argument. STRING is no Num.
+  ┌─ <internal>:3:60
+  │
+3 │         FUNCTION func1  : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                            ^ Invalid type nature for generic argument. STRING is no Num.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+
+error: Invalid type nature for generic argument. WSTRING is no Num.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Num.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_does_not_allow_time.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 137 }..TextLocation { line: 2, column: 58, offset: 138 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 212 }..TextLocation { line: 3, column: 59, offset: 213 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Num.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Num.
+
+error: Invalid type nature for generic argument. TIME is no Num.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Num.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_num_multiple_parameters.snap
@@ -1,12 +1,47 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 465 }..TextLocation { line: 14, column: 57, offset: 473 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 475 }..TextLocation { line: 14, column: 67, offset: 483 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 485 }..TextLocation { line: 14, column: 76, offset: 492 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 485 }..TextLocation { line: 14, column: 76, offset: 492 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 494 }..TextLocation { line: 14, column: 86, offset: 502 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 494 }..TextLocation { line: 14, column: 86, offset: 502 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Num.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 504 }..TextLocation { line: 14, column: 96, offset: 512 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Num.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Num.
+
+error: Invalid type nature for generic argument. BYTE is no Num.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Num.
+
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
+error: Invalid type nature for generic argument. STRING is no Num.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Num.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'REAL'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'REAL'
+
+error: Invalid type nature for generic argument. CHAR is no Num.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Num.
+
+error: Invalid type nature for generic argument. DATE is no Num.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Num.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_allows_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_allows_ints.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_allows_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_allows_reals.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 212 }..TextLocation { line: 3, column: 58, offset: 213 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 286 }..TextLocation { line: 4, column: 58, offset: 287 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 361 }..TextLocation { line: 5, column: 59, offset: 362 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 436 }..TextLocation { line: 6, column: 59, offset: 437 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Real.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Real.
+
+error: Invalid type nature for generic argument. BYTE is no Real.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Real.
+
+error: Invalid type nature for generic argument. WORD is no Real.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Real.
+
+error: Invalid type nature for generic argument. DWORD is no Real.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Real.
+
+error: Invalid type nature for generic argument. LWORD is no Real.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Real.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'REAL'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'REAL'
+
+error: Invalid type nature for generic argument. CHAR is no Real.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Real.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'REAL'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'REAL'
+
+error: Invalid type nature for generic argument. WCHAR is no Real.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Real.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 136 }..TextLocation { line: 2, column: 56, offset: 137 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 209 }..TextLocation { line: 3, column: 57, offset: 210 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 283 }..TextLocation { line: 4, column: 58, offset: 284 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 356 }..TextLocation { line: 5, column: 57, offset: 357 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 430 }..TextLocation { line: 6, column: 58, offset: 431 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Real.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Real.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Real.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Real.
+
+error: Invalid type nature for generic argument. DATE is no Real.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Real.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Real.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Real.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Real.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Real.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 141 }..TextLocation { line: 2, column: 61, offset: 142 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 141 }..TextLocation { line: 2, column: 61, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 218 }..TextLocation { line: 3, column: 61, offset: 219 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 218 }..TextLocation { line: 3, column: 61, offset: 219 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
+error: Invalid type nature for generic argument. STRING is no Real.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Real.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'REAL'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'REAL'
+
+error: Invalid type nature for generic argument. WSTRING is no Real.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Real.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_does_not_allow_time.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 138 }..TextLocation { line: 2, column: 58, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 213 }..TextLocation { line: 3, column: 59, offset: 214 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Real.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Real.
+
+error: Invalid type nature for generic argument. TIME is no Real.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Real.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_real_multiple_parameters.snap
@@ -1,12 +1,47 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 466 }..TextLocation { line: 14, column: 57, offset: 474 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 476 }..TextLocation { line: 14, column: 67, offset: 484 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 486 }..TextLocation { line: 14, column: 76, offset: 493 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 486 }..TextLocation { line: 14, column: 76, offset: 493 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'REAL'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 495 }..TextLocation { line: 14, column: 86, offset: 503 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 495 }..TextLocation { line: 14, column: 86, offset: 503 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Real.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 505 }..TextLocation { line: 14, column: 96, offset: 513 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Real.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Real.
+
+error: Invalid type nature for generic argument. BYTE is no Real.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Real.
+
+error: Invalid assignment: cannot assign 'STRING' to 'REAL'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'REAL'
+
+error: Invalid type nature for generic argument. STRING is no Real.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Real.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'REAL'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'REAL'
+
+error: Invalid type nature for generic argument. CHAR is no Real.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Real.
+
+error: Invalid type nature for generic argument. DATE is no Real.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Real.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_allows_signed_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_allows_signed_ints.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 214 }..TextLocation { line: 3, column: 58, offset: 215 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 288 }..TextLocation { line: 4, column: 58, offset: 289 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 363 }..TextLocation { line: 5, column: 59, offset: 364 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 438 }..TextLocation { line: 6, column: 59, offset: 439 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Signed.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Signed.
+
+error: Invalid type nature for generic argument. BYTE is no Signed.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Signed.
+
+error: Invalid type nature for generic argument. WORD is no Signed.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Signed.
+
+error: Invalid type nature for generic argument. DWORD is no Signed.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Signed.
+
+error: Invalid type nature for generic argument. LWORD is no Signed.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'SINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'SINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 215 }..TextLocation { line: 3, column: 59, offset: 216 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 215 }..TextLocation { line: 3, column: 59, offset: 216 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'SINT'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'SINT'
+
+error: Invalid type nature for generic argument. CHAR is no Signed.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Signed.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'SINT'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'SINT'
+
+error: Invalid type nature for generic argument. WCHAR is no Signed.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 138 }..TextLocation { line: 2, column: 56, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 211 }..TextLocation { line: 3, column: 57, offset: 212 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 285 }..TextLocation { line: 4, column: 58, offset: 286 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 358 }..TextLocation { line: 5, column: 57, offset: 359 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 432 }..TextLocation { line: 6, column: 58, offset: 433 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Signed.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Signed.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Signed.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Signed.
+
+error: Invalid type nature for generic argument. DATE is no Signed.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Signed.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Signed.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Signed.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Signed.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_reals.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 139 }..TextLocation { line: 2, column: 57, offset: 140 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 214 }..TextLocation { line: 3, column: 59, offset: 215 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Signed.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Signed.
+
+error: Invalid type nature for generic argument. LREAL is no Signed.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'SINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 143 }..TextLocation { line: 2, column: 61, offset: 144 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 143 }..TextLocation { line: 2, column: 61, offset: 144 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'SINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 220 }..TextLocation { line: 3, column: 61, offset: 221 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 220 }..TextLocation { line: 3, column: 61, offset: 221 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'SINT'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'SINT'
+
+error: Invalid type nature for generic argument. STRING is no Signed.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Signed.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'SINT'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'SINT'
+
+error: Invalid type nature for generic argument. WSTRING is no Signed.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_time.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 215 }..TextLocation { line: 3, column: 59, offset: 216 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Signed.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Signed.
+
+error: Invalid type nature for generic argument. TIME is no Signed.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_unsigned_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_does_not_allow_unsigned_ints.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. USINT is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 58, offset: 141 }..TextLocation { line: 2, column: 59, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UINT is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 215 }..TextLocation { line: 3, column: 58, offset: 216 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 58, offset: 290 }..TextLocation { line: 4, column: 59, offset: 291 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. ULINT is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 365 }..TextLocation { line: 5, column: 59, offset: 366 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. USINT is no Signed.
+  ┌─ <internal>:3:59
+  │
+3 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. USINT is no Signed.
+
+error: Invalid type nature for generic argument. UINT is no Signed.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. UINT is no Signed.
+
+error: Invalid type nature for generic argument. UDINT is no Signed.
+  ┌─ <internal>:5:59
+  │
+5 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. UDINT is no Signed.
+
+error: Invalid type nature for generic argument. ULINT is no Signed.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. ULINT is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_signed_multiple_parameters.snap
@@ -1,14 +1,59 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 432 }..TextLocation { line: 14, column: 21, offset: 440 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 442 }..TextLocation { line: 14, column: 35, offset: 454 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 468 }..TextLocation { line: 14, column: 57, offset: 476 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 478 }..TextLocation { line: 14, column: 67, offset: 486 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 488 }..TextLocation { line: 14, column: 76, offset: 495 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 488 }..TextLocation { line: 14, column: 76, offset: 495 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 497 }..TextLocation { line: 14, column: 86, offset: 505 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 497 }..TextLocation { line: 14, column: 86, offset: 505 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Signed.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 507 }..TextLocation { line: 14, column: 96, offset: 515 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Signed.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Signed.
+
+error: Invalid type nature for generic argument. UDINT is no Signed.
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid type nature for generic argument. UDINT is no Signed.
+
+error: Invalid type nature for generic argument. TIME is no Signed.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Signed.
+
+error: Invalid type nature for generic argument. BYTE is no Signed.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Signed.
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: Invalid type nature for generic argument. STRING is no Signed.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Signed.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'DINT'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'DINT'
+
+error: Invalid type nature for generic argument. CHAR is no Signed.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Signed.
+
+error: Invalid type nature for generic argument. DATE is no Signed.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Signed.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_allows_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_allows_string.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_bits.snap
@@ -1,15 +1,65 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'BOOL' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no String.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'BYTE' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 214 }..TextLocation { line: 3, column: 58, offset: 215 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no String.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 214 }..TextLocation { line: 3, column: 58, offset: 215 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WORD' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 288 }..TextLocation { line: 4, column: 58, offset: 289 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no String.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 288 }..TextLocation { line: 4, column: 58, offset: 289 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DWORD' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 363 }..TextLocation { line: 5, column: 59, offset: 364 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no String.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 363 }..TextLocation { line: 5, column: 59, offset: 364 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LWORD' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 438 }..TextLocation { line: 6, column: 59, offset: 439 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no String.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 438 }..TextLocation { line: 6, column: 59, offset: 439 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'BOOL' to 'STRING'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'BOOL' to 'STRING'
+
+error: Invalid type nature for generic argument. BOOL is no String.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no String.
+
+error: Invalid assignment: cannot assign 'BYTE' to 'STRING'
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'BYTE' to 'STRING'
+
+error: Invalid type nature for generic argument. BYTE is no String.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no String.
+
+error: Invalid assignment: cannot assign 'WORD' to 'STRING'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'WORD' to 'STRING'
+
+error: Invalid type nature for generic argument. WORD is no String.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no String.
+
+error: Invalid assignment: cannot assign 'DWORD' to 'STRING'
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'DWORD' to 'STRING'
+
+error: Invalid type nature for generic argument. DWORD is no String.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no String.
+
+error: Invalid assignment: cannot assign 'LWORD' to 'STRING'
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'LWORD' to 'STRING'
+
+error: Invalid type nature for generic argument. LWORD is no String.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no String.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no String.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 215 }..TextLocation { line: 3, column: 59, offset: 216 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no String.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 215 }..TextLocation { line: 3, column: 59, offset: 216 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'STRING'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'STRING'
+
+error: Invalid type nature for generic argument. CHAR is no String.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no String.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'STRING'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'STRING'
+
+error: Invalid type nature for generic argument. WCHAR is no String.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no String.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_date.snap
@@ -1,15 +1,65 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE_AND_TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 138 }..TextLocation { line: 2, column: 56, offset: 139 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no String.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 138 }..TextLocation { line: 2, column: 56, offset: 139 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE_AND_TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 211 }..TextLocation { line: 3, column: 57, offset: 212 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no String.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 211 }..TextLocation { line: 3, column: 57, offset: 212 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 285 }..TextLocation { line: 4, column: 58, offset: 286 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no String.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 285 }..TextLocation { line: 4, column: 58, offset: 286 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 358 }..TextLocation { line: 5, column: 57, offset: 359 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no String.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 358 }..TextLocation { line: 5, column: 57, offset: 359 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 432 }..TextLocation { line: 6, column: 58, offset: 433 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no String.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 432 }..TextLocation { line: 6, column: 58, offset: 433 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'DATE_AND_TIME' to 'STRING'
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid assignment: cannot assign 'DATE_AND_TIME' to 'STRING'
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no String.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no String.
+
+error: Invalid assignment: cannot assign 'DATE_AND_TIME' to 'STRING'
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'DATE_AND_TIME' to 'STRING'
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no String.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no String.
+
+error: Invalid assignment: cannot assign 'DATE' to 'STRING'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'DATE' to 'STRING'
+
+error: Invalid type nature for generic argument. DATE is no String.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no String.
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no String.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no String.
+
+error: Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'TIME_OF_DAY' to 'STRING'
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no String.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no String.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_ints.snap
@@ -1,21 +1,101 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'USINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 142 }..TextLocation { line: 3, column: 59, offset: 143 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. USINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 142 }..TextLocation { line: 3, column: 59, offset: 143 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 216 }..TextLocation { line: 4, column: 58, offset: 217 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 216 }..TextLocation { line: 4, column: 58, offset: 217 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 291 }..TextLocation { line: 5, column: 59, offset: 292 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 291 }..TextLocation { line: 5, column: 59, offset: 292 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'ULINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 366 }..TextLocation { line: 6, column: 59, offset: 367 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. ULINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 366 }..TextLocation { line: 6, column: 59, offset: 367 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'SINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 441 }..TextLocation { line: 8, column: 58, offset: 442 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. SINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 57, offset: 441 }..TextLocation { line: 8, column: 58, offset: 442 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 514 }..TextLocation { line: 9, column: 57, offset: 515 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. INT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 56, offset: 514 }..TextLocation { line: 9, column: 57, offset: 515 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 588 }..TextLocation { line: 10, column: 58, offset: 589 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 57, offset: 588 }..TextLocation { line: 10, column: 58, offset: 589 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 662 }..TextLocation { line: 11, column: 58, offset: 663 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 57, offset: 662 }..TextLocation { line: 11, column: 58, offset: 663 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'USINT' to 'STRING'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'USINT' to 'STRING'
+
+error: Invalid type nature for generic argument. USINT is no String.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : USINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. USINT is no String.
+
+error: Invalid assignment: cannot assign 'UINT' to 'STRING'
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'UINT' to 'STRING'
+
+error: Invalid type nature for generic argument. UINT is no String.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func2  : INT VAR x : UINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. UINT is no String.
+
+error: Invalid assignment: cannot assign 'UDINT' to 'STRING'
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'UDINT' to 'STRING'
+
+error: Invalid type nature for generic argument. UDINT is no String.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func3  : INT VAR x : UDINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. UDINT is no String.
+
+error: Invalid assignment: cannot assign 'ULINT' to 'STRING'
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'ULINT' to 'STRING'
+
+error: Invalid type nature for generic argument. ULINT is no String.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func4  : INT VAR x : ULINT; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. ULINT is no String.
+
+error: Invalid assignment: cannot assign 'SINT' to 'STRING'
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'SINT' to 'STRING'
+
+error: Invalid type nature for generic argument. SINT is no String.
+  ┌─ <internal>:9:58
+  │
+9 │         FUNCTION func5  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. SINT is no String.
+
+error: Invalid assignment: cannot assign 'INT' to 'STRING'
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid assignment: cannot assign 'INT' to 'STRING'
+
+error: Invalid type nature for generic argument. INT is no String.
+   ┌─ <internal>:10:57
+   │
+10 │         FUNCTION func6  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+   │                                                         ^ Invalid type nature for generic argument. INT is no String.
+
+error: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error: Invalid type nature for generic argument. DINT is no String.
+   ┌─ <internal>:11:58
+   │
+11 │         FUNCTION func7  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. DINT is no String.
+
+error: Invalid assignment: cannot assign 'LINT' to 'STRING'
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid assignment: cannot assign 'LINT' to 'STRING'
+
+error: Invalid type nature for generic argument. LINT is no String.
+   ┌─ <internal>:12:58
+   │
+12 │         FUNCTION func8  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+   │                                                          ^ Invalid type nature for generic argument. LINT is no String.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_reals.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 139 }..TextLocation { line: 2, column: 57, offset: 140 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no String.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 139 }..TextLocation { line: 2, column: 57, offset: 140 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'LREAL' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 214 }..TextLocation { line: 3, column: 59, offset: 215 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no String.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 214 }..TextLocation { line: 3, column: 59, offset: 215 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'REAL' to 'STRING'
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid assignment: cannot assign 'REAL' to 'STRING'
+
+error: Invalid type nature for generic argument. REAL is no String.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no String.
+
+error: Invalid assignment: cannot assign 'LREAL' to 'STRING'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'LREAL' to 'STRING'
+
+error: Invalid type nature for generic argument. LREAL is no String.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no String.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_does_not_allow_time.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no String.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 140 }..TextLocation { line: 2, column: 58, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 215 }..TextLocation { line: 3, column: 59, offset: 216 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no String.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 215 }..TextLocation { line: 3, column: 59, offset: 216 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'TIME' to 'STRING'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'TIME' to 'STRING'
+
+error: Invalid type nature for generic argument. TIME is no String.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no String.
+
+error: Invalid assignment: cannot assign 'TIME' to 'STRING'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'TIME' to 'STRING'
+
+error: Invalid type nature for generic argument. TIME is no String.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no String.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_multiple_parameters.snap
@@ -1,19 +1,89 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'REAL' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 432 }..TextLocation { line: 14, column: 21, offset: 440 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no String.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 432 }..TextLocation { line: 14, column: 21, offset: 440 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'UDINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 442 }..TextLocation { line: 14, column: 35, offset: 454 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. UDINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 23, offset: 442 }..TextLocation { line: 14, column: 35, offset: 454 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 456 }..TextLocation { line: 14, column: 47, offset: 466 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no String.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 456 }..TextLocation { line: 14, column: 47, offset: 466 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 468 }..TextLocation { line: 14, column: 57, offset: 476 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no String.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 468 }..TextLocation { line: 14, column: 57, offset: 476 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'BYTE' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 478 }..TextLocation { line: 14, column: 67, offset: 486 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no String.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 478 }..TextLocation { line: 14, column: 67, offset: 486 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 497 }..TextLocation { line: 14, column: 86, offset: 505 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no String.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 497 }..TextLocation { line: 14, column: 86, offset: 505 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'DATE' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 507 }..TextLocation { line: 14, column: 96, offset: 515 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no String.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 507 }..TextLocation { line: 14, column: 96, offset: 515 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'REAL' to 'STRING'
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid assignment: cannot assign 'REAL' to 'STRING'
+
+error: Invalid type nature for generic argument. REAL is no String.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no String.
+
+error: Invalid assignment: cannot assign 'UDINT' to 'STRING'
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid assignment: cannot assign 'UDINT' to 'STRING'
+
+error: Invalid type nature for generic argument. UDINT is no String.
+   ┌─ <internal>:15:24
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                        ^^^^^^^^^^^^ Invalid type nature for generic argument. UDINT is no String.
+
+error: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error: Invalid type nature for generic argument. DINT is no String.
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid type nature for generic argument. DINT is no String.
+
+error: Invalid assignment: cannot assign 'TIME' to 'STRING'
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'STRING'
+
+error: Invalid type nature for generic argument. TIME is no String.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no String.
+
+error: Invalid assignment: cannot assign 'BYTE' to 'STRING'
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid assignment: cannot assign 'BYTE' to 'STRING'
+
+error: Invalid type nature for generic argument. BYTE is no String.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no String.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'STRING'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'STRING'
+
+error: Invalid type nature for generic argument. CHAR is no String.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no String.
+
+error: Invalid assignment: cannot assign 'DATE' to 'STRING'
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid assignment: cannot assign 'DATE' to 'STRING'
+
+error: Invalid type nature for generic argument. DATE is no String.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no String.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_allows_unsigned_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_allows_unsigned_ints.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_bits.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_bits.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. BOOL is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 57, offset: 216 }..TextLocation { line: 3, column: 58, offset: 217 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. WORD is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 290 }..TextLocation { line: 4, column: 58, offset: 291 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DWORD is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 58, offset: 365 }..TextLocation { line: 5, column: 59, offset: 366 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LWORD is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 58, offset: 440 }..TextLocation { line: 6, column: 59, offset: 441 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. BOOL is no Unsigned.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : BOOL; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BOOL is no Unsigned.
+
+error: Invalid type nature for generic argument. BYTE is no Unsigned.
+  ┌─ <internal>:4:58
+  │
+4 │         FUNCTION func2  : INT VAR x : BYTE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. BYTE is no Unsigned.
+
+error: Invalid type nature for generic argument. WORD is no Unsigned.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : WORD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. WORD is no Unsigned.
+
+error: Invalid type nature for generic argument. DWORD is no Unsigned.
+  ┌─ <internal>:6:59
+  │
+6 │         FUNCTION func4  : INT VAR x : DWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. DWORD is no Unsigned.
+
+error: Invalid type nature for generic argument. LWORD is no Unsigned.
+  ┌─ <internal>:7:59
+  │
+7 │         FUNCTION func5  : INT VAR x : LWORD; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LWORD is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_chars.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_chars.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 217 }..TextLocation { line: 3, column: 59, offset: 218 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WCHAR is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 217 }..TextLocation { line: 3, column: 59, offset: 218 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'CHAR' to 'USINT'
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid assignment: cannot assign 'CHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. CHAR is no Unsigned.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : CHAR; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. CHAR is no Unsigned.
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid assignment: cannot assign 'WCHAR' to 'USINT'
+
+error: Invalid type nature for generic argument. WCHAR is no Unsigned.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : WCHAR; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. WCHAR is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_date.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_date.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 55, offset: 140 }..TextLocation { line: 2, column: 56, offset: 141 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE_AND_TIME is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 213 }..TextLocation { line: 3, column: 57, offset: 214 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 287 }..TextLocation { line: 4, column: 58, offset: 288 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 56, offset: 360 }..TextLocation { line: 5, column: 57, offset: 361 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME_OF_DAY is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 57, offset: 434 }..TextLocation { line: 6, column: 58, offset: 435 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Unsigned.
+  ┌─ <internal>:3:56
+  │
+3 │         FUNCTION func1  : INT VAR x : DT; END_VAR test(x); END_FUNCTION
+  │                                                        ^ Invalid type nature for generic argument. DATE_AND_TIME is no Unsigned.
+
+error: Invalid type nature for generic argument. DATE_AND_TIME is no Unsigned.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : LDT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. DATE_AND_TIME is no Unsigned.
+
+error: Invalid type nature for generic argument. DATE is no Unsigned.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DATE; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DATE is no Unsigned.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Unsigned.
+  ┌─ <internal>:6:57
+  │
+6 │         FUNCTION func4  : INT VAR x : TOD; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. TIME_OF_DAY is no Unsigned.
+
+error: Invalid type nature for generic argument. TIME_OF_DAY is no Unsigned.
+  ┌─ <internal>:7:58
+  │
+7 │         FUNCTION func5  : INT VAR x : LTOD; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME_OF_DAY is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_reals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_reals.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 56, offset: 141 }..TextLocation { line: 2, column: 57, offset: 142 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LREAL is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 216 }..TextLocation { line: 3, column: 59, offset: 217 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Unsigned.
+  ┌─ <internal>:3:57
+  │
+3 │         FUNCTION func  : INT VAR x : REAL; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. REAL is no Unsigned.
+
+error: Invalid type nature for generic argument. LREAL is no Unsigned.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func1  : INT VAR x : LREAL; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. LREAL is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_signed_ints.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_signed_ints.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. SINT is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. INT is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 56, offset: 215 }..TextLocation { line: 3, column: 57, offset: 216 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 57, offset: 289 }..TextLocation { line: 4, column: 58, offset: 290 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. LINT is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 57, offset: 363 }..TextLocation { line: 5, column: 58, offset: 364 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. SINT is no Unsigned.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : SINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. SINT is no Unsigned.
+
+error: Invalid type nature for generic argument. INT is no Unsigned.
+  ┌─ <internal>:4:57
+  │
+4 │         FUNCTION func2  : INT VAR x : INT; END_VAR test(x); END_FUNCTION
+  │                                                         ^ Invalid type nature for generic argument. INT is no Unsigned.
+
+error: Invalid type nature for generic argument. DINT is no Unsigned.
+  ┌─ <internal>:5:58
+  │
+5 │         FUNCTION func3  : INT VAR x : DINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. DINT is no Unsigned.
+
+error: Invalid type nature for generic argument. LINT is no Unsigned.
+  ┌─ <internal>:6:58
+  │
+6 │         FUNCTION func4  : INT VAR x : LINT; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. LINT is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_string.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_string.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 145 }..TextLocation { line: 2, column: 61, offset: 146 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 60, offset: 145 }..TextLocation { line: 2, column: 61, offset: 146 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'USINT'", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 222 }..TextLocation { line: 3, column: 61, offset: 223 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. WSTRING is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 60, offset: 222 }..TextLocation { line: 3, column: 61, offset: 223 }) }], err_no: type__invalid_nature }
+error: Invalid assignment: cannot assign 'STRING' to 'USINT'
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'STRING' to 'USINT'
+
+error: Invalid type nature for generic argument. STRING is no Unsigned.
+  ┌─ <internal>:3:61
+  │
+3 │         FUNCTION func1   : INT VAR x : STRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. STRING is no Unsigned.
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid assignment: cannot assign 'WSTRING' to 'USINT'
+
+error: Invalid type nature for generic argument. WSTRING is no Unsigned.
+  ┌─ <internal>:4:61
+  │
+4 │         FUNCTION func2  : INT VAR x : WSTRING; END_VAR test(x); END_FUNCTION
+  │                                                             ^ Invalid type nature for generic argument. WSTRING is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_time.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_does_not_allow_time.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 57, offset: 142 }..TextLocation { line: 2, column: 58, offset: 143 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 58, offset: 217 }..TextLocation { line: 3, column: 59, offset: 218 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. TIME is no Unsigned.
+  ┌─ <internal>:3:58
+  │
+3 │         FUNCTION func1  : INT VAR x : TIME; END_VAR test(x); END_FUNCTION
+  │                                                          ^ Invalid type nature for generic argument. TIME is no Unsigned.
+
+error: Invalid type nature for generic argument. TIME is no Unsigned.
+  ┌─ <internal>:4:59
+  │
+4 │         FUNCTION func2  : INT VAR x : LTIME; END_VAR test(x); END_FUNCTION
+  │                                                           ^ Invalid type nature for generic argument. TIME is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_multiple_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_unsigned_multiple_parameters.snap
@@ -1,14 +1,59 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 13, offset: 434 }..TextLocation { line: 14, column: 21, offset: 442 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DINT is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 37, offset: 458 }..TextLocation { line: 14, column: 47, offset: 468 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 49, offset: 470 }..TextLocation { line: 14, column: 57, offset: 478 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. BYTE is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 59, offset: 480 }..TextLocation { line: 14, column: 67, offset: 488 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 490 }..TextLocation { line: 14, column: 76, offset: 497 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. STRING is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 69, offset: 490 }..TextLocation { line: 14, column: 76, offset: 497 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'UDINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 499 }..TextLocation { line: 14, column: 86, offset: 507 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid type nature for generic argument. CHAR is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 78, offset: 499 }..TextLocation { line: 14, column: 86, offset: 507 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. DATE is no Unsigned.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 88, offset: 509 }..TextLocation { line: 14, column: 96, offset: 517 }) }], err_no: type__invalid_nature }
+error: Invalid type nature for generic argument. REAL is no Unsigned.
+   ┌─ <internal>:15:14
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │              ^^^^^^^^ Invalid type nature for generic argument. REAL is no Unsigned.
+
+error: Invalid type nature for generic argument. DINT is no Unsigned.
+   ┌─ <internal>:15:38
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                      ^^^^^^^^^^ Invalid type nature for generic argument. DINT is no Unsigned.
+
+error: Invalid type nature for generic argument. TIME is no Unsigned.
+   ┌─ <internal>:15:50
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                  ^^^^^^^^ Invalid type nature for generic argument. TIME is no Unsigned.
+
+error: Invalid type nature for generic argument. BYTE is no Unsigned.
+   ┌─ <internal>:15:60
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                            ^^^^^^^^ Invalid type nature for generic argument. BYTE is no Unsigned.
+
+error: Invalid assignment: cannot assign 'STRING' to 'UDINT'
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'UDINT'
+
+error: Invalid type nature for generic argument. STRING is no Unsigned.
+   ┌─ <internal>:15:70
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                      ^^^^^^^ Invalid type nature for generic argument. STRING is no Unsigned.
+
+error: Invalid assignment: cannot assign 'CHAR' to 'UDINT'
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'UDINT'
+
+error: Invalid type nature for generic argument. CHAR is no Unsigned.
+   ┌─ <internal>:15:79
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                               ^^^^^^^^ Invalid type nature for generic argument. CHAR is no Unsigned.
+
+error: Invalid type nature for generic argument. DATE is no Unsigned.
+   ┌─ <internal>:15:89
+   │
+15 │         func(var_real, var_unsigned, var_signed, var_time, var_byte, var_str, var_char, var_date);
+   │                                                                                         ^^^^^^^^ Invalid type nature for generic argument. DATE is no Unsigned.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__non_resolved_generics_reported.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__non_resolved_generics_reported.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/generic_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Could not resolve generic type T with nature String", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 30, offset: 86 }..TextLocation { line: 2, column: 37, offset: 93 }) }], err_no: type__unresolved_generic }
+error: Could not resolve generic type T with nature String
+  ┌─ <internal>:3:31
+  │
+3 │         FUNCTION func  : INT  test(); END_FUNCTION
+  │                               ^^^^^^^ Could not resolve generic type T with nature String
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__bool_literal_casts_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__bool_literal_casts_are_validated.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/literals_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Literal 2 out of range (BOOL)", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 120 }..TextLocation { line: 6, column: 18, offset: 126 }) }], err_no: type__literal_out_of_range }
-SyntaxError { message: "Literal 2.3 is not compatible to BOOL", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 140 }..TextLocation { line: 7, column: 20, offset: 148 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal 'abc' is not compatible to BOOL", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 162 }..TextLocation { line: 8, column: 22, offset: 172 }) }], err_no: type__incompatible_literal_cast }
+error: Literal 2 out of range (BOOL)
+  ┌─ <internal>:7:13
+  │
+7 │             BOOL#2;
+  │             ^^^^^^ Literal 2 out of range (BOOL)
+
+error: Literal 2.3 is not compatible to BOOL
+  ┌─ <internal>:8:13
+  │
+8 │             BOOL#2.3;
+  │             ^^^^^^^^ Literal 2.3 is not compatible to BOOL
+
+error: Literal 'abc' is not compatible to BOOL
+  ┌─ <internal>:9:13
+  │
+9 │             BOOL#'abc';
+  │             ^^^^^^^^^^ Literal 'abc' is not compatible to BOOL
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__char_cast_validate.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__char_cast_validate.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/literals_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Literal \"XY\" out of range (CHAR)", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 80 }..TextLocation { line: 6, column: 21, offset: 89 }) }], err_no: type__literal_out_of_range }
-SyntaxError { message: "Literal 'YZ' out of range (WCHAR)", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 103 }..TextLocation { line: 7, column: 22, offset: 113 }) }], err_no: type__literal_out_of_range }
+error: Literal "XY" out of range (CHAR)
+  ┌─ <internal>:7:13
+  │
+7 │             CHAR#"XY";
+  │             ^^^^^^^^^ Literal "XY" out of range (CHAR)
+
+error: Literal 'YZ' out of range (WCHAR)
+  ┌─ <internal>:8:13
+  │
+8 │             WCHAR#'YZ';
+  │             ^^^^^^^^^^ Literal 'YZ' out of range (WCHAR)
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__date_literal_casts_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__date_literal_casts_are_validated.snap
@@ -1,17 +1,77 @@
 ---
 source: src/validation/tests/literals_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Literal DATE_AND_TIME is not compatible to LINT", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 12, offset: 33 }..TextLocation { line: 2, column: 42, offset: 63 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal TIME_OF_DAY is not compatible to LINT", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 77 }..TextLocation { line: 3, column: 41, offset: 106 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal TIME is not compatible to LINT", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 12, offset: 120 }..TextLocation { line: 4, column: 28, offset: 136 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal DATE is not compatible to LINT", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 12, offset: 150 }..TextLocation { line: 5, column: 32, offset: 170 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal DATE_AND_TIME is not compatible to ULINT", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 185 }..TextLocation { line: 7, column: 43, offset: 216 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal TIME_OF_DAY is not compatible to ULINT", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 230 }..TextLocation { line: 8, column: 42, offset: 260 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal TIME is not compatible to ULINT", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 12, offset: 274 }..TextLocation { line: 9, column: 29, offset: 291 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal DATE is not compatible to ULINT", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 12, offset: 305 }..TextLocation { line: 10, column: 33, offset: 326 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal DATE_AND_TIME is not compatible to INT", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 12, offset: 341 }..TextLocation { line: 12, column: 41, offset: 370 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal TIME_OF_DAY is not compatible to INT", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 12, offset: 384 }..TextLocation { line: 13, column: 40, offset: 412 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal TIME is not compatible to INT", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 12, offset: 426 }..TextLocation { line: 14, column: 27, offset: 441 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal DATE is not compatible to INT", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 12, offset: 455 }..TextLocation { line: 15, column: 31, offset: 474 }) }], err_no: type__incompatible_literal_cast }
+error: Literal DATE_AND_TIME is not compatible to LINT
+  ┌─ <internal>:3:13
+  │
+3 │             LINT#DT#1989-06-15-13:56:14.77;
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Literal DATE_AND_TIME is not compatible to LINT
+
+error: Literal TIME_OF_DAY is not compatible to LINT
+  ┌─ <internal>:4:13
+  │
+4 │             LINT#TIME_OF_DAY#15:36:30.123;
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Literal TIME_OF_DAY is not compatible to LINT
+
+error: Literal TIME is not compatible to LINT
+  ┌─ <internal>:5:13
+  │
+5 │             LINT#T#12h34m15s;
+  │             ^^^^^^^^^^^^^^^^ Literal TIME is not compatible to LINT
+
+error: Literal DATE is not compatible to LINT
+  ┌─ <internal>:6:13
+  │
+6 │             LINT#DATE#1996-05-06;
+  │             ^^^^^^^^^^^^^^^^^^^^ Literal DATE is not compatible to LINT
+
+error: Literal DATE_AND_TIME is not compatible to ULINT
+  ┌─ <internal>:8:13
+  │
+8 │             ULINT#DT#1989-06-15-13:56:14.77;
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Literal DATE_AND_TIME is not compatible to ULINT
+
+error: Literal TIME_OF_DAY is not compatible to ULINT
+  ┌─ <internal>:9:13
+  │
+9 │             ULINT#TIME_OF_DAY#15:36:30.123;
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Literal TIME_OF_DAY is not compatible to ULINT
+
+error: Literal TIME is not compatible to ULINT
+   ┌─ <internal>:10:13
+   │
+10 │             ULINT#T#12h34m15s;
+   │             ^^^^^^^^^^^^^^^^^ Literal TIME is not compatible to ULINT
+
+error: Literal DATE is not compatible to ULINT
+   ┌─ <internal>:11:13
+   │
+11 │             ULINT#DATE#1996-05-06;
+   │             ^^^^^^^^^^^^^^^^^^^^^ Literal DATE is not compatible to ULINT
+
+error: Literal DATE_AND_TIME is not compatible to INT
+   ┌─ <internal>:13:13
+   │
+13 │             INT#DT#1989-06-15-13:56:14.77;
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Literal DATE_AND_TIME is not compatible to INT
+
+error: Literal TIME_OF_DAY is not compatible to INT
+   ┌─ <internal>:14:13
+   │
+14 │             INT#TIME_OF_DAY#15:36:30.123;
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Literal TIME_OF_DAY is not compatible to INT
+
+error: Literal TIME is not compatible to INT
+   ┌─ <internal>:15:13
+   │
+15 │             INT#T#12h34m15s;
+   │             ^^^^^^^^^^^^^^^ Literal TIME is not compatible to INT
+
+error: Literal DATE is not compatible to INT
+   ┌─ <internal>:16:13
+   │
+16 │             INT#DATE#1996-05-06;
+   │             ^^^^^^^^^^^^^^^^^^^ Literal DATE is not compatible to INT
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__int_literal_casts_max_values_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__int_literal_casts_max_values_are_validated.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/literals_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Literal 256 out of range (BYTE)", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 16, offset: 67 }..TextLocation { line: 3, column: 24, offset: 75 }) }], err_no: type__literal_out_of_range }
-SyntaxError { message: "Literal 65536 out of range (UINT)", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 16, offset: 123 }..TextLocation { line: 6, column: 27, offset: 134 }) }], err_no: type__literal_out_of_range }
-SyntaxError { message: "Literal 4294967296 out of range (UDINT)", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 16, offset: 190 }..TextLocation { line: 9, column: 35, offset: 209 }) }], err_no: type__literal_out_of_range }
+error: Literal 256 out of range (BYTE)
+  ┌─ <internal>:4:17
+  │
+4 │                 BYTE#256;
+  │                 ^^^^^^^^ Literal 256 out of range (BYTE)
+
+error: Literal 65536 out of range (UINT)
+  ┌─ <internal>:7:17
+  │
+7 │                 UINT#65_536;
+  │                 ^^^^^^^^^^^ Literal 65536 out of range (UINT)
+
+error: Literal 4294967296 out of range (UDINT)
+   ┌─ <internal>:10:17
+   │
+10 │                 UDINT#4_294_967_296;
+   │                 ^^^^^^^^^^^^^^^^^^^ Literal 4294967296 out of range (UDINT)
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__literal_cast_with_non_literal.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__literal_cast_with_non_literal.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/literals_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Expected literal", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 12, offset: 24 }..TextLocation { line: 1, column: 19, offset: 31 }) }], err_no: type__expected_literal }
+error: Expected literal
+  ┌─ <internal>:2:13
+  │
+2 │             INT#[x];
+  │             ^^^^^^^ Expected literal
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__literal_enum_elements_validate_without_errors.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__literal_enum_elements_validate_without_errors.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/literals_validation_tests.rs
+expression: "&diagnostics"
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__real_literal_casts_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__real_literal_casts_are_validated.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/literals_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Literal '3.14' is not compatible to REAL", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 12, offset: 168 }..TextLocation { line: 10, column: 23, offset: 179 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal \"3.14\" is not compatible to LREAL", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 12, offset: 239 }..TextLocation { line: 14, column: 24, offset: 251 }) }], err_no: type__incompatible_literal_cast }
+error: Literal '3.14' is not compatible to REAL
+   ┌─ <internal>:11:13
+   │
+11 │             REAL#'3.14';
+   │             ^^^^^^^^^^^ Literal '3.14' is not compatible to REAL
+
+error: Literal "3.14" is not compatible to LREAL
+   ┌─ <internal>:15:13
+   │
+15 │             LREAL#"3.14";
+   │             ^^^^^^^^^^^^ Literal "3.14" is not compatible to LREAL
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__string_literal_casts_are_validated.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__literals_validation_tests__string_literal_casts_are_validated.snap
@@ -1,11 +1,41 @@
 ---
 source: src/validation/tests/literals_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Literal true is not compatible to STRING", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 90 }..TextLocation { line: 6, column: 23, offset: 101 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal false is not compatible to WSTRING", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 115 }..TextLocation { line: 7, column: 25, offset: 128 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal 22 is not compatible to STRING", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 12, offset: 143 }..TextLocation { line: 9, column: 21, offset: 152 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal 33 is not compatible to WSTRING", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 12, offset: 166 }..TextLocation { line: 10, column: 22, offset: 176 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal 3.14 is not compatible to STRING", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 12, offset: 191 }..TextLocation { line: 12, column: 23, offset: 202 }) }], err_no: type__incompatible_literal_cast }
-SyntaxError { message: "Literal 1.0 is not compatible to WSTRING", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 12, offset: 216 }..TextLocation { line: 13, column: 23, offset: 227 }) }], err_no: type__incompatible_literal_cast }
+error: Literal true is not compatible to STRING
+  ┌─ <internal>:7:13
+  │
+7 │             STRING#TRUE;
+  │             ^^^^^^^^^^^ Literal true is not compatible to STRING
+
+error: Literal false is not compatible to WSTRING
+  ┌─ <internal>:8:13
+  │
+8 │             WSTRING#FALSE;
+  │             ^^^^^^^^^^^^^ Literal false is not compatible to WSTRING
+
+error: Literal 22 is not compatible to STRING
+   ┌─ <internal>:10:13
+   │
+10 │             STRING#22;
+   │             ^^^^^^^^^ Literal 22 is not compatible to STRING
+
+error: Literal 33 is not compatible to WSTRING
+   ┌─ <internal>:11:13
+   │
+11 │             WSTRING#33;
+   │             ^^^^^^^^^^ Literal 33 is not compatible to WSTRING
+
+error: Literal 3.14 is not compatible to STRING
+   ┌─ <internal>:13:13
+   │
+13 │             STRING#3.14;
+   │             ^^^^^^^^^^^ Literal 3.14 is not compatible to STRING
+
+error: Literal 1.0 is not compatible to WSTRING
+   ┌─ <internal>:14:13
+   │
+14 │             WSTRING#1.0;
+   │             ^^^^^^^^^^^ Literal 1.0 is not compatible to WSTRING
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__BOOL.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__BOOL.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "BOOL can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "BOOL: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: BOOL can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE BOOL : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ BOOL can not be used as a name because it is a built-in datatype
+
+error: BOOL: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE BOOL : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ BOOL: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__BYTE.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__BYTE.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "BYTE can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "BYTE: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: BYTE can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE BYTE : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ BYTE can not be used as a name because it is a built-in datatype
+
+error: BYTE: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE BYTE : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ BYTE: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__CHAR.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__CHAR.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "CHAR can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "CHAR: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: CHAR can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE CHAR : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ CHAR can not be used as a name because it is a built-in datatype
+
+error: CHAR: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE CHAR : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ CHAR: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__D.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__D.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "D can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 6, offset: 6 }) }], err_no: type__invalid_name }
-SyntaxError { message: "D: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 6, offset: 6 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: D can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE D : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^ D can not be used as a name because it is a built-in datatype
+
+error: D: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE D : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^ D: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DATE.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DATE.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "DATE can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "DATE: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: DATE can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DATE : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ DATE can not be used as a name because it is a built-in datatype
+
+error: DATE: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DATE : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ DATE: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DATE_AND_TIME.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DATE_AND_TIME.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "DATE_AND_TIME can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 18, offset: 18 }) }], err_no: type__invalid_name }
-SyntaxError { message: "DATE_AND_TIME: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 18, offset: 18 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: DATE_AND_TIME can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DATE_AND_TIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^^^ DATE_AND_TIME can not be used as a name because it is a built-in datatype
+
+error: DATE_AND_TIME: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DATE_AND_TIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^^^ DATE_AND_TIME: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DINT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DINT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "DINT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "DINT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: DINT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ DINT can not be used as a name because it is a built-in datatype
+
+error: DINT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ DINT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "DT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 7, offset: 7 }) }], err_no: type__invalid_name }
-SyntaxError { message: "DT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 7, offset: 7 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: DT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^ DT can not be used as a name because it is a built-in datatype
+
+error: DT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^ DT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DWORD.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__DWORD.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "DWORD can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "DWORD: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: DWORD can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DWORD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ DWORD can not be used as a name because it is a built-in datatype
+
+error: DWORD: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE DWORD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ DWORD: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__INT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__INT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "INT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 8, offset: 8 }) }], err_no: type__invalid_name }
-SyntaxError { message: "INT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 8, offset: 8 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: INT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE INT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^ INT can not be used as a name because it is a built-in datatype
+
+error: INT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE INT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^ INT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LD.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LD.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LD can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 7, offset: 7 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LD: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 7, offset: 7 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LD can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^ LD can not be used as a name because it is a built-in datatype
+
+error: LD: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^ LD: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LDATE.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LDATE.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LDATE can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LDATE: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LDATE can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LDATE : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LDATE can not be used as a name because it is a built-in datatype
+
+error: LDATE: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LDATE : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LDATE: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LDATE_AND_TIME.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LDATE_AND_TIME.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LDATE_AND_TIME can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 19, offset: 19 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LDATE_AND_TIME: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 19, offset: 19 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LDATE_AND_TIME can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LDATE_AND_TIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^^^^ LDATE_AND_TIME can not be used as a name because it is a built-in datatype
+
+error: LDATE_AND_TIME: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LDATE_AND_TIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^^^^ LDATE_AND_TIME: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LDT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LDT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LDT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 8, offset: 8 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LDT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 8, offset: 8 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LDT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LDT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^ LDT can not be used as a name because it is a built-in datatype
+
+error: LDT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LDT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^ LDT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LINT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LINT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LINT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LINT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LINT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ LINT can not be used as a name because it is a built-in datatype
+
+error: LINT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ LINT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LREAL.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LREAL.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LREAL can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LREAL: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LREAL can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LREAL : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LREAL can not be used as a name because it is a built-in datatype
+
+error: LREAL: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LREAL : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LREAL: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 7, offset: 7 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 7, offset: 7 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^ LT can not be used as a name because it is a built-in datatype
+
+error: LT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^ LT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LTIME.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LTIME.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LTIME can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LTIME: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LTIME can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LTIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LTIME can not be used as a name because it is a built-in datatype
+
+error: LTIME: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LTIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LTIME: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LTIME_OF_DAY.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LTIME_OF_DAY.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LTIME_OF_DAY can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 17, offset: 17 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LTIME_OF_DAY: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 17, offset: 17 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LTIME_OF_DAY can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LTIME_OF_DAY : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^^ LTIME_OF_DAY can not be used as a name because it is a built-in datatype
+
+error: LTIME_OF_DAY: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LTIME_OF_DAY : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^^ LTIME_OF_DAY: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LTOD.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LTOD.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LTOD can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LTOD: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LTOD can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LTOD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ LTOD can not be used as a name because it is a built-in datatype
+
+error: LTOD: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LTOD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ LTOD: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LWORD.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__LWORD.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "LWORD can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "LWORD: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: LWORD can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LWORD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LWORD can not be used as a name because it is a built-in datatype
+
+error: LWORD: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE LWORD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ LWORD: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__REAL.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__REAL.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "REAL can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "REAL: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: REAL can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE REAL : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ REAL can not be used as a name because it is a built-in datatype
+
+error: REAL: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE REAL : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ REAL: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__SINT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__SINT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "SINT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "SINT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: SINT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE SINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ SINT can not be used as a name because it is a built-in datatype
+
+error: SINT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE SINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ SINT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__STRING.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__STRING.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "STRING can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 11, offset: 11 }) }], err_no: type__invalid_name }
-SyntaxError { message: "STRING: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 11, offset: 11 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: STRING can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE STRING : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^ STRING can not be used as a name because it is a built-in datatype
+
+error: STRING: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE STRING : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^ STRING: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__T.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__T.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "T can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 6, offset: 6 }) }], err_no: type__invalid_name }
-SyntaxError { message: "T: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 6, offset: 6 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: T can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE T : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^ T can not be used as a name because it is a built-in datatype
+
+error: T: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE T : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^ T: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__TIME.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__TIME.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "TIME can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "TIME: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: TIME can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE TIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ TIME can not be used as a name because it is a built-in datatype
+
+error: TIME: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE TIME : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ TIME: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__TIME_OF_DAY.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__TIME_OF_DAY.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "TIME_OF_DAY can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 16, offset: 16 }) }], err_no: type__invalid_name }
-SyntaxError { message: "TIME_OF_DAY: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 16, offset: 16 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: TIME_OF_DAY can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE TIME_OF_DAY : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^ TIME_OF_DAY can not be used as a name because it is a built-in datatype
+
+error: TIME_OF_DAY: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE TIME_OF_DAY : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^^^^^ TIME_OF_DAY: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__TOD.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__TOD.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "TOD can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 8, offset: 8 }) }], err_no: type__invalid_name }
-SyntaxError { message: "TOD: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 8, offset: 8 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: TOD can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE TOD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^ TOD can not be used as a name because it is a built-in datatype
+
+error: TOD: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE TOD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^ TOD: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__UDINT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__UDINT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "UDINT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "UDINT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: UDINT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE UDINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ UDINT can not be used as a name because it is a built-in datatype
+
+error: UDINT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE UDINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ UDINT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__UINT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__UINT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "UINT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "UINT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: UINT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE UINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ UINT can not be used as a name because it is a built-in datatype
+
+error: UINT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE UINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ UINT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__ULINT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__ULINT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "ULINT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "ULINT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: ULINT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE ULINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ ULINT can not be used as a name because it is a built-in datatype
+
+error: ULINT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE ULINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ ULINT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__USINT.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__USINT.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "USINT can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "USINT: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: USINT can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE USINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ USINT can not be used as a name because it is a built-in datatype
+
+error: USINT: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE USINT : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ USINT: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__WCHAR.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__WCHAR.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "WCHAR can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }], err_no: type__invalid_name }
-SyntaxError { message: "WCHAR: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 10, offset: 10 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: WCHAR can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE WCHAR : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ WCHAR can not be used as a name because it is a built-in datatype
+
+error: WCHAR: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE WCHAR : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^ WCHAR: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__WORD.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__WORD.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "WORD can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "WORD: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: WORD can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE WORD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ WORD can not be used as a name because it is a built-in datatype
+
+error: WORD: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE WORD : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ WORD: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__WSTRING.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test__WSTRING.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "WSTRING can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 12, offset: 12 }) }], err_no: type__invalid_name }
-SyntaxError { message: "WSTRING: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 12, offset: 12 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: WSTRING can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE WSTRING : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^ WSTRING can not be used as a name because it is a built-in datatype
+
+error: WSTRING: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE WSTRING : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^^^^ WSTRING: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test____U1.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__naming_validation_test____U1.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/naming_validation_test.rs
-expression: res
+expression: "&result"
 ---
-SyntaxError { message: "__U1 can not be used as a name because it is a built-in datatype", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }], err_no: type__invalid_name }
-SyntaxError { message: "__U1: Ambiguous datatype.", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 5, offset: 5 }..TextLocation { line: 0, column: 9, offset: 9 }) }, SourceLocation { span: None }], err_no: duplicate_symbol }
+error: __U1 can not be used as a name because it is a built-in datatype
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE __U1 : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ __U1 can not be used as a name because it is a built-in datatype
+
+error: __U1: Ambiguous datatype.
+  ┌─ <internal>:1:6
+  │
+1 │ TYPE __U1 : STRUCT x : DINT; END_STRUCT END_TYPE
+  │      ^^^^ __U1: Ambiguous datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__actions_container_no_name.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__actions_container_no_name.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-ImprovementSuggestion { message: "Missing Actions Container Name", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 24, offset: 24 }..TextLocation { line: 0, column: 34, offset: 34 }) }] }
+warning: Missing Actions Container Name
+  ┌─ <internal>:1:25
+  │
+1 │ ACTIONS ACTION myAction END_ACTION END_ACTIONS
+  │                         ^^^^^^^^^^ Missing Actions Container Name
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__class_has_implementation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__class_has_implementation.snap
@@ -1,6 +1,12 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "A class cannot have an implementation", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 12, offset: 88 }..TextLocation { line: 6, column: 17, offset: 120 }) }], err_no: syntax__generic_error }
+error: A class cannot have an implementation
+  ┌─ <internal>:6:13
+  │  
+6 │ ╭             LIGHT := TRUE;
+7 │ │         END_CLASS
+  │ ╰─────────────────^ A class cannot have an implementation
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__class_with_return_type.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__class_with_return_type.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "POU Type Class does not support a return type. Did you mean Function?", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 18, offset: 19 }..TextLocation { line: 1, column: 23, offset: 24 }) }], err_no: pou__unexpected_return_type }
-SyntaxError { message: "A class cannot have a return type", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 14, offset: 15 }..TextLocation { line: 1, column: 17, offset: 18 }) }], err_no: syntax__generic_error }
+error: POU Type Class does not support a return type. Did you mean Function?
+  ┌─ <internal>:2:19
+  │
+2 │         CLASS cls : INT
+  │                   ^^^^^ POU Type Class does not support a return type. Did you mean Function?
+
+error: A class cannot have a return type
+  ┌─ <internal>:2:15
+  │
+2 │         CLASS cls : INT
+  │               ^^^ A class cannot have a return type
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__function_has_super_class.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__function_has_super_class.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "A function cannot use EXTEND", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 17, offset: 55 }..TextLocation { line: 4, column: 21, offset: 59 }) }], err_no: syntax__generic_error }
-SyntaxError { message: "Function Return type missing", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 17, offset: 55 }..TextLocation { line: 4, column: 21, offset: 59 }) }], err_no: pou__missing_return_type }
+error: A function cannot use EXTEND
+  ┌─ <internal>:5:18
+  │
+5 │         FUNCTION func EXTENDS cls
+  │                  ^^^^ A function cannot use EXTEND
+
+error: Function Return type missing
+  ┌─ <internal>:5:18
+  │
+5 │         FUNCTION func EXTENDS cls
+  │                  ^^^^ Function Return type missing
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__function_no_return_unsupported.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__function_no_return_unsupported.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Function Return type missing", range: [SourceLocation { span: Range(TextLocation { line: 0, column: 9, offset: 9 }..TextLocation { line: 0, column: 12, offset: 12 }) }], err_no: pou__missing_return_type }
+error: Function Return type missing
+  ┌─ <internal>:1:10
+  │
+1 │ FUNCTION foo VAR_INPUT END_VAR END_FUNCTION
+  │          ^^^ Function Return type missing
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__in_out_variable_not_allowed_in_class.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__in_out_variable_not_allowed_in_class.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "A class cannot have a var in/out/inout blocks", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 14, offset: 15 }..TextLocation { line: 1, column: 17, offset: 18 }) }], err_no: syntax__generic_error }
+error: A class cannot have a var in/out/inout blocks
+  ┌─ <internal>:2:15
+  │
+2 │         CLASS cls
+  │               ^^^ A class cannot have a var in/out/inout blocks
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__in_out_variable_out_of_order.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__in_out_variable_out_of_order.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Missing inout parameter: myOtherInOut", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 8, offset: 218 }..TextLocation { line: 8, column: 10, offset: 220 }) }], err_no: pou__missing_action_container }
-SyntaxError { message: "Expected a reference for parameter myInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 14, offset: 286 }..TextLocation { line: 9, column: 18, offset: 290 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Missing inout parameter: myOtherInOut", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 8, offset: 280 }..TextLocation { line: 9, column: 10, offset: 282 }) }], err_no: pou__missing_action_container }
+error: Missing inout parameter: myOtherInOut
+  ┌─ <internal>:9:9
+  │
+9 │         fb(myInOut := out2); // invalid: missing in-out param
+  │         ^^ Missing inout parameter: myOtherInOut
+
+error: Expected a reference for parameter myInOut because their type is InOut
+   ┌─ <internal>:10:15
+   │
+10 │         fb(0, TRUE);  // invalid: one in-out is a literal, the other is missing
+   │               ^^^^ Expected a reference for parameter myInOut because their type is InOut
+
+error: Missing inout parameter: myOtherInOut
+   ┌─ <internal>:10:9
+   │
+10 │         fb(0, TRUE);  // invalid: one in-out is a literal, the other is missing
+   │         ^^ Missing inout parameter: myOtherInOut
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__input_variable_not_allowed_in_class.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__input_variable_not_allowed_in_class.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "A class cannot have a var in/out/inout blocks", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 14, offset: 15 }..TextLocation { line: 1, column: 17, offset: 18 }) }], err_no: syntax__generic_error }
+error: A class cannot have a var in/out/inout blocks
+  ┌─ <internal>:2:15
+  │
+2 │         CLASS cls
+  │               ^^^ A class cannot have a var in/out/inout blocks
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__output_variable_not_allowed_in_class.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__output_variable_not_allowed_in_class.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "A class cannot have a var in/out/inout blocks", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 14, offset: 15 }..TextLocation { line: 1, column: 17, offset: 18 }) }], err_no: syntax__generic_error }
+error: A class cannot have a var in/out/inout blocks
+  ┌─ <internal>:2:15
+  │
+2 │         CLASS cls
+  │               ^^^ A class cannot have a var in/out/inout blocks
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__program_has_super_class.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__pou_validation_tests__program_has_super_class.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/pou_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "A program cannot use EXTEND", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 16, offset: 54 }..TextLocation { line: 4, column: 20, offset: 58 }) }], err_no: syntax__generic_error }
+error: A program cannot use EXTEND
+  ┌─ <internal>:5:17
+  │
+5 │         PROGRAM prog EXTENDS cls
+  │                 ^^^^ A program cannot use EXTEND
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_aba_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_aba_input.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 27, offset: 128 }..TextLocation { line: 5, column: 28, offset: 129 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+6 │             FUNCTION_BLOCK B
+  │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_aba_output.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_aba_output.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 27, offset: 128 }..TextLocation { line: 5, column: 28, offset: 129 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+6 │             FUNCTION_BLOCK B
+  │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_bcb.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_bcb.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `B -> C -> B` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 17, offset: 117 }..TextLocation { line: 5, column: 18, offset: 118 }) }, SourceLocation { span: Range(TextLocation { line: 9, column: 17, offset: 216 }..TextLocation { line: 9, column: 18, offset: 217 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `B -> C -> B` has infinite size
+   ┌─ <internal>:6:18
+   │
+ 6 │             TYPE B : STRUCT
+   │                  ^ Recursive data structure `B -> C -> B` has infinite size
+   ·
+10 │             TYPE C : STRUCT
+   │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_with_multiple_identical_members_aba.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__one_cycle_with_multiple_identical_members_aba.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 7, column: 17, offset: 196 }..TextLocation { line: 7, column: 18, offset: 197 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+8 │             TYPE B : STRUCT
+  │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__two_cycles_aa_and_aba.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__two_cycles_aa_and_aba.snap
@@ -1,7 +1,20 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }], err_no: pou__recursive_data_structure }
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 6, column: 17, offset: 155 }..TextLocation { line: 6, column: 18, offset: 156 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> A` has infinite size
+
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+7 │             TYPE B : STRUCT
+  │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__two_cycles_with_branch_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__arrays__two_cycles_with_branch_input.snap
@@ -1,7 +1,35 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `F -> G -> H -> I -> F` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 27, offset: 488 }..TextLocation { line: 21, column: 28, offset: 489 }) }, SourceLocation { span: Range(TextLocation { line: 28, column: 17, offset: 643 }..TextLocation { line: 28, column: 18, offset: 644 }) }, SourceLocation { span: Range(TextLocation { line: 32, column: 27, offset: 737 }..TextLocation { line: 32, column: 28, offset: 738 }) }, SourceLocation { span: Range(TextLocation { line: 38, column: 17, offset: 865 }..TextLocation { line: 38, column: 18, offset: 866 }) }], err_no: pou__recursive_data_structure }
-SemanticError { message: "Recursive data structure `B -> C -> E -> F -> B` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 17, offset: 156 }..TextLocation { line: 7, column: 18, offset: 157 }) }, SourceLocation { span: Range(TextLocation { line: 11, column: 27, offset: 250 }..TextLocation { line: 11, column: 28, offset: 251 }) }, SourceLocation { span: Range(TextLocation { line: 17, column: 17, offset: 378 }..TextLocation { line: 17, column: 18, offset: 379 }) }, SourceLocation { span: Range(TextLocation { line: 21, column: 27, offset: 488 }..TextLocation { line: 21, column: 28, offset: 489 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ┌─ <internal>:22:28
+   │
+22 │             FUNCTION_BLOCK F
+   │                            ^ Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ·
+29 │             TYPE G : STRUCT
+   │                  - see also
+   ·
+33 │             FUNCTION_BLOCK H
+   │                            - see also
+   ·
+39 │             TYPE I : STRUCT
+   │                  - see also
+
+error: Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ┌─ <internal>:8:18
+   │
+ 8 │             TYPE B : STRUCT
+   │                  ^ Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ·
+12 │             FUNCTION_BLOCK C
+   │                            - see also
+   ·
+18 │             TYPE E : STRUCT
+   │                  - see also
+   ·
+22 │             FUNCTION_BLOCK F
+   │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__external_function_should_not_trigger.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__external_function_should_not_trigger.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/recursive_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__pointers_should_not_be_considered_as_cycle.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__pointers_should_not_be_considered_as_cycle.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/recursive_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__struct_and_function_with_same_name.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__struct_and_function_with_same_name.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/recursive_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__struct_and_function_with_same_name_2.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__struct_and_function_with_same_name_2.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/recursive_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__struct_and_function_with_same_name_3.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__edgecases__struct_and_function_with_same_name_3.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/recursive_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_inout.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_inout.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/recursive_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_input.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 27, offset: 28 }..TextLocation { line: 1, column: 28, offset: 29 }) }, SourceLocation { span: Range(TextLocation { line: 8, column: 27, offset: 167 }..TextLocation { line: 8, column: 28, offset: 168 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:28
+  │
+2 │             FUNCTION_BLOCK A
+  │                            ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+9 │             FUNCTION_BLOCK B
+  │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_output.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_output.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 27, offset: 28 }..TextLocation { line: 1, column: 28, offset: 29 }) }, SourceLocation { span: Range(TextLocation { line: 8, column: 27, offset: 168 }..TextLocation { line: 8, column: 28, offset: 169 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:28
+  │
+2 │             FUNCTION_BLOCK A
+  │                            ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+9 │             FUNCTION_BLOCK B
+  │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_var.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__one_cycle_aba_var.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 27, offset: 28 }..TextLocation { line: 1, column: 28, offset: 29 }) }, SourceLocation { span: Range(TextLocation { line: 8, column: 27, offset: 161 }..TextLocation { line: 8, column: 28, offset: 162 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:28
+  │
+2 │             FUNCTION_BLOCK A
+  │                            ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+9 │             FUNCTION_BLOCK B
+  │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__two_cycles_with_branch_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__functionblocks__two_cycles_with_branch_input.snap
@@ -1,7 +1,35 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `F -> G -> H -> I -> F` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 25, column: 27, offset: 580 }..TextLocation { line: 25, column: 28, offset: 581 }) }, SourceLocation { span: Range(TextLocation { line: 32, column: 27, offset: 745 }..TextLocation { line: 32, column: 28, offset: 746 }) }, SourceLocation { span: Range(TextLocation { line: 38, column: 27, offset: 883 }..TextLocation { line: 38, column: 28, offset: 884 }) }, SourceLocation { span: Range(TextLocation { line: 44, column: 27, offset: 1021 }..TextLocation { line: 44, column: 28, offset: 1022 }) }], err_no: pou__recursive_data_structure }
-SemanticError { message: "Recursive data structure `B -> C -> E -> F -> B` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 27, offset: 166 }..TextLocation { line: 7, column: 28, offset: 167 }) }, SourceLocation { span: Range(TextLocation { line: 13, column: 27, offset: 304 }..TextLocation { line: 13, column: 28, offset: 305 }) }, SourceLocation { span: Range(TextLocation { line: 19, column: 27, offset: 442 }..TextLocation { line: 19, column: 28, offset: 443 }) }, SourceLocation { span: Range(TextLocation { line: 25, column: 27, offset: 580 }..TextLocation { line: 25, column: 28, offset: 581 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ┌─ <internal>:26:28
+   │
+26 │             FUNCTION_BLOCK F
+   │                            ^ Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ·
+33 │             FUNCTION_BLOCK G
+   │                            - see also
+   ·
+39 │             FUNCTION_BLOCK H
+   │                            - see also
+   ·
+45 │             FUNCTION_BLOCK I
+   │                            - see also
+
+error: Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ┌─ <internal>:8:28
+   │
+ 8 │             FUNCTION_BLOCK B
+   │                            ^ Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ·
+14 │             FUNCTION_BLOCK C
+   │                            - see also
+   ·
+20 │             FUNCTION_BLOCK E
+   │                            - see also
+   ·
+26 │             FUNCTION_BLOCK F
+   │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__mixed_structs_and_functionblocks__one_cycle_aba_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__mixed_structs_and_functionblocks__one_cycle_aba_input.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 27, offset: 112 }..TextLocation { line: 5, column: 28, offset: 113 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+6 │             FUNCTION_BLOCK B
+  │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__mixed_structs_and_functionblocks__one_cycle_aba_output.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__mixed_structs_and_functionblocks__one_cycle_aba_output.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 27, offset: 112 }..TextLocation { line: 5, column: 28, offset: 113 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+6 │             FUNCTION_BLOCK B
+  │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__mixed_structs_and_functionblocks__two_cycles_with_branch_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__mixed_structs_and_functionblocks__two_cycles_with_branch_input.snap
@@ -1,7 +1,35 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `F -> G -> H -> I -> F` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 27, offset: 472 }..TextLocation { line: 21, column: 28, offset: 473 }) }, SourceLocation { span: Range(TextLocation { line: 28, column: 17, offset: 627 }..TextLocation { line: 28, column: 18, offset: 628 }) }, SourceLocation { span: Range(TextLocation { line: 32, column: 27, offset: 721 }..TextLocation { line: 32, column: 28, offset: 722 }) }, SourceLocation { span: Range(TextLocation { line: 38, column: 17, offset: 849 }..TextLocation { line: 38, column: 18, offset: 850 }) }], err_no: pou__recursive_data_structure }
-SemanticError { message: "Recursive data structure `B -> C -> E -> F -> B` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 17, offset: 156 }..TextLocation { line: 7, column: 18, offset: 157 }) }, SourceLocation { span: Range(TextLocation { line: 11, column: 27, offset: 250 }..TextLocation { line: 11, column: 28, offset: 251 }) }, SourceLocation { span: Range(TextLocation { line: 17, column: 17, offset: 378 }..TextLocation { line: 17, column: 18, offset: 379 }) }, SourceLocation { span: Range(TextLocation { line: 21, column: 27, offset: 472 }..TextLocation { line: 21, column: 28, offset: 473 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ┌─ <internal>:22:28
+   │
+22 │             FUNCTION_BLOCK F
+   │                            ^ Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ·
+29 │             TYPE G : STRUCT
+   │                  - see also
+   ·
+33 │             FUNCTION_BLOCK H
+   │                            - see also
+   ·
+39 │             TYPE I : STRUCT
+   │                  - see also
+
+error: Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ┌─ <internal>:8:18
+   │
+ 8 │             TYPE B : STRUCT
+   │                  ^ Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ·
+12 │             FUNCTION_BLOCK C
+   │                            - see also
+   ·
+18 │             TYPE E : STRUCT
+   │                  - see also
+   ·
+22 │             FUNCTION_BLOCK F
+   │                            - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_aba.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_aba.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 17, offset: 102 }..TextLocation { line: 5, column: 18, offset: 103 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+6 │             TYPE B : STRUCT
+  │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_abca.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_abca.snap
@@ -1,6 +1,17 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> C -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 5, column: 17, offset: 102 }..TextLocation { line: 5, column: 18, offset: 103 }) }, SourceLocation { span: Range(TextLocation { line: 9, column: 17, offset: 186 }..TextLocation { line: 9, column: 18, offset: 187 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> C -> A` has infinite size
+   ┌─ <internal>:2:18
+   │
+ 2 │             TYPE A : STRUCT
+   │                  ^ Recursive data structure `A -> B -> C -> A` has infinite size
+   ·
+ 6 │             TYPE B : STRUCT
+   │                  - see also
+   ·
+10 │             TYPE C : STRUCT
+   │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_bcb.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_bcb.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `B -> C -> B` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 17, offset: 102 }..TextLocation { line: 5, column: 18, offset: 103 }) }, SourceLocation { span: Range(TextLocation { line: 9, column: 17, offset: 186 }..TextLocation { line: 9, column: 18, offset: 187 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `B -> C -> B` has infinite size
+   ┌─ <internal>:6:18
+   │
+ 6 │             TYPE B : STRUCT
+   │                  ^ Recursive data structure `B -> C -> B` has infinite size
+   ·
+10 │             TYPE C : STRUCT
+   │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_multiple_self_a.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_multiple_self_a.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> A` has infinite size
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_self_a.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_self_a.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> A` has infinite size
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_with_multiple_identical_members_aba.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__one_cycle_with_multiple_identical_members_aba.snap
@@ -1,6 +1,14 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 7, column: 17, offset: 151 }..TextLocation { line: 7, column: 18, offset: 152 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+8 │             TYPE B : STRUCT
+  │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__two_cycles_aa_and_aba.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__two_cycles_aa_and_aba.snap
@@ -1,7 +1,20 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `A -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }], err_no: pou__recursive_data_structure }
-SemanticError { message: "Recursive data structure `A -> B -> A` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 17, offset: 18 }..TextLocation { line: 1, column: 18, offset: 19 }) }, SourceLocation { span: Range(TextLocation { line: 6, column: 17, offset: 125 }..TextLocation { line: 6, column: 18, offset: 126 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `A -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> A` has infinite size
+
+error: Recursive data structure `A -> B -> A` has infinite size
+  ┌─ <internal>:2:18
+  │
+2 │             TYPE A : STRUCT
+  │                  ^ Recursive data structure `A -> B -> A` has infinite size
+  ·
+7 │             TYPE B : STRUCT
+  │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__two_cycles_branch_cc_and_cec.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__two_cycles_branch_cc_and_cec.snap
@@ -1,7 +1,20 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `C -> C` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 17, offset: 186 }..TextLocation { line: 9, column: 18, offset: 187 }) }], err_no: pou__recursive_data_structure }
-SemanticError { message: "Recursive data structure `C -> E -> C` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 17, offset: 186 }..TextLocation { line: 9, column: 18, offset: 187 }) }, SourceLocation { span: Range(TextLocation { line: 14, column: 17, offset: 293 }..TextLocation { line: 14, column: 18, offset: 294 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `C -> C` has infinite size
+   ┌─ <internal>:10:18
+   │
+10 │             TYPE C : STRUCT
+   │                  ^ Recursive data structure `C -> C` has infinite size
+
+error: Recursive data structure `C -> E -> C` has infinite size
+   ┌─ <internal>:10:18
+   │
+10 │             TYPE C : STRUCT
+   │                  ^ Recursive data structure `C -> E -> C` has infinite size
+   ·
+15 │             TYPE E : STRUCT
+   │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__two_cycles_with_branch.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__recursive_validation_tests__structs__two_cycles_with_branch.snap
@@ -1,7 +1,35 @@
 ---
 source: src/validation/tests/recursive_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SemanticError { message: "Recursive data structure `F -> G -> H -> I -> F` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 17, offset: 354 }..TextLocation { line: 17, column: 18, offset: 355 }) }, SourceLocation { span: Range(TextLocation { line: 22, column: 17, offset: 461 }..TextLocation { line: 22, column: 18, offset: 462 }) }, SourceLocation { span: Range(TextLocation { line: 26, column: 17, offset: 545 }..TextLocation { line: 26, column: 18, offset: 546 }) }, SourceLocation { span: Range(TextLocation { line: 30, column: 17, offset: 629 }..TextLocation { line: 30, column: 18, offset: 630 }) }], err_no: pou__recursive_data_structure }
-SemanticError { message: "Recursive data structure `B -> C -> E -> F -> B` has infinite size", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 17, offset: 102 }..TextLocation { line: 5, column: 18, offset: 103 }) }, SourceLocation { span: Range(TextLocation { line: 9, column: 17, offset: 186 }..TextLocation { line: 9, column: 18, offset: 187 }) }, SourceLocation { span: Range(TextLocation { line: 13, column: 17, offset: 270 }..TextLocation { line: 13, column: 18, offset: 271 }) }, SourceLocation { span: Range(TextLocation { line: 17, column: 17, offset: 354 }..TextLocation { line: 17, column: 18, offset: 355 }) }], err_no: pou__recursive_data_structure }
+error: Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ┌─ <internal>:18:18
+   │
+18 │             TYPE F : STRUCT
+   │                  ^ Recursive data structure `F -> G -> H -> I -> F` has infinite size
+   ·
+23 │             TYPE G : STRUCT
+   │                  - see also
+   ·
+27 │             TYPE H : STRUCT
+   │                  - see also
+   ·
+31 │             TYPE I : STRUCT
+   │                  - see also
+
+error: Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ┌─ <internal>:6:18
+   │
+ 6 │             TYPE B : STRUCT
+   │                  ^ Recursive data structure `B -> C -> E -> F -> B` has infinite size
+   ·
+10 │             TYPE C : STRUCT
+   │                  - see also
+   ·
+14 │             TYPE E : STRUCT
+   │                  - see also
+   ·
+18 │             TYPE F : STRUCT
+   │                  - see also
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initialized.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initialized.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/reference_resolve_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__fb_pointer_access_call_statement_resolves_without_validation_errors.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__fb_pointer_access_call_statement_resolves_without_validation_errors.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/reference_resolve_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__program_vars_are_allowed_in_their_actions.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__program_vars_are_allowed_in_their_actions.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/reference_resolve_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__reference_to_private_variable_in_intermediate_fb.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__reference_to_private_variable_in_intermediate_fb.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Illegal access to private member fb1.f", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 18, offset: 393 }..TextLocation { line: 18, column: 19, offset: 394 }) }], err_no: reference__illegal_access }
+error: Illegal access to private member fb1.f
+   ┌─ <internal>:19:19
+   │
+19 │                 a.f.x := 7;
+   │                   ^ Illegal access to private member fb1.f
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__reference_to_private_variable_is_illegal.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__reference_to_private_variable_is_illegal.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Illegal access to private member prg.s", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 20, offset: 174 }..TextLocation { line: 8, column: 21, offset: 175 }) }], err_no: reference__illegal_access }
+error: Illegal access to private member prg.s
+  ┌─ <internal>:9:21
+  │
+9 │                 prg.s := 7;
+  │                     ^ Illegal access to private member prg.s
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resole_struct_member_access.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resole_struct_member_access.snap
@@ -1,11 +1,41 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Could not resolve reference to field10", range: [SourceLocation { span: Range(TextLocation { line: 27, column: 18, offset: 691 }..TextLocation { line: 27, column: 25, offset: 698 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to field20", range: [SourceLocation { span: Range(TextLocation { line: 28, column: 18, offset: 718 }..TextLocation { line: 28, column: 25, offset: 725 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to field30", range: [SourceLocation { span: Range(TextLocation { line: 29, column: 18, offset: 745 }..TextLocation { line: 29, column: 25, offset: 752 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to subfield10", range: [SourceLocation { span: Range(TextLocation { line: 37, column: 22, offset: 951 }..TextLocation { line: 37, column: 32, offset: 961 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to subfield20", range: [SourceLocation { span: Range(TextLocation { line: 38, column: 22, offset: 985 }..TextLocation { line: 38, column: 32, offset: 995 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to subfield30", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 22, offset: 1019 }..TextLocation { line: 39, column: 32, offset: 1029 }) }], err_no: reference__unresolved }
+error: Could not resolve reference to field10
+   ┌─ <internal>:28:19
+   │
+28 │                 s.field10;
+   │                   ^^^^^^^ Could not resolve reference to field10
+
+error: Could not resolve reference to field20
+   ┌─ <internal>:29:19
+   │
+29 │                 s.field20;
+   │                   ^^^^^^^ Could not resolve reference to field20
+
+error: Could not resolve reference to field30
+   ┌─ <internal>:30:19
+   │
+30 │                 s.field30;
+   │                   ^^^^^^^ Could not resolve reference to field30
+
+error: Could not resolve reference to subfield10
+   ┌─ <internal>:38:23
+   │
+38 │                 s.sub.subfield10;
+   │                       ^^^^^^^^^^ Could not resolve reference to subfield10
+
+error: Could not resolve reference to subfield20
+   ┌─ <internal>:39:23
+   │
+39 │                 s.sub.subfield20;
+   │                       ^^^^^^^^^^ Could not resolve reference to subfield20
+
+error: Could not resolve reference to subfield30
+   ┌─ <internal>:40:23
+   │
+40 │                 s.sub.subfield30;
+   │                       ^^^^^^^^^^ Could not resolve reference to subfield30
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_array_of_struct_as_member_of_another_struct_initializer.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_array_of_struct_as_member_of_another_struct_initializer.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/reference_resolve_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_field_access.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_field_access.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/reference_resolve_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_in_structs_and_field_access.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_block_calls_in_structs_and_field_access.snap
@@ -1,11 +1,41 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Could not resolve reference to fb3", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 29, offset: 648 }..TextLocation { line: 24, column: 32, offset: 651 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to a", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 33, offset: 652 }..TextLocation { line: 24, column: 34, offset: 653 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to fb3", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 43, offset: 662 }..TextLocation { line: 24, column: 46, offset: 665 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to b", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 47, offset: 666 }..TextLocation { line: 24, column: 48, offset: 667 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to fb3", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 57, offset: 676 }..TextLocation { line: 24, column: 60, offset: 679 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to c", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 61, offset: 680 }..TextLocation { line: 24, column: 62, offset: 681 }) }], err_no: reference__unresolved }
+error: Could not resolve reference to fb3
+   ┌─ <internal>:25:30
+   │
+25 │                 s.fb1(a := s.fb3.a, b := s.fb3.b, c := s.fb3.c);
+   │                              ^^^ Could not resolve reference to fb3
+
+error: Could not resolve reference to a
+   ┌─ <internal>:25:34
+   │
+25 │                 s.fb1(a := s.fb3.a, b := s.fb3.b, c := s.fb3.c);
+   │                                  ^ Could not resolve reference to a
+
+error: Could not resolve reference to fb3
+   ┌─ <internal>:25:44
+   │
+25 │                 s.fb1(a := s.fb3.a, b := s.fb3.b, c := s.fb3.c);
+   │                                            ^^^ Could not resolve reference to fb3
+
+error: Could not resolve reference to b
+   ┌─ <internal>:25:48
+   │
+25 │                 s.fb1(a := s.fb3.a, b := s.fb3.b, c := s.fb3.c);
+   │                                                ^ Could not resolve reference to b
+
+error: Could not resolve reference to fb3
+   ┌─ <internal>:25:58
+   │
+25 │                 s.fb1(a := s.fb3.a, b := s.fb3.b, c := s.fb3.c);
+   │                                                          ^^^ Could not resolve reference to fb3
+
+error: Could not resolve reference to c
+   ┌─ <internal>:25:62
+   │
+25 │                 s.fb1(a := s.fb3.a, b := s.fb3.b, c := s.fb3.c);
+   │                                                              ^ Could not resolve reference to c
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_calls_and_parameters.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_calls_and_parameters.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Could not resolve reference to boo", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 16, offset: 101 }..TextLocation { line: 4, column: 19, offset: 104 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to c", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 20, offset: 105 }..TextLocation { line: 4, column: 21, offset: 106 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to c", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 25, offset: 163 }..TextLocation { line: 6, column: 26, offset: 164 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to y", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 20, offset: 187 }..TextLocation { line: 7, column: 21, offset: 188 }) }], err_no: reference__unresolved }
+error: Could not resolve reference to boo
+  ┌─ <internal>:5:17
+  │
+5 │                 boo(c);
+  │                 ^^^ Could not resolve reference to boo
+
+error: Could not resolve reference to c
+  ┌─ <internal>:5:21
+  │
+5 │                 boo(c);
+  │                     ^ Could not resolve reference to c
+
+error: Could not resolve reference to c
+  ┌─ <internal>:7:26
+  │
+7 │                 foo(x := c);
+  │                          ^ Could not resolve reference to c
+
+error: Could not resolve reference to y
+  ┌─ <internal>:8:21
+  │
+8 │                 foo(y := a);
+  │                     ^ Could not resolve reference to y
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_members_via_qualifier.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_function_members_via_qualifier.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Could not resolve reference to a", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 20, offset: 180 }..TextLocation { line: 6, column: 21, offset: 181 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to b", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 20, offset: 216 }..TextLocation { line: 7, column: 21, offset: 217 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to c", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 20, offset: 252 }..TextLocation { line: 8, column: 21, offset: 253 }) }], err_no: reference__unresolved }
+error: Could not resolve reference to a
+  ┌─ <internal>:7:21
+  │
+7 │                 foo.a; (* not ok *)
+  │                     ^ Could not resolve reference to a
+
+error: Could not resolve reference to b
+  ┌─ <internal>:8:21
+  │
+8 │                 foo.b; (* not ok *)
+  │                     ^ Could not resolve reference to b
+
+error: Could not resolve reference to c
+  ┌─ <internal>:9:21
+  │
+9 │                 foo.c; (* not ok *)
+  │                     ^ Could not resolve reference to c
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_simple_variable_references.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__reference_resolve_tests__resolve_simple_variable_references.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/reference_resolve_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Could not resolve reference to b", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 16, offset: 168 }..TextLocation { line: 9, column: 17, offset: 169 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Could not resolve reference to gb", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 16, offset: 207 }..TextLocation { line: 11, column: 18, offset: 209 }) }], err_no: reference__unresolved }
+error: Could not resolve reference to b
+   ┌─ <internal>:10:17
+   │
+10 │                 b;
+   │                 ^ Could not resolve reference to b
+
+error: Could not resolve reference to gb
+   ┌─ <internal>:12:17
+   │
+12 │                 gb;
+   │                 ^^ Could not resolve reference to gb
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__action_implicit_downcast.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__action_implicit_downcast.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 29, offset: 213 }..TextLocation { line: 8, column: 37, offset: 221 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[1..3] OF LINT' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 31, offset: 276 }..TextLocation { line: 9, column: 38, offset: 283 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+  ┌─ <internal>:9:30
+  │
+9 │             fb.foo(var_lint, var_wstr); // downcast, invalid
+  │                              ^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+
+error: Invalid assignment: cannot assign 'ARRAY[1..3] OF LINT' to 'STRING'
+   ┌─ <internal>:10:32
+   │
+10 │             prog.bar(var_lint, var_arr); // downcast, invalid
+   │                                ^^^^^^^ Invalid assignment: cannot assign 'ARRAY[1..3] OF LINT' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__aliased_int_compare_function_causes_no_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__aliased_int_compare_function_causes_no_error.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__aliased_subrange_compare_function_causes_no_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__aliased_subrange_compare_function_causes_no_error.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__allowed_assignable_types.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__allowed_assignable_types.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assign_pointer_to_lword.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assign_pointer_to_lword.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assign_pointer_to_too_small_type_result_in_an_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assign_pointer_to_too_small_type_result_in_an_error.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "The type DWORD 32 is too small to hold a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 174 }..TextLocation { line: 8, column: 26, offset: 188 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'REF_TO INT' to 'DWORD'", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 174 }..TextLocation { line: 8, column: 26, offset: 188 }) }], err_no: var__invalid_assignment }
+error: The type DWORD 32 is too small to hold a Pointer
+  ┌─ <internal>:9:13
+  │
+9 │             address := ptr;         //should throw error as address is too small to store full pointer
+  │             ^^^^^^^^^^^^^^ The type DWORD 32 is too small to hold a Pointer
+
+error: Invalid assignment: cannot assign 'REF_TO INT' to 'DWORD'
+  ┌─ <internal>:9:13
+  │
+9 │             address := ptr;         //should throw error as address is too small to store full pointer
+  │             ^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REF_TO INT' to 'DWORD'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assign_too_small_type_to_pointer_result_in_an_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assign_too_small_type_to_pointer_result_in_an_error.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "The type DWORD 32 is too small to to be stored in a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 174 }..TextLocation { line: 8, column: 26, offset: 188 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'DWORD' to 'REF_TO INT'", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 174 }..TextLocation { line: 8, column: 26, offset: 188 }) }], err_no: var__invalid_assignment }
+error: The type DWORD 32 is too small to to be stored in a Pointer
+  ┌─ <internal>:9:13
+  │
+9 │             ptr := address;         //should throw error as address is too small to store full pointer
+  │             ^^^^^^^^^^^^^^ The type DWORD 32 is too small to to be stored in a Pointer
+
+error: Invalid assignment: cannot assign 'DWORD' to 'REF_TO INT'
+  ┌─ <internal>:9:13
+  │
+9 │             ptr := address;         //should throw error as address is too small to store full pointer
+  │             ^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'DWORD' to 'REF_TO INT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assigning_to_qualified_references_allowed.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assigning_to_qualified_references_allowed.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assigning_to_rvalue.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assigning_to_rvalue.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Expression is not assignable", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 12, offset: 189 }..TextLocation { line: 11, column: 13, offset: 190 }) }], err_no: reference__expected }
-SyntaxError { message: "Expression is not assignable", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 12, offset: 209 }..TextLocation { line: 12, column: 13, offset: 210 }) }], err_no: reference__expected }
-SyntaxError { message: "Expression is not assignable", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 17, offset: 234 }..TextLocation { line: 13, column: 18, offset: 235 }) }], err_no: reference__expected }
+error: Expression is not assignable
+   ┌─ <internal>:12:13
+   │
+12 │             1 := 1;
+   │             ^ Expression is not assignable
+
+error: Expression is not assignable
+   ┌─ <internal>:13:13
+   │
+13 │             1 := i;
+   │             ^ Expression is not assignable
+
+error: Expression is not assignable
+   ┌─ <internal>:14:18
+   │
+14 │             func(1 := 1);
+   │                  ^ Expression is not assignable
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assigning_to_rvalue_allowed_for_directaccess.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assigning_to_rvalue_allowed_for_directaccess.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assignment_to_constants_result_in_an_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assignment_to_constants_result_in_an_error.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Cannot assign to CONSTANT 'prg.cl'", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 12, offset: 327 }..TextLocation { line: 19, column: 14, offset: 329 }) }], err_no: var__cannot_assign_to_const }
-SyntaxError { message: "Cannot assign to CONSTANT 'ci'", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 12, offset: 371 }..TextLocation { line: 21, column: 14, offset: 373 }) }], err_no: var__cannot_assign_to_const }
+error: Cannot assign to CONSTANT 'prg.cl'
+   ┌─ <internal>:20:13
+   │
+20 │             cl  := 4;
+   │             ^^ Cannot assign to CONSTANT 'prg.cl'
+
+error: Cannot assign to CONSTANT 'ci'
+   ┌─ <internal>:22:13
+   │
+22 │             ci  := 4;
+   │             ^^ Cannot assign to CONSTANT 'ci'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assignment_to_enum_literals_results_in_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__assignment_to_enum_literals_results_in_error.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Cannot assign to CONSTANT '__prg_state.OPEN'", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 12, offset: 228 }..TextLocation { line: 12, column: 16, offset: 232 }) }], err_no: var__cannot_assign_to_const }
-SyntaxError { message: "Cannot assign to CONSTANT '__global_g_enum.B'", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 12, offset: 251 }..TextLocation { line: 13, column: 13, offset: 252 }) }], err_no: var__cannot_assign_to_const }
-SyntaxError { message: "Cannot assign to CONSTANT 'Color.red'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 12, offset: 271 }..TextLocation { line: 14, column: 15, offset: 274 }) }], err_no: var__cannot_assign_to_const }
+error: Cannot assign to CONSTANT '__prg_state.OPEN'
+   ┌─ <internal>:13:13
+   │
+13 │             OPEN := 3;
+   │             ^^^^ Cannot assign to CONSTANT '__prg_state.OPEN'
+
+error: Cannot assign to CONSTANT '__global_g_enum.B'
+   ┌─ <internal>:14:13
+   │
+14 │             B := A;
+   │             ^ Cannot assign to CONSTANT '__global_g_enum.B'
+
+error: Cannot assign to CONSTANT 'Color.red'
+   ┌─ <internal>:15:13
+   │
+15 │             red := green;
+   │             ^^^ Cannot assign to CONSTANT 'Color.red'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__bit_access_with_incorrect_operator_causes_warning.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Could not resolve reference to n1", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 24, offset: 287 }..TextLocation { line: 11, column: 26, offset: 289 }) }], err_no: reference__unresolved }
-ImprovementSuggestion { message: "If you meant to directly access a bit/byte/word/.., use %X/%B/%Wn1 instead.", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 24, offset: 287 }..TextLocation { line: 11, column: 26, offset: 289 }) }] }
+error: Could not resolve reference to n1
+   ┌─ <internal>:12:25
+   │
+12 │             Output.var1.n1             := Input.var1; // bitaccess without %X -> Warning
+   │                         ^^ Could not resolve reference to n1
+
+warning: If you meant to directly access a bit/byte/word/.., use %X/%B/%Wn1 instead.
+   ┌─ <internal>:12:25
+   │
+12 │             Output.var1.n1             := Input.var1; // bitaccess without %X -> Warning
+   │                         ^^ If you meant to directly access a bit/byte/word/.., use %X/%B/%Wn1 instead.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__case_condition_used_outside_case_statement.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__case_condition_used_outside_case_statement.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Case condition used outside of case statement! Did you mean to use ';'?", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 12, offset: 86 }..TextLocation { line: 5, column: 32, offset: 106 }) }], err_no: case__case_condition_outside_case_statement }
-SyntaxError { message: "Case condition used outside of case statement! Did you mean to use ';'?", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 124 }..TextLocation { line: 6, column: 14, offset: 126 }) }], err_no: case__case_condition_outside_case_statement }
+error: Case condition used outside of case statement! Did you mean to use ';'?
+  ┌─ <internal>:6:13
+  │
+6 │             var1 := TOD#20:15:30:123;
+  │             ^^^^^^^^^^^^^^^^^^^^ Case condition used outside of case statement! Did you mean to use ';'?
+
+error: Case condition used outside of case statement! Did you mean to use ';'?
+  ┌─ <internal>:7:13
+  │
+7 │             23:
+  │             ^^ Case condition used outside of case statement! Did you mean to use ';'?
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__function_block_implicit_downcast.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__function_block_implicit_downcast.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 16, offset: 464 }..TextLocation { line: 15, column: 24, offset: 472 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+   ┌─ <internal>:16:17
+   │
+16 │                 var_wstr, // invalid
+   │                 ^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__function_call_parameter_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__function_call_parameter_validation.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Cannot mix implicit and explicit call parameters!", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 33, offset: 507 }..TextLocation { line: 22, column: 37, offset: 511 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Cannot mix implicit and explicit call parameters!", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 39, offset: 513 }..TextLocation { line: 22, column: 43, offset: 517 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 16, offset: 581 }..TextLocation { line: 24, column: 30, offset: 595 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "The type DINT 32 is too small to hold a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 32, offset: 597 }..TextLocation { line: 24, column: 46, offset: 611 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 32, offset: 597 }..TextLocation { line: 24, column: 46, offset: 611 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 16, offset: 770 }..TextLocation { line: 26, column: 20, offset: 774 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "The type DINT 32 is too small to hold a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 22, offset: 776 }..TextLocation { line: 26, column: 26, offset: 780 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 22, offset: 776 }..TextLocation { line: 26, column: 26, offset: 780 }) }], err_no: var__invalid_assignment }
+error: Cannot mix implicit and explicit call parameters!
+   ┌─ <internal>:23:34
+   │
+23 │             foo(output1 => var1, var1, var1); // invalid cannot mix explicit and implicit
+   │                                  ^^^^ Cannot mix implicit and explicit call parameters!
+
+error: Cannot mix implicit and explicit call parameters!
+   ┌─ <internal>:23:40
+   │
+23 │             foo(output1 => var1, var1, var1); // invalid cannot mix explicit and implicit
+   │                                        ^^^^ Cannot mix implicit and explicit call parameters!
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:25:17
+   │
+25 │             foo(input1 := var2, inout1 := var3, output1 => var4); // invalid types assigned
+   │                 ^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: The type DINT 32 is too small to hold a Pointer
+   ┌─ <internal>:25:33
+   │
+25 │             foo(input1 := var2, inout1 := var3, output1 => var4); // invalid types assigned
+   │                                 ^^^^^^^^^^^^^^ The type DINT 32 is too small to hold a Pointer
+
+error: Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+   ┌─ <internal>:25:33
+   │
+25 │             foo(input1 := var2, inout1 := var3, output1 => var4); // invalid types assigned
+   │                                 ^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:27:17
+   │
+27 │             foo(var2, var3, var4); // invalid types assigned
+   │                 ^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: The type DINT 32 is too small to hold a Pointer
+   ┌─ <internal>:27:23
+   │
+27 │             foo(var2, var3, var4); // invalid types assigned
+   │                       ^^^^ The type DINT 32 is too small to hold a Pointer
+
+error: Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+   ┌─ <internal>:27:23
+   │
+27 │             foo(var2, var3, var4); // invalid types assigned
+   │                       ^^^^ Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__implicit_param_downcast_in_function_call.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__implicit_param_downcast_in_function_call.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 16, offset: 633 }..TextLocation { line: 16, column: 31, offset: 648 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+   ┌─ <internal>:17:17
+   │
+17 │                 var_in_out_wstr, // invalid
+   │                 ^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__invalid_cast_statement_causes_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__invalid_cast_statement_causes_error.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Could not resolve reference to var1", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 27, offset: 141 }..TextLocation { line: 6, column: 31, offset: 145 }) }], err_no: reference__unresolved }
+error: Could not resolve reference to var1
+  ┌─ <internal>:7:28
+  │
+7 │                 i := INT#s.var1; // illegal, var1 cannot be found in INT
+  │                            ^^^^ Could not resolve reference to var1
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__invalid_char_assignments.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__invalid_char_assignments.snap
@@ -1,17 +1,77 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Value: 'AJK%&/231' exceeds length for type: CHAR", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 12, offset: 205 }..TextLocation { line: 10, column: 28, offset: 221 }) }], err_no: syntax__generic_error }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 12, offset: 205 }..TextLocation { line: 10, column: 28, offset: 221 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Value: '898JKAN' exceeds length for type: WCHAR", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 12, offset: 246 }..TextLocation { line: 11, column: 27, offset: 261 }) }], err_no: syntax__generic_error }
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'WCHAR'", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 12, offset: 246 }..TextLocation { line: 11, column: 27, offset: 261 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'WCHAR' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 12, offset: 287 }..TextLocation { line: 13, column: 19, offset: 294 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'WCHAR'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 12, offset: 319 }..TextLocation { line: 14, column: 19, offset: 326 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'INT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 12, offset: 373 }..TextLocation { line: 17, column: 18, offset: 379 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 12, offset: 404 }..TextLocation { line: 18, column: 19, offset: 411 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'CHAR'", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 12, offset: 461 }..TextLocation { line: 21, column: 18, offset: 467 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'WCHAR'", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 12, offset: 492 }..TextLocation { line: 22, column: 19, offset: 499 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 12, offset: 525 }..TextLocation { line: 24, column: 18, offset: 531 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'CHAR' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 25, column: 12, offset: 556 }..TextLocation { line: 25, column: 18, offset: 562 }) }], err_no: var__invalid_assignment }
+error: Value: 'AJK%&/231' exceeds length for type: CHAR
+   ┌─ <internal>:11:13
+   │
+11 │             c := 'AJK%&/231'; // invalid
+   │             ^^^^^^^^^^^^^^^^ Value: 'AJK%&/231' exceeds length for type: CHAR
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:11:13
+   │
+11 │             c := 'AJK%&/231'; // invalid
+   │             ^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Value: '898JKAN' exceeds length for type: WCHAR
+   ┌─ <internal>:12:13
+   │
+12 │             wc := "898JKAN"; // invalid
+   │             ^^^^^^^^^^^^^^^ Value: '898JKAN' exceeds length for type: WCHAR
+
+error: Invalid assignment: cannot assign 'WSTRING' to 'WCHAR'
+   ┌─ <internal>:12:13
+   │
+12 │             wc := "898JKAN"; // invalid
+   │             ^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'WCHAR'
+
+error: Invalid assignment: cannot assign 'WCHAR' to 'CHAR'
+   ┌─ <internal>:14:13
+   │
+14 │             c := wc; // invalid
+   │             ^^^^^^^ Invalid assignment: cannot assign 'WCHAR' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'WCHAR'
+   ┌─ <internal>:15:13
+   │
+15 │             wc := c; // invalid
+   │             ^^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'WCHAR'
+
+error: Invalid assignment: cannot assign 'INT' to 'CHAR'
+   ┌─ <internal>:18:13
+   │
+18 │             c := i; // invalid
+   │             ^^^^^^ Invalid assignment: cannot assign 'INT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'DINT' to 'CHAR'
+   ┌─ <internal>:19:13
+   │
+19 │             c := 42; // invalid
+   │             ^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'CHAR'
+   ┌─ <internal>:22:13
+   │
+22 │             c := s; // invalid
+   │             ^^^^^^ Invalid assignment: cannot assign 'STRING' to 'CHAR'
+
+error: Invalid assignment: cannot assign 'STRING' to 'WCHAR'
+   ┌─ <internal>:23:13
+   │
+23 │             wc := s; // invalid
+   │             ^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'WCHAR'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'INT'
+   ┌─ <internal>:25:13
+   │
+25 │             i := c; // invalid
+   │             ^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'INT'
+
+error: Invalid assignment: cannot assign 'CHAR' to 'STRING'
+   ┌─ <internal>:26:13
+   │
+26 │             s := c; // invalid
+   │             ^^^^^^ Invalid assignment: cannot assign 'CHAR' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__method_implicit_downcast.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__method_implicit_downcast.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[1..3] OF DINT' to 'ARRAY[1..3] OF SINT'", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 32, offset: 156 }..TextLocation { line: 7, column: 39, offset: 163 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[1..3] OF DINT' to 'ARRAY[1..3] OF SINT'
+  ┌─ <internal>:8:33
+  │
+8 │         cl.testMethod(var_lint, var_arr, ADR(var_arr)); // downcast, invalid, ok
+  │                                 ^^^^^^^ Invalid assignment: cannot assign 'ARRAY[1..3] OF DINT' to 'ARRAY[1..3] OF SINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__missing_string_compare_function_causes_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__missing_string_compare_function_causes_error.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 12, offset: 33 }..TextLocation { line: 2, column: 22, offset: 43 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 89 }..TextLocation { line: 3, column: 22, offset: 99 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_LESS : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 12, offset: 145 }..TextLocation { line: 4, column: 22, offset: 155 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_GREATER : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 12, offset: 201 }..TextLocation { line: 5, column: 22, offset: 211 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_LESS : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 257 }..TextLocation { line: 6, column: 22, offset: 267 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 257 }..TextLocation { line: 6, column: 22, offset: 267 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_GREATER : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 313 }..TextLocation { line: 7, column: 22, offset: 323 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 313 }..TextLocation { line: 7, column: 22, offset: 323 }) }], err_no: codegen__missing_compare_function }
+error: Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:3:13
+  │
+3 │             'a' =  'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:4:13
+  │
+4 │             'a' <> 'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION STRING_LESS : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:5:13
+  │
+5 │             'a' <  'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_LESS : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION STRING_GREATER : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:6:13
+  │
+6 │             'a' >  'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_GREATER : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION STRING_LESS : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:7:13
+  │
+7 │             'a' <= 'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_LESS : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:7:13
+  │
+7 │             'a' <= 'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION STRING_GREATER : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:8:13
+  │
+8 │             'a' >= 'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_GREATER : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:8:13
+  │
+8 │             'a' >= 'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__missing_wstring_compare_function_causes_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__missing_wstring_compare_function_causes_error.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 12, offset: 33 }..TextLocation { line: 2, column: 22, offset: 43 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 89 }..TextLocation { line: 3, column: 22, offset: 99 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_LESS : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 12, offset: 145 }..TextLocation { line: 4, column: 22, offset: 155 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_GREATER : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 12, offset: 201 }..TextLocation { line: 5, column: 22, offset: 211 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_LESS : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 257 }..TextLocation { line: 6, column: 22, offset: 267 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 257 }..TextLocation { line: 6, column: 22, offset: 267 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_GREATER : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 313 }..TextLocation { line: 7, column: 22, offset: 323 }) }], err_no: codegen__missing_compare_function }
-SyntaxError { message: "Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 313 }..TextLocation { line: 7, column: 22, offset: 323 }) }], err_no: codegen__missing_compare_function }
+error: Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:3:13
+  │
+3 │             "a" =  "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:4:13
+  │
+4 │             "a" <> "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION WSTRING_LESS : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:5:13
+  │
+5 │             "a" <  "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_LESS : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION WSTRING_GREATER : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:6:13
+  │
+6 │             "a" >  "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_GREATER : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION WSTRING_LESS : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:7:13
+  │
+7 │             "a" <= "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_LESS : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:7:13
+  │
+7 │             "a" <= "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION WSTRING_GREATER : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:8:13
+  │
+8 │             "a" >= "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_GREATER : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
+error: Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+  ┌─ <internal>:8:13
+  │
+8 │             "a" >= "b"; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR ...'.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__passing_compatible_numeric_types_to_functions_is_allowed.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__passing_compatible_numeric_types_to_functions_is_allowed.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__program_call_parameter_validation.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__program_call_parameter_validation.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Cannot mix implicit and explicit call parameters!", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 34, offset: 501 }..TextLocation { line: 22, column: 38, offset: 505 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Cannot mix implicit and explicit call parameters!", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 40, offset: 507 }..TextLocation { line: 22, column: 44, offset: 511 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 17, offset: 576 }..TextLocation { line: 24, column: 31, offset: 590 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "The type DINT 32 is too small to hold a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 33, offset: 592 }..TextLocation { line: 24, column: 47, offset: 606 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 33, offset: 592 }..TextLocation { line: 24, column: 47, offset: 606 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 17, offset: 767 }..TextLocation { line: 26, column: 21, offset: 771 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "The type DINT 32 is too small to hold a Pointer", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 23, offset: 773 }..TextLocation { line: 26, column: 27, offset: 777 }) }], err_no: type__incompatible_size }
-SyntaxError { message: "Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 23, offset: 773 }..TextLocation { line: 26, column: 27, offset: 777 }) }], err_no: var__invalid_assignment }
+error: Cannot mix implicit and explicit call parameters!
+   ┌─ <internal>:23:35
+   │
+23 │             prog(output1 => var1, var1, var1); // invalid cannot mix explicit and implicit
+   │                                   ^^^^ Cannot mix implicit and explicit call parameters!
+
+error: Cannot mix implicit and explicit call parameters!
+   ┌─ <internal>:23:41
+   │
+23 │             prog(output1 => var1, var1, var1); // invalid cannot mix explicit and implicit
+   │                                         ^^^^ Cannot mix implicit and explicit call parameters!
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:25:18
+   │
+25 │             prog(input1 := var2, inout1 := var3, output1 => var4); // invalid types assigned
+   │                  ^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: The type DINT 32 is too small to hold a Pointer
+   ┌─ <internal>:25:34
+   │
+25 │             prog(input1 := var2, inout1 := var3, output1 => var4); // invalid types assigned
+   │                                  ^^^^^^^^^^^^^^ The type DINT 32 is too small to hold a Pointer
+
+error: Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+   ┌─ <internal>:25:34
+   │
+25 │             prog(input1 := var2, inout1 := var3, output1 => var4); // invalid types assigned
+   │                                  ^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+
+error: Invalid assignment: cannot assign 'STRING' to 'DINT'
+   ┌─ <internal>:27:18
+   │
+27 │             prog(var2, var3, var4); // invalid types assigned
+   │                  ^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+
+error: The type DINT 32 is too small to hold a Pointer
+   ┌─ <internal>:27:24
+   │
+27 │             prog(var2, var3, var4); // invalid types assigned
+   │                        ^^^^ The type DINT 32 is too small to hold a Pointer
+
+error: Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+   ┌─ <internal>:27:24
+   │
+27 │             prog(var2, var3, var4); // invalid types assigned
+   │                        ^^^^ Invalid assignment: cannot assign 'REF_TO WSTRING' to 'DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__program_implicit_downcast.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__program_implicit_downcast.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'WSTRING' to 'STRING'", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 16, offset: 466 }..TextLocation { line: 15, column: 24, offset: 474 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+   ┌─ <internal>:16:17
+   │
+16 │                 var_wstr, // invalid
+   │                 ^^^^^^^^ Invalid assignment: cannot assign 'WSTRING' to 'STRING'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__program_missing_inout_assignment.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__program_missing_inout_assignment.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Missing inout parameter: inout1", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 12, offset: 327 }..TextLocation { line: 17, column: 16, offset: 331 }) }], err_no: pou__missing_action_container }
-SyntaxError { message: "Missing inout parameter: inout1", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 12, offset: 378 }..TextLocation { line: 18, column: 16, offset: 382 }) }], err_no: pou__missing_action_container }
-SyntaxError { message: "Missing inout parameter: inout1", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 12, offset: 408 }..TextLocation { line: 19, column: 16, offset: 412 }) }], err_no: pou__missing_action_container }
-SyntaxError { message: "Missing inout parameter: inout1", range: [SourceLocation { span: Range(TextLocation { line: 20, column: 12, offset: 432 }..TextLocation { line: 20, column: 16, offset: 436 }) }], err_no: pou__missing_action_container }
+error: Missing inout parameter: inout1
+   ┌─ <internal>:18:13
+   │
+18 │             prog(input1 := var1, output1 => var2);
+   │             ^^^^ Missing inout parameter: inout1
+
+error: Missing inout parameter: inout1
+   ┌─ <internal>:19:13
+   │
+19 │             prog(var1, var2);
+   │             ^^^^ Missing inout parameter: inout1
+
+error: Missing inout parameter: inout1
+   ┌─ <internal>:20:13
+   │
+20 │             prog(var1);
+   │             ^^^^ Missing inout parameter: inout1
+
+error: Missing inout parameter: inout1
+   ┌─ <internal>:21:13
+   │
+21 │             prog();
+   │             ^^^^ Missing inout parameter: inout1
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__ref_builtin_function_reports_invalid_param_count.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__ref_builtin_function_reports_invalid_param_count.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid parameter count. Received 0 parameters while 1 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 12, offset: 134 }..TextLocation { line: 6, column: 15, offset: 137 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 4 parameters while 1 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 12, offset: 153 }..TextLocation { line: 7, column: 15, offset: 156 }) }], err_no: call__invalid_parameter_count }
+error: Invalid parameter count. Received 0 parameters while 1 parameters were expected.
+  ┌─ <internal>:7:13
+  │
+7 │             REF();
+  │             ^^^ Invalid parameter count. Received 0 parameters while 1 parameters were expected.
+
+error: Invalid parameter count. Received 4 parameters while 1 parameters were expected.
+  ┌─ <internal>:8:13
+  │
+8 │             REF(x, 1, 2, 'abc');
+  │             ^^^ Invalid parameter count. Received 4 parameters while 1 parameters were expected.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__reference_to_reference_assignments_in_function_arguments.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__reference_to_reference_assignments_in_function_arguments.snap
@@ -1,11 +1,41 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_INT' to 'REF_TO STRUCT_params'", range: [SourceLocation { span: Range(TextLocation { line: 46, column: 12, offset: 1286 }..TextLocation { line: 46, column: 34, offset: 1308 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT_params'", range: [SourceLocation { span: Range(TextLocation { line: 47, column: 12, offset: 1322 }..TextLocation { line: 47, column: 34, offset: 1344 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT_params'", range: [SourceLocation { span: Range(TextLocation { line: 48, column: 12, offset: 1358 }..TextLocation { line: 48, column: 34, offset: 1380 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_INT' to 'REF_TO STRUCT_params'", range: [SourceLocation { span: Range(TextLocation { line: 54, column: 12, offset: 1588 }..TextLocation { line: 54, column: 32, offset: 1608 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT_params'", range: [SourceLocation { span: Range(TextLocation { line: 55, column: 12, offset: 1622 }..TextLocation { line: 55, column: 32, offset: 1642 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign '__POINTER_TO___global_global6' to 'REF_TO STRUCT_params'", range: [SourceLocation { span: Range(TextLocation { line: 56, column: 12, offset: 1656 }..TextLocation { line: 56, column: 32, offset: 1676 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign '__POINTER_TO_INT' to 'REF_TO STRUCT_params'
+   ┌─ <internal>:47:13
+   │
+47 │             input1 := REF(global4),
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_INT' to 'REF_TO STRUCT_params'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT_params'
+   ┌─ <internal>:48:13
+   │
+48 │             input2 := REF(global5),
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT_params'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT_params'
+   ┌─ <internal>:49:13
+   │
+49 │             input3 := REF(global6),
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_STRING' to 'REF_TO STRUCT_params'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_INT' to 'REF_TO STRUCT_params'
+   ┌─ <internal>:55:13
+   │
+55 │             input1 := &(global4),
+   │             ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_INT' to 'REF_TO STRUCT_params'
+
+error: Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT_params'
+   ┌─ <internal>:56:13
+   │
+56 │             input2 := &(global5),
+   │             ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO_REAL' to 'REF_TO STRUCT_params'
+
+error: Invalid assignment: cannot assign '__POINTER_TO___global_global6' to 'REF_TO STRUCT_params'
+   ┌─ <internal>:57:13
+   │
+57 │             input3 := &(global6),
+   │             ^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__POINTER_TO___global_global6' to 'REF_TO STRUCT_params'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__string_compare_function_cause_no_error_if_functions_exist.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__string_compare_function_cause_no_error_if_functions_exist.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__string_compare_function_with_wrong_signature_causes_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__string_compare_function_with_wrong_signature_causes_error.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 12, offset: 114 }..TextLocation { line: 4, column: 22, offset: 124 }) }], err_no: codegen__missing_compare_function }
+error: Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+  ┌─ <internal>:5:13
+  │
+5 │             'a' =  'b'; // missing compare function :-(
+  │             ^^^^^^^^^^ Missing compare function 'FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR ...'.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__subrange_compare_function_causes_no_error.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__subrange_compare_function_causes_no_error.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case_duplicate_integer.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case_duplicate_integer.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Duplicate condition value: 4. Occurred more than once!", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 16, offset: 332 }..TextLocation { line: 15, column: 22, offset: 338 }) }], err_no: case__duplicate_condition }
-SyntaxError { message: "Duplicate condition value: 4. Occurred more than once!", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 16, offset: 386 }..TextLocation { line: 17, column: 25, offset: 395 }) }], err_no: case__duplicate_condition }
-SyntaxError { message: "Duplicate condition value: 4. Occurred more than once!", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 16, offset: 443 }..TextLocation { line: 19, column: 24, offset: 451 }) }], err_no: case__duplicate_condition }
-SyntaxError { message: "Duplicate condition value: 4. Occurred more than once!", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 16, offset: 499 }..TextLocation { line: 21, column: 19, offset: 502 }) }], err_no: case__duplicate_condition }
+error: Duplicate condition value: 4. Occurred more than once!
+   ┌─ <internal>:16:17
+   │
+16 │                 BASE*2:
+   │                 ^^^^^^ Duplicate condition value: 4. Occurred more than once!
+
+error: Duplicate condition value: 4. Occurred more than once!
+   ┌─ <internal>:18:17
+   │
+18 │                 BASE+GLOB:
+   │                 ^^^^^^^^^ Duplicate condition value: 4. Occurred more than once!
+
+error: Duplicate condition value: 4. Occurred more than once!
+   ┌─ <internal>:20:17
+   │
+20 │                 MYTYPE_A:
+   │                 ^^^^^^^^ Duplicate condition value: 4. Occurred more than once!
+
+error: Duplicate condition value: 4. Occurred more than once!
+   ┌─ <internal>:22:17
+   │
+22 │                 2+2:
+   │                 ^^^ Duplicate condition value: 4. Occurred more than once!
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case_duplicate_integer_non_const_var_reference.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case_duplicate_integer_non_const_var_reference.snap
@@ -1,9 +1,29 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "'x' is no const reference. Non constant variables are not supported in case conditions", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 16, offset: 246 }..TextLocation { line: 13, column: 17, offset: 247 }) }], err_no: type__invalid_type }
-SyntaxError { message: "'y' is no const reference. Non constant variables are not supported in case conditions", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 16, offset: 324 }..TextLocation { line: 15, column: 17, offset: 325 }) }], err_no: type__invalid_type }
-SyntaxError { message: "'x' is no const reference. Non constant variables are not supported in case conditions", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 16, offset: 402 }..TextLocation { line: 17, column: 19, offset: 405 }) }], err_no: type__invalid_type }
-SyntaxError { message: "'x' is no const reference. Non constant variables are not supported in case conditions", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 16, offset: 535 }..TextLocation { line: 21, column: 23, offset: 542 }) }], err_no: type__invalid_type }
+error: 'x' is no const reference. Non constant variables are not supported in case conditions
+   ┌─ <internal>:14:17
+   │
+14 │                 x: // x is no constant => error
+   │                 ^ 'x' is no const reference. Non constant variables are not supported in case conditions
+
+error: 'y' is no const reference. Non constant variables are not supported in case conditions
+   ┌─ <internal>:16:17
+   │
+16 │                 y: // y is no constant => error
+   │                 ^ 'y' is no const reference. Non constant variables are not supported in case conditions
+
+error: 'x' is no const reference. Non constant variables are not supported in case conditions
+   ┌─ <internal>:18:17
+   │
+18 │                 2+x: // x is no constant => error
+   │                 ^^^ 'x' is no const reference. Non constant variables are not supported in case conditions
+
+error: 'x' is no const reference. Non constant variables are not supported in case conditions
+   ┌─ <internal>:22:17
+   │
+22 │                 CONST+x: // x is no constant => error
+   │                 ^^^^^^^ 'x' is no const reference. Non constant variables are not supported in case conditions
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case_invalid_case_conditions.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__switch_case_invalid_case_conditions.snap
@@ -1,8 +1,43 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid case condition!", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 16, offset: 174 }..TextLocation { line: 10, column: 22, offset: 180 }) }], err_no: case__case_condition_outside_case_statement }
-SyntaxError { message: "Cannot resolve constant: CallStatement {\n    operator: ReferenceExpr {\n        kind: Member(\n            Identifier {\n                name: \"foo\",\n            },\n        ),\n        base: None,\n    },\n    parameters: None,\n}. Non constant variables are not supported in case conditions", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 16, offset: 174 }..TextLocation { line: 10, column: 22, offset: 180 }) }], err_no: type__invalid_type }
-SyntaxError { message: "Invalid case condition!", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 16, offset: 227 }..TextLocation { line: 12, column: 24, offset: 235 }) }], err_no: case__case_condition_outside_case_statement }
+error: Invalid case condition!
+   ┌─ <internal>:11:17
+   │
+11 │                 foo():
+   │                 ^^^^^^ Invalid case condition!
+
+error: Cannot resolve constant: CallStatement {
+    operator: ReferenceExpr {
+        kind: Member(
+            Identifier {
+                name: "foo",
+            },
+        ),
+        base: None,
+    },
+    parameters: None,
+}. Non constant variables are not supported in case conditions
+   ┌─ <internal>:11:17
+   │
+11 │                 foo():
+   │                 ^^^^^^ Cannot resolve constant: CallStatement {
+    operator: ReferenceExpr {
+        kind: Member(
+            Identifier {
+                name: "foo",
+            },
+        ),
+        base: None,
+    },
+    parameters: None,
+}. Non constant variables are not supported in case conditions
+
+error: Invalid case condition!
+   ┌─ <internal>:13:17
+   │
+13 │                 res := 2:
+   │                 ^^^^^^^^ Invalid case condition!
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_array_elements_passed_to_functions_by_ref.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_array_elements_passed_to_functions_by_ref.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 17, offset: 323 }..TextLocation { line: 16, column: 18, offset: 324 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'INT'", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 20, offset: 326 }..TextLocation { line: 16, column: 21, offset: 327 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'INT'
+   ┌─ <internal>:17:18
+   │
+17 │             func(x, x);                                    // Invalid because we pass a whole array
+   │                  ^ Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'INT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'INT'
+   ┌─ <internal>:17:21
+   │
+17 │             func(x, x);                                    // Invalid because we pass a whole array
+   │                     ^ Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'INT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_arrays_passed_to_functions.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_arrays_passed_to_functions.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF SINT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 25, column: 17, offset: 959 }..TextLocation { line: 25, column: 25, offset: 967 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 17, offset: 987 }..TextLocation { line: 26, column: 24, offset: 994 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 28, column: 17, offset: 1042 }..TextLocation { line: 28, column: 25, offset: 1050 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF REAL' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 29, column: 17, offset: 1070 }..TextLocation { line: 29, column: 25, offset: 1078 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF LREAL' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 30, column: 17, offset: 1098 }..TextLocation { line: 30, column: 26, offset: 1107 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[1..10] OF DINT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 35, column: 17, offset: 1300 }..TextLocation { line: 35, column: 30, offset: 1313 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[10..100] OF DINT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 36, column: 17, offset: 1333 }..TextLocation { line: 36, column: 32, offset: 1348 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF ARRAY[0..1] OF DINT' to 'ARRAY[0..1] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 39, column: 17, offset: 1425 }..TextLocation { line: 39, column: 28, offset: 1436 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF SINT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:26:18
+   │
+26 │             func(arr_sint);
+   │                  ^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF SINT' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:27:18
+   │
+27 │             func(arr_int);
+   │                  ^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF INT' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:29:18
+   │
+29 │             func(arr_lint);
+   │                  ^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF LINT' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF REAL' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:30:18
+   │
+30 │             func(arr_real);
+   │                  ^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF REAL' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF LREAL' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:31:18
+   │
+31 │             func(arr_lreal);
+   │                  ^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF LREAL' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[1..10] OF DINT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:36:18
+   │
+36 │             func(arr_dint_1_10);
+   │                  ^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[1..10] OF DINT' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[10..100] OF DINT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:37:18
+   │
+37 │             func(arr_dint_10_100);
+   │                  ^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[10..100] OF DINT' to 'ARRAY[0..1] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF ARRAY[0..1] OF DINT' to 'ARRAY[0..1] OF DINT'
+   ┌─ <internal>:40:18
+   │
+40 │             func(arr_dint_2d);
+   │                  ^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF ARRAY[0..1] OF DINT' to 'ARRAY[0..1] OF DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_call_by_ref.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_call_by_ref.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Expected a reference for parameter byRefInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 20, offset: 561 }..TextLocation { line: 22, column: 21, offset: 562 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefOutput because their type is Output", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 23, offset: 564 }..TextLocation { line: 22, column: 24, offset: 565 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 23, column: 20, offset: 588 }..TextLocation { line: 23, column: 21, offset: 589 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefOutput because their type is Output", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 23, offset: 618 }..TextLocation { line: 24, column: 24, offset: 619 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 20, offset: 678 }..TextLocation { line: 26, column: 21, offset: 679 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefOutput because their type is Output", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 23, offset: 681 }..TextLocation { line: 26, column: 24, offset: 682 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 27, column: 20, offset: 705 }..TextLocation { line: 27, column: 21, offset: 706 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefOutput because their type is Output", range: [SourceLocation { span: Range(TextLocation { line: 28, column: 23, offset: 735 }..TextLocation { line: 28, column: 24, offset: 736 }) }], err_no: call__invalid_parameter_type }
+error: Expected a reference for parameter byRefInOut because their type is InOut
+   ┌─ <internal>:23:21
+   │
+23 │             func(1, 2, 3);
+   │                     ^ Expected a reference for parameter byRefInOut because their type is InOut
+
+error: Expected a reference for parameter byRefOutput because their type is Output
+   ┌─ <internal>:23:24
+   │
+23 │             func(1, 2, 3);
+   │                        ^ Expected a reference for parameter byRefOutput because their type is Output
+
+error: Expected a reference for parameter byRefInOut because their type is InOut
+   ┌─ <internal>:24:21
+   │
+24 │             func(1, 2, x);
+   │                     ^ Expected a reference for parameter byRefInOut because their type is InOut
+
+error: Expected a reference for parameter byRefOutput because their type is Output
+   ┌─ <internal>:25:24
+   │
+25 │             func(1, x, 3);
+   │                        ^ Expected a reference for parameter byRefOutput because their type is Output
+
+error: Expected a reference for parameter byRefInOut because their type is InOut
+   ┌─ <internal>:27:21
+   │
+27 │             func(x, 2, 3);
+   │                     ^ Expected a reference for parameter byRefInOut because their type is InOut
+
+error: Expected a reference for parameter byRefOutput because their type is Output
+   ┌─ <internal>:27:24
+   │
+27 │             func(x, 2, 3);
+   │                        ^ Expected a reference for parameter byRefOutput because their type is Output
+
+error: Expected a reference for parameter byRefInOut because their type is InOut
+   ┌─ <internal>:28:21
+   │
+28 │             func(x, 2, x);
+   │                     ^ Expected a reference for parameter byRefInOut because their type is InOut
+
+error: Expected a reference for parameter byRefOutput because their type is Output
+   ┌─ <internal>:29:24
+   │
+29 │             func(x, x, 3);
+   │                        ^ Expected a reference for parameter byRefOutput because their type is Output
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_call_by_ref_explicit.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__validate_call_by_ref_explicit.snap
@@ -1,10 +1,35 @@
 ---
 source: src/validation/tests/statement_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Expected a reference for parameter byRefInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 48, offset: 589 }..TextLocation { line: 22, column: 49, offset: 590 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 48, offset: 772 }..TextLocation { line: 24, column: 49, offset: 773 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefOutput because their type is Output", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 66, offset: 790 }..TextLocation { line: 24, column: 67, offset: 791 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefInOut because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 25, column: 48, offset: 842 }..TextLocation { line: 25, column: 49, offset: 843 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Expected a reference for parameter byRefOutput because their type is Output", range: [SourceLocation { span: Range(TextLocation { line: 26, column: 66, offset: 930 }..TextLocation { line: 26, column: 67, offset: 931 }) }], err_no: call__invalid_parameter_type }
+error: Expected a reference for parameter byRefInOut because their type is InOut
+   ┌─ <internal>:23:49
+   │
+23 │             func(byValInput := 1, byRefInOut := 2, byRefOutput =>  );
+   │                                                 ^ Expected a reference for parameter byRefInOut because their type is InOut
+
+error: Expected a reference for parameter byRefInOut because their type is InOut
+   ┌─ <internal>:25:49
+   │
+25 │             func(byValInput := 1, byRefInOut := 2, byRefOutput => 3);
+   │                                                 ^ Expected a reference for parameter byRefInOut because their type is InOut
+
+error: Expected a reference for parameter byRefOutput because their type is Output
+   ┌─ <internal>:25:67
+   │
+25 │             func(byValInput := 1, byRefInOut := 2, byRefOutput => 3);
+   │                                                                   ^ Expected a reference for parameter byRefOutput because their type is Output
+
+error: Expected a reference for parameter byRefInOut because their type is InOut
+   ┌─ <internal>:26:49
+   │
+26 │             func(byValInput := 1, byRefInOut := 2, byRefOutput => x);
+   │                                                 ^ Expected a reference for parameter byRefInOut because their type is InOut
+
+error: Expected a reference for parameter byRefOutput because their type is Output
+   ┌─ <internal>:27:67
+   │
+27 │             func(byValInput := 1, byRefInOut := x, byRefOutput => 3);
+   │                                                                   ^ Expected a reference for parameter byRefOutput because their type is Output
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__wstring_compare_function_cause_no_error_if_functions_exist.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__statement_validation_tests__wstring_compare_function_cause_no_error_if_functions_exist.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/statement_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__access__variable_length_array_access.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__access__variable_length_array_access.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "Expected array access with 1 dimensions, found 2", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 20, offset: 187 }..TextLocation { line: 7, column: 24, offset: 191 }) }], err_no: vla__invalid_array_access }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..5, 5..10] OF DINT' to 'ARRAY[*] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 19, offset: 514 }..TextLocation { line: 17, column: 26, offset: 521 }) }], err_no: var__invalid_assignment }
+error: Expected array access with 1 dimensions, found 2
+  ┌─ <internal>:8:21
+  │
+8 │                 arr[0, 0]   := 1; // This should fail (arr is defined as a 1D array)
+  │                     ^^^^ Expected array access with 1 dimensions, found 2
+
+error: Invalid assignment: cannot assign 'ARRAY[0..5, 5..10] OF DINT' to 'ARRAY[*] OF DINT'
+   ┌─ <internal>:18:20
+   │
+18 │                 fn(local_b); // This call should fail, because we expect a 1D array
+   │                    ^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..5, 5..10] OF DINT' to 'ARRAY[*] OF DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__access__variable_length_array_incompatible_datatypes.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__access__variable_length_array_incompatible_datatypes.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF INT' to 'ARRAY[*] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 19, offset: 436 }..TextLocation { line: 14, column: 28, offset: 445 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF REAL' to 'ARRAY[*] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 19, offset: 467 }..TextLocation { line: 15, column: 30, offset: 478 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF STRING' to 'ARRAY[*] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 19, offset: 500 }..TextLocation { line: 16, column: 31, offset: 512 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF INT' to 'ARRAY[*] OF DINT'
+   ┌─ <internal>:15:20
+   │
+15 │                 fn(local_int);
+   │                    ^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF INT' to 'ARRAY[*] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF REAL' to 'ARRAY[*] OF DINT'
+   ┌─ <internal>:16:20
+   │
+16 │                 fn(local_float);
+   │                    ^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF REAL' to 'ARRAY[*] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF STRING' to 'ARRAY[*] OF DINT'
+   ┌─ <internal>:17:20
+   │
+17 │                 fn(local_string);
+   │                    ^^^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF STRING' to 'ARRAY[*] OF DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__assignment__function_calls.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__assignment__function_calls.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[*] OF DINT' to 'ARRAY[0..10] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 16, offset: 267 }..TextLocation { line: 11, column: 26, offset: 277 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..10] OF DINT' to 'ARRAY[*] OF DINT'", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 16, offset: 295 }..TextLocation { line: 12, column: 24, offset: 303 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[*] OF DINT' to 'ARRAY[0..10] OF DINT'
+   ┌─ <internal>:12:17
+   │
+12 │                 a   := vla;
+   │                 ^^^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[*] OF DINT' to 'ARRAY[0..10] OF DINT'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..10] OF DINT' to 'ARRAY[*] OF DINT'
+   ┌─ <internal>:13:17
+   │
+13 │                 vla := a;
+   │                 ^^^^^^^^ Invalid assignment: cannot assign 'ARRAY[0..10] OF DINT' to 'ARRAY[*] OF DINT'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__builtins__builtins_called_with_invalid_index.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__builtins__builtins_called_with_invalid_index.snap
@@ -1,11 +1,41 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 29, offset: 361 }..TextLocation { line: 17, column: 35, offset: 367 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 29, offset: 410 }..TextLocation { line: 18, column: 36, offset: 417 }) }], err_no: type__invalid_nature }
-SemanticError { message: "Index out of bounds.", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 12, offset: 443 }..TextLocation { line: 19, column: 23, offset: 454 }) }], err_no: vla__dimension_idx_out_of_bounds }
-SyntaxError { message: "Invalid type nature for generic argument. REAL is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 21, column: 29, offset: 517 }..TextLocation { line: 21, column: 35, offset: 523 }) }], err_no: type__invalid_nature }
-SyntaxError { message: "Invalid type nature for generic argument. TIME is no Int.", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 29, offset: 566 }..TextLocation { line: 22, column: 36, offset: 573 }) }], err_no: type__invalid_nature }
-SemanticError { message: "Index out of bounds.", range: [SourceLocation { span: Range(TextLocation { line: 23, column: 12, offset: 599 }..TextLocation { line: 23, column: 23, offset: 610 }) }], err_no: vla__dimension_idx_out_of_bounds }
+error: Invalid type nature for generic argument. REAL is no Int.
+   ┌─ <internal>:18:30
+   │
+18 │             LOWER_BOUND(vla, 3.1415); // invalid
+   │                              ^^^^^^ Invalid type nature for generic argument. REAL is no Int.
+
+error: Invalid type nature for generic argument. TIME is no Int.
+   ┌─ <internal>:19:30
+   │
+19 │             LOWER_BOUND(vla, TIME#3s); // invalid
+   │                              ^^^^^^^ Invalid type nature for generic argument. TIME is no Int.
+
+error: Index out of bounds.
+   ┌─ <internal>:20:13
+   │
+20 │             LOWER_BOUND(vla, 0); // index out of bounds
+   │             ^^^^^^^^^^^ Index out of bounds.
+
+error: Invalid type nature for generic argument. REAL is no Int.
+   ┌─ <internal>:22:30
+   │
+22 │             UPPER_BOUND(vla, 3.1415); // invalid
+   │                              ^^^^^^ Invalid type nature for generic argument. REAL is no Int.
+
+error: Invalid type nature for generic argument. TIME is no Int.
+   ┌─ <internal>:23:30
+   │
+23 │             UPPER_BOUND(vla, TIME#3s); // invalid
+   │                              ^^^^^^^ Invalid type nature for generic argument. TIME is no Int.
+
+error: Index out of bounds.
+   ┌─ <internal>:24:13
+   │
+24 │             UPPER_BOUND(vla, 0); // index out of bounds
+   │             ^^^^^^^^^^^ Index out of bounds.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__builtins__builtins_called_with_invalid_number_of_params.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__builtins__builtins_called_with_invalid_number_of_params.snap
@@ -1,17 +1,77 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid parameter count. Received 0 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 12, offset: 251 }..TextLocation { line: 12, column: 23, offset: 262 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 1 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 12, offset: 278 }..TextLocation { line: 13, column: 23, offset: 289 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 1 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 12, offset: 308 }..TextLocation { line: 14, column: 23, offset: 319 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Expected a reference for parameter arr because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 24, offset: 320 }..TextLocation { line: 14, column: 25, offset: 321 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 24, offset: 320 }..TextLocation { line: 14, column: 25, offset: 321 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid parameter count. Received 4 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 12, offset: 336 }..TextLocation { line: 15, column: 23, offset: 347 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 0 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 12, offset: 376 }..TextLocation { line: 17, column: 23, offset: 387 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 1 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 12, offset: 403 }..TextLocation { line: 18, column: 23, offset: 414 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Invalid parameter count. Received 1 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 12, offset: 433 }..TextLocation { line: 19, column: 23, offset: 444 }) }], err_no: call__invalid_parameter_count }
-SyntaxError { message: "Expected a reference for parameter arr because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 24, offset: 445 }..TextLocation { line: 19, column: 25, offset: 446 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Invalid assignment: cannot assign 'DINT' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 24, offset: 445 }..TextLocation { line: 19, column: 25, offset: 446 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid parameter count. Received 4 parameters while 2 parameters were expected.", range: [SourceLocation { span: Range(TextLocation { line: 20, column: 12, offset: 461 }..TextLocation { line: 20, column: 23, offset: 472 }) }], err_no: call__invalid_parameter_count }
+error: Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+   ┌─ <internal>:13:13
+   │
+13 │             LOWER_BOUND();
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+   ┌─ <internal>:14:13
+   │
+14 │             LOWER_BOUND(vla);
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+   ┌─ <internal>:15:13
+   │
+15 │             LOWER_BOUND(1);
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+
+error: Expected a reference for parameter arr because their type is InOut
+   ┌─ <internal>:15:25
+   │
+15 │             LOWER_BOUND(1);
+   │                         ^ Expected a reference for parameter arr because their type is InOut
+
+error: Invalid assignment: cannot assign 'DINT' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:15:25
+   │
+15 │             LOWER_BOUND(1);
+   │                         ^ Invalid assignment: cannot assign 'DINT' to 'VARIABLE LENGTH ARRAY'
+
+error: Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+   ┌─ <internal>:16:13
+   │
+16 │             LOWER_BOUND(vla, 1, 2, 3);
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+   ┌─ <internal>:18:13
+   │
+18 │             UPPER_BOUND();
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 0 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+   ┌─ <internal>:19:13
+   │
+19 │             UPPER_BOUND(vla);
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+
+error: Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+   ┌─ <internal>:20:13
+   │
+20 │             UPPER_BOUND(1);
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 1 parameters while 2 parameters were expected.
+
+error: Expected a reference for parameter arr because their type is InOut
+   ┌─ <internal>:20:25
+   │
+20 │             UPPER_BOUND(1);
+   │                         ^ Expected a reference for parameter arr because their type is InOut
+
+error: Invalid assignment: cannot assign 'DINT' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:20:25
+   │
+20 │             UPPER_BOUND(1);
+   │                         ^ Invalid assignment: cannot assign 'DINT' to 'VARIABLE LENGTH ARRAY'
+
+error: Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+   ┌─ <internal>:21:13
+   │
+21 │             UPPER_BOUND(vla, 1, 2, 3);
+   │             ^^^^^^^^^^^ Invalid parameter count. Received 4 parameters while 2 parameters were expected.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__builtins__builtins_called_with_invalid_type.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__builtins__builtins_called_with_invalid_type.snap
@@ -1,13 +1,53 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: diagnostics
 ---
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF DINT' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 9, column: 24, offset: 221 }..TextLocation { line: 9, column: 27, offset: 224 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 24, offset: 265 }..TextLocation { line: 10, column: 32, offset: 273 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Expected a reference for parameter arr because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 24, offset: 303 }..TextLocation { line: 11, column: 39, offset: 318 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 24, offset: 303 }..TextLocation { line: 11, column: 39, offset: 318 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'ARRAY[0..1] OF DINT' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 24, offset: 349 }..TextLocation { line: 13, column: 27, offset: 352 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Invalid assignment: cannot assign 'TIME' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 24, offset: 393 }..TextLocation { line: 14, column: 32, offset: 401 }) }], err_no: var__invalid_assignment }
-SyntaxError { message: "Expected a reference for parameter arr because their type is InOut", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 24, offset: 431 }..TextLocation { line: 15, column: 39, offset: 446 }) }], err_no: call__invalid_parameter_type }
-SyntaxError { message: "Invalid assignment: cannot assign 'STRING' to 'VARIABLE LENGTH ARRAY'", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 24, offset: 431 }..TextLocation { line: 15, column: 39, offset: 446 }) }], err_no: var__invalid_assignment }
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF DINT' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:10:25
+   │
+10 │             LOWER_BOUND(arr, MY_CONST + 1);
+   │                         ^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF DINT' to 'VARIABLE LENGTH ARRAY'
+
+error: Invalid assignment: cannot assign 'TIME' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:11:25
+   │
+11 │             LOWER_BOUND(duration, 1);
+   │                         ^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'VARIABLE LENGTH ARRAY'
+
+error: Expected a reference for parameter arr because their type is InOut
+   ┌─ <internal>:12:25
+   │
+12 │             LOWER_BOUND('i am a string', 1);
+   │                         ^^^^^^^^^^^^^^^ Expected a reference for parameter arr because their type is InOut
+
+error: Invalid assignment: cannot assign 'STRING' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:12:25
+   │
+12 │             LOWER_BOUND('i am a string', 1);
+   │                         ^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'VARIABLE LENGTH ARRAY'
+
+error: Invalid assignment: cannot assign 'ARRAY[0..1] OF DINT' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:14:25
+   │
+14 │             UPPER_BOUND(arr, MY_CONST + 1);
+   │                         ^^^ Invalid assignment: cannot assign 'ARRAY[0..1] OF DINT' to 'VARIABLE LENGTH ARRAY'
+
+error: Invalid assignment: cannot assign 'TIME' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:15:25
+   │
+15 │             UPPER_BOUND(duration, 1);
+   │                         ^^^^^^^^ Invalid assignment: cannot assign 'TIME' to 'VARIABLE LENGTH ARRAY'
+
+error: Expected a reference for parameter arr because their type is InOut
+   ┌─ <internal>:16:25
+   │
+16 │             UPPER_BOUND('i am a string', 1);
+   │                         ^^^^^^^^^^^^^^^ Expected a reference for parameter arr because their type is InOut
+
+error: Invalid assignment: cannot assign 'STRING' to 'VARIABLE LENGTH ARRAY'
+   ┌─ <internal>:16:25
+   │
+16 │             UPPER_BOUND('i am a string', 1);
+   │                         ^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'VARIABLE LENGTH ARRAY'
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__functions__variable_length_array_function_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__functions__variable_length_array_function_input.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: "parse_and_validate_buffered(&function.replace(\"<VAR_TYPE>\", \"INPUT\"))"
 ---
-ImprovementSuggestion { message: "Variable Length Arrays are always by-ref, even when declared in a by-value block", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 54 }..TextLocation { line: 3, column: 15, offset: 57 }) }] }
+warning: Variable Length Arrays are always by-ref, even when declared in a by-value block
+  ┌─ <internal>:4:13
+  │
+4 │             arr : ARRAY[*] OF DINT;
+  │             ^^^ Variable Length Arrays are always by-ref, even when declared in a by-value block
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__naming__global_vla_does_not_cause_name_conflict.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__naming__global_vla_does_not_cause_name_conflict.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: diag
 ---
-SemanticError { message: "VLAs can not be defined as global variables", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 12, offset: 32 }..TextLocation { line: 2, column: 15, offset: 35 }) }], err_no: vla__invalid_container }
+error: VLAs can not be defined as global variables
+  ┌─ <internal>:3:13
+  │
+3 │             vla : ARRAY[*, *] OF DINT;
+  │             ^^^ VLAs can not be defined as global variables
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_inout.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_inout.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: program_inout
 ---
-SyntaxError { message: "POU Type Program does not support a return type. Did you mean Function?", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 15, offset: 16 }..TextLocation { line: 1, column: 21, offset: 22 }) }], err_no: pou__unexpected_return_type }
-SemanticError { message: "Variable Length Arrays are not allowed to be defined inside a Program", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 54 }..TextLocation { line: 3, column: 15, offset: 57 }) }], err_no: vla__invalid_container }
+error: POU Type Program does not support a return type. Did you mean Function?
+  ┌─ <internal>:2:16
+  │
+2 │     PROGRAM fn : DINT
+  │                ^^^^^^ POU Type Program does not support a return type. Did you mean Function?
+
+error: Variable Length Arrays are not allowed to be defined inside a Program
+  ┌─ <internal>:4:13
+  │
+4 │             arr : ARRAY[*] OF DINT;
+  │             ^^^ Variable Length Arrays are not allowed to be defined inside a Program
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_input.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_input.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: program_input
 ---
-SyntaxError { message: "POU Type Program does not support a return type. Did you mean Function?", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 15, offset: 16 }..TextLocation { line: 1, column: 21, offset: 22 }) }], err_no: pou__unexpected_return_type }
-SemanticError { message: "Variable Length Arrays are not allowed to be defined inside a Program", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 53 }..TextLocation { line: 3, column: 15, offset: 56 }) }], err_no: vla__invalid_container }
+error: POU Type Program does not support a return type. Did you mean Function?
+  ┌─ <internal>:2:16
+  │
+2 │     PROGRAM fn : DINT
+  │                ^^^^^^ POU Type Program does not support a return type. Did you mean Function?
+
+error: Variable Length Arrays are not allowed to be defined inside a Program
+  ┌─ <internal>:4:13
+  │
+4 │             arr : ARRAY[*] OF DINT;
+  │             ^^^ Variable Length Arrays are not allowed to be defined inside a Program
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_input_ref.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_input_ref.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: program_input
 ---
-SyntaxError { message: "POU Type Program does not support a return type. Did you mean Function?", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 15, offset: 16 }..TextLocation { line: 1, column: 21, offset: 22 }) }], err_no: pou__unexpected_return_type }
-SemanticError { message: "Variable Length Arrays are not allowed to be defined inside a Program", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 59 }..TextLocation { line: 3, column: 15, offset: 62 }) }], err_no: vla__invalid_container }
+error: POU Type Program does not support a return type. Did you mean Function?
+  ┌─ <internal>:2:16
+  │
+2 │     PROGRAM fn : DINT
+  │                ^^^^^^ POU Type Program does not support a return type. Did you mean Function?
+
+error: Variable Length Arrays are not allowed to be defined inside a Program
+  ┌─ <internal>:4:13
+  │
+4 │             arr : ARRAY[*] OF DINT;
+  │             ^^^ Variable Length Arrays are not allowed to be defined inside a Program
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_output.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__program__variable_length_array_program_output.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: program_output
 ---
-SyntaxError { message: "POU Type Program does not support a return type. Did you mean Function?", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 15, offset: 16 }..TextLocation { line: 1, column: 21, offset: 22 }) }], err_no: pou__unexpected_return_type }
-SemanticError { message: "Variable Length Arrays are not allowed to be defined inside a Program", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 12, offset: 54 }..TextLocation { line: 3, column: 15, offset: 57 }) }], err_no: vla__invalid_container }
+error: POU Type Program does not support a return type. Did you mean Function?
+  ┌─ <internal>:2:16
+  │
+2 │     PROGRAM fn : DINT
+  │                ^^^^^^ POU Type Program does not support a return type. Did you mean Function?
+
+error: Variable Length Arrays are not allowed to be defined inside a Program
+  ┌─ <internal>:4:13
+  │
+4 │             arr : ARRAY[*] OF DINT;
+  │             ^^^ Variable Length Arrays are not allowed to be defined inside a Program
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__variable_length_array_defined_as_a_global_variable.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_length_array_test__variable_length_array_defined_as_a_global_variable.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/variable_length_array_test.rs
-expression: res
+expression: parse_and_validate_buffered(src)
 ---
-SemanticError { message: "VLAs can not be defined as global variables", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 12, offset: 32 }..TextLocation { line: 2, column: 15, offset: 35 }) }], err_no: vla__invalid_container }
+error: VLAs can not be defined as global variables
+  ┌─ <internal>:3:13
+  │
+3 │             arr : ARRAY[*] OF DINT;
+  │             ^^^ VLAs can not be defined as global variables
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__constant_fb_instances_are_illegal.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__constant_fb_instances_are_illegal.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Invalid constant y - Functionblock- and Class-instances cannot be delcared constant", range: [SourceLocation { span: Range(TextLocation { line: 14, column: 12, offset: 319 }..TextLocation { line: 14, column: 13, offset: 320 }) }], err_no: var__invalid_constant }
-SyntaxError { message: "Invalid constant z - Functionblock- and Class-instances cannot be delcared constant", range: [SourceLocation { span: Range(TextLocation { line: 15, column: 12, offset: 341 }..TextLocation { line: 15, column: 13, offset: 342 }) }], err_no: var__invalid_constant }
+error: Invalid constant y - Functionblock- and Class-instances cannot be delcared constant
+   ┌─ <internal>:15:13
+   │
+15 │             y : MyFb;
+   │             ^ Invalid constant y - Functionblock- and Class-instances cannot be delcared constant
+
+error: Invalid constant z - Functionblock- and Class-instances cannot be delcared constant
+   ┌─ <internal>:16:13
+   │
+16 │             z : cls;
+   │             ^ Invalid constant z - Functionblock- and Class-instances cannot be delcared constant
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__constant_on_illegal_var_blocks_cause_validation_issue.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__constant_on_illegal_var_blocks_cause_validation_issue.snap
@@ -1,11 +1,41 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "This variable block does not support the CONSTANT modifier", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 12, offset: 83 }..TextLocation { line: 5, column: 21, offset: 92 }) }], err_no: var__invalid_constant_block }
-SyntaxError { message: "This variable block does not support the CONSTANT modifier", range: [SourceLocation { span: Range(TextLocation { line: 8, column: 12, offset: 145 }..TextLocation { line: 8, column: 22, offset: 155 }) }], err_no: var__invalid_constant_block }
-SyntaxError { message: "This variable block does not support the CONSTANT modifier", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 12, offset: 208 }..TextLocation { line: 11, column: 22, offset: 218 }) }], err_no: var__invalid_constant_block }
-SyntaxError { message: "This variable block does not support the CONSTANT modifier", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 16, offset: 447 }..TextLocation { line: 24, column: 25, offset: 456 }) }], err_no: var__invalid_constant_block }
-SyntaxError { message: "This variable block does not support the CONSTANT modifier", range: [SourceLocation { span: Range(TextLocation { line: 27, column: 16, offset: 517 }..TextLocation { line: 27, column: 26, offset: 527 }) }], err_no: var__invalid_constant_block }
-SyntaxError { message: "This variable block does not support the CONSTANT modifier", range: [SourceLocation { span: Range(TextLocation { line: 30, column: 16, offset: 588 }..TextLocation { line: 30, column: 26, offset: 598 }) }], err_no: var__invalid_constant_block }
+error: This variable block does not support the CONSTANT modifier
+  ┌─ <internal>:6:13
+  │
+6 │             VAR_INPUT CONSTANT //illegal
+  │             ^^^^^^^^^ This variable block does not support the CONSTANT modifier
+
+error: This variable block does not support the CONSTANT modifier
+  ┌─ <internal>:9:13
+  │
+9 │             VAR_OUTPUT CONSTANT //illegal
+  │             ^^^^^^^^^^ This variable block does not support the CONSTANT modifier
+
+error: This variable block does not support the CONSTANT modifier
+   ┌─ <internal>:12:13
+   │
+12 │             VAR_IN_OUT CONSTANT //illegal
+   │             ^^^^^^^^^^ This variable block does not support the CONSTANT modifier
+
+error: This variable block does not support the CONSTANT modifier
+   ┌─ <internal>:25:17
+   │
+25 │                 VAR_INPUT CONSTANT //illegal
+   │                 ^^^^^^^^^ This variable block does not support the CONSTANT modifier
+
+error: This variable block does not support the CONSTANT modifier
+   ┌─ <internal>:28:17
+   │
+28 │                 VAR_OUTPUT CONSTANT //illegal
+   │                 ^^^^^^^^^^ This variable block does not support the CONSTANT modifier
+
+error: This variable block does not support the CONSTANT modifier
+   ┌─ <internal>:31:17
+   │
+31 │                 VAR_IN_OUT CONSTANT //illegal
+   │                 ^^^^^^^^^^ This variable block does not support the CONSTANT modifier
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_aliases.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_aliases.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 1, column: 35, offset: 36 }..TextLocation { line: 1, column: 40, offset: 41 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type REAL", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 35, offset: 87 }..TextLocation { line: 2, column: 49, offset: 101 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LREAL", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 35, offset: 147 }..TextLocation { line: 3, column: 58, offset: 170 }) }], err_no: var__overflow }
+error: This will overflow for type INT
+  ┌─ <internal>:2:36
+  │
+2 │         TYPE MyINT      : INT   := 60000; END_TYPE
+  │                                    ^^^^^ This will overflow for type INT
+
+error: This will overflow for type REAL
+  ┌─ <internal>:3:36
+  │
+3 │         TYPE MyREAL     : REAL  := 3.50282347E+38; END_TYPE
+  │                                    ^^^^^^^^^^^^^^ This will overflow for type REAL
+
+error: This will overflow for type LREAL
+  ┌─ <internal>:4:36
+  │
+4 │         TYPE MyLREAL    : LREAL := 1.8076931348623157E+308; END_TYPE
+  │                                    ^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LREAL
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_array_initializer.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_array_initializer.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type UINT", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 45, offset: 65 }..TextLocation { line: 2, column: 47, offset: 67 }) }], err_no: var__overflow }
+error: This will overflow for type UINT
+  ┌─ <internal>:3:46
+  │
+3 │             arr : ARRAY[0..5] OF UINT := [0, -1, -2, -3, -4, -5];
+  │                                              ^^ This will overflow for type UINT
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_constants.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_constants.snap
@@ -1,6 +1,13 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 23, offset: 52 }..TextLocation { line: 3, column: 28, offset: 93 }) }], err_no: var__overflow }
+error: This will overflow for type INT
+  ┌─ <internal>:3:24
+  │  
+3 │               a : INT := 16384; // OK
+  │ ╭────────────────────────^
+4 │ │             b : INT := 16384; // OK
+  │ ╰────────────────────────────^ This will overflow for type INT
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_expressions.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_expressions.snap
@@ -1,25 +1,125 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type SINT", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 41, offset: 108 }..TextLocation { line: 4, column: 54, offset: 121 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type SINT", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 42, offset: 177 }..TextLocation { line: 5, column: 54, offset: 189 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type USINT", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 42, offset: 245 }..TextLocation { line: 6, column: 53, offset: 256 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type USINT", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 42, offset: 310 }..TextLocation { line: 7, column: 54, offset: 322 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 40, offset: 398 }..TextLocation { line: 10, column: 56, offset: 414 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 41, offset: 470 }..TextLocation { line: 11, column: 56, offset: 485 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UINT", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 41, offset: 541 }..TextLocation { line: 12, column: 52, offset: 552 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UINT", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 41, offset: 606 }..TextLocation { line: 13, column: 56, offset: 621 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type DINT", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 41, offset: 698 }..TextLocation { line: 16, column: 64, offset: 721 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type DINT", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 42, offset: 785 }..TextLocation { line: 17, column: 64, offset: 807 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UDINT", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 42, offset: 871 }..TextLocation { line: 18, column: 53, offset: 882 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UDINT", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 42, offset: 944 }..TextLocation { line: 19, column: 64, offset: 966 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LINT", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 41, offset: 1051 }..TextLocation { line: 22, column: 76, offset: 1086 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LINT", range: [SourceLocation { span: Range(TextLocation { line: 23, column: 42, offset: 1162 }..TextLocation { line: 23, column: 76, offset: 1196 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type ULINT", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 42, offset: 1272 }..TextLocation { line: 24, column: 53, offset: 1283 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type ULINT", range: [SourceLocation { span: Range(TextLocation { line: 25, column: 42, offset: 1357 }..TextLocation { line: 25, column: 77, offset: 1392 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type REAL", range: [SourceLocation { span: Range(TextLocation { line: 28, column: 38, offset: 1487 }..TextLocation { line: 28, column: 61, offset: 1510 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type REAL", range: [SourceLocation { span: Range(TextLocation { line: 29, column: 38, offset: 1570 }..TextLocation { line: 29, column: 61, offset: 1593 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LREAL", range: [SourceLocation { span: Range(TextLocation { line: 32, column: 40, offset: 1679 }..TextLocation { line: 32, column: 72, offset: 1711 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LREAL", range: [SourceLocation { span: Range(TextLocation { line: 33, column: 40, offset: 1782 }..TextLocation { line: 33, column: 72, offset: 1814 }) }], err_no: var__overflow }
+error: This will overflow for type SINT
+  ┌─ <internal>:5:42
+  │
+5 │                 min_sint    : SINT  := ((-128 * 1) * 2);    // -128
+  │                                          ^^^^^^^^^^^^^ This will overflow for type SINT
+
+error: This will overflow for type SINT
+  ┌─ <internal>:6:43
+  │
+6 │                 max_sint    : SINT  :=  ((127 * 1) * 2);    //  127
+  │                                           ^^^^^^^^^^^^ This will overflow for type SINT
+
+error: This will overflow for type USINT
+  ┌─ <internal>:7:43
+  │
+7 │                 min_usint   : USINT  := ((1 * 1) * -2);     // 0
+  │                                           ^^^^^^^^^^^ This will overflow for type USINT
+
+error: This will overflow for type USINT
+  ┌─ <internal>:8:43
+  │
+8 │                 max_usint   : USINT  := ((256 * 1) * 2);    // 256
+  │                                           ^^^^^^^^^^^^ This will overflow for type USINT
+
+error: This will overflow for type INT
+   ┌─ <internal>:11:41
+   │
+11 │                 min_int     : INT  := ((-32_768 * 1) * 2);   // -32768
+   │                                         ^^^^^^^^^^^^^^^^ This will overflow for type INT
+
+error: This will overflow for type INT
+   ┌─ <internal>:12:42
+   │
+12 │                 max_int     : INT  :=  ((32_767 * 1) * 2);   //  32767
+   │                                          ^^^^^^^^^^^^^^^ This will overflow for type INT
+
+error: This will overflow for type UINT
+   ┌─ <internal>:13:42
+   │
+13 │                 min_uint    : UINT  := ((1 * 1) * -2);      // 0
+   │                                          ^^^^^^^^^^^ This will overflow for type UINT
+
+error: This will overflow for type UINT
+   ┌─ <internal>:14:42
+   │
+14 │                 max_uint    : UINT  := ((65_536 * 1) * 2);  // 65536
+   │                                          ^^^^^^^^^^^^^^^ This will overflow for type UINT
+
+error: This will overflow for type DINT
+   ┌─ <internal>:17:42
+   │
+17 │                 min_dint    : DINT  := ((-2_147_483_649 * 1) * 2);  // -2_147_483_648
+   │                                          ^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type DINT
+
+error: This will overflow for type DINT
+   ┌─ <internal>:18:43
+   │
+18 │                 max_dint    : DINT  := (( 2_147_483_648 * 1) * 2);  //  2_147_483_647
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type DINT
+
+error: This will overflow for type UDINT
+   ┌─ <internal>:19:43
+   │
+19 │                 min_udint   : UDINT  := ((1 * 1) * -2);             // 0
+   │                                           ^^^^^^^^^^^ This will overflow for type UDINT
+
+error: This will overflow for type UDINT
+   ┌─ <internal>:20:43
+   │
+20 │                 max_udint   : UDINT  := ((4_294_967_296 * 1) * 2);  // 4_294_967_296
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type UDINT
+
+error: This will overflow for type LINT
+   ┌─ <internal>:23:42
+   │
+23 │                 min_lint    : LINT  := ((-9_223_372_036_854_775_808 * 1) * 2);  // -9_223_372_036_854_775_808
+   │                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LINT
+
+error: This will overflow for type LINT
+   ┌─ <internal>:24:43
+   │
+24 │                 max_lint    : LINT  := (( 9_223_372_036_854_775_807 * 1) * 2);  //  9_223_372_036_854_775_807
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LINT
+
+error: This will overflow for type ULINT
+   ┌─ <internal>:25:43
+   │
+25 │                 min_ulint   : ULINT  := ((1 * 1) * -2);                         // 0
+   │                                           ^^^^^^^^^^^ This will overflow for type ULINT
+
+error: This will overflow for type ULINT
+   ┌─ <internal>:26:43
+   │
+26 │                 max_ulint   : ULINT  := ((18_446_744_073_709_551_615 * 1) * 2); // 18_446_744_073_709_551_615
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type ULINT
+
+error: This will overflow for type REAL
+   ┌─ <internal>:29:39
+   │
+29 │                 min_real : REAL := ((-3.40282347E+38 * 1) * 2); // -3.40282347E+38
+   │                                       ^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type REAL
+
+error: This will overflow for type REAL
+   ┌─ <internal>:30:39
+   │
+30 │                 max_real : REAL := (( 3.40282347E+38 * 1) * 2); //  3.40282347E+38
+   │                                       ^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type REAL
+
+error: This will overflow for type LREAL
+   ┌─ <internal>:33:41
+   │
+33 │                 min_lreal : LREAL := ((-1.7976931348623157E+308 * 1) * 2); // -1.7976931348623157E+308
+   │                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LREAL
+
+error: This will overflow for type LREAL
+   ┌─ <internal>:34:41
+   │
+34 │                 max_lreal : LREAL := (( 1.7976931348623157E+308 * 1) * 2); //  1.7976931348623157E+308
+   │                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LREAL
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_globals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_globals.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 2, column: 23, offset: 43 }..TextLocation { line: 2, column: 28, offset: 48 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 23, offset: 73 }..TextLocation { line: 3, column: 32, offset: 82 }) }], err_no: var__overflow }
+error: This will overflow for type INT
+  ┌─ <internal>:3:24
+  │
+3 │             a : INT := 32768;
+  │                        ^^^^^ This will overflow for type INT
+
+error: This will overflow for type INT
+  ┌─ <internal>:4:24
+  │
+4 │             b : INT := 32767 + 1;
+  │                        ^^^^^^^^^ This will overflow for type INT
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_hex.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_hex.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type WORD", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 29, offset: 95 }..TextLocation { line: 3, column: 37, offset: 103 }) }], err_no: var__overflow }
-SyntaxError { message: "Literal 1048575 out of range (WORD)", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 24, offset: 90 }..TextLocation { line: 3, column: 37, offset: 103 }) }], err_no: type__literal_out_of_range }
+error: This will overflow for type WORD
+  ┌─ <internal>:4:30
+  │
+4 │             y : UINT := WORD#16#fffff;  // Not OK, should have been `ffff` not `ffff_f_`
+  │                              ^^^^^^^^ This will overflow for type WORD
+
+error: Literal 1048575 out of range (WORD)
+  ┌─ <internal>:4:25
+  │
+4 │             y : UINT := WORD#16#fffff;  // Not OK, should have been `ffff` not `ffff_f_`
+  │                         ^^^^^^^^^^^^^ Literal 1048575 out of range (WORD)
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_literals.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_literals.snap
@@ -1,25 +1,125 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type SINT", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 39, offset: 106 }..TextLocation { line: 4, column: 43, offset: 110 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type SINT", range: [SourceLocation { span: Range(TextLocation { line: 5, column: 40, offset: 163 }..TextLocation { line: 5, column: 43, offset: 166 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type USINT", range: [SourceLocation { span: Range(TextLocation { line: 6, column: 40, offset: 219 }..TextLocation { line: 6, column: 42, offset: 221 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type USINT", range: [SourceLocation { span: Range(TextLocation { line: 7, column: 40, offset: 272 }..TextLocation { line: 7, column: 43, offset: 275 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 10, column: 38, offset: 348 }..TextLocation { line: 10, column: 45, offset: 355 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type INT", range: [SourceLocation { span: Range(TextLocation { line: 11, column: 38, offset: 406 }..TextLocation { line: 11, column: 44, offset: 412 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UINT", range: [SourceLocation { span: Range(TextLocation { line: 12, column: 39, offset: 465 }..TextLocation { line: 12, column: 41, offset: 467 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UINT", range: [SourceLocation { span: Range(TextLocation { line: 13, column: 39, offset: 518 }..TextLocation { line: 13, column: 45, offset: 524 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type DINT", range: [SourceLocation { span: Range(TextLocation { line: 16, column: 39, offset: 598 }..TextLocation { line: 16, column: 53, offset: 612 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type DINT", range: [SourceLocation { span: Range(TextLocation { line: 17, column: 40, offset: 673 }..TextLocation { line: 17, column: 53, offset: 686 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UDINT", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 40, offset: 747 }..TextLocation { line: 18, column: 42, offset: 749 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type UDINT", range: [SourceLocation { span: Range(TextLocation { line: 19, column: 40, offset: 808 }..TextLocation { line: 19, column: 53, offset: 821 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LINT", range: [SourceLocation { span: Range(TextLocation { line: 22, column: 39, offset: 903 }..TextLocation { line: 22, column: 65, offset: 929 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LINT", range: [SourceLocation { span: Range(TextLocation { line: 23, column: 40, offset: 1002 }..TextLocation { line: 23, column: 65, offset: 1027 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type ULINT", range: [SourceLocation { span: Range(TextLocation { line: 24, column: 40, offset: 1100 }..TextLocation { line: 24, column: 42, offset: 1102 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type ULINT", range: [SourceLocation { span: Range(TextLocation { line: 25, column: 40, offset: 1173 }..TextLocation { line: 25, column: 66, offset: 1199 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type REAL", range: [SourceLocation { span: Range(TextLocation { line: 28, column: 36, offset: 1291 }..TextLocation { line: 28, column: 50, offset: 1305 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type REAL", range: [SourceLocation { span: Range(TextLocation { line: 29, column: 36, offset: 1362 }..TextLocation { line: 29, column: 50, offset: 1376 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LREAL", range: [SourceLocation { span: Range(TextLocation { line: 32, column: 38, offset: 1459 }..TextLocation { line: 32, column: 61, offset: 1482 }) }], err_no: var__overflow }
-SemanticError { message: "This will overflow for type LREAL", range: [SourceLocation { span: Range(TextLocation { line: 33, column: 38, offset: 1550 }..TextLocation { line: 33, column: 61, offset: 1573 }) }], err_no: var__overflow }
+error: This will overflow for type SINT
+  ┌─ <internal>:5:40
+  │
+5 │                 min_sint    : SINT  := -129;    // -128
+  │                                        ^^^^ This will overflow for type SINT
+
+error: This will overflow for type SINT
+  ┌─ <internal>:6:41
+  │
+6 │                 max_sint    : SINT  :=  128;    //  127
+  │                                         ^^^ This will overflow for type SINT
+
+error: This will overflow for type USINT
+  ┌─ <internal>:7:41
+  │
+7 │                 min_usint   : USINT  := -1;     // 0
+  │                                         ^^ This will overflow for type USINT
+
+error: This will overflow for type USINT
+  ┌─ <internal>:8:41
+  │
+8 │                 max_usint   : USINT  := 257;    // 256
+  │                                         ^^^ This will overflow for type USINT
+
+error: This will overflow for type INT
+   ┌─ <internal>:11:39
+   │
+11 │                 min_int     : INT  := -32_769;  // -32768
+   │                                       ^^^^^^^ This will overflow for type INT
+
+error: This will overflow for type INT
+   ┌─ <internal>:12:39
+   │
+12 │                 max_int     : INT  := 32_768;   //  32767
+   │                                       ^^^^^^ This will overflow for type INT
+
+error: This will overflow for type UINT
+   ┌─ <internal>:13:40
+   │
+13 │                 min_uint    : UINT  := -1;      // 0
+   │                                        ^^ This will overflow for type UINT
+
+error: This will overflow for type UINT
+   ┌─ <internal>:14:40
+   │
+14 │                 max_uint    : UINT  := 65_537;  // 65536
+   │                                        ^^^^^^ This will overflow for type UINT
+
+error: This will overflow for type DINT
+   ┌─ <internal>:17:40
+   │
+17 │                 min_dint    : DINT  := -2_147_483_649;  // -2_147_483_648
+   │                                        ^^^^^^^^^^^^^^ This will overflow for type DINT
+
+error: This will overflow for type DINT
+   ┌─ <internal>:18:41
+   │
+18 │                 max_dint    : DINT  :=  2_147_483_648;  //  2_147_483_647
+   │                                         ^^^^^^^^^^^^^ This will overflow for type DINT
+
+error: This will overflow for type UDINT
+   ┌─ <internal>:19:41
+   │
+19 │                 min_udint   : UDINT  := -1;             // 0
+   │                                         ^^ This will overflow for type UDINT
+
+error: This will overflow for type UDINT
+   ┌─ <internal>:20:41
+   │
+20 │                 max_udint   : UDINT  := 4_294_967_296;  // 4_294_967_296
+   │                                         ^^^^^^^^^^^^^ This will overflow for type UDINT
+
+error: This will overflow for type LINT
+   ┌─ <internal>:23:40
+   │
+23 │                 min_lint    : LINT  := -9_223_372_036_854_775_809;  // -9_223_372_036_854_775_808
+   │                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LINT
+
+error: This will overflow for type LINT
+   ┌─ <internal>:24:41
+   │
+24 │                 max_lint    : LINT  :=  9_223_372_036_854_775_808;  //  9_223_372_036_854_775_807
+   │                                         ^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LINT
+
+error: This will overflow for type ULINT
+   ┌─ <internal>:25:41
+   │
+25 │                 min_ulint   : ULINT  := -1;                         // 0
+   │                                         ^^ This will overflow for type ULINT
+
+error: This will overflow for type ULINT
+   ┌─ <internal>:26:41
+   │
+26 │                 max_ulint   : ULINT  := 18_446_744_073_709_551_616; // 18_446_744_073_709_551_615
+   │                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type ULINT
+
+error: This will overflow for type REAL
+   ┌─ <internal>:29:37
+   │
+29 │                 min_real : REAL := -3.50282347E+38; // -3.40282347E+38
+   │                                     ^^^^^^^^^^^^^^ This will overflow for type REAL
+
+error: This will overflow for type REAL
+   ┌─ <internal>:30:37
+   │
+30 │                 max_real : REAL :=  3.50282347E+38; //  3.40282347E+38
+   │                                     ^^^^^^^^^^^^^^ This will overflow for type REAL
+
+error: This will overflow for type LREAL
+   ┌─ <internal>:33:39
+   │
+33 │                 min_lreal : LREAL := -1.8076931348623157E+308; // -1.7976931348623157E+308
+   │                                       ^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LREAL
+
+error: This will overflow for type LREAL
+   ┌─ <internal>:34:39
+   │
+34 │                 max_lreal : LREAL :=  1.8076931348623157E+308; //  1.7976931348623157E+308
+   │                                       ^^^^^^^^^^^^^^^^^^^^^^^ This will overflow for type LREAL
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_non_global_constants.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_non_global_constants.snap
@@ -1,0 +1,11 @@
+---
+source: src/validation/tests/variable_validation_tests.rs
+expression: diagnostics
+---
+error: Unresolved constant 'c' variable: 'a' is no const reference
+  ┌─ <internal>:5:24
+  │
+5 │             c : INT := a + b; // Will overflow
+  │                        ^^^^^ Unresolved constant 'c' variable: 'a' is no const reference
+
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_not.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__overflows__overflows_with_not.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: diagnostics
 ---
-SemanticError { message: "This will overflow for type UINT", range: [SourceLocation { span: Range(TextLocation { line: 3, column: 24, offset: 86 }..TextLocation { line: 3, column: 33, offset: 95 }) }], err_no: var__overflow }
+error: This will overflow for type UINT
+  ┌─ <internal>:4:25
+  │
+4 │             y : UINT := NOT -1234;  // Not OK (because of -1234)
+  │                         ^^^^^^^^^ This will overflow for type UINT
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__sized_varargs_require_type.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__sized_varargs_require_type.snap
@@ -1,6 +1,11 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Missing datatype : Sized Variadics require a known datatype.", range: [SourceLocation { span: Range(TextLocation { line: 4, column: 26, offset: 103 }..TextLocation { line: 4, column: 29, offset: 106 }) }], err_no: var__missing_type }
+error: Missing datatype : Sized Variadics require a known datatype.
+  ┌─ <internal>:5:27
+  │
+5 │             args : {sized}...;
+  │                           ^^^ Missing datatype : Sized Variadics require a known datatype.
+
 

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__uninitialized_constants_fall_back_to_the_default.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__uninitialized_constants_fall_back_to_the_default.snap
@@ -1,0 +1,5 @@
+---
+source: src/validation/tests/variable_validation_tests.rs
+expression: diagnostics
+---
+

--- a/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__unresolvable_variables_are_reported.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__variable_validation_tests__unresolvable_variables_are_reported.snap
@@ -1,8 +1,23 @@
 ---
 source: src/validation/tests/variable_validation_tests.rs
-expression: res
+expression: "&diagnostics"
 ---
-SyntaxError { message: "Unresolved constant 'cx' variable", range: [SourceLocation { span: Range(TextLocation { line: 18, column: 28, offset: 372 }..TextLocation { line: 18, column: 30, offset: 374 }) }], err_no: var__unresolved_constant }
-SyntaxError { message: "Could not resolve reference to a", range: [SourceLocation { span: Range(TextLocation { line: 20, column: 29, offset: 453 }..TextLocation { line: 20, column: 30, offset: 454 }) }], err_no: reference__unresolved }
-SyntaxError { message: "Unresolved constant 'cai' variable", range: [SourceLocation { span: Range(TextLocation { line: 20, column: 29, offset: 453 }..TextLocation { line: 20, column: 30, offset: 454 }) }], err_no: var__unresolved_constant }
+error: Unresolved constant 'cx' variable
+   ┌─ <internal>:19:29
+   │
+19 │                 cx : INT := cx;  //unresolvable
+   │                             ^^ Unresolved constant 'cx' variable
+
+error: Could not resolve reference to a
+   ┌─ <internal>:21:30
+   │
+21 │                 cai : INT := a;  //unresolvable
+   │                              ^ Could not resolve reference to a
+
+error: Unresolved constant 'cai' variable
+   ┌─ <internal>:21:30
+   │
+21 │                 cai : INT := a;  //unresolvable
+   │                              ^ Unresolved constant 'cai' variable
+
 

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -1,14 +1,12 @@
 use insta::assert_snapshot;
-use plc_diagnostics::diagnostics::Diagnostic;
 
-use crate::assert_validation_snapshot;
-use crate::test_utils::tests::{parse_and_validate, parse_and_validate_buffered};
+use crate::test_utils::tests::parse_and_validate_buffered;
 
 #[test]
 fn assign_pointer_to_too_small_type_result_in_an_error() {
     //GIVEN assignment statements to DWORD
     //WHEN it is validated
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM FOO
             VAR
@@ -23,14 +21,14 @@ fn assign_pointer_to_too_small_type_result_in_an_error() {
     );
 
     //THEN assignment with different type sizes are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn assign_too_small_type_to_pointer_result_in_an_error() {
     //GIVEN assignment statements to pointer
     //WHEN it is validated
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM FOO
             VAR
@@ -45,14 +43,14 @@ fn assign_too_small_type_to_pointer_result_in_an_error() {
     );
 
     //THEN assignment with different type sizes are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn assign_pointer_to_lword() {
     //GIVEN assignment statements to lword
     //WHEN it is validated
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM FOO
             VAR
@@ -67,14 +65,14 @@ fn assign_pointer_to_lword() {
     );
 
     //THEN every assignment is valid
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn assignment_to_constants_result_in_an_error() {
     // GIVEN assignment statements to constants, some to writable variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         VAR_GLOBAL CONSTANT
             ci: INT := 1;
@@ -102,14 +100,14 @@ fn assignment_to_constants_result_in_an_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn assignment_to_enum_literals_results_in_error() {
     // GIVEN assignment statements to constants, some to writable variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         TYPE Color: (red, yellow, green); END_TYPE
 
@@ -130,14 +128,14 @@ fn assignment_to_enum_literals_results_in_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn invalid_char_assignments() {
     // GIVEN invalid assignments to CHAR/WCHAR
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM mainProg
         VAR
@@ -176,14 +174,14 @@ fn invalid_char_assignments() {
     );
 
     // THEN every assignment should be reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn missing_string_compare_function_causes_error() {
     // GIVEN assignment statements to constants, some to writable variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM prg
             'a' =  'b'; // missing compare function :-(
@@ -197,14 +195,14 @@ fn missing_string_compare_function_causes_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn string_compare_function_cause_no_error_if_functions_exist() {
     // GIVEN assignment statements to constants, some to writable variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION STRING_EQUAL : BOOL VAR_INPUT a,b : STRING; END_VAR END_FUNCTION
         FUNCTION STRING_GREATER : BOOL VAR_INPUT a,b : STRING; END_VAR END_FUNCTION
@@ -222,14 +220,14 @@ fn string_compare_function_cause_no_error_if_functions_exist() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn string_compare_function_with_wrong_signature_causes_error() {
     // GIVEN assignment statements to constants, some to writable variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION STRING_EQUAL : BOOL VAR_INPUT a : STRING; END_VAR END_FUNCTION
 
@@ -240,14 +238,14 @@ fn string_compare_function_with_wrong_signature_causes_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn missing_wstring_compare_function_causes_error() {
     // GIVEN assignment statements to constants, some to writable variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prg
             "a" =  "b"; // missing compare function :-(
@@ -261,14 +259,14 @@ fn missing_wstring_compare_function_causes_error() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn wstring_compare_function_cause_no_error_if_functions_exist() {
     // GIVEN assignment statements to constants, some to writable variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION WSTRING_EQUAL : BOOL VAR_INPUT a,b : WSTRING; END_VAR END_FUNCTION
         FUNCTION WSTRING_GREATER : BOOL VAR_INPUT a,b : WSTRING; END_VAR END_FUNCTION
@@ -286,14 +284,14 @@ fn wstring_compare_function_cause_no_error_if_functions_exist() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn switch_case() {
     // GIVEN switch case statement
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         VAR_GLOBAL CONSTANT
             BASE : DINT := 1;
@@ -325,14 +323,14 @@ fn switch_case() {
     );
 
     // THEN no errors should occure
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn switch_case_duplicate_integer_non_const_var_reference() {
     // GIVEN switch case with non constant variables
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         VAR_GLOBAL CONSTANT
             CONST : DINT := 8;
@@ -362,14 +360,14 @@ fn switch_case_duplicate_integer_non_const_var_reference() {
     );
 
     // THEN the non constant variables are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn switch_case_duplicate_integer() {
     // GIVEN switch case with duplicate constant conditions
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         VAR_GLOBAL CONSTANT
             BASE : DINT := 2;
@@ -399,14 +397,14 @@ fn switch_case_duplicate_integer() {
     );
 
     // THEN the non constant variables are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn switch_case_invalid_case_conditions() {
     // GIVEN switch case statement
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION foo : DINT
         END_FUNCTION
@@ -427,14 +425,14 @@ fn switch_case_invalid_case_conditions() {
     );
 
     // THEN
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn case_condition_used_outside_case_statement() {
     // GIVEN switch case statement
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM main
         VAR
@@ -448,14 +446,14 @@ fn case_condition_used_outside_case_statement() {
     );
 
     // THEN
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn subrange_compare_function_causes_no_error() {
     // GIVEN comparison of subranges
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM main
         VAR
@@ -475,14 +473,14 @@ fn subrange_compare_function_causes_no_error() {
     );
 
     // THEN the validator does not throw an error
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn aliased_subrange_compare_function_causes_no_error() {
     // GIVEN comparison of aliased subranges
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         TYPE MyInt: INT(0..500); END_TYPE
         PROGRAM main
@@ -503,14 +501,14 @@ fn aliased_subrange_compare_function_causes_no_error() {
     );
 
     // THEN the validator does not throw an error
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn aliased_int_compare_function_causes_no_error() {
     // GIVEN comparison of aliased integers
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         TYPE MyInt: INT; END_TYPE
         PROGRAM main
@@ -531,13 +529,13 @@ fn aliased_int_compare_function_causes_no_error() {
     );
 
     // THEN the validator does not throw an error
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn program_missing_inout_assignment() {
     // GIVEN
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM prog
         VAR_INPUT
@@ -563,14 +561,14 @@ fn program_missing_inout_assignment() {
         ",
     );
     // THEN
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn function_call_parameter_validation() {
     // GIVEN
     // WHEN
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION foo : DINT
         VAR_INPUT
@@ -604,14 +602,14 @@ fn function_call_parameter_validation() {
     );
 
     // THEN
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn program_call_parameter_validation() {
     // GIVEN
     // WHEN
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prog
         VAR_INPUT
@@ -645,12 +643,12 @@ fn program_call_parameter_validation() {
     );
 
     // THEN
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn reference_to_reference_assignments_in_function_arguments() {
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     VAR_GLOBAL
         global1 : STRUCT_params;
@@ -713,12 +711,12 @@ fn reference_to_reference_assignments_in_function_arguments() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn ref_builtin_function_reports_invalid_param_count() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION main : DINT
         VAR
@@ -731,7 +729,7 @@ fn ref_builtin_function_reports_invalid_param_count() {
     ",
     );
 
-    assert_validation_snapshot!(diagnostics);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -773,7 +771,7 @@ fn address_of_operations() {
 
 #[test]
 fn validate_call_by_ref() {
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION func : DINT
             VAR_INPUT
@@ -808,12 +806,12 @@ fn validate_call_by_ref() {
         ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn validate_call_by_ref_explicit() {
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION func : DINT
             VAR_INPUT
@@ -846,12 +844,12 @@ fn validate_call_by_ref_explicit() {
         ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn implicit_param_downcast_in_function_call() {
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         PROGRAM main
         VAR
@@ -893,12 +891,12 @@ fn implicit_param_downcast_in_function_call() {
         ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn function_block_implicit_downcast() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM main
         VAR
@@ -939,12 +937,12 @@ fn function_block_implicit_downcast() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn program_implicit_downcast() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM main
         VAR
@@ -985,12 +983,12 @@ fn program_implicit_downcast() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn action_implicit_downcast() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM main
         VAR
@@ -1029,12 +1027,12 @@ fn action_implicit_downcast() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn method_implicit_downcast() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     PROGRAM main
     VAR
@@ -1061,12 +1059,12 @@ fn method_implicit_downcast() {
     "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn validate_array_elements_passed_to_functions_by_ref() {
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION func : DINT
             VAR_IN_OUT
@@ -1090,12 +1088,12 @@ fn validate_array_elements_passed_to_functions_by_ref() {
         ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn validate_arrays_passed_to_functions() {
-    let diagnostics: Vec<Diagnostic> = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION func : DINT
             VAR_INPUT
@@ -1140,12 +1138,12 @@ fn validate_arrays_passed_to_functions() {
         ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn assigning_to_rvalue() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         FUNCTION func : DINT
         VAR_INPUT
@@ -1164,12 +1162,12 @@ fn assigning_to_rvalue() {
         "#,
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn assigning_to_qualified_references_allowed() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM prg
         VAR_INPUT
@@ -1183,12 +1181,12 @@ fn assigning_to_qualified_references_allowed() {
         "#,
     );
 
-    assert_eq!(diagnostics.len(), 0);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn assigning_to_rvalue_allowed_for_directaccess() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM main
         VAR
@@ -1201,12 +1199,12 @@ fn assigning_to_rvalue_allowed_for_directaccess() {
         "#,
     );
 
-    assert_eq!(diagnostics.len(), 0);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn allowed_assignable_types() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
         PROGRAM main
         VAR
@@ -1225,7 +1223,7 @@ fn allowed_assignable_types() {
         "#,
     );
 
-    assert_eq!(diagnostics.len(), 0);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
@@ -1250,7 +1248,7 @@ fn assignment_of_incompatible_types_is_reported() {
 
 #[test]
 fn passing_compatible_numeric_types_to_functions_is_allowed() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         r#"
     PROGRAM prog
     VAR
@@ -1271,12 +1269,12 @@ fn passing_compatible_numeric_types_to_functions_is_allowed() {
     "#,
     );
 
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn bit_access_with_incorrect_operator_causes_warning() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "PROGRAM mainProg
         VAR_INPUT
             Input : STRUCT1;
@@ -1311,12 +1309,12 @@ fn bit_access_with_incorrect_operator_causes_warning() {
         END_TYPE",
     );
 
-    assert_validation_snapshot!(diagnostics);
+    assert_snapshot!(diagnostics);
 }
 
 #[test]
 fn invalid_cast_statement_causes_error() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "PROGRAM mainProg
             VAR_INPUT
                 s : STRUCT1;
@@ -1336,5 +1334,5 @@ fn invalid_cast_statement_causes_error() {
        ",
     );
 
-    assert_validation_snapshot!(diagnostics);
+    assert_snapshot!(diagnostics);
 }

--- a/src/validation/tests/variable_length_array_test.rs
+++ b/src/validation/tests/variable_length_array_test.rs
@@ -1,4 +1,5 @@
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+use crate::test_utils::tests::parse_and_validate_buffered;
+use insta::assert_snapshot;
 
 static SOURCE: &str = "
     <POU_TYPE> fn : DINT
@@ -24,71 +25,71 @@ fn variable_length_array_defined_as_a_global_variable() {
         END_VAR
     ";
 
-    assert_validation_snapshot!(parse_and_validate(src));
+    assert_snapshot!(parse_and_validate_buffered(src));
 }
 
 mod functions {
-    use crate::{
-        assert_validation_snapshot, test_utils::tests::parse_and_validate,
-        validation::tests::variable_length_array_test::SOURCE,
-    };
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use crate::validation::tests::variable_length_array_test::SOURCE;
+    use insta::assert_snapshot;
 
     #[test]
     fn variable_length_array_function_with_input_output_and_inout() {
         let function = SOURCE.replace("<POU_TYPE>", "FUNCTION");
-        assert!(parse_and_validate(&function.replace("<VAR_TYPE>", "INPUT {ref}")).is_empty());
-        assert!(parse_and_validate(&function.replace("<VAR_TYPE>", "OUTPUT")).is_empty());
-        assert!(parse_and_validate(&function.replace("<VAR_TYPE>", "IN_OUT")).is_empty());
+        assert!(parse_and_validate_buffered(&function.replace("<VAR_TYPE>", "INPUT {ref}")).is_empty());
+        assert!(parse_and_validate_buffered(&function.replace("<VAR_TYPE>", "OUTPUT")).is_empty());
+        assert!(parse_and_validate_buffered(&function.replace("<VAR_TYPE>", "IN_OUT")).is_empty());
     }
 
     #[test]
     fn variable_length_array_function_input() {
         let function = SOURCE.replace("<POU_TYPE>", "FUNCTION");
-        assert_validation_snapshot!(parse_and_validate(&function.replace("<VAR_TYPE>", "INPUT")));
+        assert_snapshot!(parse_and_validate_buffered(&function.replace("<VAR_TYPE>", "INPUT")));
     }
 }
 
 mod program {
     use crate::{
-        assert_validation_snapshot, test_utils::tests::parse_and_validate,
-        validation::tests::variable_length_array_test::SOURCE,
+        test_utils::tests::parse_and_validate_buffered, validation::tests::variable_length_array_test::SOURCE,
     };
+    use insta::assert_snapshot;
 
     #[test]
     fn variable_length_array_program_input() {
         let program = SOURCE.replace("<POU_TYPE>", "PROGRAM");
-        let program_input = parse_and_validate(&program.replace("<VAR_TYPE>", "INPUT"));
-        assert_validation_snapshot!(program_input);
+        let program_input = parse_and_validate_buffered(&program.replace("<VAR_TYPE>", "INPUT"));
+        assert_snapshot!(program_input);
     }
 
     #[test]
     fn variable_length_array_program_input_ref() {
         let program = SOURCE.replace("<POU_TYPE>", "PROGRAM");
-        let program_input = parse_and_validate(&program.replace("<VAR_TYPE>", "INPUT {ref}"));
-        assert_validation_snapshot!(program_input);
+        let program_input = parse_and_validate_buffered(&program.replace("<VAR_TYPE>", "INPUT {ref}"));
+        assert_snapshot!(program_input);
     }
 
     #[test]
     fn variable_length_array_program_output() {
         let program = SOURCE.replace("<POU_TYPE>", "PROGRAM");
-        let program_output = parse_and_validate(&program.replace("<VAR_TYPE>", "OUTPUT"));
-        assert_validation_snapshot!(program_output);
+        let program_output = parse_and_validate_buffered(&program.replace("<VAR_TYPE>", "OUTPUT"));
+        assert_snapshot!(program_output);
     }
 
     #[test]
     fn variable_length_array_program_inout() {
         let program = SOURCE.replace("<POU_TYPE>", "PROGRAM");
-        let program_inout = parse_and_validate(&program.replace("<VAR_TYPE>", "IN_OUT"));
-        assert_validation_snapshot!(program_inout);
+        let program_inout = parse_and_validate_buffered(&program.replace("<VAR_TYPE>", "IN_OUT"));
+        assert_snapshot!(program_inout);
     }
 }
 
 mod access {
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn variable_length_array_access() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION fn : DINT
                 VAR_INPUT {ref}
@@ -111,12 +112,12 @@ mod access {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn variable_length_array_incompatible_datatypes() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION fn : DINT
                 VAR_INPUT {ref}
@@ -138,16 +139,17 @@ mod access {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 }
 
 mod assignment {
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn function_calls() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
             FUNCTION fn : DINT
                 VAR_TEMP
@@ -174,15 +176,17 @@ mod assignment {
             ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 }
 
 mod naming {
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
+
     #[test]
     fn two_identical_vlas_in_same_pou_arent_duplicated_in_symbol_map() {
-        let diag = parse_and_validate(
+        let diag = parse_and_validate_buffered(
             r#"
         FUNCTION foo : INT
         VAR_INPUT{ref}
@@ -206,7 +210,7 @@ mod naming {
 
     #[test]
     fn global_vla_does_not_cause_name_conflict() {
-        let diag = parse_and_validate(
+        let diag = parse_and_validate_buffered(
             r#"
         VAR_GLOBAL
             vla : ARRAY[*, *] OF DINT;
@@ -219,16 +223,17 @@ mod naming {
         END_FUNCTION
     "#,
         );
-        assert_validation_snapshot!(diag);
+        assert_snapshot!(diag);
     }
 }
 
 mod builtins {
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn builtins_called_with_invalid_type() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         FUNCTION main : DINT
         VAR CONSTANT
@@ -249,12 +254,12 @@ mod builtins {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn builtins_called_with_invalid_index() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         FUNCTION main : DINT
         VAR
@@ -285,12 +290,12 @@ mod builtins {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn builtins_called_with_aliased_type() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         FUNCTION main : DINT
         VAR
@@ -315,12 +320,12 @@ mod builtins {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn builtins_called_with_invalid_number_of_params() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         FUNCTION main : DINT
         VAR
@@ -346,6 +351,6 @@ mod builtins {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 }

--- a/src/validation/tests/variable_validation_tests.rs
+++ b/src/validation/tests/variable_validation_tests.rs
@@ -1,10 +1,9 @@
 use crate::test_utils::tests::parse_and_validate_buffered;
-use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
 use insta::assert_snapshot;
 
 #[test]
 fn uninitialized_constants_fall_back_to_the_default() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         VAR_GLOBAL
             gX : INT;
@@ -30,12 +29,12 @@ fn uninitialized_constants_fall_back_to_the_default() {
        ",
     );
 
-    assert_eq!(diagnostics, vec![]);
+    assert_snapshot!(diagnostics)
 }
 
 #[test]
 fn unresolvable_variables_are_reported() {
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         VAR_GLOBAL
             gX : INT := 7 + cgX;
@@ -62,14 +61,14 @@ fn unresolvable_variables_are_reported() {
        ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn constant_on_illegal_var_blocks_cause_validation_issue() {
     // GIVEN different variable block types with the CONSTANT modifier
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         VAR_GLOBAL CONSTANT //OK
         END_VAR
@@ -111,14 +110,14 @@ fn constant_on_illegal_var_blocks_cause_validation_issue() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn constant_fb_instances_are_illegal() {
     // GIVEN a couple of constants, including FB instances and class-instances
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION_BLOCK MyFb
             ;
@@ -140,14 +139,14 @@ fn constant_fb_instances_are_illegal() {
     );
 
     // THEN everything but VAR and VAR_GLOBALS are reported
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 #[test]
 fn sized_varargs_require_type() {
     // GIVEN a function with a untyped sized variadic argument
     // WHEN it is validated
-    let diagnostics = parse_and_validate(
+    let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION f_with_var : INT
         VAR_INPUT
@@ -158,15 +157,16 @@ fn sized_varargs_require_type() {
       ",
     );
 
-    assert_validation_snapshot!(&diagnostics);
+    assert_snapshot!(&diagnostics);
 }
 
 mod overflows {
-    use crate::{assert_validation_snapshot, test_utils::tests::parse_and_validate};
+    use crate::test_utils::tests::parse_and_validate_buffered;
+    use insta::assert_snapshot;
 
     #[test]
     fn overflows_with_literals() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         FUNCTION main : DINT
             VAR
@@ -206,12 +206,12 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn overflows_with_expressions() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         FUNCTION main : DINT
             VAR
@@ -251,12 +251,12 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn overflows_with_globals() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         VAR_GLOBAL
             a : INT := 32768;
@@ -265,12 +265,12 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn overflows_with_aliases() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         TYPE MyINT      : INT   := 60000; END_TYPE
         TYPE MyREAL     : REAL  := 3.50282347E+38; END_TYPE
@@ -278,12 +278,12 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn overflows_with_constants() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         VAR_GLOBAL CONSTANT
             a : INT := 16384; // OK
@@ -293,12 +293,12 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn overflows_with_non_global_constants() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         VAR_GLOBAL
             a : INT := 16384; // OK
@@ -311,11 +311,7 @@ mod overflows {
         // As of now we do not evaluate `c` because the variable block isn't defined to be constant.
         // If at some point we support evaluation such cases, this test should fail. See also:
         // https://github.com/PLC-lang/rusty/issues/847
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].get_message(),
-            "Unresolved constant 'c' variable: 'a' is no const reference"
-        );
+        assert_snapshot!(diagnostics)
     }
 
     #[test]
@@ -323,7 +319,7 @@ mod overflows {
         // TODO(volsa): We currently only detect the first overflow value inside an array-initalizer because
         // the `evaluate_with_target_hint` method will return an error after it first detected such a value (i.e.
         // after `-1`).
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         VAR_GLOBAL
             arr : ARRAY[0..5] OF UINT := [0, -1, -2, -3, -4, -5];
@@ -331,12 +327,12 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics)
+        assert_snapshot!(diagnostics)
     }
 
     #[test]
     fn overflows_with_not() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         VAR_GLOBAL
             x : UINT := 1234;       // OK
@@ -345,12 +341,12 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 
     #[test]
     fn overflows_with_hex() {
-        let diagnostics = parse_and_validate(
+        let diagnostics = parse_and_validate_buffered(
             "
         VAR_GLOBAL
             x : UINT := WORD#16#ffff;   // OK
@@ -359,7 +355,7 @@ mod overflows {
         ",
         );
 
-        assert_validation_snapshot!(diagnostics);
+        assert_snapshot!(diagnostics);
     }
 }
 


### PR DESCRIPTION
All the validation tests now use the buffered validator this makes it easy to refactor the diagnostics without worrying about breaking the location of the tests. Ideally these tests should no longer change if we change diagnostics