### PR TITLE
feat(validation): improve array access/size declaration errors

### DIFF
--- a/src/index/const_expressions.rs
+++ b/src/index/const_expressions.rs
@@ -80,12 +80,16 @@ pub enum UnresolvableKind {
 
     /// Indicates that the const expression was not resolvable because it would yield an overflow.
     Overflow(String, SourceLocation),
+
+    NonConstant(String),
 }
 
 impl UnresolvableKind {
     pub fn get_reason(&self) -> &str {
         match self {
-            UnresolvableKind::Misc(val) | UnresolvableKind::Overflow(val, ..) => val,
+            UnresolvableKind::Misc(val)
+            | UnresolvableKind::Overflow(val, ..)
+            | UnresolvableKind::NonConstant(val) => val,
         }
     }
 

--- a/src/resolver/const_evaluator.rs
+++ b/src/resolver/const_evaluator.rs
@@ -562,7 +562,7 @@ fn resolve_const_reference(
     index: &Index,
 ) -> Result<Option<AstNode>, UnresolvableKind> {
     if !variable.is_constant() {
-        return Err(UnresolvableKind::Misc(format!("`{name}` is no const reference")));
+        return Err(UnresolvableKind::NonConstant(format!("`{name}` is not a constant reference")));
     }
 
     if let Some(ConstExpression::Resolved(statement)) =

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -4,25 +4,27 @@ use plc_diagnostics::diagnostics::Diagnostic;
 use plc_index::GlobalContext;
 
 use crate::{
-    index::{
-        const_expressions::{ConstExpression, UnresolvableKind},
-        Index, PouIndexEntry,
-    },
+    index::{Index, PouIndexEntry},
     resolver::AnnotationMap,
 };
 
 use self::{
-    const_expressions::ConstExpressionValidator, global::GlobalValidator, pou::{visit_implementation, visit_pou}, recursive::RecursiveValidator, types::visit_user_type_declaration, variable::visit_variable_block
+    const_expressions::ConstExpressionValidator,
+    global::GlobalValidator,
+    pou::{visit_implementation, visit_pou},
+    recursive::RecursiveValidator,
+    types::visit_user_type_declaration,
+    variable::visit_variable_block,
 };
 
 mod array;
+mod const_expressions;
 mod global;
 mod pou;
 mod recursive;
 mod statement;
 mod types;
 mod variable;
-mod const_expressions;
 
 #[cfg(test)]
 mod tests;
@@ -95,7 +97,7 @@ pub struct Validator<'a> {
     diagnostics: Vec<Diagnostic>,
     global_validator: GlobalValidator,
     recursive_validator: RecursiveValidator,
-    const_expr_validator: ConstExpressionValidator<'a>
+    const_expr_validator: ConstExpressionValidator<'a>,
 }
 
 impl<'a> Validators for Validator<'a> {
@@ -123,6 +125,7 @@ impl<'a> Validator<'a> {
         all_diagnostics.append(&mut self.take_diagnostics());
         all_diagnostics.append(&mut self.global_validator.take_diagnostics());
         all_diagnostics.append(&mut self.recursive_validator.take_diagnostics());
+        all_diagnostics.append(&mut self.const_expr_validator.take_diagnostics());
         all_diagnostics
     }
 

--- a/src/validation/const_expressions.rs
+++ b/src/validation/const_expressions.rs
@@ -1,0 +1,66 @@
+use plc_diagnostics::diagnostics::Diagnostic;
+use plc_index::GlobalContext;
+
+use crate::index::{const_expressions::{ConstExpression, UnresolvableKind}, Index};
+
+use super::Validators;
+
+pub struct ConstExpressionValidator<'ctx> {
+    context: &'ctx GlobalContext,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl<'a> Validators for ConstExpressionValidator<'a> {
+    fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+    fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
+        std::mem::take(&mut self.diagnostics)
+    }
+}
+
+impl<'ctx>  ConstExpressionValidator<'ctx>  {
+    pub fn new(context: &'ctx GlobalContext) -> Self {
+        Self {
+            context,
+            diagnostics: vec![],
+        }
+    }
+
+    pub fn validate(&mut self, index: &Index) {
+        for it in index.get_const_expressions().into_iter() {
+            let Some(expr) = index.get_const_expressions().find_const_expression(&it.0) else { continue };
+
+            match expr {
+                ConstExpression::Unresolvable {
+                    reason: UnresolvableKind::Overflow(reason, location), ..
+                } => self.push_diagnostic(
+                    Diagnostic::warning(reason).with_error_code("E038").with_location(location.to_owned()),
+                ),
+                ConstExpression::Unresolvable { statement, reason } => {
+                    dbg!(statement, reason);
+                },
+                ConstExpression::Unresolved { statement, ..} => {
+                    if let Some(name) = statement.get_flat_reference_name() {
+                            self.push_diagnostic(
+                                Diagnostic::error(format!(
+                                        "Unresolved constant reference: `{name}`",
+                                    ))
+                                    .with_error_code("E033")
+                                    .with_location(statement.get_location())
+                                    )
+                    } else {
+                        let expr = self.context.slice(&statement.location);
+                        self.push_diagnostic(Diagnostic::error(format!(
+                            "Unresolved constant expression: `{}`", expr
+                        ))
+                        .with_error_code("E033")
+                        .with_location(statement.get_location()))
+                    }
+                }
+                _ => continue,
+            }
+        }
+    }
+}
+

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -555,7 +555,8 @@ fn validate_array_access<T: AnnotationMap>(
             // XXX: myArray[FOO()], FOO being a function/action/... with no return type (i.e. VOID) should not be reported
             // as unresolvable, but rather with the attempted VOID access.
             Some(context.annotations.get_type_or_void(access, context.index))
-        }.map(|it| it.get_type_information());
+        }
+        .map(|it| it.get_type_information());
 
         let Some(type_info) = type_info else {
             let loc = access.get_location();

--- a/src/validation/tests/array_validation_test.rs
+++ b/src/validation/tests/array_validation_test.rs
@@ -49,6 +49,84 @@ fn array_access_validation() {
 }
 
 #[test]
+fn array_access_with_unresolved_reference() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        FUNCTION main : DINT
+        VAR
+            myArray : ARRAY[0..2] OF DINT;
+        END_VAR
+            main := myArray[unresolvedRef];
+        END_FUNCTION
+        "
+    );
+
+    assert_snapshot!(&diagnostics);
+}
+
+#[test]
+fn array_declaration_with_unresolved_reference() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        FUNCTION main : DINT
+        VAR
+            myArray : ARRAY[0..UNRESOLVED_CONSTANT] OF DINT;
+            myString: STRING[UNRESOLVED_CONSTANT];
+            myOtherArray : ARRAY[UNRESOLVED_CONSTANT + 2 .. 1000 * UNRESOLVED_CONSTANT] OF DINT;
+        END_VAR
+        END_FUNCTION
+        "
+    );
+
+    assert_snapshot!(&diagnostics);
+}
+
+
+#[test]
+fn array_declaration_with_non_constant_variable() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        VAR_GLOBAL
+            myNonConstVar : DINT;
+        END_VAR
+
+        FUNCTION main : DINT
+        VAR
+            myArray : ARRAY[0..myNonConstVar] OF DINT;
+        END_VAR
+        END_FUNCTION
+        "
+    );
+
+    assert_snapshot!(&diagnostics);
+}
+
+#[test]
+fn array_declaration_with_void_returning_call() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        FUNCTION_BLOCK FOO
+        END_FUNCTION_BLOCK
+
+        ACTIONS
+            ACTION NOP
+            END_ACTION
+        END_ACTIONS
+
+        FUNCTION main : DINT
+        VAR
+            myArray : ARRAY[0..1] OF DINT;
+            myFb : FOO;
+        END_VAR
+            main := myArray[myFb.NOP()]
+        END_FUNCTION
+        "
+    );
+
+    assert_snapshot!(&diagnostics);
+}
+
+#[test]
 fn array_initialization_validation() {
     let diagnostics = parse_and_validate_buffered(
         "

--- a/src/validation/tests/array_validation_test.rs
+++ b/src/validation/tests/array_validation_test.rs
@@ -49,16 +49,18 @@ fn array_access_validation() {
 }
 
 #[test]
-fn array_access_with_unresolved_reference() {
+fn array_access_with_unresolved_and_non_const_reference() {
     let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION main : DINT
         VAR
             myArray : ARRAY[0..2] OF DINT;
+            myNonConstVar : DINT := 3;
         END_VAR
-            main := myArray[unresolvedRef];
+            myArray[unresolvedRef];
+            myArray[myNonConstVar];
         END_FUNCTION
-        "
+        ",
     );
 
     assert_snapshot!(&diagnostics);
@@ -70,17 +72,18 @@ fn array_declaration_with_unresolved_reference() {
         "
         FUNCTION main : DINT
         VAR
+            myNonConstVar : DINT := 9;
             myArray : ARRAY[0..UNRESOLVED_CONSTANT] OF DINT;
             myString: STRING[UNRESOLVED_CONSTANT];
             myOtherArray : ARRAY[UNRESOLVED_CONSTANT + 2 .. 1000 * UNRESOLVED_CONSTANT] OF DINT;
+            myThirdArray: ARRAY[myNonConstVar + 8 + myNonConstVar * 2] OF DINT;
         END_VAR
         END_FUNCTION
-        "
+        ",
     );
 
     assert_snapshot!(&diagnostics);
 }
-
 
 #[test]
 fn array_declaration_with_non_constant_variable() {
@@ -95,7 +98,7 @@ fn array_declaration_with_non_constant_variable() {
             myArray : ARRAY[0..myNonConstVar] OF DINT;
         END_VAR
         END_FUNCTION
-        "
+        ",
     );
 
     assert_snapshot!(&diagnostics);
@@ -118,9 +121,9 @@ fn array_declaration_with_void_returning_call() {
             myArray : ARRAY[0..1] OF DINT;
             myFb : FOO;
         END_VAR
-            main := myArray[myFb.NOP()]
+            myArray[myFb.NOP()];
         END_FUNCTION
-        "
+        ",
     );
 
     assert_snapshot!(&diagnostics);

--- a/src/validation/variable.rs
+++ b/src/validation/variable.rs
@@ -123,31 +123,31 @@ fn validate_variable<T: AnnotationMap>(
             .initial_value
             .and_then(|initial_id| context.index.get_const_expressions().find_const_expression(&initial_id))
         {
-            Some(ConstExpression::Unresolvable { reason, statement }) if reason.is_misc() => {
-                validator.push_diagnostic(
-                    Diagnostic::error(format!(
-                        "Unresolved constant `{}` variable: {}",
-                        variable.name.as_str(),
-                        reason.get_reason()
-                    ))
-                    .with_error_code("E033")
-                    .with_location(statement.get_location()),
-                );
-            }
-            Some(ConstExpression::Unresolved { statement, .. }) => {
-                validator.push_diagnostic(
-                    Diagnostic::error(format!("Unresolved constant `{}` variable", variable.name.as_str(),))
-                        .with_error_code("E033")
-                        .with_location(statement.get_location()),
-                );
-            }
-            None if v_entry.is_constant() => {
-                validator.push_diagnostic(
-                    Diagnostic::error(format!("Unresolved constant `{}` variable", variable.name.as_str(),))
-                        .with_error_code("E033")
-                        .with_location(variable.location.clone()),
-                );
-            }
+            // Some(ConstExpression::Unresolvable { reason, statement }) if reason.is_misc() => {
+            //     validator.push_diagnostic(
+            //         Diagnostic::error(format!(
+            //             "Unresolved constant `{}` variable: {}",
+            //             variable.name.as_str(),
+            //             reason.get_reason()
+            //         ))
+            //         .with_error_code("E033")
+            //         .with_location(statement.get_location()),
+            //     );
+            // }
+            // Some(ConstExpression::Unresolved { statement, .. }) => {
+            //     validator.push_diagnostic(
+            //         Diagnostic::error(format!("Unresolved constant `{}` variable", variable.name.as_str(),))
+            //             .with_error_code("E033")
+            //             .with_location(statement.get_location()),
+            //     );
+            // }
+            // None if v_entry.is_constant() => {
+            //     validator.push_diagnostic(
+            //         Diagnostic::error(format!("Unresolved constant `{}` variable", variable.name.as_str(),))
+            //             .with_error_code("E033")
+            //             .with_location(variable.location.clone()),
+            //     );
+            // }
             _ => {
                 if let Some(rhs) = variable.initializer.as_ref() {
                     validate_enum_variant_assignment(


### PR DESCRIPTION
Tasks to improve error messages/detect issues before codegen phase:
- [x] unresolved constant in array size initializer (`ARRAY[0..LENGTH]`): fails during codegen
- [x] unresolved variable in array access (`myArray[unresolvedReference]`): always reports `invalid VOID type for array access`
- [ ] non-constant array size initializer