### PR TITLE
Fix false datatype validation 1154

### DIFF
--- a/compiler/plc_ast/src/pre_processor.rs
+++ b/compiler/plc_ast/src/pre_processor.rs
@@ -179,7 +179,7 @@ fn preprocess_generic_structs(pou: &mut Pou) -> Vec<UserTypeDeclaration> {
     let mut generic_types = HashMap::new();
     let mut types = vec![];
     for binding in &pou.generics {
-        let new_name = format!("__{}__{}", pou.name, binding.name); // TODO: Naming convention (see plc_util/src/convention.rs)
+        let new_name = plc_util::convention::generic_binding_type_name(&pou.name, &binding.name);
 
         //Generate a type for the generic
         let data_type = UserTypeDeclaration {

--- a/compiler/plc_util/src/convention.rs
+++ b/compiler/plc_util/src/convention.rs
@@ -12,6 +12,10 @@ pub fn internal_type_name<T: AsRef<str> + Display>(prefix: T, original_type_name
     format!("__{prefix}{original_type_name}")
 }
 
+pub fn generic_binding_type_name<T: AsRef<str> + Display>(pou: T, binding: T) -> String {
+    format!("__{pou}__{binding}")
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -644,6 +644,7 @@ impl AnnotationMapImpl {
         self.type_hint_map.extend(other.type_hint_map);
         self.hidden_function_calls.extend(other.hidden_function_calls);
         self.new_index.import(other.new_index);
+        self.generic_nature_map.extend(other.generic_nature_map);
     }
 
     /// annotates the given statement (using it's `get_id()`) with the given type-name

--- a/src/resolver/generics.rs
+++ b/src/resolver/generics.rs
@@ -9,7 +9,7 @@ use crate::{
     index::{Index, PouIndexEntry},
     resolver::AnnotationMap,
     typesystem::{
-        self, DataType, DataTypeInformation, StringEncoding, BOOL_TYPE, CHAR_TYPE, DATE_TYPE, REAL_TYPE,
+        self, DataType, DataTypeInformation, StringEncoding, BYTE_TYPE, CHAR_TYPE, DATE_TYPE, REAL_TYPE,
         SINT_TYPE, STRING_TYPE, TIME_TYPE, USINT_TYPE, WSTRING_TYPE,
     },
 };
@@ -457,7 +457,7 @@ pub fn get_smallest_possible_type(nature: &TypeNature) -> &str {
         TypeNature::Unsigned => USINT_TYPE,
         TypeNature::Signed => SINT_TYPE,
         TypeNature::Duration => TIME_TYPE,
-        TypeNature::Bit => BOOL_TYPE,
+        TypeNature::Bit => BYTE_TYPE,
         TypeNature::Chars | TypeNature::Char => CHAR_TYPE,
         TypeNature::String => STRING_TYPE,
         TypeNature::Date => DATE_TYPE,

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -1324,10 +1324,7 @@ fn validate_type_nature<T: AnnotationMap>(
         {
             // check if type_hint and actual_type is compatible
             // should be handled by assignment validation
-            if !(actual_type.has_nature(*generic_nature, context.index)
-                // INT parameter for REAL is allowed
-                | (type_hint.is_real() & actual_type.is_numerical()))
-            {
+            if !actual_type.has_nature(*generic_nature, context.index) {
                 validator.push_diagnostic(
                     Diagnostic::new(format!(
                         "Invalid type nature for generic argument. {} is no {}",


### PR DESCRIPTION
Try to fix false datatype validation refered in #1154 #1044 .
Since this modification alters the previous behavior of generic validator, we may need to update the affected test cases to ensure the results are as expected.
But before that, I wish someone to review my patch to make sure I didn't make any other mistakes ^_^

By the way, the failed test cases are:

```
failures:
    validation::tests::generic_validation_tests::any_bit_does_not_allow_chars
    validation::tests::generic_validation_tests::any_bit_does_not_allow_string
    validation::tests::generic_validation_tests::any_real_allows_ints
    validation::tests::generic_validation_tests::any_real_multiple_parameters
```