### PR TITLE
Move functions to ELF sections with mangled names.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
  "plc_xml",
  "pretty_assertions",
  "regex",
+ "section_mangler",
  "serde",
  "serde_json",
  "serial_test",
@@ -2457,6 +2458,10 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "section_mangler"
+version = "0.0.1"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ plc_ast = { path = "./compiler/plc_ast" }
 plc_util = { path = "./compiler/plc_util" }
 plc_diagnostics = { path = "./compiler/plc_diagnostics" }
 plc_index = { path = "./compiler/plc_index" }
+section_mangler = { path = "./compiler/section_mangler" }
 logos = "0.12.0"
 thiserror = "1.0"
 clap = { version = "3.0", features = ["derive"] }
@@ -72,6 +73,7 @@ members = [
     "compiler/plc_xml",
     "compiler/plc_derive",
     "compiler/plc_index",
+    "compiler/section_mangler",
 ]
 default-members = [".", "compiler/plc_driver", "compiler/plc_xml"]
 

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_function_call.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_function_call.snap
@@ -5,7 +5,7 @@ expression: "results.join(\"\\n\")"
 ; ModuleID = 'main.st'
 source_filename = "main.st"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -14,10 +14,9 @@ entry:
   ret i16 %main_ret
 }
 
-declare i16 @external()
+declare i16 @external() section "fn-external:i16"
 
 ; ModuleID = 'external.st'
 source_filename = "external.st"
 
-declare i16 @external()
-
+declare i16 @external() section "fn-external:i16"

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_global_var.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_global_var.snap
@@ -8,7 +8,7 @@ source_filename = "main.st"
 @x = external global i16
 @y = external global i16
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -19,7 +19,7 @@ entry:
   ret i16 %main_ret
 }
 
-declare i16 @external()
+declare i16 @external() section "fn-external:i16"
 
 ; ModuleID = 'external.st'
 source_filename = "external.st"
@@ -27,5 +27,4 @@ source_filename = "external.st"
 @x = external global i16
 @y = external global i16
 
-declare i16 @external()
-
+declare i16 @external() section "fn-external:i16"

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_in_different_locations_with_debug_info.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_in_different_locations_with_debug_info.snap
@@ -9,7 +9,7 @@ source_filename = "app/file1.st"
 
 @mainProg_instance = external global %mainProg, !dbg !0
 
-define i16 @main() !dbg !10 {
+define i16 @main() section "fn-main:i16" !dbg !10 {
 entry:
   %main = alloca i16, align 2, !dbg !14
   call void @llvm.dbg.declare(metadata i16* %main, metadata !15, metadata !DIExpression()), !dbg !17
@@ -19,7 +19,7 @@ entry:
   ret i16 %main_ret, !dbg !14
 }
 
-declare !dbg !18 void @mainProg(%mainProg*)
+declare !dbg !18 void @mainProg(%mainProg*) section "fn-mainProg:v"
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
@@ -56,7 +56,7 @@ source_filename = "lib/file2.st"
 
 @mainProg_instance = global %mainProg zeroinitializer, !dbg !0
 
-define void @mainProg(%mainProg* %0) !dbg !10 {
+define void @mainProg(%mainProg* %0) section "fn-mainProg:v" !dbg !10 {
 entry:
   call void @llvm.dbg.declare(metadata %mainProg* %0, metadata !13, metadata !DIExpression()), !dbg !14
   ret void, !dbg !14
@@ -85,4 +85,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !12 = !{null}
 !13 = !DILocalVariable(name: "mainProg", scope: !10, file: !2, line: 2, type: !3)
 !14 = !DILocation(line: 5, column: 4, scope: !10)
-

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_with_debug_info.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_with_debug_info.snap
@@ -9,7 +9,7 @@ source_filename = "file1.st"
 
 @mainProg_instance = external global %mainProg, !dbg !0
 
-define i16 @main() !dbg !10 {
+define i16 @main() section "fn-main:i16" !dbg !10 {
 entry:
   %main = alloca i16, align 2, !dbg !14
   call void @llvm.dbg.declare(metadata i16* %main, metadata !15, metadata !DIExpression()), !dbg !17
@@ -19,7 +19,7 @@ entry:
   ret i16 %main_ret, !dbg !14
 }
 
-declare !dbg !18 void @mainProg(%mainProg*)
+declare !dbg !18 void @mainProg(%mainProg*) section "fn-mainProg:v"
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
@@ -56,7 +56,7 @@ source_filename = "file2.st"
 
 @mainProg_instance = global %mainProg zeroinitializer, !dbg !0
 
-define void @mainProg(%mainProg* %0) !dbg !10 {
+define void @mainProg(%mainProg* %0) section "fn-mainProg:v" !dbg !10 {
 entry:
   call void @llvm.dbg.declare(metadata %mainProg* %0, metadata !13, metadata !DIExpression()), !dbg !14
   ret void, !dbg !14
@@ -85,4 +85,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !12 = !{null}
 !13 = !DILocalVariable(name: "mainProg", scope: !10, file: !2, line: 2, type: !3)
 !14 = !DILocation(line: 5, column: 4, scope: !10)
-

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_source_files_generated.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_source_files_generated.snap
@@ -9,7 +9,7 @@ source_filename = "external_file1.st"
 
 @mainProg_instance = external global %mainProg
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -18,7 +18,7 @@ entry:
   ret i16 %main_ret
 }
 
-declare void @mainProg(%mainProg*)
+declare void @mainProg(%mainProg*) section "fn-mainProg:v"
 
 ; ModuleID = 'external_file2.st'
 source_filename = "external_file2.st"
@@ -27,8 +27,7 @@ source_filename = "external_file2.st"
 
 @mainProg_instance = global %mainProg zeroinitializer
 
-define void @mainProg(%mainProg* %0) {
+define void @mainProg(%mainProg* %0) section "fn-mainProg:v" {
 entry:
   ret void
 }
-

--- a/compiler/section_mangler/Cargo.toml
+++ b/compiler/section_mangler/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "section_mangler"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]

--- a/compiler/section_mangler/src/lib.rs
+++ b/compiler/section_mangler/src/lib.rs
@@ -1,0 +1,250 @@
+//! This crate provides functionality for encoding and decoding the type
+//! information of Strutured Text functions and variables. The goal is to store
+//! that information in the resulting binary, in the section name containing the
+//! function/variable. This enables a Structured Text loader to access this
+//! type information. In order to stay simple and light, this crate should
+//! not rely on too many dependencies other than the standard library.
+//!
+//! The main type provided by this struct is [`SectionMangler`], a simple
+//! builder for creating mangling contexts for functions and variables. These
+//! contexts can then be mangled down to a string, as well as be recreated from a
+//! mangled string.
+//!
+//! You will notice the use of `unreachable!()` in a lot of places, since this crate
+//! relies on fully typechecked global variables and functions. If that is not
+//! the case, and you try adding a return type to a global variable, then it is
+//! a programming error and the compiler should crash.
+//!
+//! ## Mangling Scheme
+//!
+//! There are two main mangling schemes currently implemented: one for
+//! functions, and one for global variables. They are distinct by the prefix
+//! they use at the beginning of the mangled string: `fn` for functions, and `var`
+//! for variables.
+//!
+//! ### Mangling global variables
+//!
+//! ```text
+//! var-<name>:<type>
+//! ```
+//!
+//! Is is necessary to know the type of a global variable in order to encode it.
+//! That type is appened to the name of the variable, after a colon.
+//!
+//! ### Mangling functions
+//!
+//! ```text
+//! fn-<name>:<return_type>[<arg1>][<arg2>][<arg3>]
+//! ```
+//!
+//! Just like global variables, the function's name is added right after the
+//! function prefix. Then, a colon, and the return type of the function. Each of the
+//! function's parameters' type is then added, surrounded by brackets (`[` and `]`).
+//! This eases the parsing of the type.
+
+use std::fmt;
+
+/// The main builder type of this crate. Use it to create mangling contexts, in
+/// order to encode and decode binary type information.
+// TODO: Add example code for using this builder
+pub enum SectionMangler {
+    Function(FunctionMangler),
+    Variable(VariableMangler),
+}
+
+pub struct FunctionMangler {
+    name: String,
+    parameters: Vec<FunctionArgument>,
+    return_type: Option<Type>,
+}
+
+pub struct VariableMangler {
+    name: String,
+    ty: Type,
+}
+
+impl SectionMangler {
+    pub fn function<S: Into<String>>(name: S) -> SectionMangler {
+        SectionMangler::Function(FunctionMangler { name: name.into(), parameters: vec![], return_type: None })
+    }
+
+    pub fn variable<S: Into<String>>(name: S, ty: Type) -> SectionMangler {
+        SectionMangler::Variable(VariableMangler { name: name.into(), ty })
+    }
+
+    pub fn with_parameter(self, param: FunctionArgument) -> SectionMangler {
+        match self {
+            SectionMangler::Function(f) => {
+                let mut parameters = f.parameters;
+                parameters.push(param);
+
+                Self::Function(FunctionMangler { parameters, ..f })
+            }
+            SectionMangler::Variable(_) => unreachable!("global variables do not accept parameters."),
+        }
+    }
+
+    pub fn with_return_type(self, return_type: Option<Type>) -> SectionMangler {
+        match self {
+            SectionMangler::Function(f) => SectionMangler::Function(FunctionMangler { return_type, ..f }),
+            SectionMangler::Variable(_) => unreachable!("global variables do not have a return type."),
+        }
+    }
+
+    pub fn mangle(self) -> String {
+        let (prefix, content) = match self {
+            SectionMangler::Function(f) => ("fn", mangle_function(f)),
+            SectionMangler::Variable(v) => ("var", mangle_variable(v)),
+        };
+
+        format!("{prefix}-{content}")
+    }
+}
+
+// TODO: We have to encode if the initial value changes or not
+// pub initial_value: Option<ConstId>,
+
+// TODO: Handle ArgumentType, which looks like this: `enum ArgumentType { ByVal(VariableType), ByRef(VariableType) }`
+// and `enum VariableType { Local, Temp, Input, Output, InOut, Global, Return }`
+// so this is not really about the type in itself, but about how the parameter is passed into the function?
+// pub argument_type: ArgumentType,
+// NOTE: This is called `variable_linkage` in the `MemberInfo` struct.
+
+/// We have to encode this because if it changes, the function needs to be reloaded - this is an ABI breakage
+pub enum FunctionArgument {
+    ByValue(Type),
+    ByRef(Type),
+}
+
+impl fmt::Display for FunctionArgument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // FIXME: Mangle by-value and by-ref args differently
+        match self {
+            FunctionArgument::ByValue(ty) => write!(f, "{ty}"),
+            FunctionArgument::ByRef(ty) => write!(f, "{ty}"),
+        }
+    }
+}
+
+// TODO: Do we have to encode this? Does that affect ABI? Probably
+pub enum StringEncoding {
+    // TODO: Should we encode this differently? this could cause problems compared to encoding unsigned types
+    /// Encoded as `8u`
+    Utf8,
+    /// Encoded as `16u`
+    Utf16,
+}
+
+impl fmt::Display for StringEncoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StringEncoding::Utf8 => write!(f, "8u"),
+            StringEncoding::Utf16 => write!(f, "16u"),
+        }
+    }
+}
+
+// This maps directly to the [`DataTypeInformation`] enum in RuSTy - we simply remove some fields and add the ability to encode/decode serialize/deserialize
+// TODO: Do we have to handle Generic?
+pub enum Type {
+    /// Encoded as `v`
+    Void,
+    /// Encoded as `i<size>` or `u<size>`
+    // TODO: Handle semantic size
+    Integer {
+        signed: bool,
+        size: u32,
+        // TODO: Can the semantic size change without the size changing? Does that need a reload?
+        semantic_size: Option<u32>,
+    },
+    /// Encoded as `f<size>`
+    Float { size: u32 },
+    /// Encoded as `s<encoding><size>`
+    String {
+        size: usize, // FIXME: Is that okay? will all the constant expressions be folded at that point? Can we have TypeSize::Undetermined still?
+        encoding: StringEncoding,
+    },
+    /// Encoded as `p<inner>`. For example, a 32bit int pointer will become `pi32`
+    Pointer {
+        inner: Box<Type>,
+        // TODO: Is changing the `auto_deref` mode an ABI break?
+        // auto_deref: bool,
+    },
+
+    // --- UNIMPLEMENTED
+
+    // FIXME: Do we need any info here? How are structs codegened?
+    Struct {
+        // name: TypeId,
+        // members: Vec<VariableIndexEntry>,
+        // source: StructSource,
+    },
+
+    // FIXME: Same here
+    Enum {
+        // name: TypeId,
+        // referenced_type: TypeId,
+        // // TODO: Would it make sense to store `VariableIndexEntry`s similar to how the `Struct` variant does?
+        // //       This would allow us to pattern match in the index `find_member` method
+        // elements: Vec<String>,
+    },
+    Array {
+        inner: Box<Type>,
+        // FIXME: Handle dimensions here
+        // dimensions: Vec<Dimension>,
+    },
+    SubRange {
+        // name: TypeId,
+        // referenced_type: TypeId,
+        // sub_range: Range<AstNode>,
+    },
+    Alias {
+        // name: TypeId,
+        // referenced_type: TypeId,
+    },
+    Generic {
+        // name: TypeId,
+        // generic_symbol: String,
+        // nature: TypeNature,
+    },
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Type::Void => write!(f, "v"),
+            Type::Integer { signed: true, size, semantic_size: _ } => {
+                // FIXME: Handle semantic_size
+                write!(f, "i{size}")
+            }
+            Type::Integer { signed: false, size, semantic_size: _ } => {
+                // FIXME: Handle semantic_size
+                write!(f, "u{size}")
+            }
+            Type::Float { size } => write!(f, "f{size}"),
+            Type::String { size, encoding } => write!(f, "s{encoding}{size}",),
+            Type::Pointer { inner } => write!(f, "p{}", inner),
+            // -- Unimplemented
+            Type::Struct {} => todo!(),
+            Type::Enum {} => todo!(),
+            Type::Array { .. } => todo!(),
+            Type::SubRange {} => todo!(),
+            Type::Alias {} => todo!(),
+            Type::Generic {} => todo!(),
+        }
+    }
+}
+
+// TODO: How to encode variadics?
+fn mangle_function(FunctionMangler { name, parameters, return_type }: FunctionMangler) -> String {
+    let mangled = parameters
+        .into_iter()
+        /* FIXME: Is that correct? */
+        .fold(return_type.unwrap_or(Type::Void).to_string(), |mangled, arg| format!("{mangled}[{arg}]"));
+
+    format!("{name}:{mangled}")
+}
+
+fn mangle_variable(VariableMangler { name, ty }: VariableMangler) -> String {
+    format!("{name}:{ty}")
+}

--- a/src/codegen/generators.rs
+++ b/src/codegen/generators.rs
@@ -2,6 +2,7 @@ pub mod data_type_generator;
 pub mod expression_generator;
 pub mod llvm;
 pub mod pou_generator;
+pub mod section_names;
 pub mod statement_generator;
 pub mod variable_generator;
 

