### PR TITLE
refactor: Implement From<&SourceLocation>

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -66,13 +66,19 @@ impl Diagnostic {
         }
     }
 
-    pub fn with_location(mut self, location: SourceLocation) -> Self {
-        self.primary_location = location;
+    pub fn with_location<T>(mut self, location: T) -> Self
+    where
+        T: Into<SourceLocation>,
+    {
+        self.primary_location = location.into();
         self
     }
 
-    pub fn with_secondary_location(mut self, location: SourceLocation) -> Self {
-        self.secondary_locations.get_or_insert_with(Default::default).push(location);
+    pub fn with_secondary_location<T>(mut self, location: T) -> Self
+    where
+        T: Into<SourceLocation>,
+    {
+        self.secondary_locations.get_or_insert_with(Default::default).push(location.into());
         self
     }
 
@@ -194,7 +200,7 @@ impl Diagnostic {
 
     pub fn invalid_parameter_count(expected: usize, received: usize, location: SourceLocation) -> Diagnostic {
         Diagnostic::new(
-             format!(
+            format!(
                 "Invalid parameter count. Received {received} parameters while {expected} parameters were expected.",
             )).with_error_code("E032")
             .with_location(location)

--- a/compiler/plc_source/src/source_location.rs
+++ b/compiler/plc_source/src/source_location.rs
@@ -161,6 +161,12 @@ pub struct SourceLocation {
     file: Option<&'static str>,
 }
 
+impl From<&SourceLocation> for SourceLocation {
+    fn from(value: &SourceLocation) -> Self {
+        value.clone()
+    }
+}
+
 impl Debug for SourceLocation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut f = f.debug_struct("SourceLocation");

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -154,7 +154,7 @@ pub fn generate_data_types<'ink>(
             .map(|(name, ty)| {
                 errors
                     .remove(name)
-                    .map(|diag| diag.with_secondary_location(ty.location.clone()))
+                    .map(|diag| diag.with_secondary_location(&ty.location))
                     .unwrap_or_else(|| Diagnostic::cannot_generate_initializer(name, ty.location.clone()))
             })
             .collect::<Vec<_>>();

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1913,7 +1913,7 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
                 expected_type.get_name()
             ))
             .with_error_code("E074")
-            .with_location(location.clone())),
+            .with_location(location)),
         }
     }
 

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -667,7 +667,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
         let variable_llvm_type = self
             .llvm_index
             .get_associated_type(variable.get_type_name())
-            .map_err(|err| err.with_location(variable.source_location.clone()))?;
+            .map_err(|err| err.with_location(&variable.source_location))?;
 
         let type_size = variable_llvm_type.size_of().ok_or_else(|| {
             Diagnostic::codegen_error("Couldn't determine type size", variable.source_location.clone())

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -607,7 +607,7 @@ fn parse_number<F: FromStr>(lexer: &mut ParseSession, text: &str, location: &Sou
             lexer.accept_diagnostic(
                 Diagnostic::new(format!("Failed to parse number {text}"))
                     .with_error_code("E011")
-                    .with_location(location.clone()),
+                    .with_location(location),
             );
             None
         }
@@ -745,7 +745,7 @@ fn parse_literal_time(lexer: &mut ParseSession) -> Option<AstNode> {
                     lexer.accept_diagnostic(
                         Diagnostic::new("Invalid TIME Literal: Cannot parse segment.")
                             .with_error_code("E010")
-                            .with_location(location.clone()),
+                            .with_location(location),
                     );
                     return None;
                 }
@@ -761,7 +761,7 @@ fn parse_literal_time(lexer: &mut ParseSession) -> Option<AstNode> {
                     lexer.accept_diagnostic(
                         Diagnostic::new("Invalid TIME Literal: Missing unit (d|h|m|s|ms|us|ns)")
                             .with_error_code("E010")
-                            .with_location(location.clone()),
+                            .with_location(location),
                     );
                     return None;
                 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -153,9 +153,7 @@ impl<'a> Validator<'a> {
                 continue;
             };
 
-            self.push_diagnostic(
-                Diagnostic::new(reason).with_error_code("E039").with_location(location.to_owned()),
-            );
+            self.push_diagnostic(Diagnostic::new(reason).with_error_code("E039").with_location(location));
         }
     }
 

--- a/src/validation/global.rs
+++ b/src/validation/global.rs
@@ -47,7 +47,7 @@ impl GlobalValidator {
                         Diagnostic::new(format!(
                             "{name} can not be used as a name because it is a built-in datatype"
                         ))
-                        .with_location(other.clone())
+                        .with_location(other)
                         .with_error_code("E004"),
                     );
                 }
