### PR TITLE
Integrate Address Sanitizer

### DIFF
--- a/examples/buffer_overflow.st
+++ b/examples/buffer_overflow.st
@@ -1,0 +1,14 @@
+FUNCTION main : DINT
+    buf_overflow();
+END_FUNCTION
+
+FUNCTION buf_overflow : DINT
+VAR
+    i : DINT;
+    buf : ARRAY [0..2] OF BYTE;
+END_VAR
+
+FOR i := 0 TO 3 DO
+    buf[i] := 1;
+END_FOR
+END_FUNCTION

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -25,6 +25,7 @@ use crate::{
 use super::index::*;
 use indexmap::IndexSet;
 use inkwell::{
+    attributes::{Attribute, AttributeLoc},
     context::Context,
     execution_engine::{ExecutionEngine, JitFunction},
     memory_buffer::MemoryBuffer,
@@ -195,6 +196,26 @@ impl<'ink> CodeGen<'ink> {
         global_index: &Index,
         llvm_index: &LlvmTypedIndex,
     ) -> Result<GeneratedModule<'ink>, Diagnostic> {
+        // This loops through functions and adds the `sanitize_address` attribute.
+        // The AddressSanitizer LLVM passes will then use this to identify which
+        // functions need to be instrumented.
+        //
+        // There's likely somewhere else this should go. Placing it here for now.
+        // TODO: Once it's in it's proper place, we'll add a flag to enable/disable it.
+        for implementation in &unit.implementations {
+            // Skip non-internal functions (external links + built-ins)
+            if implementation.linkage != LinkageType::Internal {
+                continue;
+            }
+
+            let func = llvm_index
+                .find_associated_implementation(&implementation.name)
+                .expect("Unable to get function definition!");
+            let sanitizer_attribute_id = Attribute::get_named_enum_kind_id("sanitize_address");
+            let sanitizer_attribute = context.create_enum_attribute(sanitizer_attribute_id, 0);
+            func.add_attribute(AttributeLoc::Function, sanitizer_attribute);
+        }
+
         //generate all pous
         let llvm = Llvm::new(context, context.create_builder());
         let pou_generator = PouGenerator::new(llvm, global_index, annotations, llvm_index);
@@ -330,11 +351,23 @@ impl<'ink> GeneratedModule<'ink> {
         if let Some(parent) = output.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        ////Run the passes
+        // Run the passes
+        // TODO - Add asan as optional cli parameter
+        // TODO - Currently doesn't add linking parameters for the asan runtime
+        //
+        // NOTE - these pass names have changed in newer versions of LLVM.
+        //      - [Latest](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Passes/PassRegistry.def)
+        //      - [LLVM 14](https://github.com/llvm/llvm-project/blob/release/14.x/llvm/lib/Passes/PassRegistry.def)
+        // It should also be noted that the ASAN pass requies:
+        // - Specific target architectures [see here](https://github.com/google/sanitizers/wiki/AddressSanitizer).
+        // - Output is NOT IR (otherwise the pass will run twice with the next compiler (i.e. clang) and it will cause a bad time)
+
+        let passes = format!("{},asan-module,function(asan)", optimization_level.opt_params());
+
         machine
             .and_then(|it| {
                 self.module
-                    .run_passes(optimization_level.opt_params(), &it, PassBuilderOptions::create())
+                    .run_passes(&passes, &it, PassBuilderOptions::create())
                     .map_err(|it| {
                         Diagnostic::llvm_error(output.to_str().unwrap_or_default(), &it.to_string_lossy())
                     })


### PR DESCRIPTION
# Overview
[AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer#introduction) (ASAN) runs as an LLVM pass, which instruments code to detect reading and writing to out of bounds memory addresses at runtime.  

## Related Issue
- #1062

## AddressSanitizer Overview
1. Mark functions to be sanitized with the `sanitize_address` [LLVM attribute](https://llvm.org/docs/LangRef.html).
2. Run the address sanitizer passes before compiling to an object.

## Discussion
- Unlike coverage instrumentation, which requires that the pass be run even before outputting IR code, the ASAN passes should NOT be run if the target output is IR. Otherwise, when the code is later compiled (i.e. with `clang -fsanitize=address`,  the ASAN pass will run twice and cause issues. However, it is useful to run the ASAN pass with `clang`, since the `-fsanitize=address` flag will also handle linking to the runtime `ASAN` library.
- I began the pass code in this PR under `persist_to_obj`, so that if you would like to also compile binaries with ASAN using only Rusty, it's there with some notes. However, I haven't looked into how it needs to be integrated into the linker, such that the runtime libraries are found and linked properly. It may be that it's not a high priority to include this feature, given ASAN is a more advanced functionality to begin with, and it's easy enough to link with `clang`. 

## Example
You can test the address sanitizer with the following commands:
```
> cargo build
> ./target/debug/plc --ir ./examples/buffer_overflow.st
> clang -v -fsanitize=address ./buffer_overflow.st.ll -o a.out && ./a.out
...
=================================================================
==97514==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffffffdea3 at pc 0x555555632018 bp 0x7fffffffde70 sp 0x7fffffffde68
WRITE of size 1 at 0x7fffffffdea3 thread T0
    #0 0x555555632017 in buf_overflow (/workspaces/corbanvilla_rusty/a.out+0xde017) (BuildId: a3a8111854e13c79f22563ad6c5116151ae5de04)
    #1 0x555555631ead in main (/workspaces/corbanvilla_rusty/a.out+0xddead) (BuildId: a3a8111854e13c79f22563ad6c5116151ae5de04)
    #2 0x7ffff7d041c9  (/lib/x86_64-linux-gnu/libc.so.6+0x271c9) (BuildId: 51657f818beb1ae70372216a99b7412b8a100a20)
    #3 0x7ffff7d04284 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27284) (BuildId: 51657f818beb1ae70372216a99b7412b8a100a20)
    #4 0x555555574300 in _start (/workspaces/corbanvilla_rusty/a.out+0x20300) (BuildId: a3a8111854e13c79f22563ad6c5116151ae5de04)
```