--- a/src/codegen/generators/section_names.rs
+++ b/src/codegen/generators/section_names.rs
@@ -1,0 +1,33 @@
+use crate::index::Index;
+use crate::typesystem::{self, DataTypeInformation, StringEncoding, TypeSize};
+use section_mangler::{StringEncoding as SectionStringEncoding, Type};
+
+pub fn mangle_type(index: &Index, ty: &typesystem::DataType) -> section_mangler::Type {
+    // TODO: This is a bit ugly because we keep dereferencing references to Copy types like
+    // bool, u32, etc, because `DataTypeInformation::Pointer` keeps a `String` which is not
+    // Copy. the alternative is for section_mangle::Type to keep references everywhere, and
+    // have a lifetime generic parameter, e.g. `section_mangler::Type<'a>` - which is also
+    // annoying.
+    match ty.get_type_information() {
+        DataTypeInformation::Void => Type::Void,
+        DataTypeInformation::Integer { signed, size, semantic_size, .. } => {
+            Type::Integer { signed: *signed, size: *size, semantic_size: *semantic_size }
+        }
+        DataTypeInformation::Float { size, .. } => Type::Float { size: *size },
+        DataTypeInformation::String { size: TypeSize::LiteralInteger(size), encoding } => {
+            let encoding = match encoding {
+                StringEncoding::Utf8 => SectionStringEncoding::Utf8,
+                StringEncoding::Utf16 => SectionStringEncoding::Utf16,
+            };
+
+            Type::String { size: *size as usize, encoding }
+        }
+        DataTypeInformation::Pointer { inner_type_name, .. } => Type::Pointer {
+            inner: Box::new(mangle_type(index, index.get_effective_type_by_name(inner_type_name).unwrap())),
+        },
+        // FIXME: For now, encode all unknown types as "void" since this is not required for
+        // execution. Not doing so (and doing an `unreachable!()` for example) obviously causes
+        // failures, because complex types are already implemented in the compiler.
+        _ => Type::Void,
+    }
+}

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__aggregate_return_value_variable_in_function.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__aggregate_return_value_variable_in_function.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define void @myFunc([81 x i8]* %0) !dbg !4 {
+define void @myFunc([81 x i8]* %0) section "fn-myFunc:s8u81" !dbg !4 {
 entry:
   %myFunc = alloca [81 x i8]*, align 8, !dbg !8
   store [81 x i8]* %0, [81 x i8]** %myFunc, align 8, !dbg !8
@@ -53,4 +53,3 @@ attributes #2 = { argmemonly nofree nounwind willreturn }
 !13 = !{!14}
 !14 = !DISubrange(count: 80, lowerBound: 0)
 !15 = !DILocation(line: 2, column: 17, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__assignment_statement_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__assignment_statement_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -35,4 +35,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !9 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !10, align: 32)
 !10 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !11 = !DILocation(line: 2, column: 17, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -59,4 +59,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !14 = !DILocation(line: 5, column: 16, scope: !4)
 !15 = !DILocation(line: 7, column: 16, scope: !4)
 !16 = !DILocation(line: 11, column: 12, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__exit_statement_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__exit_statement_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -46,4 +46,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !11 = !DILocation(line: 2, column: 17, scope: !4)
 !12 = !DILocation(line: 3, column: 18, scope: !4)
 !13 = !DILocation(line: 6, column: 12, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
@@ -11,11 +11,11 @@ source_filename = "main"
 @myPrg_instance = external global %myPrg, !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, !dbg !5
 
-declare i32 @myFunc()
+declare i32 @myFunc() section "fn-myFunc:i32"
 
-declare void @myPrg(%myPrg*)
+declare void @myPrg(%myPrg*) section "fn-myPrg:v"
 
-declare void @myFb(%myFb*)
+declare void @myFb(%myFb*) section "fn-myFb:v"
 
 !llvm.module.flags = !{!8, !9}
 !llvm.dbg.cu = !{!10}
@@ -32,4 +32,3 @@ declare void @myFb(%myFb*)
 !9 = !{i32 2, !"Debug Info Version", i32 3}
 !10 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !11, splitDebugInlining: false)
 !11 = !{!0, !5}
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__for_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__for_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -97,4 +97,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !12 = !DILocation(line: 3, column: 16, scope: !4)
 !13 = !DILocation(line: 4, column: 16, scope: !4)
 !14 = !DILocation(line: 3, column: 37, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -35,4 +35,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !9 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !10, align: 32)
 !10 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !11 = !DILocation(line: 2, column: 17, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_in_expressions_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_in_expressions_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -37,4 +37,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !10 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !11 = !DILocation(line: 2, column: 17, scope: !4)
 !12 = !DILocation(line: 3, column: 16, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__if_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__if_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -59,4 +59,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !15 = !DILocation(line: 6, column: 16, scope: !4)
 !16 = !DILocation(line: 8, column: 16, scope: !4)
 !17 = !DILocation(line: 10, column: 12, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__implementation_added_as_subroutine.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__implementation_added_as_subroutine.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @myPrg_instance = global %myPrg zeroinitializer, !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, !dbg !5
 
-define i32 @myFunc() !dbg !12 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !12 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !15
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !16, metadata !DIExpression()), !dbg !18
@@ -20,13 +20,13 @@ entry:
   ret i32 %myFunc_ret, !dbg !15
 }
 
-define void @myPrg(%myPrg* %0) !dbg !19 {
+define void @myPrg(%myPrg* %0) section "fn-myPrg:v" !dbg !19 {
 entry:
   call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !20, metadata !DIExpression()), !dbg !21
   ret void, !dbg !21
 }
 
-define void @myFb(%myFb* %0) !dbg !22 {
+define void @myFb(%myFb* %0) section "fn-myFb:v" !dbg !22 {
 entry:
   call void @llvm.dbg.declare(metadata %myFb* %0, metadata !23, metadata !DIExpression()), !dbg !24
   ret void, !dbg !24
@@ -65,4 +65,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !22 = distinct !DISubprogram(name: "myFb", linkageName: "myFb", scope: !2, file: !2, line: 6, type: !13, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
 !23 = !DILocalVariable(name: "myFb", scope: !22, file: !2, line: 6, type: !7)
 !24 = !DILocation(line: 7, column: 8, scope: !22)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__nested_function_calls_get_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__nested_function_calls_get_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc(i32 %0) !dbg !4 {
+define i32 @myFunc(i32 %0) section "fn-myFunc:i32[i32]" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !9
   %x = alloca i32, align 4, !dbg !9
@@ -42,4 +42,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !12 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !7, align: 32)
 !13 = !DILocation(line: 2, column: 17, scope: !4)
 !14 = !DILocation(line: 4, column: 19, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_callable_expressions_have_no_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_callable_expressions_have_no_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -35,4 +35,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !9 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !10, align: 32)
 !10 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !11 = !DILocation(line: 2, column: 17, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_function_pous_have_struct_as_param.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_function_pous_have_struct_as_param.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @myProg_instance = global %myProg zeroinitializer, !dbg !0
 @__fb__init = unnamed_addr constant %fb zeroinitializer, !dbg !7
 
-define void @myProg(%myProg* %0) !dbg !16 {
+define void @myProg(%myProg* %0) section "fn-myProg:v[i32]" !dbg !16 {
 entry:
   call void @llvm.dbg.declare(metadata %myProg* %0, metadata !20, metadata !DIExpression()), !dbg !21
   %x = getelementptr inbounds %myProg, %myProg* %0, i32 0, i32 0, !dbg !21
@@ -21,7 +21,7 @@ entry:
   ret void, !dbg !21
 }
 
-define void @fb(%fb* %0) !dbg !22 {
+define void @fb(%fb* %0) section "fn-fb:v[i32]" !dbg !22 {
 entry:
   call void @llvm.dbg.declare(metadata %fb* %0, metadata !23, metadata !DIExpression()), !dbg !24
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0, !dbg !24
@@ -64,4 +64,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !22 = distinct !DISubprogram(name: "fb", linkageName: "fb", scope: !2, file: !2, line: 9, type: !17, scopeLine: 13, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !19)
 !23 = !DILocalVariable(name: "fb", scope: !22, file: !2, line: 9, type: !9)
 !24 = !DILocation(line: 13, column: 12, scope: !22)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__repeat_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__repeat_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -55,4 +55,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !12 = !DILocation(line: 4, column: 16, scope: !4)
 !13 = !DILocation(line: 5, column: 18, scope: !4)
 !14 = !DILocation(line: 6, column: 12, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__return_statement_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__return_statement_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -38,4 +38,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !9 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !10, align: 32)
 !10 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !11 = !DILocation(line: 2, column: 17, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @myPrg_instance = global %myPrg zeroinitializer, !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, !dbg !9
 
-define i32 @myFunc() !dbg !20 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !20 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !24
   %a = alloca i32, align 4, !dbg !24
@@ -29,7 +29,7 @@ entry:
   ret i32 %myFunc_ret, !dbg !24
 }
 
-define void @myPrg(%myPrg* %0) !dbg !33 {
+define void @myPrg(%myPrg* %0) section "fn-myPrg:v" !dbg !33 {
 entry:
   call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !34, metadata !DIExpression()), !dbg !35
   %a = alloca i32, align 4, !dbg !35
@@ -44,7 +44,7 @@ entry:
   ret void, !dbg !35
 }
 
-define void @myFb(%myFb* %0) !dbg !42 {
+define void @myFb(%myFb* %0) section "fn-myFb:v" !dbg !42 {
 entry:
   call void @llvm.dbg.declare(metadata %myFb* %0, metadata !43, metadata !DIExpression()), !dbg !44
   %a = alloca i32, align 4, !dbg !44
@@ -118,4 +118,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !48 = !DILocation(line: 9, column: 19, scope: !42)
 !49 = !DILocalVariable(name: "c", scope: !42, file: !2, line: 9, type: !6, align: 32)
 !50 = !DILocation(line: 9, column: 21, scope: !42)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_in_out_inout_in_function_added_as_params.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_in_out_inout_in_function_added_as_params.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc(i16* %0) !dbg !4 {
+define i32 @myFunc(i16* %0) section "fn-myFunc:i32[pi16]" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !10
   %x = alloca i16*, align 8, !dbg !10
@@ -46,4 +46,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !13 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !14, align: 32)
 !14 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !15 = !DILocation(line: 2, column: 17, scope: !4)
-

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__while_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__while_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() !dbg !4 {
+define i32 @myFunc() section "fn-myFunc:i32" !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11
@@ -52,4 +52,3 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !12 = !DILocation(line: 4, column: 16, scope: !4)
 !13 = !DILocation(line: 3, column: 18, scope: !4)
 !14 = !DILocation(line: 6, column: 12, scope: !4)
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_declared_initializer.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_declared_initializer.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__commands__init = unnamed_addr constant %commands { i8 1, i8 0 }
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %cmd1 = alloca %commands, align 8
@@ -31,4 +31,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_default_initializer.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_default_initializer.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @__commands__init = unnamed_addr constant %commands zeroinitializer
 @__main.myStr1__init = unnamed_addr constant [81 x i8] zeroinitializer
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %cmd1 = alloca %commands, align 8
@@ -41,4 +41,3 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
 attributes #1 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__initial_values_in_global_variables_out_of_order.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__initial_values_in_global_variables_out_of_order.snap
@@ -12,15 +12,14 @@ source_filename = "main"
 @__MyFB__init = unnamed_addr constant %MyFB { i16 77 }
 @prg_instance = global %prg { %MyFB { i16 77 } }
 
-define void @MyFB(%MyFB* %0) {
+define void @MyFB(%MyFB* %0) section "fn-MyFB:v" {
 entry:
   %x = getelementptr inbounds %MyFB, %MyFB* %0, i32 0, i32 0
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__class_struct_initialized_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__class_struct_initialized_in_function.snap
@@ -11,13 +11,13 @@ source_filename = "main"
 @__fb__init = unnamed_addr constant %fb { i16 9 }
 @main_instance = global %main { %fb { i16 9 } }
 
-define void @fb(%fb* %0) {
+define void @fb(%fb* %0) section "fn-fb:v" {
 entry:
   %a = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
 }
 
-define i32 @func(%fb %0) {
+define i32 @func(%fb %0) section "fn-func:i32[v]" {
 entry:
   %func = alloca i32, align 4
   %in = alloca %fb, align 8
@@ -30,7 +30,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %fb0 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %load_fb0 = load %fb, %fb* %fb0, align 2
@@ -42,4 +42,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__default_values_for_not_initialized_function_vars.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__default_values_for_not_initialized_function_vars.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @func() {
+define i16 @func() section "fn-func:i16" {
 entry:
   %func = alloca i16, align 2
   %int_var = alloca i16, align 2
@@ -26,4 +26,3 @@ entry:
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__enum_variants_have_precedence_over_global_variables_in_inline_assignment.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__enum_variants_have_precedence_over_global_variables_in_inline_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @y = unnamed_addr constant i32 2
 @y.3 = unnamed_addr constant i32 4
 
-define i32 @foo() {
+define i32 @foo() section "fn-foo:i32" {
 entry:
   %foo = alloca i32, align 4
   %position = alloca i32, align 4
@@ -21,7 +21,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define i32 @bar() {
+define i32 @bar() section "fn-bar:i32" {
 entry:
   %bar = alloca i32, align 4
   %position = alloca i32, align 4
@@ -30,4 +30,3 @@ entry:
   %bar_ret = load i32, i32* %bar, align 4
   ret i32 %bar_ret
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_block_struct_initialized_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_block_struct_initialized_in_function.snap
@@ -11,12 +11,12 @@ source_filename = "main"
 @__fb__init = unnamed_addr constant %fb zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @fb(%fb* %0) {
+define void @fb(%fb* %0) section "fn-fb:v" {
 entry:
   ret void
 }
 
-define i32 @func(%fb %0) {
+define i32 @func(%fb %0) section "fn-func:i32[v]" {
 entry:
   %func = alloca i32, align 4
   %in = alloca %fb, align 8
@@ -29,7 +29,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %fb0 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %load_fb0 = load %fb, %fb* %fb0, align 1
@@ -41,4 +41,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__MyStruct__init = unnamed_addr constant %MyStruct zeroinitializer
 
-define i16 @foo_int() {
+define i16 @foo_int() section "fn-foo_int:i16" {
 entry:
   %foo_int = alloca i16, align 2
   store i16 0, i16* %foo_int, align 2
@@ -17,7 +17,7 @@ entry:
   ret i16 %foo_int_ret
 }
 
-define void @foo_str([11 x i8]* %0) {
+define void @foo_str([11 x i8]* %0) section "fn-foo_str:s8u11" {
 entry:
   %foo_str = alloca [11 x i8]*, align 8
   store [11 x i8]* %0, [11 x i8]** %foo_str, align 8
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @foo_arr([10 x float]* %0) {
+define void @foo_arr([10 x float]* %0) section "fn-foo_arr:v" {
 entry:
   %foo_arr = alloca [10 x float]*, align 8
   store [10 x float]* %0, [10 x float]** %foo_arr, align 8
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-define void @foo_struct(%MyStruct* %0) {
+define void @foo_struct(%MyStruct* %0) section "fn-foo_struct:v" {
 entry:
   %foo_struct = alloca %MyStruct*, align 8
   store %MyStruct* %0, %MyStruct** %foo_struct, align 8
@@ -55,4 +55,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized_with_type_initializer.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized_with_type_initializer.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @__myArray__init = unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4]
 
-define void @target([4 x i32]* %0) {
+define void @target([4 x i32]* %0) section "fn-target:v" {
 entry:
   %target = alloca [4 x i32]*, align 8
   store [4 x i32]* %0, [4 x i32]** %target, align 8
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -42,4 +42,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_with_initializers_is_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_with_initializers_is_initialized.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @__MyArr__init = unnamed_addr constant [10 x float] [float 0.000000e+00, float 0x3FF19999A0000000, float 0x40019999A0000000, float 0x400A666660000000, float 0x40119999A0000000, float 5.500000e+00, float 0x401A666660000000, float 0x401ECCCCC0000000, float 0x40219999A0000000, float 0x4023CCCCC0000000]
 @__MyStrct__init = unnamed_addr constant %MyStrct { i32 1, i32 2, i32 3 }
 
-define i16 @foo_int() {
+define i16 @foo_int() section "fn-foo_int:v" {
 entry:
   %foo_int = alloca i16, align 2
   store i16 7, i16* %foo_int, align 2
@@ -19,7 +19,7 @@ entry:
   ret i16 %foo_int_ret
 }
 
-define void @foo_str([11 x i8]* %0) {
+define void @foo_str([11 x i8]* %0) section "fn-foo_str:s8u11" {
 entry:
   %foo_str = alloca [11 x i8]*, align 8
   store [11 x i8]* %0, [11 x i8]** %foo_str, align 8
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-define void @foo_arr([10 x float]* %0) {
+define void @foo_arr([10 x float]* %0) section "fn-foo_arr:v" {
 entry:
   %foo_arr = alloca [10 x float]*, align 8
   store [10 x float]* %0, [10 x float]** %foo_arr, align 8
@@ -39,7 +39,7 @@ entry:
   ret void
 }
 
-define void @foo_strct(%MyStrct* %0) {
+define void @foo_strct(%MyStrct* %0) section "fn-foo_strct:v" {
 entry:
   %foo_strct = alloca %MyStrct*, align 8
   store %MyStrct* %0, %MyStrct** %foo_strct, align 8
@@ -53,4 +53,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_without_initializers_is_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_without_initializers_is_initialized.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__MyStrct__init = unnamed_addr constant %MyStrct zeroinitializer
 
-define i16 @foo_int() {
+define i16 @foo_int() section "fn-foo_int:v" {
 entry:
   %foo_int = alloca i16, align 2
   store i16 0, i16* %foo_int, align 2
@@ -17,7 +17,7 @@ entry:
   ret i16 %foo_int_ret
 }
 
-define void @foo_str([11 x i8]* %0) {
+define void @foo_str([11 x i8]* %0) section "fn-foo_str:s8u11" {
 entry:
   %foo_str = alloca [11 x i8]*, align 8
   store [11 x i8]* %0, [11 x i8]** %foo_str, align 8
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @foo_arr([10 x float]* %0) {
+define void @foo_arr([10 x float]* %0) section "fn-foo_arr:v" {
 entry:
   %foo_arr = alloca [10 x float]*, align 8
   store [10 x float]* %0, [10 x float]** %foo_arr, align 8
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-define void @foo_strct(%MyStrct* %0) {
+define void @foo_strct(%MyStrct* %0) section "fn-foo_strct:v" {
 entry:
   %foo_strct = alloca %MyStrct*, align 8
   store %MyStrct* %0, %MyStrct** %foo_strct, align 8
@@ -55,4 +55,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_constant_values_in_pou_variables.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_constant_values_in_pou_variables.snap
@@ -12,10 +12,9 @@ source_filename = "main"
 @LEN = unnamed_addr constant i16 20
 @prg_instance = global %prg { i16 24, i16 89 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v[i16][i16]" {
 entry:
   %my_len = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %my_size = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
   ret void
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_function_block_pou.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_function_block_pou.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @__FB__init = unnamed_addr constant %FB { i16 7, i16 0, i8 1, i8 0, float 0x400921CAC0000000, float 0.000000e+00 }
 @main_instance = global %main { %FB { i16 7, i16 0, i8 1, i8 0, float 0x400921CAC0000000, float 0.000000e+00 } }
 
-define void @FB(%FB* %0) {
+define void @FB(%FB* %0) section "fn-FB:v" {
 entry:
   %x = getelementptr inbounds %FB, %FB* %0, i32 0, i32 0
   %xx = getelementptr inbounds %FB, %FB* %0, i32 0, i32 1
@@ -22,9 +22,8 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %fb = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_program_pou.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_program_pou.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @Main_instance = global %Main { i16 7, i16 0, i8 1, i8 0, float 0x400921CAC0000000, float 0.000000e+00 }
 
-define void @Main(%Main* %0) {
+define void @Main(%Main* %0) section "fn-Main:v" {
 entry:
   %x = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %xx = getelementptr inbounds %Main, %Main* %0, i32 0, i32 1
@@ -19,4 +19,3 @@ entry:
   %zz = getelementptr inbounds %Main, %Main* %0, i32 0, i32 5
   ret void
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_in_function.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @__func.arr_var__init = unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4]
 
-define i16 @func() {
+define i16 @func() section "fn-func:i16" {
 entry:
   %func = alloca i16, align 2
   %arr_var = alloca [4 x i32], align 4
@@ -22,4 +22,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_type_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_type_in_function.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @__arr__init = unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4]
 
-define i16 @func() {
+define i16 @func() section "fn-func:i16" {
 entry:
   %func = alloca i16, align 2
   %arr_var = alloca [4 x i32], align 4
@@ -22,4 +22,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__memcpy_for_struct_initialization_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__memcpy_for_struct_initialization_in_function.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____func_a__init = unnamed_addr constant %__func_a zeroinitializer
 
-define i16 @func() {
+define i16 @func() section "fn-func:i16" {
 entry:
   %func = alloca i16, align 2
   %a = alloca %__func_a, align 8
@@ -24,4 +24,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__no_memcpy_for_struct_initialization_in_program.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__no_memcpy_for_struct_initialization_in_program.snap
@@ -11,9 +11,8 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @____prog_a__init = unnamed_addr constant %__prog_a zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   %a = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_are_referenced_correctly.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_are_referenced_correctly.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @y = unnamed_addr constant i32 2
 @y.2 = unnamed_addr constant i32 4
 
-define i32 @foo() {
+define i32 @foo() section "fn-foo:i32" {
 entry:
   %foo = alloca i32, align 4
   %position = alloca i32, align 4
@@ -20,7 +20,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define i32 @bar() {
+define i32 @bar() section "fn-bar:i32" {
 entry:
   %bar = alloca i32, align 4
   %position = alloca i32, align 4
@@ -29,4 +29,3 @@ entry:
   %bar_ret = load i32, i32* %bar, align 4
   ret i32 %bar_ret
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_with_similar_names_are_referenced_correctly.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_with_similar_names_are_referenced_correctly.snap
@@ -14,7 +14,7 @@ source_filename = "main"
 @y.5 = unnamed_addr constant i32 5
 @y.6 = unnamed_addr constant i32 5
 
-define i32 @a() {
+define i32 @a() section "fn-a:i32" {
 entry:
   %a = alloca i32, align 4
   %position = alloca i32, align 4
@@ -24,7 +24,7 @@ entry:
   ret i32 %a_ret
 }
 
-define i32 @aa() {
+define i32 @aa() section "fn-aa:i32" {
 entry:
   %aa = alloca i32, align 4
   %position = alloca i32, align 4
@@ -34,7 +34,7 @@ entry:
   ret i32 %aa_ret
 }
 
-define i32 @bb() {
+define i32 @bb() section "fn-bb:i32" {
 entry:
   %bb = alloca i32, align 4
   %position = alloca i32, align 4
@@ -44,7 +44,7 @@ entry:
   ret i32 %bb_ret
 }
 
-define i32 @b() {
+define i32 @b() section "fn-b:i32" {
 entry:
   %b = alloca i32, align 4
   %position = alloca i32, align 4
@@ -53,4 +53,3 @@ entry:
   %b_ret = load i32, i32* %b, align 4
   ret i32 %b_ret
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__array_of_struct_initialization.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__array_of_struct_initialization.snap
@@ -16,10 +16,9 @@ source_filename = "main"
 @__main.arr__init = unnamed_addr constant [2 x %myStruct] [%myStruct { i32 10, i32 20, [2 x i32] [i32 30, i32 40] }, %myStruct { i32 50, i32 60, [2 x i32] [i32 70, i32 80] }]
 @__main.alias_arr__init = unnamed_addr constant [2 x %myStruct] [%myStruct { i32 10, i32 20, [2 x i32] [i32 30, i32 40] }, %myStruct { i32 50, i32 60, [2 x i32] [i32 70, i32 80] }]
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %arr = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %alias_arr = getelementptr inbounds %main, %main* %0, i32 0, i32 1
   ret void
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__enums_with_inline_initializer_are_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__enums_with_inline_initializer_are_initialized.snap
@@ -21,7 +21,7 @@ source_filename = "main"
 @red = unnamed_addr constant i32 0
 @green = unnamed_addr constant i32 2
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %y = alloca i32, align 4
@@ -36,4 +36,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__initial_values_in_fb_variable.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__initial_values_in_fb_variable.snap
@@ -13,18 +13,17 @@ source_filename = "main"
 @__main.struct1__init = unnamed_addr constant %TON { i16 10, i16 17 }
 @__main.struct2__init = unnamed_addr constant %TON { i16 17, i16 10 }
 
-define void @TON(%TON* %0) {
+define void @TON(%TON* %0) section "fn-TON:v[i16][i16]" {
 entry:
   %a = getelementptr inbounds %TON, %TON* %0, i32 0, i32 0
   %b = getelementptr inbounds %TON, %TON* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %TEN = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %struct1 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
   %struct2 = getelementptr inbounds %main, %main* %0, i32 0, i32 2
   ret void
 }
-

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__skipped_field_members_for_array_of_structs_are_zero_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__skipped_field_members_for_array_of_structs_are_zero_initialized.snap
@@ -14,9 +14,8 @@ source_filename = "main"
 @__STRUCT2__init = unnamed_addr constant %STRUCT2 zeroinitializer
 @__main.var_init1__init = unnamed_addr constant [3 x %STRUCT1] [%STRUCT1 { i32 0, [2 x %STRUCT2] [%STRUCT2 { i32 1, i32 0 }, %STRUCT2 zeroinitializer] }, %STRUCT1 { i32 2, [2 x %STRUCT2] [%STRUCT2 { i32 1, i32 1 }, %STRUCT2 zeroinitializer] }, %STRUCT1 { i32 1, [2 x %STRUCT2] [%STRUCT2 { i32 1, i32 0 }, %STRUCT2 { i32 0, i32 2 }] }]
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var_init1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__a_global_variables_generates_in_separate_global_variables.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__a_global_variables_generates_in_separate_global_variables.snap
@@ -11,8 +11,7 @@ source_filename = "main"
 @gY = global i8 0
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_array_in_struct.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_array_in_struct.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @Main_instance = global %Main zeroinitializer
 @__MyStruct__init = unnamed_addr constant %MyStruct zeroinitializer
 
-define void @Main(%Main* %0) {
+define void @Main(%Main* %0) section "fn-Main:v" {
 entry:
   %m = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %field1 = getelementptr inbounds %MyStruct, %MyStruct* %m, i32 0, i32 0
@@ -19,4 +19,3 @@ entry:
   store i16 7, i16* %tmpVar, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_structs.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_structs.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @__OuterStruct__init = unnamed_addr constant %OuterStruct zeroinitializer
 @__InnerStruct__init = unnamed_addr constant %InnerStruct zeroinitializer
 
-define void @Main(%Main* %0) {
+define void @Main(%Main* %0) section "fn-Main:v" {
 entry:
   %m = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %out1 = getelementptr inbounds %OuterStruct, %OuterStruct* %m, i32 0, i32 0
@@ -24,4 +24,3 @@ entry:
   store i16 7, i16* %inner2, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__action_called_in_program.snap
@@ -9,17 +9,16 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   call void @prg.foo(%prg* %0)
   ret void
 }
 
-define void @prg.foo(%prg* %0) {
+define void @prg.foo(%prg* %0) section "fn-prg.foo:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_cast_int_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_cast_int_type_generated.snap
@@ -9,9 +9,8 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_negative_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_negative_type_generated.snap
@@ -9,9 +9,8 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_type_generated.snap
@@ -9,9 +9,8 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_generated.snap
@@ -9,9 +9,8 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_used.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_used.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [4 x i32], [4 x i32]* %x, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store i32 %tmpVar3, i32* %tmpVar1, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_negative_start_used.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_negative_start_used.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [6 x i32], [6 x i32]* %x, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store i32 %tmpVar3, i32* %tmpVar1, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_start_used.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_start_used.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [3 x i32], [3 x i32]* %x, i32 0, i32 0
@@ -21,4 +21,3 @@ entry:
   store i32 %tmpVar3, i32* %tmpVar1, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initialized.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initialized.snap
@@ -14,9 +14,8 @@ source_filename = "main"
 @__STRUCT2__init = unnamed_addr constant %STRUCT2 zeroinitializer
 @__mainProg.var_str1__init = unnamed_addr constant [5 x %STRUCT1] [%STRUCT1 { i16 1, [5 x %STRUCT2] [%STRUCT2 { i8 1, i32 128 }, %STRUCT2 { i8 0, i32 1024 }, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer] }, %STRUCT1 { i16 2, [5 x %STRUCT2] [%STRUCT2 { i8 1, i32 256 }, %STRUCT2 { i8 0, i32 2048 }, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer] }, %STRUCT1 zeroinitializer, %STRUCT1 zeroinitializer, %STRUCT1 zeroinitializer]
 
-define void @mainProg(%mainProg* %0) {
+define void @mainProg(%mainProg* %0) section "fn-mainProg:v" {
 entry:
   %var_str1 = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_is_initialized.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_is_initialized.snap
@@ -14,9 +14,8 @@ source_filename = "main"
 @__STRUCT2__init = unnamed_addr constant %STRUCT2 zeroinitializer
 @__mainProg.var_str1__init = unnamed_addr constant %STRUCT1 { i16 10, [11 x %STRUCT2] [%STRUCT2 { i8 1, i32 128 }, %STRUCT2 { i8 0, i32 1024 }, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer] }
 
-define void @mainProg(%mainProg* %0) {
+define void @mainProg(%mainProg* %0) section "fn-mainProg:v" {
 entry:
   %var_str1 = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_constant_expressions_in_case_selectors.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_constant_expressions_in_case_selectors.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 @UP = unnamed_addr constant i32 8
 @DOWN = unnamed_addr constant i32 15
 
-define i32 @drive() {
+define i32 @drive() section "fn-drive:i32" {
 entry:
   %drive = alloca i32, align 4
   %input = alloca i32, align 4
@@ -58,4 +58,3 @@ continue:                                         ; preds = %else, %case6, %case
   %drive_ret = load i32, i32* %drive, align 4
   ret i32 %drive_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_enum_expressions_in_case_selectors.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_enum_expressions_in_case_selectors.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @UP = unnamed_addr constant i32 8
 @DOWN = unnamed_addr constant i32 28
 
-define i32 @drive() {
+define i32 @drive() section "fn-drive:i32" {
 entry:
   %drive = alloca i32, align 4
   %input = alloca i32, align 4
@@ -59,4 +59,3 @@ continue:                                         ; preds = %else, %case6, %case
   %drive_ret = load i32, i32* %drive, align 4
   ret i32 %drive_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_multiple_labels_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_multiple_labels_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -36,4 +36,3 @@ else:                                             ; preds = %entry
 continue:                                         ; preds = %else, %case1, %case
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_ranges_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_ranges_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -37,4 +37,3 @@ range_else:                                       ; preds = %range_then, %else
 continue:                                         ; preds = %range_else, %case
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_bool_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_bool_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i8 1, i8* %z, align 1
@@ -18,4 +18,3 @@ entry:
   store i8 0, i8* %z, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   store i16 %2, i16* %z, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   store i16 %2, i16* %z, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_ints_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_ints_code_gen_test.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 -1, i32* %x, align 4
   store i32 65535, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_lreal_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_lreal_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   store float %2, float* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_real_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_real_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -19,4 +19,3 @@ entry:
   store float %tmpVar, float* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_member_access_from_method.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_member_access_from_method.snap
@@ -10,14 +10,14 @@ source_filename = "main"
 
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer
 
-define void @MyClass(%MyClass* %0) {
+define void @MyClass(%MyClass* %0) section "fn-MyClass:v" {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-MyClass.testMethod:v[i16]" {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
@@ -35,4 +35,3 @@ entry:
   %tmpVar = icmp eq i32 %2, %3
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_method_in_pou.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_method_in_pou.snap
@@ -12,14 +12,14 @@ source_filename = "main"
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @MyClass(%MyClass* %0) {
+define void @MyClass(%MyClass* %0) section "fn-MyClass:v" {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-MyClass.testMethod:v[i16]" {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
@@ -38,7 +38,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %cl = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -57,4 +57,3 @@ entry:
   call void @MyClass.testMethod(%MyClass* %cl, %MyClass.testMethod* %MyClass.testMethod_instance3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__complex_pointers.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__complex_pointers.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %X = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %arrX = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -42,4 +42,3 @@ entry:
   store i16 %load_tmpVar14, i16* %tmpVar11, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expression_in_function_blocks_are_propagated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expression_in_function_blocks_are_propagated.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @__fbWithConstant__init = unnamed_addr constant %fbWithConstant { i16 0, i16 2 }
 
-define void @fbWithConstant(%fbWithConstant* %0) {
+define void @fbWithConstant(%fbWithConstant* %0) section "fn-fbWithConstant:v" {
 entry:
   %x = getelementptr inbounds %fbWithConstant, %fbWithConstant* %0, i32 0, i32 0
   %const = getelementptr inbounds %fbWithConstant, %fbWithConstant* %0, i32 0, i32 1
   store i16 2, i16* %x, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expressions_in_ranged_type_declaration_are_propagated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expressions_in_ranged_type_declaration_are_propagated.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @MIN = unnamed_addr constant i16 7
 @prg_instance = global %prg zeroinitializer
 
-define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) {
+define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) section "fn-CheckRangeSigned:i16[i16][i16][i16]" {
 entry:
   %CheckRangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -26,11 +26,10 @@ entry:
   ret i16 %CheckRangeSigned_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i16 @CheckRangeSigned(i16 5, i16 0, i16 8)
   store i16 %call, i16* %x, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_propagation_of_struct_fields_on_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_propagation_of_struct_fields_on_assignment.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @MyStruct = unnamed_addr constant %STRUCT1 { i32 99 }
 @__STRUCT1__init = unnamed_addr constant %STRUCT1 zeroinitializer
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %local_value = alloca i32, align 4
@@ -21,4 +21,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__contants_in_case_statements_resolved.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__contants_in_case_statements_resolved.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i32 0, i32 60 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %DAYS_IN_MONTH = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %SIXTY = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -52,4 +52,3 @@ range_else6:                                      ; preds = %range_then5, %range
 continue:                                         ; preds = %range_else6, %case4, %case
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_addition_in_var_output.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_addition_in_var_output.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @func(i64* %0, i64* %1) {
+define i32 @func(i64* %0, i64* %1) section "fn-func:i32[pi64][pi64]" {
 entry:
   %func = alloca i32, align 4
   %d_and_t = alloca i64*, align 8
@@ -23,4 +23,3 @@ entry:
   %func_ret = load i32, i32* %func, align 4
   ret i32 %func_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_global_constants_initialize.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_global_constants_initialize.snap
@@ -25,7 +25,7 @@ source_filename = "main"
 @cLDT_SHORT = unnamed_addr constant i64 172799123000000
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %t1 = alloca i64, align 8
   %t2 = alloca i64, align 8
@@ -77,4 +77,3 @@ entry:
   store i64 172799123000000, i64* %ldt2, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_comparisons.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_comparisons.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -25,4 +25,3 @@ entry:
   %tmpVar3 = icmp sgt i64 %load_d, 70157000000000
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__default_values_for_not_initialized_function_vars.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__default_values_for_not_initialized_function_vars.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @func() {
+define i16 @func() section "fn-func:i16" {
 entry:
   %func = alloca i16, align 2
   %int_var = alloca i16, align 2
@@ -26,4 +26,3 @@ entry:
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__different_case_references.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__different_case_references.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @prg_instance = global %prg { i16 0, i16 1, i32 2 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
   %zz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_function_with_name_generates_int_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_function_with_name_generates_int_function.snap
@@ -5,11 +5,10 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @foo() {
+define i16 @foo() section "fn-foo:i16" {
 entry:
   %foo = alloca i16, align 2
   store i16 0, i16* %foo, align 2
   %foo_ret = load i16, i16* %foo, align 2
   ret i16 %foo_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_global_variable_list_generates_nothing.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_global_variable_list_generates_nothing.snap
@@ -9,8 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_program_with_name_generates_void_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_program_with_name_generates_void_function.snap
@@ -9,8 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_statements_dont_generate_anything.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_statements_dont_generate_anything.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -17,4 +17,3 @@ entry:
   %load_y = load i32, i32* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enum_members_can_be_used_in_asignments.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enum_members_can_be_used_in_asignments.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @yellow = unnamed_addr constant i32 1
 @green = unnamed_addr constant i32 2
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %color = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   store i32 0, i32* %color, align 4
@@ -20,4 +20,3 @@ entry:
   store i32 2, i32* %color, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enums_custom_type_are_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enums_custom_type_are_generated.snap
@@ -13,9 +13,8 @@ source_filename = "main"
 @Yellow = unnamed_addr constant i32 2
 @Green = unnamed_addr constant i32 3
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %tf1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_function_called_in_program.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-declare i32 @foo()
+declare i32 @foo() section "fn-foo:i32"
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %call = call i32 @foo()
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_global_variable_generates_as_external.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_global_variable_generates_as_external.snap
@@ -11,8 +11,7 @@ source_filename = "main"
 @gY = external global i8
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_program_global_var_is_external.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_program_global_var_is_external.snap
@@ -9,5 +9,4 @@ source_filename = "main"
 
 @prg_instance = external global %prg
 
-declare void @prg(%prg*)
-
+declare void @prg(%prg*) section "fn-prg:v"

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__fb_method_in_pou.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__fb_method_in_pou.snap
@@ -12,14 +12,14 @@ source_filename = "main"
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @MyClass(%MyClass* %0) {
+define void @MyClass(%MyClass* %0) section "fn-MyClass:v" {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-MyClass.testMethod:v[i16]" {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
@@ -38,7 +38,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %cl = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -57,4 +57,3 @@ entry:
   call void @MyClass.testMethod(%MyClass* %cl, %MyClass.testMethod* %MyClass.testMethod_instance3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_continue.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_continue.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4
@@ -74,4 +74,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_int.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_int.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i16 3, i16* %x, align 2
@@ -74,4 +74,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_lint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_lint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 3, i64* %x, align 4
@@ -74,4 +74,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_sint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_sint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i8 3, i8* %x, align 1
@@ -74,4 +74,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_continue.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_continue.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4
@@ -82,4 +82,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_exit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_exit.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4
@@ -82,4 +82,3 @@ continue:                                         ; preds = %for_body, %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_references_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_references_steps_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %step = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -83,4 +83,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_steps_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4
@@ -74,4 +74,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_without_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_without_steps_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4
@@ -74,4 +74,3 @@ continue:                                         ; preds = %13
   %23 = icmp ne i8 %22, 0
   br label %13
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_instance_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_instance_call.snap
@@ -11,17 +11,16 @@ source_filename = "main"
 @__foo__init = unnamed_addr constant %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[i16][i16]" {
 entry:
   %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %y = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %fb_inst = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   call void @foo(%foo* %fb_inst)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_qualified_instance_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_qualified_instance_call.snap
@@ -13,22 +13,21 @@ source_filename = "main"
 @__bar__init = unnamed_addr constant %bar zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v" {
 entry:
   %bar_inst = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   ret void
 }
 
-define void @bar(%bar* %0) {
+define void @bar(%bar* %0) section "fn-bar:v" {
 entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %foo_inst = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %bar_inst = getelementptr inbounds %foo, %foo* %foo_inst, i32 0, i32 0
   call void @bar(%bar* %bar_inst)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_call_with_same_name_as_return_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_call_with_same_name_as_return_type.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i64 @TIME() {
+define i64 @TIME() section "fn-TIME:i64" {
 entry:
   %TIME = alloca i64, align 8
   store i64 0, i64* %TIME, align 4
@@ -17,9 +17,8 @@ entry:
   ret i64 %TIME_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %call = call i64 @TIME()
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @foo() {
+define i32 @foo() section "fn-foo:i32" {
 entry:
   %foo = alloca i32, align 4
   store i32 0, i32* %foo, align 4
@@ -18,11 +18,10 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo()
   store i32 %call, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_when_shadowed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_when_shadowed.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @foo() {
+define i32 @foo() section "fn-foo:i32" {
 entry:
   %foo = alloca i32, align 4
   store i32 0, i32* %foo, align 4
@@ -18,11 +18,10 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %froo = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo()
   store i32 %call, i32* %froo, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_temp_var_initialization.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_temp_var_initialization.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @foo(i32 %0) {
+define i32 @foo(i32 %0) section "fn-foo:i32[i32]" {
 entry:
   %foo = alloca i32, align 4
   %in1 = alloca i32, align 4
@@ -30,9 +30,8 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %call = call i32 @foo(i32 5)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_var_initialization_and_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_var_initialization_and_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @foo(i32 %0) {
+define i32 @foo(i32 %0) section "fn-foo:i32[i32]" {
 entry:
   %foo = alloca i32, align 4
   %in1 = alloca i32, align 4
@@ -26,9 +26,8 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %call = call i32 @foo(i32 5)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_parameters_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @foo(i32 %0) {
+define i32 @foo(i32 %0) section "fn-foo:i32[i32]" {
 entry:
   %foo = alloca i32, align 4
   %bar = alloca i32, align 4
@@ -20,11 +20,10 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo(i32 2)
   store i32 %call, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_two_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_two_parameters_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @foo(i32 %0, i8 %1) {
+define i32 @foo(i32 %0, i8 %1) section "fn-foo:i32[i32][u8]" {
 entry:
   %foo = alloca i32, align 4
   %bar = alloca i32, align 4
@@ -22,11 +22,10 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo(i32 2, i8 1)
   store i32 %call, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__global_variable_reference_is_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__global_variable_reference_is_generated.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @gX = global i16 0
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i16 20, i16* @gX, align 2
@@ -18,4 +18,3 @@ entry:
   store i16 %load_gX, i16* %x, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_elsif_else_generator_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_elsif_else_generator_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -51,4 +51,3 @@ else:                                             ; preds = %branch1
 continue:                                         ; preds = %else, %condition_body3, %condition_body2, %condition_body
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_generator_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_generator_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -24,4 +24,3 @@ condition_body:                                   ; preds = %entry
 continue:                                         ; preds = %condition_body, %entry
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_with_expression_generator_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_with_expression_generator_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -37,4 +37,3 @@ continue:                                         ; preds = %condition_body, %5
   %8 = icmp ne i8 %7, 0
   br i1 %8, label %condition_body, label %continue
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__inlined_array_size_from_local_scoped_constants.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__inlined_array_size_from_local_scoped_constants.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @c = unnamed_addr constant i16 5
 @aaa_instance = global %aaa { i16 3, i16 7, [5 x i8] zeroinitializer, [3 x i8] zeroinitializer }
 
-define void @aaa(%aaa* %0) {
+define void @aaa(%aaa* %0) section "fn-aaa:v" {
 entry:
   %a = getelementptr inbounds %aaa, %aaa* %0, i32 0, i32 0
   %b = getelementptr inbounds %aaa, %aaa* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   %arr2 = getelementptr inbounds %aaa, %aaa* %0, i32 0, i32 3
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_return.snap
@@ -10,12 +10,12 @@ source_filename = "main"
 
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer
 
-define void @MyClass(%MyClass* %0) {
+define void @MyClass(%MyClass* %0) section "fn-MyClass:v" {
 entry:
   ret void
 }
 
-define i16 @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
+define i16 @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-MyClass.testMethod:i16[i16]" {
 entry:
   %myMethodArg = getelementptr inbounds %MyClass.testMethod, %MyClass.testMethod* %1, i32 0, i32 0
   %testMethod = alloca i16, align 2
@@ -24,4 +24,3 @@ entry:
   %MyClass.testMethod_ret = load i16, i16* %testMethod, align 2
   ret i16 %MyClass.testMethod_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_void.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_void.snap
@@ -10,12 +10,12 @@ source_filename = "main"
 
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer
 
-define void @MyClass(%MyClass* %0) {
+define void @MyClass(%MyClass* %0) section "fn-MyClass:v" {
 entry:
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-MyClass.testMethod:v[i16]" {
 entry:
   %myMethodArg = getelementptr inbounds %MyClass.testMethod, %MyClass.testMethod* %1, i32 0, i32 0
   %myMethodLocalVar = getelementptr inbounds %MyClass.testMethod, %MyClass.testMethod* %1, i32 0, i32 1
@@ -23,4 +23,3 @@ entry:
   store i16 1, i16* %myMethodLocalVar, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__min_max_real_and_lreal_values_do_not_result_in_an_under_or_overflow.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__min_max_real_and_lreal_values_do_not_result_in_an_under_or_overflow.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { float 0xC7EFFFFFE0000000, float 0x47EFFFFFE0000000, double 0xFFEFFFFFFFFFFFFF, double 0x7FEFFFFFFFFFFFFF }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %F32_MIN = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %F32_MAX = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -17,4 +17,3 @@ entry:
   %F64_MAX = getelementptr inbounds %main, %main* %0, i32 0, i32 3
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [8 x i32], [8 x i32]* %x, i32 0, i32 4
@@ -21,4 +21,3 @@ entry:
   store i32 %tmpVar3, i32* %tmpVar1, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_declaration.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_declaration.snap
@@ -9,9 +9,8 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [4 x [2 x i32]], [4 x [2 x i32]]* %x, i32 0, i32 2
@@ -24,4 +24,3 @@ entry:
   store i32 %tmpVar6, i32* %tmpVar3, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -39,4 +39,3 @@ entry:
   store i32 %tmpVar11, i32* %tmpVar6, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes_negative_start.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes_negative_start.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -42,4 +42,3 @@ entry:
   store i32 %tmpVar11, i32* %tmpVar6, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_declaration.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_declaration.snap
@@ -9,9 +9,8 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_function_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @bar() {
+define i32 @bar() section "fn-bar:i32" {
 entry:
   %bar = alloca i32, align 4
   store i32 0, i32* %bar, align 4
@@ -18,7 +18,7 @@ entry:
   ret i32 %bar_ret
 }
 
-define i32 @foo(i32 %0) {
+define i32 @foo(i32 %0) section "fn-foo:i32[i32]" {
 entry:
   %foo = alloca i32, align 4
   %in = alloca i32, align 4
@@ -29,7 +29,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @bar()
@@ -37,4 +37,3 @@ entry:
   store i32 %call1, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__order_var_and_var_temp_block.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__order_var_and_var_temp_block.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %temp = alloca i16, align 2
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   store i16 0, i16* %temp, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pass_inout_to_inout.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pass_inout_to_inout.snap
@@ -13,14 +13,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo2(%foo2* %0) {
+define void @foo2(%foo2* %0) section "fn-foo2:v[pi32][i32]" {
 entry:
   %inout = getelementptr inbounds %foo2, %foo2* %0, i32 0, i32 0
   %in = getelementptr inbounds %foo2, %foo2* %0, i32 0, i32 1
   ret void
 }
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[pi32]" {
 entry:
   %inout = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %deref = load i32*, i32** %inout, align 8
@@ -32,11 +32,10 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32* %baz, i32** getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 8
   call void @foo(%foo* @foo_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointer_and_array_access_to_in_out.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointer_and_array_access_to_in_out.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main(i16** %0, i16* %1) {
+define i16 @main(i16** %0, i16* %1) section "fn-main:i16[ppi16][pv]" {
 entry:
   %main = alloca i16, align 2
   %a = alloca i16**, align 8
@@ -26,4 +26,3 @@ entry:
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointers_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointers_generated.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %X = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %pX = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -32,4 +32,3 @@ entry:
   store i8 %load_X5, i8* %deref4, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_called_in_program.snap
@@ -11,14 +11,13 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v" {
 entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   call void @foo(%foo* @foo_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_and_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_and_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -26,4 +26,3 @@ entry:
   %5 = phi i1 [ %1, %entry ], [ %3, %2 ]
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_bool_variables_and_references_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_bool_variables_and_references_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -17,4 +17,3 @@ entry:
   %load_y = load i8, i8* %y, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_boolean_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_boolean_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i8 1, i8* %y, align 1
   store i8 0, i8* %y, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_casted_chars_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_casted_chars_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"B\00"
 @utf16_literal_0 = private unnamed_addr constant [2 x i16] [i16 65, i16 0]
 
-define void @mainPROG(%mainPROG* %0) {
+define void @mainPROG(%mainPROG* %0) section "fn-mainPROG:v" {
 entry:
   %x = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 0
   %y = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 1
@@ -19,4 +19,3 @@ entry:
   store i16 66, i16* %y, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_chars.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_chars.snap
@@ -15,7 +15,7 @@ source_filename = "main"
 @utf16_literal_2 = private unnamed_addr constant [2 x i16] [i16 39, i16 0]
 @utf16_literal_3 = private unnamed_addr constant [2 x i16] [i16 65, i16 0]
 
-define void @mainPROG(%mainPROG* %0) {
+define void @mainPROG(%mainPROG* %0) section "fn-mainPROG:v" {
 entry:
   %x = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 0
   %y = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 1
@@ -27,4 +27,3 @@ entry:
   store i16 34, i16* %y, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %w = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -29,4 +29,3 @@ entry:
   store i64 946757708123000000, i64* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment_whit_short_datatype_names.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment_whit_short_datatype_names.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %w = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -26,4 +26,3 @@ entry:
   store i64 58804123456789, i64* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_floats_variable_and_comparison_assignment_generates_correctly.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_floats_variable_and_comparison_assignment_generates_correctly.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -39,4 +39,3 @@ entry:
   store i8 %6, i8* %y, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_local_temp_var_initialization.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_local_temp_var_initialization.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @foo_instance = global %foo { i16 7 }
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v" {
 entry:
   %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %y = alloca i16, align 2
@@ -26,9 +26,8 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   call void @foo(%foo* @foo_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_long_date_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_long_date_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %w = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -25,4 +25,3 @@ entry:
   store i64 56190123456000, i64* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_combined_expressions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_combined_expressions_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -38,4 +38,3 @@ entry:
   %8 = phi i1 [ %tmpVar3, %3 ], [ %6, %5 ]
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_expressions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_expressions_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -30,4 +30,3 @@ entry:
   %6 = phi i1 [ %2, %entry ], [ %tmpVar2, %3 ]
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_or_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_or_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -26,4 +26,3 @@ entry:
   %5 = phi i1 [ %1, %entry ], [ %3, %2 ]
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_additions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_additions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -22,4 +22,3 @@ entry:
   store float %tmpVar, float* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store float 1.562500e-01, float* %y, align 4
@@ -17,4 +17,3 @@ entry:
   store float 1.000000e+03, float* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_cast_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_cast_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -18,4 +18,3 @@ entry:
   store float %1, float* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_signed_combined_expressions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_signed_combined_expressions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -23,4 +23,3 @@ entry:
   %tmpVar5 = add i32 %tmpVar4, 3
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_special_chars_in_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_special_chars_in_string.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf16_literal_0 = private unnamed_addr constant [19 x i16] [i16 36, i16 52, i16 51, i16 32, i16 36, i16 39, i16 110, i16 111, i16 32, i16 114, i16 101, i16 112, i16 108, i16 97, i16 99, i16 101, i16 36, i16 39, i16 0]
 @utf16_literal_1 = private unnamed_addr constant [41 x i16] [i16 97, i16 10, i16 10, i16 32, i16 98, i16 10, i16 10, i16 32, i16 99, i16 12, i16 12, i16 32, i16 100, i16 13, i16 13, i16 32, i16 101, i16 9, i16 9, i16 32, i16 36, i16 32, i16 34, i16 100, i16 111, i16 117, i16 98, i16 108, i16 101, i16 34, i16 32, i16 87, i16 -10179, i16 -9066, i16 -10179, i16 -9066, i16 0, i16 0, i16 0, i16 0, i16 0]
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %should_replace_s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %should_not_replace_s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -34,4 +34,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_string_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_string_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [12 x i8] c"im a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [18 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 117, i16 116, i16 102, i16 49, i16 54, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -26,4 +26,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 0, i64* %y, align 4
@@ -23,4 +23,3 @@ entry:
   store i64 8640000001000000, i64* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_of_day_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_of_day_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 0, i64* %y, align 4
@@ -22,4 +22,3 @@ entry:
   store i64 40260000000000, i64* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_explicit_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_explicit_parameters_called_in_program.snap
@@ -11,18 +11,17 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[i32][u8]" {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   store i8 1, i8* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 1), align 1
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4
   call void @foo(%foo* @foo_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_parameters_called_in_program.snap
@@ -11,18 +11,17 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[i32][u8]" {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4
   store i8 1, i8* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 1), align 1
   call void @foo(%foo* @foo_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_inout_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_inout_called_in_program.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[pi32]" {
 entry:
   %inout = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %deref = load i32*, i32** %inout, align 8
@@ -22,7 +22,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 7, i32* %baz, align 4
@@ -30,4 +30,3 @@ entry:
   call void @foo(%foo* @foo_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_in_program.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[i32][u8]" {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4
@@ -27,4 +27,3 @@ entry:
   store i8 %1, i8* %baz, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_mixed_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_mixed_in_program.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[i32][u8]" {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4
@@ -27,4 +27,3 @@ entry:
   store i8 %1, i8* %baz, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_addition_literal_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_addition_literal_generates_void_function_and_struct_and_body.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* %x, align 4
   %tmpVar = add i32 %load_x, 7
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_arithmatic_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_arithmatic_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -30,4 +30,3 @@ entry:
   store i32 %tmpVar8, i32* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_comparison_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_comparison_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -39,4 +39,3 @@ entry:
   store i8 %6, i8* %y, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,10 +9,9 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 7, i32* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_additions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_additions_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -18,4 +18,3 @@ entry:
   %tmpVar = add i32 %load_x, %load_y
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_references_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_references_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -17,4 +17,3 @@ entry:
   %load_y = load i32, i32* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_generates_void_function_and_struct.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_generates_void_function_and_struct.snap
@@ -9,10 +9,9 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_xor_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_xor_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -23,4 +23,3 @@ entry:
   store i8 %4, i8* %z, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_action_from_fb_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_action_from_fb_called_in_program.snap
@@ -11,23 +11,22 @@ source_filename = "main"
 @bar_instance = global %bar zeroinitializer
 @__fb__init = unnamed_addr constant %fb zeroinitializer
 
-define void @bar(%bar* %0) {
+define void @bar(%bar* %0) section "fn-bar:v" {
 entry:
   %fb_inst = getelementptr inbounds %bar, %bar* %0, i32 0, i32 0
   call void @fb.foo(%fb* %fb_inst)
   ret void
 }
 
-define void @fb(%fb* %0) {
+define void @fb(%fb* %0) section "fn-fb:v" {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
 }
 
-define void @fb.foo(%fb* %0) {
+define void @fb.foo(%fb* %0) section "fn-fb.foo:v" {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_foreign_action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_foreign_action_called_in_program.snap
@@ -11,22 +11,21 @@ source_filename = "main"
 @bar_instance = global %bar zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @bar(%bar* %0) {
+define void @bar(%bar* %0) section "fn-bar:v" {
 entry:
   call void @prg.foo(%prg* @prg_instance)
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
 
-define void @prg.foo(%prg* %0) {
+define void @prg.foo(%prg* %0) section "fn-prg.foo:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_local_action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_local_action_called_in_program.snap
@@ -9,17 +9,16 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   call void @prg.foo(%prg* @prg_instance)
   ret void
 }
 
-define void @prg.foo(%prg* %0) {
+define void @prg.foo(%prg* %0) section "fn-prg.foo:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__real_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__real_function_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define float @foo() {
+define float @foo() section "fn-foo:f32" {
 entry:
   %foo = alloca float, align 4
   store float 0.000000e+00, float* %foo, align 4
@@ -18,7 +18,7 @@ entry:
   ret float %foo_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call float @foo()
@@ -26,4 +26,3 @@ entry:
   store i32 %1, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_qualified_name.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_qualified_name.snap
@@ -13,13 +13,13 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer
 @prg_instance = global %prg zeroinitializer
 
-define void @fb(%fb* %0) {
+define void @fb(%fb* %0) section "fn-fb:v[i32]" {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
 }
 
-define void @foo(%foo* %0) {
+define void @foo(%foo* %0) section "fn-foo:v[i32][i32][v]" {
 entry:
   %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %y = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4
@@ -38,4 +38,3 @@ entry:
   store i32 %load_x1, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_to_reference_assignments_in_function_arguments.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_to_reference_assignments_in_function_arguments.snap
@@ -19,7 +19,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[pv][pv][pv]" {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %input2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   store %STRUCT_params* @global1, %STRUCT_params** getelementptr inbounds (%prog, %prog* @prog_instance, i32 0, i32 0), align 8
   store %STRUCT_params* @global2, %STRUCT_params** getelementptr inbounds (%prog, %prog* @prog_instance, i32 0, i32 1), align 8
@@ -39,4 +39,3 @@ entry:
   call void @prog(%prog* @prog_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__repeat_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__repeat_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %while_body
@@ -27,4 +27,3 @@ while_body:                                       ; preds = %entry, %condition_c
 continue:                                         ; preds = %condition_check
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @smaller_than_ten(i8 %0) {
+define i16 @smaller_than_ten(i8 %0) section "fn-smaller_than_ten:i16[i8]" {
 entry:
   %smaller_than_ten = alloca i16, align 2
   %n = alloca i8, align 1
@@ -29,4 +29,3 @@ continue:                                         ; preds = %buffer_block, %entr
   %smaller_than_ten_ret1 = load i16, i16* %smaller_than_ten, align 2
   ret i16 %smaller_than_ten_ret1
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function_block.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function_block.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__abcdef__init = unnamed_addr constant %abcdef zeroinitializer
 
-define void @abcdef(%abcdef* %0) {
+define void @abcdef(%abcdef* %0) section "fn-abcdef:v[i8]" {
 entry:
   %n = getelementptr inbounds %abcdef, %abcdef* %0, i32 0, i32 0
   %load_n = load i8, i8* %n, align 1
@@ -28,4 +28,3 @@ buffer_block:                                     ; No predecessors!
 continue:                                         ; preds = %buffer_block, %entry
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_i8_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_i8_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -39,4 +39,3 @@ else:                                             ; preds = %entry
 continue:                                         ; preds = %else, %case2, %case1, %case
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -39,4 +39,3 @@ else:                                             ; preds = %entry
 continue:                                         ; preds = %else, %case2, %case1, %case
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sizeof_works_in_binary_expression_with_different_size.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sizeof_works_in_binary_expression_with_different_size.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %i = alloca i32, align 4
@@ -23,4 +23,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__structs_members_can_be_referenced.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__structs_members_can_be_referenced.snap
@@ -11,11 +11,10 @@ source_filename = "main"
 @MainProg_instance = global %MainProg zeroinitializer
 @__MyStruct__init = unnamed_addr constant %MyStruct zeroinitializer
 
-define void @MainProg(%MainProg* %0) {
+define void @MainProg(%MainProg* %0) section "fn-MainProg:v" {
 entry:
   %Cord = getelementptr inbounds %MainProg, %MainProg* %0, i32 0, i32 0
   %a = getelementptr inbounds %MyStruct, %MyStruct* %Cord, i32 0, i32 0
   store i32 0, i32* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_check_functions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_check_functions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @CheckRangeSigned(i32 %0, i32 %1, i32 %2) {
+define i32 @CheckRangeSigned(i32 %0, i32 %1, i32 %2) section "fn-CheckRangeSigned:i32[i32][i32][i32]" {
 entry:
   %CheckRangeSigned = alloca i32, align 4
   %v = alloca i32, align 4
@@ -24,7 +24,7 @@ entry:
   ret i32 %CheckRangeSigned_ret
 }
 
-define i32 @CheckRangeUnsigned(i32 %0, i32 %1, i32 %2) {
+define i32 @CheckRangeUnsigned(i32 %0, i32 %1, i32 %2) section "fn-CheckRangeUnsigned:u32[u32][u32][u32]" {
 entry:
   %CheckRangeUnsigned = alloca i32, align 4
   %v = alloca i32, align 4
@@ -39,7 +39,7 @@ entry:
   ret i32 %CheckRangeUnsigned_ret
 }
 
-define i64 @CheckLRangeSigned(i64 %0, i64 %1, i64 %2) {
+define i64 @CheckLRangeSigned(i64 %0, i64 %1, i64 %2) section "fn-CheckLRangeSigned:i64[i64][i64][i64]" {
 entry:
   %CheckLRangeSigned = alloca i64, align 8
   %v = alloca i64, align 8
@@ -54,7 +54,7 @@ entry:
   ret i64 %CheckLRangeSigned_ret
 }
 
-define i64 @CheckLRangeUnsigned(i64 %0, i64 %1, i64 %2) {
+define i64 @CheckLRangeUnsigned(i64 %0, i64 %1, i64 %2) section "fn-CheckLRangeUnsigned:u64[u64][u64][u64]" {
 entry:
   %CheckLRangeUnsigned = alloca i64, align 8
   %v = alloca i64, align 8
@@ -69,7 +69,7 @@ entry:
   ret i64 %CheckLRangeUnsigned_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -109,4 +109,3 @@ entry:
   store i64 %call9, i64* %j, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_missing.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_missing.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @Main_instance = global %Main zeroinitializer
 
-define i16 @Check_XX_RangeSigned(i16 %0, i16 %1, i16 %2) {
+define i16 @Check_XX_RangeSigned(i16 %0, i16 %1, i16 %2) section "fn-Check_XX_RangeSigned:i16[i16][i16][i16]" {
 entry:
   %Check_XX_RangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -25,10 +25,9 @@ entry:
   ret i16 %Check_XX_RangeSigned_ret
 }
 
-define void @Main(%Main* %0) {
+define void @Main(%Main* %0) section "fn-Main:v" {
 entry:
   %x = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   store i16 7, i16* %x, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_on_assigment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_on_assigment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @Main_instance = global %Main zeroinitializer
 
-define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) {
+define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) section "fn-CheckRangeSigned:i16[i16][i16][i16]" {
 entry:
   %CheckRangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -25,11 +25,10 @@ entry:
   ret i16 %CheckRangeSigned_ret
 }
 
-define void @Main(%Main* %0) {
+define void @Main(%Main* %0) section "fn-Main:v" {
 entry:
   %x = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %call = call i16 @CheckRangeSigned(i16 7, i16 0, i16 100)
   store i16 %call, i16* %x, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__time_variables_have_nano_seconds_resolution.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__time_variables_have_nano_seconds_resolution.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 1000000, i64* %y, align 4
@@ -18,4 +18,3 @@ entry:
   store i64 8640000001125000, i64* %y, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__two_global_variables_generates_in_separate_global_variables.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__two_global_variables_generates_in_separate_global_variables.snap
@@ -12,8 +12,7 @@ source_filename = "main"
 @gA = global i16 0
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__typed_enums_are_used_properly.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__typed_enums_are_used_properly.snap
@@ -18,7 +18,7 @@ source_filename = "main"
 @yellow.5 = unnamed_addr constant i32 26
 @green.6 = unnamed_addr constant i32 27
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -28,4 +28,3 @@ entry:
   store i32 26, i32* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_cast_statement_as_const_expression.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_cast_statement_as_const_expression.snap
@@ -9,9 +9,8 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_const_expression_in_range_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_const_expression_in_range_type.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @MIN = global i16 7
 @prg_instance = global %prg zeroinitializer
 
-define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) {
+define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) section "fn-CheckRangeSigned:i16[i16][i16][i16]" {
 entry:
   %CheckRangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -27,7 +27,7 @@ entry:
   ret i16 %CheckRangeSigned_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_MIN = load i16, i16* @MIN, align 2
@@ -38,4 +38,3 @@ entry:
   store i16 %call, i16* %x, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_global_consts_in_expressions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_global_consts_in_expressions.snap
@@ -12,10 +12,9 @@ source_filename = "main"
 @cC = unnamed_addr constant i16 3
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 6, i32* %z, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__variable_with_same_name_as_data_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__variable_with_same_name_as_data_type.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prog_instance = global %prog zeroinitializer
 
-define i64 @func() {
+define i64 @func() section "fn-func:i64" {
 entry:
   %func = alloca i64, align 8
   %TIME = alloca i64, align 8
@@ -19,9 +19,8 @@ entry:
   ret i64 %func_ret
 }
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   %TIME = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_loop_with_if_exit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_loop_with_if_exit.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %condition_check
@@ -43,4 +43,3 @@ buffer_block:                                     ; No predecessors!
 continue3:                                        ; preds = %buffer_block, %while_body
   br label %condition_check
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %condition_check
@@ -26,4 +26,3 @@ while_body:                                       ; preds = %condition_check
 continue:                                         ; preds = %condition_check
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_with_expression_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_with_expression_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %condition_check
@@ -29,4 +29,3 @@ while_body:                                       ; preds = %condition_check
 continue:                                         ; preds = %condition_check
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_number_type_comparing_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_number_type_comparing_test.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %x = alloca i16, align 2
@@ -27,4 +27,3 @@ entry:
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_ranged_number_type_comparing_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_ranged_number_type_comparing_test.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %x = alloca i16, align 2
@@ -27,4 +27,3 @@ entry:
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_datetime_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_datetime_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var_time = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var_time_of_day = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -41,4 +41,3 @@ entry:
   %7 = zext i1 %6 to i8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instruction_functions_with_different_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instruction_functions_with_different_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define float @foo() {
+define float @foo() section "fn-foo:f32" {
 entry:
   %foo = alloca float, align 4
   store float 0.000000e+00, float* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret float %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %ptr_float = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -125,4 +125,3 @@ entry:
   %38 = zext i1 %tmpVar35 to i8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instructions_with_different_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instructions_with_different_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i64 @foo() {
+define i64 @foo() section "fn-foo:i64" {
 entry:
   %foo = alloca i64, align 8
   store i64 0, i64* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret i64 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %ptr_int = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -98,4 +98,3 @@ entry:
   %tmpVar35 = icmp eq i64 %call33, %load_var_lint34
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_compare_instructions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_compare_instructions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i16 10, i16 20, i16* null, i8 0 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -60,4 +60,3 @@ entry:
   store i8 %18, i8* %comp, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_function_call_compare_instructions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_function_call_compare_instructions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i64 @foo() {
+define i64 @foo() section "fn-foo:i64" {
 entry:
   %foo = alloca i64, align 8
   store i64 0, i64* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret i64 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %pt = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -61,4 +61,3 @@ entry:
   store i8 %12, i8* %comp, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__ranged_number_type_comparing_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__ranged_number_type_comparing_test.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %x = alloca i16, align 2
@@ -27,4 +27,3 @@ entry:
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_comparison_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_comparison_test.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"a\00"
 @utf08_literal_1 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_EQUAL:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -20,7 +20,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1
@@ -74,4 +74,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_equal_with_constant_test.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"a\00"
 @utf08_literal_1 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_EQUAL:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -20,7 +20,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1
@@ -74,4 +74,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_or_equal_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_GREATER([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_GREATER([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_GREATER:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_GREATER = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -19,7 +19,7 @@ entry:
   ret i8 %STRING_GREATER_ret
 }
 
-define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_EQUAL:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -31,7 +31,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1
@@ -94,4 +94,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_GREATER([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_GREATER([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_GREATER:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_GREATER = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -19,7 +19,7 @@ entry:
   ret i8 %STRING_GREATER_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1
@@ -55,4 +55,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_less_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_less_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_LESS([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_LESS([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_LESS:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_LESS = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -19,7 +19,7 @@ entry:
   ret i8 %STRING_LESS_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1
@@ -55,4 +55,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_not_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_not_equal_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_EQUAL:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -19,7 +19,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1
@@ -58,4 +58,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_smaller_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_smaller_or_equal_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_LESS([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_LESS([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_LESS:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_LESS = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -19,7 +19,7 @@ entry:
   ret i8 %STRING_LESS_ret
 }
 
-define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_EQUAL:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -31,7 +31,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1
@@ -94,4 +94,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_array_variable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_array_variable.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @const_arr = unnamed_addr constant [4 x i16] [i16 1, i16 2, i16 3, i16 4]
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %arr = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast [4 x i16]* %arr to i8*
@@ -22,4 +22,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_string_variable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_string_variable.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @const_str = unnamed_addr constant [81 x i8] c"global constant string\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %str = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast [81 x i8]* %str to i8*
@@ -22,4 +22,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_struct_variable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_struct_variable.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @__Point__init = unnamed_addr constant %Point zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %strct = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast %Point* %strct to i8*
@@ -24,4 +24,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__bitaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__bitaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   %a = alloca i8, align 1
@@ -33,4 +33,3 @@ entry:
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__byteaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__byteaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   %b = alloca i16, align 2
@@ -18,4 +18,3 @@ entry:
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__chained_bit_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__chained_bit_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   %d = alloca i64, align 8
@@ -18,4 +18,3 @@ entry:
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__dwordaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__dwordaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   %d = alloca i64, align 8
@@ -18,4 +18,3 @@ entry:
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__lwordaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__lwordaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   %d = alloca i64, align 8
@@ -18,4 +18,3 @@ entry:
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__qualified_reference_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__qualified_reference_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__myStruct__init = unnamed_addr constant %myStruct { i8 1 }
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   %str = alloca %myStruct, align 8
@@ -34,4 +34,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__wordaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__wordaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   %c = alloca i32, align 4
@@ -18,4 +18,3 @@ entry:
   %main_ret = load i16, i16* %main, align 2
   ret i16 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__access_string_via_byte_array.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__access_string_via_byte_array.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @baz_instance = global %baz zeroinitializer
 
-define void @baz(%baz* %0) {
+define void @baz(%baz* %0) section "fn-baz:v" {
 entry:
   %str = getelementptr inbounds %baz, %baz* %0, i32 0, i32 0
   %ptr = getelementptr inbounds %baz, %baz* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   store [10 x i8]* %2, [10 x i8]** %bytes, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__allowed_assignable_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__allowed_assignable_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %v = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -36,4 +36,3 @@ entry:
   store i16 %or7, i16* %tmpVar5, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -28,4 +28,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4
@@ -33,4 +33,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -29,4 +29,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -20,4 +20,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4
@@ -20,4 +20,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -21,4 +21,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_adr.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_adr.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -18,4 +18,3 @@ entry:
   store i32* %2, i32** %a, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_lower_bound.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_lower_bound.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-define i32 @foo(%__foo_vla* %0) {
+define i32 @foo(%__foo_vla* %0) section "fn-foo:i32[pv]" {
 entry:
   %foo = alloca i32, align 4
   %vla = alloca %__foo_vla*, align 8
@@ -44,4 +44,3 @@ entry:
   %foo_ret = load i32, i32* %foo, align 4
   ret i32 %foo_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_move.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_move.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -17,4 +17,3 @@ entry:
   store i32 %load_b, i32* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -49,4 +49,3 @@ continue_block:                                   ; preds = %entry, %5, %4, %3, 
   store i32 %6, i32* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux_with_aggregate_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux_with_aggregate_type.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf08_literal_2 = private unnamed_addr constant [6 x i8] c"lorem\00"
 @utf08_literal_3 = private unnamed_addr constant [4 x i8] c"sit\00"
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %str1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_ref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_ref.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
   store i32* %b, i32** %a, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   store i32 %1, i32* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel_as_expression.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel_as_expression.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store i32 %tmpVar, i32* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sizeof.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sizeof.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
   store i32 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i32), i32* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-define i32 @foo(%__foo_vla* %0) {
+define i32 @foo(%__foo_vla* %0) section "fn-foo:i32[pv]" {
 entry:
   %foo = alloca i32, align 4
   %vla = alloca %__foo_vla*, align 8
@@ -44,4 +44,3 @@ entry:
   %foo_ret = load i32, i32* %foo, align 4
   ret i32 %foo_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound_expr.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound_expr.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-define i32 @foo(%__foo_vla* %0) {
+define i32 @foo(%__foo_vla* %0) section "fn-foo:i32[pv]" {
 entry:
   %foo = alloca i32, align 4
   %vla = alloca %__foo_vla*, align 8
@@ -45,4 +45,3 @@ entry:
   %foo_ret = load i32, i32* %foo, align 4
   ret i32 %foo_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -28,4 +28,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4
@@ -33,4 +33,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -29,4 +29,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -20,4 +20,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4
@@ -20,4 +20,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4
@@ -21,4 +21,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__calling_strings_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__calling_strings_in_function_return.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define void @func([81 x i8]* %0) {
+define void @func([81 x i8]* %0) section "fn-func:s8u81" {
 entry:
   %func = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %func, align 8
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1
@@ -42,4 +42,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_between_pointer_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_between_pointer_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @baz_instance = global %baz zeroinitializer
 
-define void @baz(%baz* %0) {
+define void @baz(%baz* %0) section "fn-baz:v" {
 entry:
   %ptr_x = getelementptr inbounds %baz, %baz* %0, i32 0, i32 0
   %y = getelementptr inbounds %baz, %baz* %0, i32 0, i32 1
@@ -17,4 +17,3 @@ entry:
   store i8* %1, i8** %ptr_x, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_lword_to_pointer.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_lword_to_pointer.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %ptr_x = alloca i16*, align 8
@@ -19,4 +19,3 @@ entry:
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_pointer_to_lword.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_pointer_to_lword.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   %ptr_x = alloca i16*, align 8
@@ -19,4 +19,3 @@ entry:
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__compare_date_time_literals.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__compare_date_time_literals.snap
@@ -1,6 +1,5 @@
 ---
 source: src/codegen/tests/expression_tests.rs
-assertion_line: 538
 expression: result
 ---
 ; ModuleID = 'main'
@@ -10,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %cmp1 = alloca i8, align 1
   %cmp2 = alloca i8, align 1
@@ -38,4 +37,3 @@ entry:
   store i8 1, i8* %cmp8, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_assign_codegen.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_assign_codegen.snap
@@ -9,11 +9,10 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_codegen.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_codegen.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -22,4 +22,3 @@ entry:
   store i8 0, i8* %z, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__max_int.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__max_int.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() {
+define i16 @main() section "fn-main:i16" {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -31,5 +31,4 @@ entry:
   ret i16 %main_ret
 }
 
-declare i16 @MAX__INT(i32, i16*)
-
+declare i16 @MAX__INT(i32, i16*) section "fn-MAX__INT:i16"

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__nested_call_statements.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__nested_call_statements.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0) {
+define i32 @foo(i32 %0) section "fn-foo:i32[i32]" {
 entry:
   %foo = alloca i32, align 4
   %a = alloca i32, align 4
@@ -19,10 +19,9 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %call = call i32 @foo(i32 2)
   %call1 = call i32 @foo(i32 %call)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i16 10, i16 20, i16* null }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -60,4 +60,3 @@ entry:
   store i16* %access___main_pt25, i16** %pt, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i64 @foo() {
+define i64 @foo() section "fn-foo:i64" {
 entry:
   %foo = alloca i64, align 8
   store i64 0, i64* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret i64 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %pt = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -28,4 +28,3 @@ entry:
   store i16* %access___main_pt, i16** %pt, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointers_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointers_in_function_return.snap
@@ -5,11 +5,10 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16* @func() {
+define i16* @func() section "fn-func:pi16" {
 entry:
   %func = alloca i16*, align 8
   store i16* null, i16** %func, align 8
   %func_ret = load i16*, i16** %func, align 8
   ret i16* %func_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__strings_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__strings_in_function_return.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define void @func([81 x i8]* %0, [81 x i8]* %1) {
+define void @func([81 x i8]* %0, [81 x i8]* %1) section "fn-func:s8u81[ps8u81]" {
 entry:
   %func = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %func, align 8
@@ -33,4 +33,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__structs_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__structs_in_function_return.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
 
-define void @func(%myStruct* %0, %myStruct* %1) {
+define void @func(%myStruct* %0, %myStruct* %1) section "fn-func:v[pv]" {
 entry:
   %func = alloca %myStruct*, align 8
   store %myStruct* %0, %myStruct** %func, align 8
@@ -25,4 +25,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__type_mix_in_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__type_mix_in_call.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @foo(i16 %0) {
+define i16 @foo(i16 %0) section "fn-foo:i16[i16]" {
 entry:
   %foo = alloca i16, align 2
   %in = alloca i16, align 2
@@ -15,7 +15,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i16 @baz() {
+define i16 @baz() section "fn-baz:i16" {
 entry:
   %baz = alloca i16, align 2
   store i16 0, i16* %baz, align 2
@@ -23,4 +23,3 @@ entry:
   %baz_ret = load i16, i16* %baz, align 2
   ret i16 %baz_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unary_expressions_can_be_real.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unary_expressions_can_be_real.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -19,4 +19,3 @@ entry:
   store float %tmpVar, float* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unnecessary_casts_between_pointer_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unnecessary_casts_between_pointer_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @baz_instance = global %baz zeroinitializer
 
-define void @baz(%baz* %0) {
+define void @baz(%baz* %0) section "fn-baz:v" {
 entry:
   %ptr = getelementptr inbounds %baz, %baz* %0, i32 0, i32 0
   %b = getelementptr inbounds %baz, %baz* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   store i8* %mb, i8** %ptr, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__argument_fed_by_ref_then_by_val.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__argument_fed_by_ref_then_by_val.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [5 x i32], align 4
@@ -18,7 +18,7 @@ entry:
   ret i32 %main_ret
 }
 
-define i32 @fn_by_ref(i32* %0) {
+define i32 @fn_by_ref(i32* %0) section "fn-fn_by_ref:i32[pv]" {
 entry:
   %fn_by_ref = alloca i32, align 4
   %arg_by_ref = alloca i32*, align 8
@@ -32,7 +32,7 @@ entry:
   ret i32 %fn_by_ref_ret
 }
 
-define i32 @fn_by_val([5 x i32] %0) {
+define i32 @fn_by_val([5 x i32] %0) section "fn-fn_by_val:i32[v]" {
 entry:
   %fn_by_val = alloca i32, align 4
   %arg_by_val = alloca [5 x i32], align 4
@@ -46,4 +46,3 @@ entry:
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__autocast_argument_literals_for_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__autocast_argument_literals_for_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @func(i8* %0, i16* %1, i32* %2, i64* %3, float* %4, double* %5) {
+define i32 @func(i8* %0, i16* %1, i32* %2, i64* %3, float* %4, double* %5) section "fn-func:i32[pi8][pi16][pi32][pi64][pf32][pf64]" {
 entry:
   %func = alloca i32, align 4
   %byInt1 = alloca i8*, align 8
@@ -30,7 +30,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %1 = alloca i8, align 1
   store i8 1, i8* %1, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__bitcast_argument_references_for_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__bitcast_argument_references_for_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i8 1, i8 1, i16 2, i16 2, i32 3, i32 3, i64 4, i64 4, float 5.000000e+00, float 5.000000e+00, double 6.000000e+00, double 6.000000e+00 }
 
-define i8 @fn_sint(i8* %0, i8* %1) {
+define i8 @fn_sint(i8* %0, i8* %1) section "fn-fn_sint:i8[pi8][pi8]" {
 entry:
   %fn_sint = alloca i8, align 1
   %in_ref = alloca i8*, align 8
@@ -21,7 +21,7 @@ entry:
   ret i8 %fn_sint_ret
 }
 
-define i64 @fn_lint(i64* %0, i64* %1) {
+define i64 @fn_lint(i64* %0, i64* %1) section "fn-fn_lint:i64[pi64][pi64]" {
 entry:
   %fn_lint = alloca i64, align 8
   %in_ref = alloca i64*, align 8
@@ -33,7 +33,7 @@ entry:
   ret i64 %fn_lint_ret
 }
 
-define i64 @fn_real(float* %0, float* %1) {
+define i64 @fn_real(float* %0, float* %1) section "fn-fn_real:i64[pf32][pf32]" {
 entry:
   %fn_real = alloca i64, align 8
   %in_ref = alloca float*, align 8
@@ -45,7 +45,7 @@ entry:
   ret i64 %fn_real_ret
 }
 
-define i64 @fn_lreal(double* %0, double* %1) {
+define i64 @fn_lreal(double* %0, double* %1) section "fn-fn_lreal:i64[pf64][pf64]" {
 entry:
   %fn_lreal = alloca i64, align 8
   %in_ref = alloca double*, align 8
@@ -57,7 +57,7 @@ entry:
   ret i64 %fn_lreal_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1_sint = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2_sint = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_ref_sized_string_varargs_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_ref_sized_string_varargs_called_in_program.snap
@@ -12,9 +12,9 @@ source_filename = "main"
 @utf08_literal_1 = private unnamed_addr constant [4 x i8] c"abc\00"
 @utf08_literal_2 = private unnamed_addr constant [7 x i8] c"abcdef\00"
 
-declare i32 @foo(i32, i8**)
+declare i32 @foo(i32, i8**) section "fn-foo:i32"
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %1 = alloca [3 x i8*], align 8
@@ -29,4 +29,3 @@ entry:
   store i32 %call, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_sized_varargs_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_sized_varargs_called_in_program.snap
@@ -9,9 +9,9 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-declare i32 @foo(i32, i32*)
+declare i32 @foo(i32, i32*) section "fn-foo:i32"
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* %x, align 4
@@ -28,4 +28,3 @@ entry:
   store i32 %call, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_varargs_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_varargs_called_in_program.snap
@@ -9,9 +9,9 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-declare i32 @foo(...)
+declare i32 @foo(...) section "fn-foo:i32"
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* %x, align 4
@@ -20,4 +20,3 @@ entry:
   store i32 %call, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__literal_string_argument_passed_by_ref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__literal_string_argument_passed_by_ref.snap
@@ -10,9 +10,9 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-declare void @func([81 x i8]*, i8*)
+declare void @func([81 x i8]*, i8*) section "fn-func:s8u81[ps8u81]"
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %res = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1
@@ -27,4 +27,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__member_variables_in_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__member_variables_in_body.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @func(i16 %0, i8* %1, i64* %2) {
+define i32 @func(i16 %0, i8* %1, i64* %2) section "fn-func:i32[i16][pi8][pi64]" {
 entry:
   %func = alloca i32, align 4
   %i = alloca i16, align 2
@@ -41,4 +41,3 @@ entry:
   %func_ret = load i32, i32* %func, align 4
   ret i32 %func_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__on_functions_var_output_should_be_passed_as_a_pointer.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__on_functions_var_output_should_be_passed_as_a_pointer.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @bump(i8* %0) {
+define i32 @bump(i8* %0) section "fn-bump:i32[pi8]" {
 entry:
   %bump = alloca i32, align 4
   %v = alloca i8*, align 8
@@ -17,4 +17,3 @@ entry:
   %bump_ret = load i32, i32* %bump, align 4
   ret i32 %bump_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"12345\00"
 
-define i32 @func([6 x i8] %0) {
+define i32 @func([6 x i8] %0) section "fn-func:i32[s8u6]" {
 entry:
   %func = alloca i32, align 4
   %x = alloca [6 x i8], align 1
@@ -20,7 +20,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [6 x i8], align 1
@@ -49,4 +49,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function_as_reference.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function_as_reference.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"12345\00"
 
-define i32 @func(i8* %0) {
+define i32 @func(i8* %0) section "fn-func:i32[ps8u6]" {
 entry:
   %func = alloca i32, align 4
   %x = alloca i8*, align 8
@@ -20,7 +20,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast [6 x i8]* %a to i8*
@@ -28,4 +28,3 @@ entry:
   %call1 = call i32 @func(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_0, i32 0, i32 0))
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_arguments_to_functions_by_ref_and_val.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_arguments_to_functions_by_ref_and_val.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @func(i16* %0, i32* %1, i16 %2, i32 %3) {
+define i32 @func(i16* %0, i32* %1, i16 %2, i32 %3) section "fn-func:i32[pi16][pi32][i16][i32]" {
 entry:
   %func = alloca i32, align 4
   %byRef1 = alloca i16*, align 8
@@ -38,7 +38,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %1 = alloca i16, align 2
   store i16 1, i16* %1, align 2
@@ -47,4 +47,3 @@ entry:
   %call = call i32 @func(i16* %1, i32* %2, i16 3, i32 4)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__return_variable_in_nested_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__return_variable_in_nested_call.snap
@@ -5,7 +5,7 @@ expression: codegen(src)
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4
@@ -20,7 +20,7 @@ entry:
   ret i32 %main_ret
 }
 
-define i32 @SMC_Read(i64 %0) {
+define i32 @SMC_Read(i64 %0) section "fn-SMC_Read:i32[u64]" {
 entry:
   %SMC_Read = alloca i32, align 4
   %ValAddr = alloca i64, align 8
@@ -29,4 +29,3 @@ entry:
   %SMC_Read_ret = load i32, i32* %SMC_Read, align 4
   ret i32 %SMC_Read_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__simple_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__simple_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @func(i32 %0) {
+define i32 @func(i32 %0) section "fn-func:i32[i32]" {
 entry:
   %func = alloca i32, align 4
   %x = alloca i32, align 4
@@ -19,7 +19,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %load_a = load i32, i32* %a, align 4
@@ -30,4 +30,3 @@ entry:
   %call3 = call i32 @func(i32 %tmpVar)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__var_output_in_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__var_output_in_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i16 4 }
 
-define i32 @func(i16* %0) {
+define i32 @func(i16* %0) section "fn-func:i32[pi16]" {
 entry:
   %func = alloca i32, align 4
   %o = alloca i16*, align 8
@@ -22,10 +22,9 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %call = call i32 @func(i16* %x)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__any_real_function_called_with_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__any_real_function_called_with_ints.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define float @foo__REAL(float %0) {
+define float @foo__REAL(float %0) section "fn-foo__REAL:f32[f32]" {
 entry:
   %foo__REAL = alloca float, align 4
   %in1 = alloca float, align 4
@@ -19,7 +19,7 @@ entry:
   ret float %foo__REAL_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %res_sint = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %res_int = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -56,5 +56,4 @@ entry:
   ret void
 }
 
-declare double @foo__LREAL(double)
-
+declare double @foo__LREAL(double) section "fn-foo__LREAL:f64[f64]"

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_call_gets_cast_to_biggest_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_call_gets_cast_to_biggest_type.snap
@@ -5,7 +5,7 @@ expression: codegen(src)
 ; ModuleID = 'main'
 source_filename = "main"
 
-define double @main() {
+define double @main() section "fn-main:f64" {
 entry:
   %main = alloca double, align 8
   store double 0.000000e+00, double* %main, align 8
@@ -25,5 +25,4 @@ entry:
   ret double %main_ret
 }
 
-declare double @MAX__LREAL(i32, double*)
-
+declare double @MAX__LREAL(i32, double*) section "fn-MAX__LREAL:f64"

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_function_call_generates_real_type_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_function_call_generates_real_type_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i32 @MAX__DINT(i32 %0, i32 %1) {
+define i32 @MAX__DINT(i32 %0, i32 %1) section "fn-MAX__DINT:i32[i32][i32]" {
 entry:
   %MAX__DINT = alloca i32, align 4
   %in1 = alloca i32, align 4
@@ -21,7 +21,7 @@ entry:
   ret i32 %MAX__DINT_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -32,5 +32,4 @@ entry:
   ret void
 }
 
-declare i16 @MAX__INT(i16, i16)
-
+declare i16 @MAX__INT(i16, i16) section "fn-MAX__INT:i16[i16][i16]"

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_output_parameter.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_output_parameter.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define i16 @foo__INT(i64 %0, i16* %1) {
+define i16 @foo__INT(i64 %0, i16* %1) section "fn-foo__INT:i16[i64][pi16]" {
 entry:
   %foo__INT = alloca i16, align 2
   %in1 = alloca i64, align 8
@@ -21,7 +21,7 @@ entry:
   ret i16 %foo__INT_ret
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %theInt = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %iResult = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -31,4 +31,3 @@ entry:
   store i16 %call, i16* %iResult, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_in_module.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_in_module.snap
@@ -18,9 +18,8 @@ source_filename = "prog.st"
 @prog_instance = global %prog zeroinitializer
 @__myStruct__init = external global %myStruct.1
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_no_deps_in_module.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_no_deps_in_module.snap
@@ -16,9 +16,8 @@ source_filename = "prog.st"
 
 @prog_instance = global %prog zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_initialized_in_external_file_in_module.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_initialized_in_external_file_in_module.snap
@@ -12,9 +12,8 @@ source_filename = "prog.st"
 
 @prog_instance = global %prog { i16 5 }
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__enum_referenced_in_fb_nested.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__enum_referenced_in_fb_nested.snap
@@ -16,7 +16,7 @@ source_filename = "fb.st"
 
 @__fb__init = unnamed_addr constant %fb zeroinitializer
 
-define void @fb(%fb* %0) {
+define void @fb(%fb* %0) section "fn-fb:v" {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
@@ -31,7 +31,7 @@ source_filename = "myStruct.st"
 @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
 @__fb__init = external global %fb.2
 
-declare void @fb(%fb.2*)
+declare void @fb(%fb.2*) section "fn-fb:v"
 
 ; ModuleID = 'fb2.st'
 source_filename = "fb2.st"
@@ -44,13 +44,13 @@ source_filename = "fb2.st"
 @__myStruct__init = external global %myStruct.4
 @__fb__init = external global %fb.5
 
-define void @fb2(%fb2* %0) {
+define void @fb2(%fb2* %0) section "fn-fb2:v" {
 entry:
   %x = getelementptr inbounds %fb2, %fb2* %0, i32 0, i32 0
   ret void
 }
 
-declare void @fb(%fb.5*)
+declare void @fb(%fb.5*) section "fn-fb:v"
 
 ; ModuleID = 'fb3.st'
 source_filename = "fb3.st"
@@ -59,8 +59,7 @@ source_filename = "fb3.st"
 
 @__fb3__init = unnamed_addr constant %fb3 zeroinitializer
 
-define void @fb3(%fb3* %0) {
+define void @fb3(%fb3* %0) section "fn-fb3:v" {
 entry:
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__function_defined_in_external_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__function_defined_in_external_file.snap
@@ -5,7 +5,7 @@ expression: "codegen_multi(units, crate::DebugLevel::None).join(\"\\n\")"
 ; ModuleID = 'func.st'
 source_filename = "func.st"
 
-define i32 @func() {
+define i32 @func() section "fn-func:i32" {
 entry:
   %func = alloca i32, align 4
   store i32 0, i32* %func, align 4
@@ -20,7 +20,7 @@ source_filename = "fb.st"
 
 @__fb__init = unnamed_addr constant %fb zeroinitializer
 
-define void @fb(%fb* %0) {
+define void @fb(%fb* %0) section "fn-fb:v" {
 entry:
   ret void
 }
@@ -32,7 +32,7 @@ source_filename = "prg.st"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
@@ -45,7 +45,7 @@ source_filename = "prg2.st"
 
 @prg2_instance = global %prg2 zeroinitializer
 
-define void @prg2(%prg2* %0) {
+define void @prg2(%prg2* %0) section "fn-prg2:v" {
 entry:
   %b = getelementptr inbounds %prg2, %prg2* %0, i32 0, i32 0
   ret void
@@ -64,7 +64,7 @@ source_filename = "prog.st"
 @prg_instance = external global %prg.5
 @prg2_instance = external global %prg2.6
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   %myFb = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %load_a = load i32, i32* getelementptr inbounds (%prg.5, %prg.5* @prg_instance, i32 0, i32 0), align 4
@@ -74,11 +74,10 @@ entry:
   ret void
 }
 
-declare void @fb(%fb.4*)
+declare void @fb(%fb.4*) section "fn-fb:v"
 
-declare void @prg(%prg.5*)
+declare void @prg(%prg.5*) section "fn-prg:v"
 
-declare void @prg2(%prg2.6*)
+declare void @prg2(%prg2.6*) section "fn-prg2:v"
 
-declare i32 @func()
-
+declare i32 @func() section "fn-func:i32"

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__global_value_from_different_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__global_value_from_different_file.snap
@@ -26,9 +26,8 @@ source_filename = "prog.st"
 @c = external global i32
 @x = external global i32
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   store i32 7, i32* @x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__struct_with_custom_init_in_different_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__struct_with_custom_init_in_different_file.snap
@@ -28,10 +28,9 @@ source_filename = "prog.st"
 @__myStruct2__init = external global %myStruct2.3
 @__prog.x__init = unnamed_addr constant %myStruct.2 { i32 5, i16 2 }
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v" {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %y = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_input_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_input_param.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @__fb_t__init = unnamed_addr constant %fb_t zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @fb_t(%fb_t* %0) {
+define void @fb_t(%fb_t* %0) section "fn-fb_t:v[i32][i32]" {
 entry:
   %in1 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %in2 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %fb = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = getelementptr inbounds %fb_t, %fb_t* %fb, i32 0, i32 0
@@ -26,4 +26,3 @@ entry:
   call void @fb_t(%fb_t* %fb)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_output_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_output_param.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @__fb_t__init = unnamed_addr constant %fb_t zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @fb_t(%fb_t* %0) {
+define void @fb_t(%fb_t* %0) section "fn-fb_t:v[i32][i32]" {
 entry:
   %out1 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %out2 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %fb = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -28,4 +28,3 @@ entry:
   store i32 %2, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_input_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_input_param.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @foo(i32 %0, i32 %1) {
+define void @foo(i32 %0, i32 %1) section "fn-foo:v[i32][i32]" {
 entry:
   %in1 = alloca i32, align 4
   store i32 %0, i32* %in1, align 4
@@ -18,11 +18,10 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %1 = alloca i32, align 4
   %2 = load i32, i32* %1, align 4
   call void @foo(i32 1, i32 %2)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_output_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_output_param.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define void @foo(i32* %0, i32* %1) {
+define void @foo(i32* %0, i32* %1) section "fn-foo:v[pi32][pi32]" {
 entry:
   %out1 = alloca i32*, align 8
   store i32* %0, i32** %out1, align 8
@@ -18,11 +18,10 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca i32, align 4
   call void @foo(i32* %x, i32* %1)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_all_parameters_assigned.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_all_parameters_assigned.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -36,4 +36,3 @@ entry:
   %call4 = call i32 @foo(i32 %load_var13, i32* %var2, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_default_value_parameter_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_default_value_parameter_type.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2, i32* %3) {
+define i32 @foo(i32 %0, i32* %1, i32* %2, i32* %3) section "fn-foo:i32[i32][pi32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -25,7 +25,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -37,4 +37,3 @@ entry:
   %call = call i32 @foo(i32 20, i32* %2, i32* %1, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_inout_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_inout_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -33,4 +33,3 @@ entry:
   %call = call i32 @foo(i32 %load_var1, i32* %var2, i32* %1)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_input_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_input_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -33,4 +33,3 @@ entry:
   %call = call i32 @foo(i32 %2, i32* %var2, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -33,4 +33,3 @@ entry:
   %call = call i32 @foo(i32 %load_var1, i32* %1, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_default_value_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_default_value_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -34,4 +34,3 @@ entry:
   %call = call i32 @foo(i32 %load_var1, i32* %1, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_inout_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_inout_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -33,4 +33,3 @@ entry:
   %call = call i32 @foo(i32 %load_var1, i32* %var2, i32* %1)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -33,4 +33,3 @@ entry:
   %call = call i32 @foo(i32 %2, i32* %var2, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_default_value_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_default_value_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -31,4 +31,3 @@ entry:
   %call = call i32 @foo(i32 10, i32* %var2, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -33,4 +33,3 @@ entry:
   %call = call i32 @foo(i32 %load_var1, i32* %1, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_default_value_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_default_value_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) {
+define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-foo:i32[i32][pi32][pi32]" {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -34,4 +34,3 @@ entry:
   %call = call i32 @foo(i32 %load_var1, i32* %1, i32* %var3)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__parameters_behind_function_block_pointer_are_assigned_to.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__parameters_behind_function_block_pointer_are_assigned_to.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @__file_t__init = unnamed_addr constant %file_t zeroinitializer
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %file = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %FileOpen = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -23,10 +23,9 @@ entry:
   ret void
 }
 
-define void @file_t(%file_t* %0) {
+define void @file_t(%file_t* %0) section "fn-file_t:v[u8][u8]" {
 entry:
   %var1 = getelementptr inbounds %file_t, %file_t* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %file_t, %file_t* %0, i32 0, i32 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_input_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_input_param.snap
@@ -11,17 +11,16 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[i32][i32]" {
 entry:
   %in1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %in2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   store i32 1, i32* getelementptr inbounds (%prog, %prog* @prog_instance, i32 0, i32 0), align 4
   call void @prog(%prog* @prog_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_output_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_output_param.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[i32][i32]" {
 entry:
   %out1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %out2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -20,7 +20,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   call void @prog(%prog* @prog_instance)
@@ -28,4 +28,3 @@ entry:
   store i32 %1, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_explicit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_explicit.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[i32][i32][pi32]" {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -38,4 +38,3 @@ entry:
   store i32 %2, i32* %var2, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_implicit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_implicit.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[i32][i32][pi32]" {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -32,4 +32,3 @@ entry:
   store i32 %1, i32* %var2, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_empty_inout_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_empty_inout_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[i32][i32][pi32]" {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -33,4 +33,3 @@ entry:
   store i32 %1, i32* %var2, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_input_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_input_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[i32][i32][pi32]" {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -30,4 +30,3 @@ entry:
   store i32 %1, i32* %var2, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_output_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_output_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer
 @main_instance = global %main zeroinitializer
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[i32][i32][pi32]" {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -30,4 +30,3 @@ entry:
   call void @prog(%prog* @prog_instance)
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__var_in_out_params_can_be_out_of_order.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__var_in_out_params_can_be_out_of_order.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @mainProg_instance = global %mainProg zeroinitializer
 @__fb_t__init = unnamed_addr constant %fb_t zeroinitializer
 
-define void @mainProg(%mainProg* %0) {
+define void @mainProg(%mainProg* %0) section "fn-mainProg:v" {
 entry:
   %fb = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 0
   %out1 = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 1
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-define void @fb_t(%fb_t* %0) {
+define void @fb_t(%fb_t* %0) section "fn-fb_t:v[u8][pu8][u8][pu8]" {
 entry:
   %myVar = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %myInput = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1
@@ -45,7 +45,7 @@ entry:
   ret void
 }
 
-define void @fb_t.foo(%fb_t* %0) {
+define void @fb_t.foo(%fb_t* %0) section "fn-fb_t.foo:v" {
 entry:
   %myVar = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %myInput = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1
@@ -58,4 +58,3 @@ entry:
   store i8 %load_myOtherInOut, i8* %deref, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__bitaccess_generated_as_rsh_and_trunc_i1.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__bitaccess_generated_as_rsh_and_trunc_i1.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__byteaccess_generated_as_rsh_and_trunc_i8.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__byteaccess_generated_as_rsh_and_trunc_i8.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -28,4 +28,3 @@ entry:
   store i8 %3, i8* %a, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__dwordaccess_generated_as_rsh_and_trunc_i32.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__dwordaccess_generated_as_rsh_and_trunc_i32.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -28,4 +28,3 @@ entry:
   store i32 %3, i32* %a, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__floating_point_type_casting.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__floating_point_type_casting.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @fn() {
+define i32 @fn() section "fn-fn:i32" {
 entry:
   %fn = alloca i32, align 4
   %a = alloca float, align 4
@@ -30,4 +30,3 @@ entry:
   %fn_ret = load i32, i32* %fn, align 4
   ret i32 %fn_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
@@ -5,9 +5,9 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-declare void @CONCAT([1025 x i8]*, [1025 x i8], [1025 x i8])
+declare void @CONCAT([1025 x i8]*, [1025 x i8], [1025 x i8]) section "fn-CONCAT:s8u1025[s8u1025][s8u1025]"
 
-define i8 @LIST_ADD([1001 x i8] %0, [2 x i8] %1) {
+define i8 @LIST_ADD([1001 x i8] %0, [2 x i8] %1) section "fn-LIST_ADD:u8[s8u1001][s8u2]" {
 entry:
   %LIST_ADD = alloca i8, align 1
   %INS = alloca [1001 x i8], align 1
@@ -46,4 +46,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
@@ -5,9 +5,9 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-declare void @CONCAT([1025 x i8]*, [1025 x i8], [1025 x i8])
+declare void @CONCAT([1025 x i8]*, [1025 x i8], [1025 x i8]) section "fn-CONCAT:s8u1025[s8u1025][s8u1025]"
 
-define i8 @LIST_ADD([1001 x i8] %0, [2 x i8] %1) {
+define i8 @LIST_ADD([1001 x i8] %0, [2 x i8] %1) section "fn-LIST_ADD:u8[s8u1001][s8u2]" {
 entry:
   %LIST_ADD = alloca i8, align 1
   %INS = alloca [1001 x i8], align 1
@@ -46,4 +46,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__nested_bitwise_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__nested_bitwise_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__variable_based_bitwise_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__variable_based_bitwise_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__wordaccess_generated_as_rsh_and_trunc_i16.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__wordaccess_generated_as_rsh_and_trunc_i16.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -28,4 +28,3 @@ entry:
   store i16 %3, i16* %a, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__casted_string_assignment_uses_memcpy.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__casted_string_assignment_uses_memcpy.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [4 x i8] c"abc\00"
 @utf16_literal_0 = private unnamed_addr constant [4 x i16] [i16 97, i16 98, i16 99, i16 0]
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -30,4 +30,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returning_generic_string_should_return_by_ref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returning_generic_string_should_return_by_ref.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @utf08_literal_0 = private unnamed_addr constant [4 x i8] c"abc\00"
 
-define void @MID__STRING([81 x i8]* %0, i8* %1, i32 %2, i32 %3) {
+define void @MID__STRING([81 x i8]* %0, i8* %1, i32 %2, i32 %3) section "fn-MID__STRING:s8u81[ps8u81][i32][i32]" {
 entry:
   %MID__STRING = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %MID__STRING, align 8
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v[s8u61][s8u81]" {
 entry:
   %fmt = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -50,4 +50,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returns_a_literal_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returns_a_literal_string.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @utf08_literal_0 = private unnamed_addr constant [4 x i8] c"abc\00"
 
-define void @ret([81 x i8]* %0) {
+define void @ret([81 x i8]* %0) section "fn-ret:s8u81" {
 entry:
   %ret = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %ret, align 8
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %str = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1
@@ -42,4 +42,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_takes_string_paramter_and_returns_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_takes_string_paramter_and_returns_string.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @utf08_literal_0 = private unnamed_addr constant [154 x i8] c"abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc\00"
 
-define void @read_string([81 x i8]* %0, [81 x i8] %1) {
+define void @read_string([81 x i8]* %0, [81 x i8] %1) section "fn-read_string:s8u81[s8u81]" {
 entry:
   %read_string = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %read_string, align 8
@@ -26,7 +26,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %text1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1
@@ -51,4 +51,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_var_constant_strings_should_be_collected_as_literals.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_var_constant_strings_should_be_collected_as_literals.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"#\00"
 @utf08_literal_1 = private unnamed_addr constant [2 x i8] c"*\00"
 
-define i64 @FSTRING_TO_DT() {
+define i64 @FSTRING_TO_DT() section "fn-FSTRING_TO_DT:v" {
 entry:
   %FSTRING_TO_DT = alloca i64, align 8
   %ignore = alloca [2 x i8], align 1
@@ -35,4 +35,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_string_output.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_string_output.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [7 x i8] c"string\00"
 @utf16_literal_0 = private unnamed_addr constant [8 x i16] [i16 119, i16 115, i16 116, i16 114, i16 105, i16 110, i16 103, i16 0]
 
-define void @prog(%prog* %0) {
+define void @prog(%prog* %0) section "fn-prog:v[s8u81][s16u81]" {
 entry:
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -24,7 +24,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -40,4 +40,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_casted_string_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_casted_string_assignment.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf16_literal_0 = private unnamed_addr constant [12 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 @utf16_literal_1 = private unnamed_addr constant [18 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 117, i16 116, i16 102, i16 49, i16 54, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -28,4 +28,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_string_type_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_string_type_assignment.snap
@@ -14,7 +14,7 @@ source_filename = "main"
 @utf08_literal_1 = private unnamed_addr constant [17 x i8] c"im also a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [17 x i16] [i16 105, i16 109, i16 32, i16 97, i16 108, i16 115, i16 111, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -32,4 +32,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__string_function_parameters.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__string_function_parameters.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @__prg.s__init = unnamed_addr constant [11 x i8] c"hello\00\00\00\00\00\00"
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define i16 @foo([81 x i8] %0) {
+define i16 @foo([81 x i8] %0) section "fn-foo:i16[s8u81]" {
 entry:
   %foo = alloca i16, align 2
   %s = alloca [81 x i8], align 1
@@ -25,7 +25,7 @@ buffer_block:                                     ; No predecessors!
   ret i16 %foo_ret1
 }
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -60,4 +60,3 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
 attributes #1 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @__FSTRING_TO_DT.ignore__init = unnamed_addr constant [2 x i8] c"*\00"
 @__FSTRING_TO_DT.fchar__init = unnamed_addr constant [2 x i8] c"#\00"
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-STRING_EQUAL:u8[ps8u1025][ps8u1025]" {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca i8*, align 8
@@ -20,7 +20,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i64 @FSTRING_TO_DT() {
+define i64 @FSTRING_TO_DT() section "fn-FSTRING_TO_DT:v" {
 entry:
   %FSTRING_TO_DT = alloca i64, align 8
   %ignore = alloca [2 x i8], align 1
@@ -55,4 +55,3 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) 
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
 attributes #1 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable_nonref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable_nonref.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @__FSTRING_TO_DT.ignore__init = unnamed_addr constant [2 x i8] c"*\00"
 @__FSTRING_TO_DT.fchar__init = unnamed_addr constant [2 x i8] c"#\00"
 
-define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) {
+define i8 @STRING_EQUAL([1025 x i8] %0, [1025 x i8] %1) section "fn-STRING_EQUAL:u8[s8u1025][s8u1025]" {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -20,7 +20,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i64 @FSTRING_TO_DT() {
+define i64 @FSTRING_TO_DT() section "fn-FSTRING_TO_DT:v" {
 entry:
   %FSTRING_TO_DT = alloca i64, align 8
   %ignore = alloca [2 x i8], align 1
@@ -70,4 +70,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
 attributes #1 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_can_be_created.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_can_be_created.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [12 x i8] c"im a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [12 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -30,4 +30,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_using_constants_can_be_created.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_using_constants_can_be_created.snap
@@ -15,7 +15,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [12 x i8] c"im a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [12 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -32,4 +32,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_string_assignment_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_string_assignment_test.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @prg_instance = global %prg { [16 x i8] zeroinitializer, [31 x i8] c"xyz\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00" }
 @__prg.z__init = unnamed_addr constant [31 x i8] c"xyz\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -27,4 +27,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__vartmp_string_init_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__vartmp_string_init_test.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @prg_instance = global %prg zeroinitializer
 @__prg.z__init = unnamed_addr constant [31 x i8] c"xyz\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %y = alloca [16 x i8], align 1
   %z = alloca [31 x i8], align 1
@@ -29,4 +29,3 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noa
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
 attributes #1 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__aliased_datatypes_respect_conversion_rules.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__aliased_datatypes_respect_conversion_rules.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -26,4 +26,3 @@ entry:
   store i8 %2, i8* %b, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_larger_than_int_promote_the_second_operand.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_larger_than_int_promote_the_second_operand.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store i64 %tmpVar, i64* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_smaller_than_dint_promoted_to_dint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_smaller_than_dint_promoted_to_dint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store i32 %tmpVar, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__even_all_sint_expressions_fallback_to_dint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__even_all_sint_expressions_fallback_to_dint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -23,4 +23,3 @@ entry:
   store i8 %3, i8* %x, align 1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_and_double_mix_converted_to_double.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_and_double_mix_converted_to_double.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store double %tmpVar, double* %c, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assigned_to_int_is_cast.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assigned_to_int_is_cast.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -22,4 +22,3 @@ entry:
   store i16 %2, i16* %b, align 2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assinged_to_double_to_double.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assinged_to_double_to_double.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -18,4 +18,3 @@ entry:
   store double %1, double* %b, align 8
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_assigned_to_float_is_cast.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_assigned_to_float_is_cast.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -22,4 +22,3 @@ entry:
   store float %2, float* %c, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_byte_promoted_on_compare_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_byte_promoted_on_compare_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -19,4 +19,3 @@ entry:
   %tmpVar = icmp slt i64 %load_b, %1
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_float_converted_to_double.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_float_converted_to_double.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -20,4 +20,3 @@ entry:
   %tmpVar = fadd double %1, %2
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_smaller_or_equal_to_float_converted_to_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_smaller_or_equal_to_float_converted_to_float.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store float %tmpVar, float* %c, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__numerical_promotion_for_variadic_functions_without_declaration.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__numerical_promotion_for_variadic_functions_without_declaration.snap
@@ -10,9 +10,9 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer
 @__main.s__init = unnamed_addr constant [81 x i8] c"\0A numbers: %f %f %f %d \0A \0A\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 
-declare i32 @printf(i8*, ...)
+declare i32 @printf(i8*, ...) section "fn-printf:i32[ps8u81]"
 
-define void @main(%main* %0) {
+define void @main(%main* %0) section "fn-main:v" {
 entry:
   %s = alloca [81 x i8], align 1
   %float = alloca float, align 4
@@ -37,4 +37,3 @@ entry:
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__small_int_varargs_get_promoted_while_32bit_and_higher_keep_their_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__small_int_varargs_get_promoted_while_32bit_and_higher_keep_their_type.snap
@@ -8,9 +8,9 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [26 x i8] c"(d) result : %d %d %d %u\0A\00"
 @utf08_literal_1 = private unnamed_addr constant [27 x i8] c"(hd) result : %hd %hd %hd\0A\00"
 
-declare i32 @printf(i8*, ...)
+declare i32 @printf(i8*, ...) section "fn-printf:i32[ps8u81]"
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %out1 = alloca i16, align 2
@@ -36,4 +36,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__unsingned_datatypes_smaller_than_dint_promoted_to_dint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__unsingned_datatypes_smaller_than_dint_promoted_to_dint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer
 
-define void @prg(%prg* %0) {
+define void @prg(%prg* %0) section "fn-prg:v" {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -21,4 +21,3 @@ entry:
   store i32 %tmpVar, i32* %x, align 4
   ret void
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__consecutive_calls_with_differently_sized_arrays.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__consecutive_calls_with_differently_sized_arrays.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define i16 @foo(%__foo_vla %0) {
+define i16 @foo(%__foo_vla %0) section "fn-foo:i16[v]" {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -55,7 +55,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [60 x i16], align 2
@@ -91,4 +91,3 @@ entry:
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__global_variable_passed_to_function_as_vla.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__global_variable_passed_to_function_as_vla.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @arr = global [2 x i16] zeroinitializer
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define i16 @foo(%__foo_vla %0) {
+define i16 @foo(%__foo_vla %0) section "fn-foo:i16[v]" {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -30,7 +30,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   store i32 0, i32* %main, align 4
@@ -45,4 +45,3 @@ entry:
   %main_ret = load i32, i32* %main, align 4
   ret i32 %main_ret
 }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__internal_vla_struct_is_generated_for_call_statements.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__internal_vla_struct_is_generated_for_call_statements.snap
@@ -9,14 +9,14 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define void @foo(%__foo_vla %0) {
+define void @foo(%__foo_vla %0) section "fn-foo:v[v]" {
 entry:
   %vla = alloca %__foo_vla, align 8
   store %__foo_vla %0, %__foo_vla* %vla, align 8
   ret void
 }
 
-define void @bar() {
+define void @bar() section "fn-bar:v" {
 entry:
   %arr = alloca [2 x i16], align 2
   %0 = bitcast [2 x i16]* %arr to i8*
@@ -37,4 +37,3 @@ entry:
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__multi_dimensional_vla.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__multi_dimensional_vla.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define i16 @foo(%__foo_vla %0) {
+define i16 @foo(%__foo_vla %0) section "fn-foo:i16[v]" {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -55,7 +55,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [20 x i16], align 2
@@ -79,4 +79,3 @@ entry:
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
 
-define i16 @foo(%__foo_vla %0) {
+define i16 @foo(%__foo_vla %0) section "fn-foo:i16[v]" {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -30,7 +30,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [2 x i16], align 2
@@ -54,4 +54,3 @@ entry:
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
 
 attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-

--- a/src/tests/adr/arrays_adr.rs
+++ b/src/tests/adr/arrays_adr.rs
@@ -73,7 +73,7 @@ fn assigning_full_arrays() {
     @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9] }
     @__Data__init = unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -126,7 +126,7 @@ fn accessing_array_elements() {
     @__Data__init = unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
     @__prg.b__init = unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/enum_adr.rs
+++ b/src/tests/adr/enum_adr.rs
@@ -129,7 +129,7 @@ fn using_enums() {
     @open.1 = unnamed_addr constant i32 8
     @closed.2 = unnamed_addr constant i32 16
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/pou_adr.rs
+++ b/src/tests/adr/pou_adr.rs
@@ -235,7 +235,7 @@ fn codegen_of_a_program_pou() {
 
     @main_prg_instance = global %main_prg zeroinitializer
 
-    define void @main_prg(%main_prg* %0) {
+    define void @main_prg(%main_prg* %0) section "fn-main_prg:v[i16][pi16][i16]" {
     entry:
       %i = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 1
@@ -273,7 +273,7 @@ fn calling_a_program() {
 
     @main_prg_instance = global %main_prg zeroinitializer
 
-    define i16 @foo() {
+    define i16 @foo() section "fn-foo:i16" {
     entry:
       %foo = alloca i16, align 2
       %x = alloca i16, align 2
@@ -290,7 +290,7 @@ fn calling_a_program() {
       ret i16 %foo_ret
     }
 
-    define void @main_prg(%main_prg* %0) {
+    define void @main_prg(%main_prg* %0) section "fn-main_prg:v[i16][pi16][i16]" {
     entry:
       %i = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 1
@@ -337,7 +337,7 @@ fn function_blocks_get_a_method_with_a_self_parameter() {
 
     @__main_fb__init = unnamed_addr constant %main_fb { i16 6, i16* null, i16 0, i16 1 }
 
-    define void @main_fb(%main_fb* %0) {
+    define void @main_fb(%main_fb* %0) section "fn-main_fb:v[i16][pi16][i16]" {
     entry:
       %i = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 1
@@ -378,7 +378,7 @@ fn calling_a_function_block() {
     @foo_instance = global %foo { i16 0, i16 0, %main_fb { i16 6, i16* null, i16 0, i16 1 } }
     @__main_fb__init = unnamed_addr constant %main_fb { i16 6, i16* null, i16 0, i16 1 }
 
-    define void @foo(%foo* %0) {
+    define void @foo(%foo* %0) section "fn-foo:v" {
     entry:
       %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
       %y = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
@@ -394,7 +394,7 @@ fn calling_a_function_block() {
       ret void
     }
 
-    define void @main_fb(%main_fb* %0) {
+    define void @main_fb(%main_fb* %0) section "fn-main_fb:v[i16][pi16][i16]" {
     entry:
       %i = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 1
@@ -431,7 +431,7 @@ fn function_get_a_method_with_by_ref_parameters() {
     ; ModuleID = 'main'
     source_filename = "main"
 
-    define i32 @main_fun(i16 %0, i8* %1, i64* %2) {
+    define i32 @main_fun(i16 %0, i8* %1, i64* %2) section "fn-main_fun:i32[i16][pi8][pi64]" {
     entry:
       %main_fun = alloca i32, align 4
       %i = alloca i16, align 2
@@ -477,7 +477,7 @@ fn calling_a_function() {
 
     @prg_instance = global %prg zeroinitializer
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -487,7 +487,7 @@ fn calling_a_function() {
       ret void
     }
 
-    define i32 @main_fun(i16 %0, i8* %1, i64* %2) {
+    define i32 @main_fun(i16 %0, i8* %1, i64* %2) section "fn-main_fun:i32[i16][pi8][pi64]" {
     entry:
       %main_fun = alloca i32, align 4
       %i = alloca i16, align 2
@@ -540,7 +540,7 @@ fn return_a_complex_type_from_function() {
     @prg_instance = global %prg zeroinitializer
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
-    define void @foo([81 x i8]* %0) {
+    define void @foo([81 x i8]* %0) section "fn-foo:s8u81" {
     entry:
       %foo = alloca [81 x i8]*, align 8
       store [81 x i8]* %0, [81 x i8]** %foo, align 8
@@ -553,7 +553,7 @@ fn return_a_complex_type_from_function() {
       ret void
     }
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %1 = alloca [81 x i8], align 1
@@ -610,7 +610,7 @@ fn passing_by_ref_to_functions() {
 
     @main_instance = global %main zeroinitializer
 
-    define i8 @StrEqual(i8* %0, i8* %1) {
+    define i8 @StrEqual(i8* %0, i8* %1) section "fn-StrEqual:u8[ps8u81][ps8u81]" {
     entry:
       %StrEqual = alloca i8, align 1
       %o1 = alloca i8*, align 8
@@ -622,7 +622,7 @@ fn passing_by_ref_to_functions() {
       ret i8 %StrEqual_ret
     }
 
-    define void @main(%main* %0) {
+    define void @main(%main* %0) section "fn-main:v" {
     entry:
       %str1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
       %str2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/tests/adr/strings_adr.rs
+++ b/src/tests/adr/strings_adr.rs
@@ -70,7 +70,7 @@ fn assigning_strings() {
 
     @prg_instance = global %prg zeroinitializer
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -113,7 +113,7 @@ fn assigning_string_literals() {
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/structs_adr.rs
+++ b/src/tests/adr/structs_adr.rs
@@ -103,7 +103,7 @@ fn initializing_a_struct() {
     @__prg.rect1__init = unnamed_addr constant %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }
     @__prg.rect2__init = unnamed_addr constant %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } }
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %rect1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %rect2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -146,7 +146,7 @@ fn assigning_structs() {
     @prg_instance = global %prg zeroinitializer
     @__Point__init = unnamed_addr constant %Point zeroinitializer
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %p1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %p2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -204,7 +204,7 @@ fn accessing_struct_members() {
     @__Rect__init = unnamed_addr constant %Rect zeroinitializer
     @__Point__init = unnamed_addr constant %Point zeroinitializer
 
-    define void @prg(%prg* %0) {
+    define void @prg(%prg* %0) section "fn-prg:v" {
     entry:
       %rect1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %rect2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/vla_adr.rs
+++ b/src/tests/adr/vla_adr.rs
@@ -318,7 +318,7 @@ fn pass() {
 
     @____foo_arr__init = unnamed_addr constant %__foo_arr zeroinitializer
 
-    define i32 @main() {
+    define i32 @main() section "fn-main:i32" {
     entry:
       %main = alloca i32, align 4
       %local = alloca [6 x i32], align 4
@@ -340,7 +340,7 @@ fn pass() {
       ret i32 %main_ret
     }
 
-    define i32 @foo(%__foo_arr* %0) {
+    define i32 @foo(%__foo_arr* %0) section "fn-foo:i32[pv]" {
     entry:
       %foo = alloca i32, align 4
       %arr = alloca %__foo_arr*, align 8
@@ -384,7 +384,7 @@ fn access() {
 
     @____foo_arr__init = unnamed_addr constant %__foo_arr zeroinitializer
 
-    define i32 @foo(%__foo_arr* %0) {
+    define i32 @foo(%__foo_arr* %0) section "fn-foo:i32[pv]" {
     entry:
       %foo = alloca i32, align 4
       %arr = alloca %__foo_arr*, align 8
@@ -435,58 +435,58 @@ fn multi_dimensional() {
     // is borderline incomprehensible as a result, if not given readable names.
     insta::assert_snapshot!(codegen(src),
     @r###"
-        ; ModuleID = 'main'
-        source_filename = "main"
+    ; ModuleID = 'main'
+    source_filename = "main"
 
-        %__foo_arr = type { i32*, [4 x i32] }
+    %__foo_arr = type { i32*, [4 x i32] }
 
-        @____foo_arr__init = unnamed_addr constant %__foo_arr zeroinitializer
+    @____foo_arr__init = unnamed_addr constant %__foo_arr zeroinitializer
 
-        define i32 @foo(%__foo_arr* %0) {
-        entry:
-          %foo = alloca i32, align 4
-          %arr = alloca %__foo_arr*, align 8
-          store %__foo_arr* %0, %__foo_arr** %arr, align 8
-          store i32 0, i32* %foo, align 4
-          %deref = load %__foo_arr*, %__foo_arr** %arr, align 8
-          %vla_arr_gep = getelementptr inbounds %__foo_arr, %__foo_arr* %deref, i32 0, i32 0
-          %vla_arr_ptr = load i32*, i32** %vla_arr_gep, align 8
-          %dim_arr = getelementptr inbounds %__foo_arr, %__foo_arr* %deref, i32 0, i32 1
-          %start_idx_ptr0 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 0
-          %end_idx_ptr0 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 1
-          %start_idx_value0 = load i32, i32* %start_idx_ptr0, align 4
-          %end_idx_value0 = load i32, i32* %end_idx_ptr0, align 4
-          %start_idx_ptr1 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 2
-          %end_idx_ptr1 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 3
-          %start_idx_value1 = load i32, i32* %start_idx_ptr1, align 4
-          %end_idx_value1 = load i32, i32* %end_idx_ptr1, align 4
-          %1 = sub i32 %end_idx_value0, %start_idx_value0
-          %len_dim0 = add i32 1, %1
-          %2 = sub i32 %end_idx_value1, %start_idx_value1
-          %len_dim1 = add i32 1, %2
-          %accum = alloca i32, align 4
-          store i32 1, i32* %accum, align 4
-          %load_accum = load i32, i32* %accum, align 4
-          %product = mul i32 %load_accum, %len_dim1
-          store i32 %product, i32* %accum, align 4
-          %accessor_factor = load i32, i32* %accum, align 4
-          %adj_access0 = sub i32 0, %start_idx_value0
-          %adj_access1 = sub i32 1, %start_idx_value1
-          %accum1 = alloca i32, align 4
-          store i32 0, i32* %accum1, align 4
-          %multiply = mul i32 %adj_access0, %accessor_factor
-          %load_accum2 = load i32, i32* %accum1, align 4
-          %accumulate = add i32 %load_accum2, %multiply
-          store i32 %accumulate, i32* %accum1, align 4
-          %multiply3 = mul i32 %adj_access1, 1
-          %load_accum4 = load i32, i32* %accum1, align 4
-          %accumulate5 = add i32 %load_accum4, %multiply3
-          store i32 %accumulate5, i32* %accum1, align 4
-          %accessor = load i32, i32* %accum1, align 4
-          %arr_val = getelementptr inbounds i32, i32* %vla_arr_ptr, i32 %accessor
-          store i32 12345, i32* %arr_val, align 4
-          %foo_ret = load i32, i32* %foo, align 4
-          ret i32 %foo_ret
-        }
+    define i32 @foo(%__foo_arr* %0) section "fn-foo:i32[pv]" {
+    entry:
+      %foo = alloca i32, align 4
+      %arr = alloca %__foo_arr*, align 8
+      store %__foo_arr* %0, %__foo_arr** %arr, align 8
+      store i32 0, i32* %foo, align 4
+      %deref = load %__foo_arr*, %__foo_arr** %arr, align 8
+      %vla_arr_gep = getelementptr inbounds %__foo_arr, %__foo_arr* %deref, i32 0, i32 0
+      %vla_arr_ptr = load i32*, i32** %vla_arr_gep, align 8
+      %dim_arr = getelementptr inbounds %__foo_arr, %__foo_arr* %deref, i32 0, i32 1
+      %start_idx_ptr0 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 0
+      %end_idx_ptr0 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 1
+      %start_idx_value0 = load i32, i32* %start_idx_ptr0, align 4
+      %end_idx_value0 = load i32, i32* %end_idx_ptr0, align 4
+      %start_idx_ptr1 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 2
+      %end_idx_ptr1 = getelementptr inbounds [4 x i32], [4 x i32]* %dim_arr, i32 0, i32 3
+      %start_idx_value1 = load i32, i32* %start_idx_ptr1, align 4
+      %end_idx_value1 = load i32, i32* %end_idx_ptr1, align 4
+      %1 = sub i32 %end_idx_value0, %start_idx_value0
+      %len_dim0 = add i32 1, %1
+      %2 = sub i32 %end_idx_value1, %start_idx_value1
+      %len_dim1 = add i32 1, %2
+      %accum = alloca i32, align 4
+      store i32 1, i32* %accum, align 4
+      %load_accum = load i32, i32* %accum, align 4
+      %product = mul i32 %load_accum, %len_dim1
+      store i32 %product, i32* %accum, align 4
+      %accessor_factor = load i32, i32* %accum, align 4
+      %adj_access0 = sub i32 0, %start_idx_value0
+      %adj_access1 = sub i32 1, %start_idx_value1
+      %accum1 = alloca i32, align 4
+      store i32 0, i32* %accum1, align 4
+      %multiply = mul i32 %adj_access0, %accessor_factor
+      %load_accum2 = load i32, i32* %accum1, align 4
+      %accumulate = add i32 %load_accum2, %multiply
+      store i32 %accumulate, i32* %accum1, align 4
+      %multiply3 = mul i32 %adj_access1, 1
+      %load_accum4 = load i32, i32* %accum1, align 4
+      %accumulate5 = add i32 %load_accum4, %multiply3
+      store i32 %accumulate5, i32* %accum1, align 4
+      %accessor = load i32, i32* %accum1, align 4
+      %arr_val = getelementptr inbounds i32, i32* %vla_arr_ptr, i32 %accessor
+      store i32 12345, i32* %arr_val, align 4
+      %foo_ret = load i32, i32* %foo, align 4
+      ret i32 %foo_ret
+    }
     "###);
 }

--- a/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @main_instance = global %main zeroinitializer, !dbg !0
 
-define void @main(%main* %0) !dbg !12 {
+define void @main(%main* %0) section "fn-main:v" !dbg !12 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !16, metadata !DIExpression()), !dbg !17
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !18
@@ -17,7 +17,7 @@ entry:
   ret void, !dbg !20
 }
 
-define void @main.newAction(%main* %0) !dbg !21 {
+define void @main.newAction(%main* %0) section "fn-main.newAction:v" !dbg !21 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !16, metadata !DIExpression()), !dbg !22
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !23
@@ -28,7 +28,7 @@ entry:
   ret void, !dbg !22
 }
 
-define void @main.newAction2(%main* %0) !dbg !24 {
+define void @main.newAction2(%main* %0) section "fn-main.newAction2:v" !dbg !24 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !16, metadata !DIExpression()), !dbg !25
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !26

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/integration/cfc.rs
-expression: output_file_content_without_headers.join(NEWLINE)
+expression: output_file_content_without_headers
 ---
 %conditional_return = type { i32 }
 
 @__conditional_return__init = unnamed_addr constant %conditional_return zeroinitializer
 
-define void @conditional_return(%conditional_return* %0) {
+define void @conditional_return(%conditional_return* %0) section "fn-conditional_return:v[i32]" {
 entry:
   %val = getelementptr inbounds %conditional_return, %conditional_return* %0, i32 0, i32 0
   %load_val = load i32, i32* %val, align 4

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_debug.snap
@@ -2,7 +2,7 @@
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
 ---
-define i32 @foo(i32 %0) !dbg !4 {
+define i32 @foo(i32 %0) section "fn-foo:i32[i32]" !dbg !4 {
 entry:
   %foo = alloca i32, align 4, !dbg !9
   %val = alloca i32, align 4, !dbg !9

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/integration/cfc.rs
-expression: output_file_content_without_headers.join(NEWLINE)
+expression: output_file_content_without_headers
 ---
 %conditional_return = type { i32 }
 
 @__conditional_return__init = constant %conditional_return zeroinitializer
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %my_val = alloca i32, align 4
@@ -29,7 +29,7 @@ entry:
 ; Function Attrs: argmemonly nofree nounwind willreturn
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
-define void @conditional_return(%conditional_return* %0) {
+define void @conditional_return(%conditional_return* %0) section "fn-conditional_return:v[i32]" {
 entry:
   %val = getelementptr inbounds %conditional_return, %conditional_return* %0, i32 0, i32 0
   %load_val = load i32, i32* %val, align 4

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/integration/cfc.rs
-expression: output_file_content_without_headers.join(NEWLINE)
+expression: output_file_content_without_headers
 ---
 %conditional_return = type { i32 }
 
 @__conditional_return__init = constant %conditional_return zeroinitializer
 
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %my_val = alloca i32, align 4
@@ -29,7 +29,7 @@ entry:
 ; Function Attrs: argmemonly nofree nounwind willreturn
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
-define void @conditional_return(%conditional_return* %0) {
+define void @conditional_return(%conditional_return* %0) section "fn-conditional_return:v[i32]" {
 entry:
   %val = getelementptr inbounds %conditional_return, %conditional_return* %0, i32 0, i32 0
   %load_val = load i32, i32* %val, align 4

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @foo_instance = global %foo zeroinitializer, !dbg !0
 
-define void @foo(%foo* %0) !dbg !11 {
+define void @foo(%foo* %0) section "fn-foo:v" !dbg !11 {
 entry:
   call void @llvm.dbg.declare(metadata %foo* %0, metadata !15, metadata !DIExpression()), !dbg !16
   %val = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0, !dbg !17

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_false.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_false.snap
@@ -2,7 +2,7 @@
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
 ---
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x = alloca i8, align 1

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_true.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_true.snap
@@ -2,7 +2,7 @@
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
 ---
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %x = alloca i8, align 1

--- a/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @main_instance = global %main zeroinitializer, !dbg !0
 
-define void @main(%main* %0) !dbg !11 {
+define void @main(%main* %0) section "fn-main:v" !dbg !11 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !15, metadata !DIExpression()), !dbg !16
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !17

--- a/tests/integration/snapshots/tests__integration__cfc__ir__variable_source_to_variable_and_block_sink.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__variable_source_to_variable_and_block_sink.snap
@@ -1,8 +1,8 @@
 ---
 source: tests/integration/cfc.rs
-expression: output_file_content_without_headers.join(NEWLINE)
+expression: output_file_content_without_headers
 ---
-define i32 @main() {
+define i32 @main() section "fn-main:i32" {
 entry:
   %main = alloca i32, align 4
   %value = alloca i32, align 4
@@ -15,7 +15,7 @@ entry:
   ret i32 %main_ret
 }
 
-define i32 @myAdd(i32 %0, i32 %1) {
+define i32 @myAdd(i32 %0, i32 %1) section "fn-myAdd:i32[i32][i32]" {
 entry:
   %myAdd = alloca i32, align 4
   %a = alloca i32, align 4
@@ -31,7 +31,7 @@ entry:
   ret i32 %myAdd_ret
 }
 
-define i32 @myConnection(i32 %0) {
+define i32 @myConnection(i32 %0) section "fn-myConnection:i32[i32]" {
 entry:
   %myConnection = alloca i32, align 4
   %x = alloca i32, align 4

--- a/tests/integration/snapshots/tests__integration__command_line_compile__ir_generation_full_pass.snap
+++ b/tests/integration/snapshots/tests__integration__command_line_compile__ir_generation_full_pass.snap
@@ -2,4 +2,4 @@
 source: tests/integration/command_line_compile.rs
 expression: content
 ---
-define i32 @myFunc(i32 %0, i32 %1, i32 %2) {entry:  %myFunc = alloca i32, align 4  %a = alloca i32, align 4  store i32 %0, i32* %a, align 4  %b = alloca i32, align 4  store i32 %1, i32* %b, align 4  %c = alloca i32, align 4  store i32 %2, i32* %c, align 4  store i32 0, i32* %myFunc, align 4  %myFunc_ret = load i32, i32* %myFunc, align 4  ret i32 %myFunc_ret}
+define i32 @myFunc(i32 %0, i32 %1, i32 %2) section "fn-myFunc:i32[i32][i32][i32]" {entry:  %myFunc = alloca i32, align 4  %a = alloca i32, align 4  store i32 %0, i32* %a, align 4  %b = alloca i32, align 4  store i32 %1, i32* %b, align 4  %c = alloca i32, align 4  store i32 %2, i32* %c, align 4  store i32 0, i32* %myFunc, align 4  %myFunc_ret = load i32, i32* %myFunc, align 4  ret i32 %myFunc_ret}


### PR DESCRIPTION
This PR adds a basic section name mangling library to encode the type information of variables and functions as a section name within the resulting binary. When codegen'ing POUs, we can now set the section name of the function using the provided inkwell API. I'll add the same functionality for variables in a later PR.

The section-mangler library should stay quite simple but it will also include decoding of a mangled string, to enable reconstructing an instance of `SectionMangler` from a section name. Let me know if you'd like the API to look differently or if using a simple builder-like pattern like this one is okay.

Last commit updates all of the snapshots, hence making that PR quite big.