### PR TITLE
fix: Derive root directory from unit

### DIFF
--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -350,8 +350,8 @@ impl<T: SourceContainer + Sync> AnnotatedProject<T> {
                                 .with_internal_error(it.into())
                             })?
                         } else if unit_location.has_root() {
-                            let root = Path::new("/").canonicalize()?;
-                            unit_location.strip_prefix(root).expect("Name has root")
+                            let root = unit_location.ancestors().last().expect("Should exist?");
+                            unit_location.strip_prefix(root).expect("The root directory should exist")
                         } else {
                             unit_location.as_path()
                         };


### PR DESCRIPTION
Fixes a bug for Windows where compilation would panic if the compiler was executed in another drive than where a project was located in. For example if `plc build D:/project/conf/plc.json [...]` was executed from the `C:/` drive, the pipeline would try to strip the root `C:/` from the path `D:/project/...` which panics because of the method [`strip_prefix`](https://doc.rust-lang.org/std/path/struct.Path.html#method.strip_prefix). For linux and macOS this was no problem because the root is always `/`.