@@ -56,7 +56,7 @@ impl GlobalValidator {
                 self.push_diagnostic(
                     Diagnostic::new(format!("{name}: {additional_text}"))
                         .with_error_code("E004")
-                        .with_location((*v).clone())
+                        .with_location(*v)
                         .with_secondary_locations(others),
                 );
             }

--- a/src/validation/pou.rs
+++ b/src/validation/pou.rs
@@ -25,7 +25,7 @@ pub fn visit_implementation<T: AnnotationMap>(
         validator.push_diagnostic(
             Diagnostic::new("A class cannot have an implementation")
                 .with_error_code("E017")
-                .with_location(implementation.location.to_owned()),
+                .with_location(&implementation.location),
         );
     }
     if implementation.linkage != LinkageType::External {
@@ -44,7 +44,7 @@ pub fn visit_implementation<T: AnnotationMap>(
                         validator.push_diagnostic(
                             Diagnostic::new(format!("{}: Duplicate label.", &first.name))
                                 .with_error_code("E018")
-                                .with_location(first.location.clone())
+                                .with_location(&first.location)
                                 .with_secondary_locations(locations),
                         );
                     }
@@ -81,7 +81,7 @@ fn validate_class<T: AnnotationMap>(validator: &mut Validator, pou: &Pou, contex
         validator.push_diagnostic(
             Diagnostic::new("A class cannot contain VAR_IN VAR_IN_OUT or VAR_OUT blocks")
                 .with_error_code("E019")
-                .with_location(pou.name_location.to_owned()),
+                .with_location(&pou.name_location),
         );
     }
 
@@ -90,7 +90,7 @@ fn validate_class<T: AnnotationMap>(validator: &mut Validator, pou: &Pou, contex
         validator.push_diagnostic(
             Diagnostic::new("A class cannot have a return type")
                 .with_error_code("E020")
-                .with_location(pou.name_location.clone()),
+                .with_location(&pou.name_location),
         );
     }
 }
@@ -101,7 +101,7 @@ fn validate_function(validator: &mut Validator, pou: &Pou) {
         validator.push_diagnostic(
             Diagnostic::new("A function cannot use `EXTEND`")
                 .with_error_code("E021")
-                .with_location(pou.name_location.to_owned()),
+                .with_location(&pou.name_location),
         );
     }
 }
@@ -112,7 +112,7 @@ fn validate_program(validator: &mut Validator, pou: &Pou) {
         validator.push_diagnostic(
             Diagnostic::new("A program cannot use `EXTEND`")
                 .with_error_code("E021")
-                .with_location(pou.name_location.to_owned()),
+                .with_location(&pou.name_location),
         );
     }
 }
@@ -122,7 +122,7 @@ pub fn validate_action_container(validator: &mut Validator, implementation: &Imp
         validator.push_diagnostic(
             Diagnostic::new("Missing Actions Container Name")
                 .with_error_code("E022")
-                .with_location(implementation.location.clone()),
+                .with_location(&implementation.location),
         );
     }
 }

--- a/src/validation/recursive.rs
+++ b/src/validation/recursive.rs
@@ -115,13 +115,13 @@ impl RecursiveValidator {
                         .with_error_code("E029");
 
                 let diagnostic = if let Some(first) = ranges.first() {
-                    diagnostic.with_location(first.clone())
+                    diagnostic.with_location(first)
                 } else {
                     diagnostic
                 };
 
                 let diagnostic = if ranges.len() > 1 {
-                    ranges.iter().fold(diagnostic, |prev, it| prev.with_secondary_location(it.clone()))
+                    ranges.iter().fold(diagnostic, |prev, it| prev.with_secondary_location(it))
                 } else {
                     diagnostic
                 };

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -367,7 +367,7 @@ fn validate_cast_literal<T: AnnotationMap>(
                 validator.context.slice(&statement.get_location())
             ))
             .with_error_code("E061")
