### PR TITLE
ci: Prepare for Rust 1.77 version bump

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Run Check
         run: |
-         ./scripts/build.sh --check
+          ./scripts/build.sh --check
 
   test-linux:
     name: Test Linux
@@ -67,7 +67,7 @@ jobs:
     name: Test Windows
     runs-on: windows-2022
     env:
-      toolchain-version: 1.75.0
+      toolchain-version: 1.77.0
       llvm-version: 14.0.6
     steps:
 
@@ -138,7 +138,7 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
-            files: lcov.info
+          files: lcov.info
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1

--- a/compiler/plc_xml/src/xml_parser.rs
+++ b/compiler/plc_xml/src/xml_parser.rs
@@ -140,14 +140,11 @@ impl<'parse, 'xml> ParseSession<'parse, 'xml> {
 
     /// parse the compilation unit from the addData field
     fn try_parse_declaration(&self) -> Option<(CompilationUnit, Vec<Diagnostic>)> {
-        let Some(content) = self
+        let content = self
             .project
             .pous
             .first()
-            .and_then(|it| it.interface.as_ref().and_then(|it| it.get_data_content()))
-        else {
-            return None;
-        };
+            .and_then(|it| it.interface.as_ref().and_then(|it| it.get_data_content()))?;
 
         //TODO: if our ST parser returns a diagnostic here, we might not have a text declaration and need to rely on the XML to provide us with
         // the necessary data. for now, we will assume to always have a text declaration

--- a/src/index/visitor.rs
+++ b/src/index/visitor.rs
@@ -225,7 +225,7 @@ fn visit_implementation(index: &mut Index, implementation: &Implementation) {
         .map(|it| it.get_location())
         .as_ref()
         .or(Some(&implementation.location))
-        .map(Clone::clone)
+        .cloned()
         .unwrap();
     index.register_implementation(
         &implementation.name,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -199,7 +199,7 @@ fn parse_pou(
             // blocks are not allowed inside of class declarations.
             let mut variable_blocks = vec![];
             let allowed_var_types =
-                vec![KeywordVar, KeywordVarInput, KeywordVarOutput, KeywordVarInOut, KeywordVarTemp];
+                [KeywordVar, KeywordVarInput, KeywordVarOutput, KeywordVarInOut, KeywordVarTemp];
             while allowed_var_types.contains(&lexer.token) {
                 variable_blocks.push(parse_variable_block(lexer, LinkageType::Internal));
             }

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -1520,9 +1520,7 @@ mod helper {
         }
 
         let path = right.get_flat_reference_name().unwrap_or_default();
-        let Some(element) = context.index.find_variable(context.qualifier, &[path]) else {
-            return None;
-        };
+        let element = context.index.find_variable(context.qualifier, &[path])?;
 
         context
             .index


### PR DESCRIPTION
- Bumps the Windows Rust Version to 1.77 for test runs
- Applies 1.77 clippy and rustfmt suggestions