### PR TITLE
refactor: Suppress printing of LLVM IR in test runs

### DIFF
--- a/compiler/plc_driver/src/runner.rs
+++ b/compiler/plc_driver/src/runner.rs
@@ -46,7 +46,6 @@ pub fn compile<T: Compilable>(context: &CodegenContext, source: T) -> GeneratedM
 pub fn compile_and_run<T, U, S: Compilable>(source: S, params: &mut T) -> U {
     let context: CodegenContext = CodegenContext::create();
     let module = compile(&context, source);
-    module.print_to_stderr();
     module.run::<T, U>("main", params)
 }
 


### PR DESCRIPTION
No idea why we had this in the first place, but it just clutters the whole terminal with LLVM IR we (probably) are uninterested in.