-            .with_location(location.clone()),
+            .with_location(location),
         )
     } else if cast_type.is_date_or_time_type() || literal_type.is_date_or_time_type() {
         validator.push_diagnostic(incompatible_literal_cast(
@@ -433,7 +433,7 @@ fn validate_access_index<T: AnnotationMap>(
                         &range.end
                     ))
                     .with_error_code("E057")
-                    .with_location(location.clone()),
+                    .with_location(location),
                 )
             }
         }
@@ -443,7 +443,7 @@ fn validate_access_index<T: AnnotationMap>(
                 validator.push_diagnostic(
                     Diagnostic::new(format!("Invalid type {} for direct variable access. Only variables of Integer types are allowed", ref_type.get_name()))
                     .with_error_code("E056")
-                    .with_location(location.clone())
+                    .with_location(location)
                 )
             }
         }
@@ -476,7 +476,7 @@ fn validate_reference<T: AnnotationMap>(
                 validator.push_diagnostic(
                     Diagnostic::new(format!("If you meant to directly access a bit/byte/word/..., use %X/%B/%W{ref_name} instead."))
                     .with_error_code("E060")
-                    .with_location(location.clone())
+                    .with_location(location)
                 );
             }
         }
@@ -501,7 +501,7 @@ fn validate_reference<T: AnnotationMap>(
                     //TODO: maybe default to warning?
                     Diagnostic::new(format!("Illegal access to private member {qualified_name}"))
                         .with_error_code("E049")
-                        .with_location(location.clone()),
+                        .with_location(location),
                 );
             }
         }
@@ -516,7 +516,7 @@ fn validate_reference<T: AnnotationMap>(
                 validator.push_diagnostic(
                     Diagnostic::new(format!("A reference to {qualified_name} exists, but it is an ACTION. If you meant to call it, add `()` to the statement: `{qualified_name}()`"))
                         .with_error_code("E095")
-                        .with_location(location.clone())
+                        .with_location(location)
                 );
             }
         }
@@ -808,7 +808,7 @@ fn validate_assignment<T: AnnotationMap>(
                 validator.push_diagnostic(
                     Diagnostic::new("VAR_INPUT {ref} variables are mutable and changes to them will also affect the referenced variable. For increased clarity use VAR_IN_OUT instead.")
                     .with_error_code("E042")
-                    .with_location(location.to_owned())
+                    .with_location(location)
                     );
             }
         }
@@ -826,7 +826,7 @@ fn validate_assignment<T: AnnotationMap>(
         if has_return_assignment_in_void_function(context, left) {
             validator.push_diagnostic(
                 Diagnostic::new("Function declared as VOID, but trying to assign a return value")
-                    .with_location(location.to_owned())
+                    .with_location(location)
                     .with_error_code("E093"),
             )
         }
@@ -864,7 +864,7 @@ fn validate_assignment<T: AnnotationMap>(
                         get_datatype_name_or_slice(validator.context, right_type)
                     ))
                     .with_error_code("E090")
-                    .with_location(location.clone()),
+                    .with_location(location),
                 );
             } else {
                 validator.push_diagnostic(Diagnostic::invalid_assignment(
@@ -927,7 +927,7 @@ pub(crate) fn validate_enum_variant_assignment<T: AnnotationMap>(
                     get_datatype_name_or_slice(validator.context, left_dt)
                 ))
                 .with_location(right.get_location())
-                .with_secondary_location(left_dt.location.clone())
+                .with_secondary_location(&left_dt.location)
                 .with_error_code("E091"),
             );
         }
@@ -949,7 +949,7 @@ pub(crate) fn validate_enum_variant_assignment<T: AnnotationMap>(
                     ))
                     .with_error_code("E092")
                     .with_location(right.get_location())
-                    .with_secondary_location(left_dt.location.clone()),
+                    .with_secondary_location(&left_dt.location),
                 );
             }
         }
@@ -961,7 +961,7 @@ pub(crate) fn validate_enum_variant_assignment<T: AnnotationMap>(
                     get_datatype_name_or_slice(validator.context, left_dt)
                 ))
                 .with_location(right.get_location())
-                .with_secondary_location(left_dt.location.clone())
+                .with_secondary_location(&left_dt.location)
                 .with_error_code("E040"),
             );
         }
@@ -1046,7 +1046,7 @@ fn is_valid_string_to_char_assignment(
                             .as_str(),
                     )
                     .with_error_code("E065")
