### PR TITLE
feat: exit with error status on compilation failure

### DIFF
--- a/compiler/plc_driver/src/main.rs
+++ b/compiler/plc_driver/src/main.rs
@@ -1,9 +1,11 @@
-use anyhow::Result;
 use std::env;
 
-fn main() -> Result<()> {
+fn main() {
     //Initialize the logging
     env_logger::init();
     let args: Vec<String> = env::args().collect();
-    plc_driver::compile(&args)
+    if let Err(e) = plc_driver::compile(&args) {
+        eprintln!("{e}");
+        std::process::exit(1)
+    }
 }


### PR DESCRIPTION
When the compilation ends with a diagnostic with severity `Error`, we now no longer exit with `0` (Success) but rather `1` (Catchall for general errors, as defined in the [Linux Documentation Project](https://tldp.org/LDP/abs/html/exitcodes.html)). I've also looked at the [BSD standards](https://man.freebsd.org/cgi/man.cgi?query=sysexits&manpath=FreeBSD+4.3-RELEASE) (mirrored in the [exitcode crate](https://crates.io/crates/exitcode)) and, if we want to follow these guidelines, we could opt to change it to `65 - Data Error`, but I would suggest to stick with `1` for now until we decide on a more fine-grained exit approach for different error scenarios.

Refs: #817 