### PR TITLE
fix: linking and Incudle folders now work again

### DIFF
--- a/book/src/using_rusty.md
+++ b/book/src/using_rusty.md
@@ -83,8 +83,8 @@ plc hello_world.st -o hello_world --linker=cc
 Please note that RuSTy will attempt to link the generated object file by default to generate an executable if you didn't specify something else (option `-c`).
 
 - The `--linker=cc` flag tells RuSTy that it should link with the system's compiler driver  instead of the built in linker. This provides support to create executables.
-- Additional libraries can be linked using the `-l` flag, additial library pathes can be added with `-L`
-- You add library search pathes by providing additional `-L /path/...` options. By default, this will be the current directory.
+- Additional libraries can be linked using the `-l` flag, additial library paths can be added with `-L`
+- You add library search paths by providing additional `-L /path/...` options. By default, this will be the current directory.
 - The linker will prefer a dynamically linked library if available, and revert to a static one otherwise.
 
 ### Building for separate targets

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -19,7 +19,8 @@ use std::{
 use cli::{CompileParameters, ParameterError};
 use pipelines::AnnotatedProject;
 use plc::{
-    codegen::CodegenContext, output::FormatOption, DebugLevel, ErrorFormat, OptimizationLevel, Threads,
+    codegen::CodegenContext, linker::LinkerType, output::FormatOption, DebugLevel, ErrorFormat,
+    OptimizationLevel, Target, Threads,
 };
 
 use plc_diagnostics::{diagnostician::Diagnostician, diagnostics::Diagnostic};
@@ -52,6 +53,7 @@ pub struct CompileOptions {
     pub optimization: OptimizationLevel,
     pub error_format: ErrorFormat,
     pub debug_level: DebugLevel,
+    pub single_module: bool,
 }
 
 impl Default for CompileOptions {
@@ -64,6 +66,7 @@ impl Default for CompileOptions {
             optimization: OptimizationLevel::None,
             error_format: ErrorFormat::None,
             debug_level: DebugLevel::None,
+            single_module: false,
         }
     }
 }
@@ -73,7 +76,8 @@ pub struct LinkOptions {
     pub libraries: Vec<String>,
     pub library_pathes: Vec<PathBuf>,
     pub format: FormatOption,
-    pub linker: Option<String>,
+    pub linker: LinkerType,
+    pub lib_location: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -119,12 +123,19 @@ impl Display for CompileError {
     }
 }
 
