### PR TITLE
perf: Use non-cryptographic FxHash algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -2897,6 +2897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2968,7 @@ dependencies = [
  "plc_xml",
  "pretty_assertions",
  "regex",
+ "rustc-hash",
  "section_mangler",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ shell-words = "1.1.0"
 plc_derive = { path = "./compiler/plc_derive" }
 lld_rs = "140.0.0"
 which = "4.2.5"
+rustc-hash = "1.1"
 log.workspace = true
 inkwell.workspace = true
 chrono.workspace = true
@@ -48,7 +49,7 @@ num = "0.4"
 insta = "1.31.0"
 pretty_assertions = "1.3.0"
 driver = { path = "./compiler/plc_driver/", package = "plc_driver" }
-project = { path = "./compiler/plc_project/", package = "plc_project", features = ["integration"]}
+project = { path = "./compiler/plc_project/", package = "plc_project", features = ["integration"] }
 plc_xml = { path = "./compiler/plc_xml" }
 serial_test = "*"
 tempfile = "3"

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,9 +1,11 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
 use std::collections::HashSet;
+use std::hash::BuildHasherDefault;
 
 use indexmap::IndexMap;
 use itertools::Itertools;
+use rustc_hash::FxHasher;
 
 use plc_ast::ast::{
     AstId, AstNode, AstStatement, DirectAccessType, GenericBinding, HardwareAccessType, LinkageType, PouType,
@@ -825,7 +827,7 @@ pub struct Index {
     /// all implementations
     // we keep an IndexMap for implementations since duplication issues regarding implementations
     // is handled by the `pous` SymbolMap
-    implementations: IndexMap<String, ImplementationIndexEntry>,
+    implementations: IndexMap<String, ImplementationIndexEntry, BuildHasherDefault<FxHasher>>,
 
     /// an index with all type-information
     type_index: TypeIndex,
@@ -1359,7 +1361,9 @@ impl Index {
         self.enum_global_variables.values().collect()
     }
 
-    pub fn get_implementations(&self) -> &IndexMap<String, ImplementationIndexEntry> {
+    pub fn get_implementations(
+        &self,
+    ) -> &IndexMap<String, ImplementationIndexEntry, BuildHasherDefault<FxHasher>> {
         &self.implementations
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 
 use indexmap::IndexMap;
@@ -33,6 +33,12 @@ pub mod symbol;
 #[cfg(test)]
 mod tests;
 pub mod visitor;
+
+/// Type alias for a HashMap using the `fx` algorithm, see https://github.com/rust-lang/rustc-hash
+pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+
+/// Type alias for an IndexMap using the `fx` algorithm, see https://github.com/rust-lang/rustc-hash
+pub type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
 /// A label represents a possible jump point in the source.
 /// It can be referenced by jump elements in the same unit
@@ -827,7 +833,7 @@ pub struct Index {
     /// all implementations
     // we keep an IndexMap for implementations since duplication issues regarding implementations
     // is handled by the `pous` SymbolMap
-    implementations: IndexMap<String, ImplementationIndexEntry, BuildHasherDefault<FxHasher>>,
+    implementations: FxIndexMap<String, ImplementationIndexEntry>,
 
     /// an index with all type-information
     type_index: TypeIndex,
@@ -1361,9 +1367,7 @@ impl Index {
         self.enum_global_variables.values().collect()
     }
 
-    pub fn get_implementations(
-        &self,
-    ) -> &IndexMap<String, ImplementationIndexEntry, BuildHasherDefault<FxHasher>> {
+    pub fn get_implementations(&self) -> &FxIndexMap<String, ImplementationIndexEntry> {
         &self.implementations
     }
 

--- a/src/index/symbol.rs
+++ b/src/index/symbol.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2022 Ghaith Hachem and Mathias Rieder
 
 use indexmap::{Equivalent, IndexMap};
-use std::hash::Hash;
+use rustc_hash::FxHasher;
+use std::hash::{BuildHasherDefault, Hash};
 
 /// A multi-map implementation with a stable order of elements. When iterating
 /// the keys or the values, the iterator reflects the order of insertion.
@@ -9,7 +10,7 @@ use std::hash::Hash;
 pub struct SymbolMap<K, V> {
     /// internal storage of the SymbolMap that uses an *
     /// IndexMap of Vectors
-    inner_map: IndexMap<K, Vec<V>>,
+    inner_map: IndexMap<K, Vec<V>, BuildHasherDefault<FxHasher>>,
 }
 
 impl<K, V> Default for SymbolMap<K, V> {

--- a/src/index/symbol.rs
+++ b/src/index/symbol.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022 Ghaith Hachem and Mathias Rieder
 
-use indexmap::{Equivalent, IndexMap};
-use rustc_hash::FxHasher;
-use std::hash::{BuildHasherDefault, Hash};
+use crate::index::FxIndexMap;
+use indexmap::Equivalent;
+use std::hash::Hash;
 
 /// A multi-map implementation with a stable order of elements. When iterating
 /// the keys or the values, the iterator reflects the order of insertion.
@@ -10,7 +10,7 @@ use std::hash::{BuildHasherDefault, Hash};
 pub struct SymbolMap<K, V> {
     /// internal storage of the SymbolMap that uses an *
     /// IndexMap of Vectors
-    inner_map: IndexMap<K, Vec<V>, BuildHasherDefault<FxHasher>>,
+    inner_map: FxIndexMap<K, Vec<V>>,
 }
 
 impl<K, V> Default for SymbolMap<K, V> {


### PR DESCRIPTION
Use the non-cryptographic FxHash algorithm for HashMaps, reducing the `plc check` times by a few hundred milliseconds; also used in `rustc`

From https://github.com/rust-lang/rustc-hash
> A speedy, non-cryptographic hashing algorithm used by rustc and Firefox. The [hash map in std](https://doc.rust-lang.org/std/collections/struct.HashMap.html) uses SipHash by default, which provides resistance against DOS attacks. These attacks aren't as much of a concern in the compiler so we prefer to use the quicker, non-cryptographic Fx algorithm.

> The Fx algorithm is a unique one used by Firefox. It is fast because it can hash eight bytes at a time. Within rustc, it consistently outperforms every other tested algorithm (such as FNV). The collision rate is similar or slightly worse than other low-quality hash functions.