-                    .with_location(location.clone()),
+                    .with_location(location),
                 );
                 return false;
             }
@@ -1077,7 +1077,7 @@ fn is_invalid_pointer_assignment(
                 left_type.get_size_in_bits(index)
             ))
             .with_error_code("E065")
-            .with_location(location.clone()),
+            .with_location(location),
         );
         return true;
     }
@@ -1093,7 +1093,7 @@ fn is_invalid_pointer_assignment(
                 right_type.get_size_in_bits(index)
             ))
             .with_error_code("E065")
-            .with_location(location.clone()),
+            .with_location(location),
         );
         return true;
     }

--- a/src/validation/types.rs
+++ b/src/validation/types.rs
@@ -50,7 +50,7 @@ fn validate_data_type(validator: &mut Validator, data_type: &DataType, location:
                 validator.push_diagnostic(
                     Diagnostic::new("Variable block is empty")
                         .with_error_code("E028")
-                        .with_location(location.clone()),
+                        .with_location(location),
                 );
             }
         }
@@ -59,15 +59,13 @@ fn validate_data_type(validator: &mut Validator, data_type: &DataType, location:
             ..
         } if expressions.is_empty() => {
             validator.push_diagnostic(
-                Diagnostic::new("Variable block is empty")
-                    .with_error_code("E028")
-                    .with_location(location.clone()),
+                Diagnostic::new("Variable block is empty").with_error_code("E028").with_location(location),
             );
         }
         DataType::VarArgs { referenced_type: None, sized: true } => validator.push_diagnostic(
             Diagnostic::new("Missing datatype: Sized Variadics require a known datatype.")
                 .with_error_code("E038")
-                .with_location(location.clone()),
+                .with_location(location),
         ),
         _ => {}
     }

--- a/src/validation/variable.rs
+++ b/src/validation/variable.rs
@@ -36,7 +36,7 @@ fn validate_variable_block(validator: &mut Validator, block: &VariableBlock) {
         validator.push_diagnostic(
             Diagnostic::new("This variable block does not support the CONSTANT modifier")
                 .with_error_code("E034")
-                .with_location(block.location.clone()),
+                .with_location(&block.location),
         )
     }
 }
@@ -60,7 +60,7 @@ fn validate_vla(validator: &mut Validator, pou: Option<&Pou>, block: &VariableBl
             validator.push_diagnostic(
                 Diagnostic::new("VLAs can not be defined as global variables")
                     .with_error_code("E044")
-                    .with_location(variable.location.clone()),
+                    .with_location(&variable.location),
             )
         }
 
@@ -73,13 +73,13 @@ fn validate_vla(validator: &mut Validator, pou: Option<&Pou>, block: &VariableBl
                 "Variable Length Arrays are always by-ref, even when declared in a by-value block",
             )
             .with_error_code("E047")
-            .with_location(variable.location.clone()),
+            .with_location(&variable.location),
         ),
 
         (PouType::Program, _) => validator.push_diagnostic(
             Diagnostic::new("Variable Length Arrays are not allowed to be defined inside a Program")
                 .with_error_code("E044")
-                .with_location(variable.location.clone()),
+                .with_location(&variable.location),
         ),
 
         (
@@ -96,7 +96,7 @@ fn validate_vla(validator: &mut Validator, pou: Option<&Pou>, block: &VariableBl
                 block.variable_block_type, pou.pou_type
             ))
             .with_error_code("E044")
-            .with_location(variable.location.clone()),
+            .with_location(&variable.location),
         ),
     }
 }
@@ -145,7 +145,7 @@ fn validate_variable<T: AnnotationMap>(
                 validator.push_diagnostic(
                     Diagnostic::new(format!("Unresolved constant `{}` variable", variable.name.as_str(),))
                         .with_error_code("E033")
-                        .with_location(variable.location.clone()),
+                        .with_location(&variable.location),
                 );
             }
             _ => {
@@ -170,7 +170,7 @@ fn validate_variable<T: AnnotationMap>(
                     v_entry.get_name()
                 ))
                 .with_error_code("E035")
-                .with_location(variable.location.clone()),
+                .with_location(&variable.location),
             );
         }
     }


### PR DESCRIPTION
Delegates `clone()` calls into the `From<&SourceLocation>` implementation rather than the caller. Specifically code like `with_location(location.clone())` can now be rewritten into `with_location(location)`.