-pub fn compile<T: AsRef<str> + AsRef<OsStr> + Debug>(args: &[T]) -> Result<()> {
-    //Parse the arguments
+pub struct CompilationContext {
+    pub compile_parameters: CompileParameters,
+    pub project: Project<PathBuf>,
+    pub diagnostician: Diagnostician,
+    pub compile_options: CompileOptions,
+    pub link_options: LinkOptions,
+}
+
+pub fn get_compilation_context<T: AsRef<str> + AsRef<OsStr> + Debug>(
+    args: &[T],
+) -> Result<CompilationContext> {
     let compile_parameters = CompileParameters::parse(args)?;
-    if let Some((options, format)) = compile_parameters.get_config_options() {
-        return print_config_options(options, format);
-    }
+    //Create the project that will be compiled
     let project = get_project(&compile_parameters)?;
     let output_format = compile_parameters.output_format().unwrap_or_else(|| project.get_output_format());
     let location = project.get_location().map(|it| it.to_path_buf());
@@ -142,11 +153,51 @@ pub fn compile<T: AsRef<str> + AsRef<OsStr> + Debug>(args: &[T]) -> Result<()> {
         log::debug!("LIB_LOCATION={}", location.to_string_lossy());
         env::set_var("LIB_LOCATION", location);
     }
-    let mut diagnostician = match compile_parameters.error_format {
+    let diagnostician = match compile_parameters.error_format {
         ErrorFormat::Rich => Diagnostician::default(),
         ErrorFormat::Clang => Diagnostician::clang_format_diagnostician(),
         ErrorFormat::None => Diagnostician::null_diagnostician(),
     };
+
+    let compile_options = CompileOptions {
+        root: location,
+        build_location: compile_parameters.get_build_location(),
+        output: project.get_output_name(),
+        output_format,
+        optimization: compile_parameters.optimization,
+        error_format: compile_parameters.error_format,
+        debug_level: compile_parameters.debug_level(),
+        single_module: compile_parameters.single_module,
+    };
+
+    let libraries =
+        project.get_libraries().iter().map(LibraryInformation::get_link_name).map(str::to_string).collect();
+    let mut library_pathes: Vec<PathBuf> = project
+        .get_libraries()
+        .iter()
+        .filter_map(LibraryInformation::get_path)
+        .map(Path::to_path_buf)
+        .collect();
+
+    library_pathes.extend_from_slice(dbg!(project.get_library_pathes()));
+
+    let link_options = LinkOptions {
+        libraries,
+        library_pathes,
+        format: output_format,
+        linker: compile_parameters.linker.as_deref().into(),
+        lib_location,
+    };
+
+    Ok(CompilationContext { compile_parameters, project, diagnostician, compile_options, link_options })
+}
+
+pub fn compile_with_options(compile_options: CompilationContext) -> Result<()> {
+    let CompilationContext { compile_parameters, project, mut diagnostician, compile_options, link_options } =
+        compile_options;
+    if let Some((options, format)) = compile_parameters.get_config_options() {
+        return print_config_options(options, format);
+    }
 
     //Set the global thread count
     let thread_pool = rayon::ThreadPoolBuilder::new();
@@ -178,25 +229,23 @@ pub fn compile<T: AsRef<str> + AsRef<OsStr> + Debug>(args: &[T]) -> Result<()> {
         )?;
 
     // 1 : Parse, 2. Index and 3. Resolve / Annotate
-    let annotated_project = pipelines::ParsedProject::parse(&ctxt, &project, &mut diagnostician)?
+    let annotated_project = pipelines::ParsedProject::parse(&ctxt, project, &mut diagnostician)?
         .index(ctxt.provider())
         .annotate(ctxt.provider());
 
     // 4 : Validate
     annotated_project.validate(&ctxt, &mut diagnostician)?;
 
+    if let Some((location, format)) =
+        compile_parameters.hardware_config.as_ref().zip(compile_parameters.config_format())
+    {
+        annotated_project.generate_hardware_information(format, location)?;
+    }
+
     // 5 : Codegen
     if !compile_parameters.is_check() {
-        let res = generate(
-            location,
-            compile_parameters,
-            project,
-            output_format,
-            annotated_project,
-            build_location,
-            lib_location,
-        )
-        .map_err(|err| Diagnostic::codegen_error(err.get_message(), err.get_location()));
+        let res = generate(&compile_options, &link_options, compile_parameters.target, annotated_project)
+            .map_err(|err| Diagnostic::codegen_error(err.get_message(), err.get_location()));
         if let Err(res) = res {
             diagnostician.handle(&[res]);
             return Err(Diagnostic::error("Compilation aborted due to previous errors")
@@ -204,8 +253,13 @@ pub fn compile<T: AsRef<str> + AsRef<OsStr> + Debug>(args: &[T]) -> Result<()> {
                 .into());
         }
     }
-
     Ok(())
+}
+
+pub fn compile<T: AsRef<str> + AsRef<OsStr> + Debug>(args: &[T]) -> Result<()> {
+    //Parse the arguments
+    let compile_context = get_compilation_context(args)?;
+    compile_with_options(compile_context)
 }
 
 fn print_config_options(
@@ -226,12 +280,12 @@ fn print_config_options(
 pub fn parse_and_annotate<T: SourceContainer>(
     name: &str,
     src: Vec<T>,
-) -> Result<(GlobalContext, AnnotatedProject), Diagnostic> {
+) -> Result<(GlobalContext, AnnotatedProject<T>), Diagnostic> {
     // Parse the source to ast
     let project = Project::new(name.to_string()).with_sources(src);
     let ctxt = GlobalContext::new().with_source(project.get_sources(), None)?;
     let mut diagnostician = Diagnostician::default();
-    let parsed = pipelines::ParsedProject::parse(&ctxt, &project, &mut diagnostician)?;
+    let parsed = pipelines::ParsedProject::parse(&ctxt, project, &mut diagnostician)?;
 
     // Create an index, add builtins then resolve
     let provider = ctxt.provider();
@@ -271,61 +325,31 @@ fn generate_to_string_internal<T: SourceContainer>(
 }
 
 fn generate(
-    location: Option<PathBuf>,
-    compile_parameters: CompileParameters,
-    project: Project<PathBuf>,
-    output_format: FormatOption,
-    annotated_project: AnnotatedProject,
-    build_location: Option<PathBuf>,
-    lib_location: Option<PathBuf>,
+    compile_options: &CompileOptions,
+    linker_options: &LinkOptions,
+    targets: Vec<Target>,
+    annotated_project: AnnotatedProject<PathBuf>,
 ) -> Result<(), Diagnostic> {
-    let compile_options = CompileOptions {
-        root: location,
-        build_location: compile_parameters.get_build_location(),
-        output: project.get_output_name(),
-        output_format,
-        optimization: compile_parameters.optimization,
-        error_format: compile_parameters.error_format,
-        debug_level: compile_parameters.debug_level(),
-    };
-    let res = if compile_parameters.single_module {
+    let res = if compile_options.single_module {
         log::info!("Using single module mode");
-        annotated_project.codegen_single_module(compile_options, &compile_parameters.target)?
+        annotated_project.codegen_single_module(compile_options, &targets)?
     } else {
-        annotated_project.codegen(compile_options, &compile_parameters.target)?
+        annotated_project.codegen(compile_options, &targets)?
     };
-    let libraries =
-        project.get_libraries().iter().map(LibraryInformation::get_link_name).map(str::to_string).collect();
-    let library_pathes = project
-        .get_libraries()
-        .iter()
-        .filter_map(LibraryInformation::get_path)
-        .map(Path::to_path_buf)
-        .collect();
-    let linker_options = LinkOptions {
-        libraries,
-        library_pathes,
-        format: output_format,
-        linker: compile_parameters.linker.to_owned(),
-    };
+    let project = annotated_project.get_project();
     let output_name = project.get_output_name();
     res.into_par_iter()
         .map(|res| {
             res.link(
                 project.get_objects(),
-                build_location.as_deref(),
-                lib_location.as_deref(),
+                compile_options.build_location.as_deref(),
+                linker_options.lib_location.as_deref(),
                 &output_name,
                 linker_options.clone(),
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
-    if let Some((location, format)) =
-        compile_parameters.hardware_config.as_ref().zip(compile_parameters.config_format())
-    {
-        annotated_project.generate_hardware_information(format, location)?;
-    }
-    if let Some(lib_location) = lib_location {
+    if let Some(lib_location) = &linker_options.lib_location {
         for library in
             project.get_libraries().iter().filter(|it| it.should_copy()).map(|it| it.get_compiled_lib())
         {
@@ -372,6 +396,7 @@ fn get_project(compile_parameters: &CompileParameters) -> Result<Project<PathBuf
         let project = Project::new(name.to_string())
             .with_file_pathes(compile_parameters.input.iter().map(PathBuf::from).collect())
             .with_include_pathes(compile_parameters.includes.iter().map(PathBuf::from).collect())
+            .with_library_pathes(compile_parameters.library_paths.iter().map(PathBuf::from).collect())
             .with_libraries(compile_parameters.libraries.clone());
         Ok(project)
     };

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -74,7 +74,7 @@ impl Default for CompileOptions {
 #[derive(Clone, Default, Debug)]
 pub struct LinkOptions {
     pub libraries: Vec<String>,
-    pub library_pathes: Vec<PathBuf>,
+    pub library_paths: Vec<PathBuf>,
     pub format: FormatOption,
     pub linker: LinkerType,
     pub lib_location: Option<PathBuf>,
@@ -172,18 +172,18 @@ pub fn get_compilation_context<T: AsRef<str> + AsRef<OsStr> + Debug>(
 
     let libraries =
         project.get_libraries().iter().map(LibraryInformation::get_link_name).map(str::to_string).collect();
-    let mut library_pathes: Vec<PathBuf> = project
+    let mut library_paths: Vec<PathBuf> = project
         .get_libraries()
         .iter()
         .filter_map(LibraryInformation::get_path)
         .map(Path::to_path_buf)
         .collect();
 
-    library_pathes.extend_from_slice(dbg!(project.get_library_pathes()));
+    library_paths.extend_from_slice(project.get_library_paths());
 
     let link_options = LinkOptions {
         libraries,
-        library_pathes,
+        library_paths,
         format: output_format,
         linker: compile_parameters.linker.as_deref().into(),
         lib_location,
@@ -394,9 +394,9 @@ fn get_project(compile_parameters: &CompileParameters) -> Result<Project<PathBuf
             .and_then(|it| it.to_str())
             .unwrap_or(DEFAULT_OUTPUT_NAME);
         let project = Project::new(name.to_string())
-            .with_file_pathes(compile_parameters.input.iter().map(PathBuf::from).collect())
-            .with_include_pathes(compile_parameters.includes.iter().map(PathBuf::from).collect())
-            .with_library_pathes(compile_parameters.library_paths.iter().map(PathBuf::from).collect())
+            .with_file_paths(compile_parameters.input.iter().map(PathBuf::from).collect())
+            .with_include_paths(compile_parameters.includes.iter().map(PathBuf::from).collect())
+            .with_library_paths(compile_parameters.library_paths.iter().map(PathBuf::from).collect())
             .with_libraries(compile_parameters.libraries.clone());
         Ok(project)
     };

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -35,14 +35,17 @@ use source_code::{source_location::SourceLocation, SourceContainer};
 ///Represents a parsed project
 ///For this struct to be built, the project would have been parsed correctly and an AST would have
 ///been generated
-pub struct ParsedProject(Vec<CompilationUnit>);
+pub struct ParsedProject<T: SourceContainer + Sync> {
+    project: Project<T>,
+    units: Vec<CompilationUnit>,
+}
 
-impl ParsedProject {
+impl<T: SourceContainer + Sync> ParsedProject<T> {
     /// Parses a giving project, transforming it to a `ParsedProject`
     /// Reports parsing diagnostics such as Syntax error on the fly
-    pub fn parse<T: SourceContainer>(
+    pub fn parse(
         ctxt: &GlobalContext,
-        project: &Project<T>,
+        project: Project<T>,
         diagnostician: &mut Diagnostician,
     ) -> Result<Self, Diagnostic> {
         //TODO in parallel
@@ -88,13 +91,13 @@ impl ParsedProject {
             .collect::<Result<Vec<_>, Diagnostic>>()?;
         units.extend(lib_includes);
 
-        Ok(ParsedProject(units))
+        Ok(ParsedProject { project, units })
     }
 
     /// Creates an index out of a pased project. The index could then be used to query datatypes
-    pub fn index(self, id_provider: IdProvider) -> IndexedProject {
+    pub fn index(self, id_provider: IdProvider) -> IndexedProject<T> {
         let indexed_units = self
-            .0
+            .units
             .into_par_iter()
             .map(|mut unit| {
                 //Preprocess
@@ -121,20 +124,24 @@ impl ParsedProject {
         let builtins = plc::builtins::parse_built_ins(id_provider);
         global_index.import(plc::index::visitor::visit(&builtins));
 
-        IndexedProject { units, index: global_index }
+        IndexedProject { project: ParsedProject { project: self.project, units }, index: global_index }
+    }
+
+    pub fn get_project(&self) -> &Project<T> {
+        &self.project
     }
 }
 
 ///A project that has also been indexed
 /// Units inside an index project could be resolved and annotated
-pub struct IndexedProject {
-    units: Vec<CompilationUnit>,
+pub struct IndexedProject<T: SourceContainer + Sync> {
+    project: ParsedProject<T>,
     index: Index,
 }
 
-impl IndexedProject {
+impl<T: SourceContainer + Sync> IndexedProject<T> {
     /// Creates annotations on the project in order to facilitate codegen and validation
-    pub fn annotate(self, mut id_provider: IdProvider) -> AnnotatedProject {
+    pub fn annotate(self, mut id_provider: IdProvider) -> AnnotatedProject<T> {
         //Resolve constants
         //TODO: Not sure what we are currently doing with unresolvables
         let (mut full_index, _unresolvables) = plc::resolver::const_evaluator::evaluate_constants(self.index);
@@ -143,6 +150,7 @@ impl IndexedProject {
         let mut all_annotations = AnnotationMapImpl::default();
 
         let result = self
+            .project
             .units
             .into_par_iter()
             .map(|unit| {
@@ -161,18 +169,35 @@ impl IndexedProject {
 
         let annotations = AstAnnotations::new(all_annotations, id_provider.next_id());
 
-        AnnotatedProject { units: annotated_units, index: full_index, annotations }
+        AnnotatedProject {
+            project: self.project.project,
+            units: annotated_units,
+            index: full_index,
+            annotations,
+        }
+    }
+
+    fn get_parsed_project(&self) -> &ParsedProject<T> {
+        &self.project
+    }
+
+    pub fn get_project(&self) -> &Project<T> {
+        self.get_parsed_project().get_project()
     }
 }
 
 /// A project that has been annotated with information about different types and used units
-pub struct AnnotatedProject {
+pub struct AnnotatedProject<T: SourceContainer + Sync> {
+    pub project: Project<T>,
     pub units: Vec<(CompilationUnit, IndexSet<Dependency>, StringLiterals)>,
     pub index: Index,
     pub annotations: AstAnnotations,
 }
 
-impl AnnotatedProject {
+impl<T: SourceContainer + Sync> AnnotatedProject<T> {
+    pub fn get_project(&self) -> &Project<T> {
+        &self.project
+    }
     /// Validates the project, reports any new diagnostics on the fly
     pub fn validate(
         &self,
@@ -262,7 +287,7 @@ impl AnnotatedProject {
 
     pub fn codegen_single_module<'ctx>(
         &'ctx self,
-        compile_options: CompileOptions,
+        compile_options: &CompileOptions,
         targets: &'ctx [Target],
     ) -> Result<Vec<GeneratedProject>, Diagnostic> {
         let compile_directory = compile_options.build_location.clone().unwrap_or_else(|| {
@@ -272,7 +297,7 @@ impl AnnotatedProject {
         ensure_compile_dirs(targets, &compile_directory)?;
         let context = CodegenContext::create(); //Create a build location for the generated object files
         let targets = if targets.is_empty() { &[Target::System] } else { targets };
-        let module = self.generate_single_module(&context, &compile_options)?.unwrap();
+        let module = self.generate_single_module(&context, compile_options)?.unwrap();
         let mut result = vec![];
         for target in targets {
             let obj: Object = module
@@ -293,7 +318,7 @@ impl AnnotatedProject {
 
     pub fn codegen<'ctx>(
         &'ctx self,
-        compile_options: CompileOptions,
+        compile_options: &CompileOptions,
         targets: &'ctx [Target],
     ) -> Result<Vec<GeneratedProject>, Diagnostic> {
         let compile_directory = compile_options.build_location.clone().unwrap_or_else(|| {
@@ -336,7 +361,7 @@ impl AnnotatedProject {
 
                         let context = CodegenContext::create(); //Create a build location for the generated object files
                         let module =
-                            self.generate_module(&context, &compile_options, unit, dependencies, literals)?;
+                            self.generate_module(&context, compile_options, unit, dependencies, literals)?;
                         module
                             .persist(
                                 Some(&compile_directory),
@@ -451,10 +476,8 @@ impl GeneratedProject {
             _ => {
                 // Only initialize a linker if we need to use it
                 let target_triple = self.target.get_target_triple();
-                let mut linker = plc::linker::Linker::new(
-                    &target_triple.as_str().to_string_lossy(),
-                    link_options.linker.as_deref(),
-                )?;
+                let mut linker =
+                    plc::linker::Linker::new(&target_triple.as_str().to_string_lossy(), link_options.linker)?;
                 for obj in &self.objects {
                     linker.add_obj(&obj.get_path().to_string_lossy());
                 }

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -484,7 +484,7 @@ impl GeneratedProject {
                 for obj in objects {
                     linker.add_obj(&obj.get_path().to_string_lossy());
                 }
-                for lib_path in &link_options.library_pathes {
+                for lib_path in &link_options.library_paths {
                     linker.add_lib_path(&lib_path.to_string_lossy());
                 }
                 for lib in &link_options.libraries {

--- a/compiler/plc_driver/src/runner.rs
+++ b/compiler/plc_driver/src/runner.rs
@@ -28,7 +28,7 @@ pub fn compile<T: Compilable>(context: &CodegenContext, source: T) -> GeneratedM
     let project = Project::new("TestProject".to_string()).with_sources(source);
     let ctxt = GlobalContext::new().with_source(project.get_sources(), None).unwrap();
     let mut diagnostician = Diagnostician::null_diagnostician();
-    let parsed_project = ParsedProject::parse(&ctxt, &project, &mut diagnostician).unwrap();
+    let parsed_project = ParsedProject::parse(&ctxt, project, &mut diagnostician).unwrap();
     let indexed_project = parsed_project.index(ctxt.provider());
     let annotated_project = indexed_project.annotate(ctxt.provider());
     let compile_options = CompileOptions {

--- a/compiler/plc_driver/src/tests.rs
+++ b/compiler/plc_driver/src/tests.rs
@@ -48,7 +48,7 @@ where
         optimization: plc::OptimizationLevel::None,
         ..Default::default()
     };
-    pipelines::ParsedProject::parse(&ctxt, &project, &mut diagnostician)?
+    pipelines::ParsedProject::parse(&ctxt, project, &mut diagnostician)?
         //Index
         .index(ctxt.provider())
         //Resolve

--- a/compiler/plc_project/src/project.rs
+++ b/compiler/plc_project/src/project.rs
@@ -77,8 +77,8 @@ pub struct Project<T: SourceContainer> {
     objects: Vec<Object>,
     /// Libraries included in the project configuration
     libraries: Vec<LibraryInformation<T>>,
-    /// Additional library pathes to consider
-    library_pathes: Vec<PathBuf>,
+    /// Additional library paths to consider
+    library_paths: Vec<PathBuf>,
     /// Output format
     format: FormatOption,
     /// Output Name
@@ -171,11 +171,11 @@ impl Project<PathBuf> {
             output: project_config.output,
             includes: vec![],
             objects: vec![],
-            library_pathes: vec![],
+            library_paths: vec![],
         })
     }
 
-    pub fn with_file_pathes(self, files: Vec<PathBuf>) -> Self {
+    pub fn with_file_paths(self, files: Vec<PathBuf>) -> Self {
         let mut proj = self;
         let files = resolve_file_paths(proj.get_location(), files).unwrap();
         for file in files {
@@ -189,15 +189,15 @@ impl Project<PathBuf> {
         proj
     }
 
-    pub fn with_include_pathes(self, files: Vec<PathBuf>) -> Self {
+    pub fn with_include_paths(self, files: Vec<PathBuf>) -> Self {
         let mut proj = self;
         proj.includes = resolve_file_paths(proj.get_location(), files).unwrap();
         proj
     }
 
-    pub fn with_library_pathes(self, pathes: Vec<PathBuf>) -> Self {
+    pub fn with_library_paths(self, paths: Vec<PathBuf>) -> Self {
         let mut proj = self;
-        proj.library_pathes.extend(resolve_file_paths(proj.get_location(), pathes).unwrap());
+        proj.library_paths.extend(resolve_file_paths(proj.get_location(), paths).unwrap());
         proj
     }
 
@@ -213,8 +213,8 @@ impl Project<PathBuf> {
         proj
     }
 
-    pub fn get_library_pathes(&self) -> &[PathBuf] {
-        &self.library_pathes
+    pub fn get_library_paths(&self) -> &[PathBuf] {
+        &self.library_paths
     }
 }
 
@@ -227,7 +227,7 @@ impl<S: SourceContainer> Project<S> {
             includes: vec![],
             objects: vec![],
             libraries: vec![],
-            library_pathes: vec![],
+            library_paths: vec![],
             format: FormatOption::default(),
             output: None,
         }
@@ -299,6 +299,8 @@ impl<S: SourceContainer> Project<S> {
 
 fn resolve_file_paths(location: Option<&Path>, inputs: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
     let mut sources = Vec::new();
+    //Ensure we are working with a directory
+    let location = location.and_then(|it| if it.is_file() { it.parent() } else { Some(it) });
     for input in &inputs {
         let input = location.map(|it| it.join(input)).unwrap_or(input.to_path_buf());
         let path = &input.to_string_lossy();

--- a/compiler/plc_project/src/project.rs
+++ b/compiler/plc_project/src/project.rs
@@ -77,6 +77,8 @@ pub struct Project<T: SourceContainer> {
     objects: Vec<Object>,
     /// Libraries included in the project configuration
     libraries: Vec<LibraryInformation<T>>,
+    /// Additional library pathes to consider
+    library_pathes: Vec<PathBuf>,
     /// Output format
     format: FormatOption,
     /// Output Name
@@ -169,6 +171,7 @@ impl Project<PathBuf> {
             output: project_config.output,
             includes: vec![],
             objects: vec![],
+            library_pathes: vec![],
         })
     }
 
@@ -192,6 +195,12 @@ impl Project<PathBuf> {
         proj
     }
 
+    pub fn with_library_pathes(self, pathes: Vec<PathBuf>) -> Self {
+        let mut proj = self;
+        proj.library_pathes.extend(resolve_file_paths(proj.get_location(), pathes).unwrap());
+        proj
+    }
+
     pub fn with_format(self, format: FormatOption) -> Self {
         let mut proj = self;
         proj.format = format;
@@ -202,6 +211,10 @@ impl Project<PathBuf> {
         let mut proj = self;
         proj.output = output.or(proj.output);
         proj
+    }
+
+    pub fn get_library_pathes(&self) -> &[PathBuf] {
+        &self.library_pathes
     }
 }
 
@@ -214,6 +227,7 @@ impl<S: SourceContainer> Project<S> {
             includes: vec![],
             objects: vec![],
             libraries: vec![],
+            library_pathes: vec![],
             format: FormatOption::default(),
             output: None,
         }

--- a/compiler/plc_source/src/lib.rs
+++ b/compiler/plc_source/src/lib.rs
@@ -23,7 +23,7 @@ pub enum SourceType {
 
 /// SourceContainers offer source-code to be compiled via the load_source function.
 /// Furthermore it offers a location-String used when reporting diagnostics.
-pub trait SourceContainer {
+pub trait SourceContainer: Sync {
     /// loads and returns the SourceEntry that contains the SourceCode and the path it was loaded from
     fn load_source(&self, encoding: Option<&'static Encoding>) -> Result<SourceCode, String>;
     /// returns the location of this source-container. Used when reporting diagnostics.
@@ -88,7 +88,7 @@ impl SourceCodeFactory for &str {
     }
 }
 
-impl<T: AsRef<Path>> SourceContainer for T {
+impl<T: AsRef<Path> + Sync> SourceContainer for T {
     fn load_source(&self, encoding: Option<&'static Encoding>) -> Result<SourceCode, String> {
         let source_type = self.get_type();
         if matches!(source_type, SourceType::Text | SourceType::Xml) {

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -10,21 +10,38 @@ use std::{
     process::Command,
 };
 
+use std::sync::{Arc, Mutex};
+
 pub struct Linker {
     errors: Vec<LinkerError>,
     linker: Box<dyn LinkerInterface>,
 }
 
+#[derive(Clone, Default, Debug)]
+pub enum LinkerType {
+    #[default]
+    Internal,
+    External(String),
+    Test(MockLinker),
+}
+
+impl From<Option<&str>> for LinkerType {
+    fn from(value: Option<&str>) -> Self {
+        match value {
+            None => LinkerType::Internal,
+            Some(linker) => LinkerType::External(linker.to_string()),
+        }
+    }
+}
+
 impl Linker {
-    pub fn new(target: &str, linker: Option<&str>) -> Result<Linker, LinkerError> {
+    pub fn new(target: &str, linker: LinkerType) -> Result<Linker, LinkerError> {
         Ok(Linker {
             errors: Vec::default(),
             linker: match linker {
-                Some(linker) => Box::new(CcLinker::new(linker)),
-
                 // TODO: Linker for Windows is missing, see also:
                 // https://github.com/PLC-lang/rusty/pull/702/files#r1052446296
-                None => {
+                LinkerType::Internal => {
                     let [platform, target_os] = target.split('-').collect::<Vec<&str>>()[1..=2] else {
                         return Err(LinkerError::Target(target.into()));
                     };
@@ -38,6 +55,8 @@ impl Linker {
                         _ => Box::new(LdLinker::new()),
                     }
                 }
+                LinkerType::External(linker) => Box::new(CcLinker::new(&linker)),
+                LinkerType::Test(linker) => Box::new(linker),
             },
         })
     }
@@ -115,15 +134,21 @@ impl CcLinker {
 }
 
 impl LinkerInterface for CcLinker {
-    fn args(&mut self) -> &mut Vec<String> {
-        &mut self.args
+    fn add_arg(&mut self, value: String) {
+        self.args.push(value)
+    }
+
+    fn get_build_command(&self) -> Result<String, LinkerError> {
+        let linker_location = which(&self.linker)
+            .map_err(|e| LinkerError::Link(format!("{e} for linker: {}", &self.linker)))?;
+        Ok(format!("{} {}", linker_location.to_string_lossy(), self.args.join(" ")))
     }
 
     fn finalize(&mut self) -> Result<(), LinkerError> {
         let linker_location = which(&self.linker)
             .map_err(|e| LinkerError::Link(format!("{e} for linker: {}", &self.linker)))?;
 
-        log::debug!("Linker command : {} {}", linker_location.to_string_lossy(), self.args.join(" "));
+        log::debug!("Linker command : {}", self.get_build_command()?);
 
         let status = Command::new(linker_location).args(&self.args).status()?;
         if status.success() {
@@ -145,51 +170,76 @@ impl LdLinker {
 }
 
 impl LinkerInterface for LdLinker {
-    fn args(&mut self) -> &mut Vec<String> {
-        &mut self.args
+    fn add_arg(&mut self, value: String) {
+        self.args.push(value)
+    }
+
+    fn get_build_command(&self) -> Result<String, LinkerError> {
+        Ok(format!("ld.lld {}", self.args.join(" ")))
     }
 
     fn finalize(&mut self) -> Result<(), LinkerError> {
-        log::debug!("Linker arguments : {}", self.args.join(" "));
+        log::debug!("Linker arguments : {}", self.get_build_command()?);
         lld_rs::link(lld_rs::LldFlavor::Elf, &self.args).ok().map_err(LinkerError::Link)
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct MockLinker {
+    pub args: Arc<Mutex<Vec<String>>>,
+}
+
+impl LinkerInterface for MockLinker {
+    fn add_arg(&mut self, value: String) {
+        self.args.lock().unwrap().push(value)
+    }
+
+    fn get_build_command(&self) -> Result<String, LinkerError> {
+        Ok(format!("ld.lld {}", self.args.lock()?.join(" ")))
+    }
+
+    fn finalize(&mut self) -> Result<(), LinkerError> {
+        println!("Test Executing build command {}", self.get_build_command()?);
+        Ok(())
+    }
+}
+
 trait LinkerInterface {
-    fn args(&mut self) -> &mut Vec<String>;
+    fn add_arg(&mut self, value: String);
+    fn get_build_command(&self) -> Result<String, LinkerError>;
     fn finalize(&mut self) -> Result<(), LinkerError>;
 
     fn add_obj(&mut self, path: &str) {
-        self.args().push(path.into());
+        self.add_arg(path.into());
     }
 
     fn add_lib_path(&mut self, path: &str) {
-        self.args().push(format!("-L{path}"));
+        self.add_arg(format!("-L{path}"));
     }
 
     fn add_lib(&mut self, path: &str) {
-        self.args().push(format!("-l{path}"));
+        self.add_arg(format!("-l{path}"));
     }
 
     fn add_sysroot(&mut self, path: &str) {
-        self.args().push(format!("--sysroot={path}"));
+        self.add_arg(format!("--sysroot={path}"));
     }
 
     fn build_shared_object(&mut self, path: &str) {
-        self.args().push("--shared".into());
-        self.args().push("-o".into());
-        self.args().push(path.into());
+        self.add_arg("--shared".into());
+        self.add_arg("-o".into());
+        self.add_arg(path.into());
     }
 
     fn build_exectuable(&mut self, path: &str) {
-        self.args().push("-o".into());
-        self.args().push(path.into());
+        self.add_arg("-o".into());
+        self.add_arg(path.into());
     }
 
     fn build_relocatable(&mut self, path: &str) {
-        self.args().push("-r".into()); // equivalent to --relocatable
-        self.args().push("-o".into());
-        self.args().push(path.into());
+        self.add_arg("-r".into()); // equivalent to --relocatable
+        self.add_arg("-o".into());
+        self.add_arg(path.into());
     }
 }
 
@@ -230,31 +280,36 @@ impl<T: Error> From<T> for LinkerError {
     }
 }
 
-#[test]
-fn windows_target_triple_should_result_in_error() {
-    for target in &[
-        "x86_64-pc-windows-gnu",
-        "x86_64-pc-win32-gnu",
-        "x86_64-windows-gnu",
-        "x86_64-win32-gnu",
-        "aarch64-pc-windows-gnu",
-        "aarch64-pc-win32-gnu",
-        "aarch64-windows-gnu",
-        "aarch64-win32-gnu",
-        "i686-pc-windows-gnu",
-        "i686-pc-win32-gnu",
-        "i686-windows-gnu",
-        "i686-win32-gnu",
-    ] {
-        assert!(Linker::new(target, None).is_err());
-    }
-}
+#[cfg(test)]
+mod test {
+    use crate::linker::{Linker, LinkerType};
 
-#[test]
-fn non_windows_target_triple_should_result_in_ok() {
-    for target in
-        &["x86_64-linux-gnu", "x86_64-pc-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
-    {
-        assert!(Linker::new(target, None).is_ok());
+    #[test]
+    fn windows_target_triple_should_result_in_error() {
+        for target in &[
+            "x86_64-pc-windows-gnu",
+            "x86_64-pc-win32-gnu",
+            "x86_64-windows-gnu",
+            "x86_64-win32-gnu",
+            "aarch64-pc-windows-gnu",
+            "aarch64-pc-win32-gnu",
+            "aarch64-windows-gnu",
+            "aarch64-win32-gnu",
+            "i686-pc-windows-gnu",
+            "i686-pc-win32-gnu",
+            "i686-windows-gnu",
+            "i686-win32-gnu",
+        ] {
+            assert!(Linker::new(target, LinkerType::Internal).is_err());
+        }
+    }
+
+    #[test]
+    fn non_windows_target_triple_should_result_in_ok() {
+        for target in
+            &["x86_64-linux-gnu", "x86_64-pc-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
+        {
+            assert!(Linker::new(target, LinkerType::Internal).is_ok());
+        }
     }
 }

--- a/tests/integration/data/linking/lib.o
+++ b/tests/integration/data/linking/lib.o
@@ -1,0 +1,1 @@
+THIS FILE JUST HAS THE .O extenstion to be used in the test, do not delete

--- a/tests/integration/linking.rs
+++ b/tests/integration/linking.rs
@@ -1,7 +1,12 @@
-use std::{env, fs};
+use std::{
+    env::{self, current_dir},
+    fs,
+    sync::{Arc, Mutex},
+};
 
 use crate::get_test_file;
-use driver::compile;
+use driver::{compile, compile_with_options, get_compilation_context};
+use rusty::linker::{LinkerType, MockLinker};
 
 static TARGET: Option<&str> = Some("x86_64-linux-gnu");
 
@@ -236,4 +241,23 @@ fn link_files_with_same_name_but_different_extension() {
     // `const.o` file, which causes linking issues and more specifically "duplicate symbol" errors. Hence we only
     // check whether the compilation resulted in some Ok value here.
     assert!(compile(&["plc", file1.as_str(), file2.as_str(), "--target", TARGET.unwrap()]).is_ok());
+}
+
+#[test]
+fn link_with_library_path() {
+    let file1 = get_test_file("linking/lib.o");
+    let dir = current_dir().unwrap();
+
+    let mut compile_context =
+        get_compilation_context(&["plc", file1.as_str(), "-ltest", "-L", &dir.to_string_lossy()]).unwrap();
+    //Change the linker
+    let vec: Vec<String> = vec![];
+    let vec = Arc::new(Mutex::new(vec));
+    let test_linker = MockLinker { args: vec.clone() };
+    compile_context.link_options.linker = LinkerType::Test(test_linker);
+    compile_with_options(compile_context).unwrap();
+    dbg!(&vec.lock().unwrap());
+    assert!(vec.lock().unwrap().as_slice().contains(&"-L.".to_string()));
+    assert!(vec.lock().unwrap().contains(&"-ltest".to_string()));
+    assert!(vec.lock().unwrap().contains(&format!("-L{}", dir.to_string_lossy())));
 }

--- a/tests/integration/linking.rs
+++ b/tests/integration/linking.rs
@@ -256,7 +256,6 @@ fn link_with_library_path() {
     let test_linker = MockLinker { args: vec.clone() };
     compile_context.link_options.linker = LinkerType::Test(test_linker);
     compile_with_options(compile_context).unwrap();
-    dbg!(&vec.lock().unwrap());
     assert!(vec.lock().unwrap().as_slice().contains(&"-L.".to_string()));
     assert!(vec.lock().unwrap().contains(&"-ltest".to_string()));
     assert!(vec.lock().unwrap().contains(&format!("-L{}", dir.to_string_lossy())));


### PR DESCRIPTION
We had a problem when parsing relative paths that if a file was given as the root path, we could not get relative locations of libraries.
In addition, the -L flag was being ignored by the project creation.