### PR TITLE
feat: show diagnostics in `panic` in `runner::compile`

### DIFF
--- a/compiler/plc_driver/src/runner.rs
+++ b/compiler/plc_driver/src/runner.rs
@@ -37,7 +37,10 @@ pub fn compile<T: Compilable>(context: &CodegenContext, source: T) -> GeneratedM
         ..Default::default()
     };
 
-    annotated_project.generate_single_module(context, &compile_options).unwrap().unwrap()
+    match annotated_project.generate_single_module(context, &compile_options) {
+        Ok(res) => res.unwrap(),
+        Err(e) => panic!("{e}"),
+    }
 }
 
 ///


### PR DESCRIPTION
Should a integration/correctness-test result in a diagnostic, we now panic with the diagnostic as message instead of calling `unwrap` on the result in `runner::compile`.
This makes it easier to see the reason for why tests might have failed at a glance.