### PR TITLE
feat: Generate a custom GOT array and save/load its layout

### DIFF
--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -101,6 +101,18 @@ pub struct CompileParameters {
     pub hardware_config: Option<String>,
 
     #[clap(
+        name = "got-layout-file",
+        long,
+        global = true,
+        help = "Obtain information about the current custom GOT layout from the given file if it exists.
+    Save information about the generated custom GOT layout to the given file.
+    Format is detected by extension.
+    Supported formats : json, toml",
+    parse(try_from_str = validate_config)
+    ) ]
+    pub got_layout_file: Option<String>,
+
+    #[clap(
         name = "optimization",
         long,
         short = 'O',
@@ -377,6 +389,10 @@ impl CompileParameters {
 
     pub fn config_format(&self) -> Option<ConfigFormat> {
         self.hardware_config.as_deref().and_then(get_config_format)
+    }
+
+    pub fn got_layout_format(&self) -> Option<ConfigFormat> {
+        self.got_layout_file.as_deref().and_then(get_config_format)
     }
 
     /// Returns the location where the build artifacts should be stored / output

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -19,8 +19,8 @@ use std::{
 use cli::{CompileParameters, ParameterError, SubCommands};
 use pipelines::AnnotatedProject;
 use plc::{
-    codegen::CodegenContext, linker::LinkerType, output::FormatOption, DebugLevel, ErrorFormat,
-    OptimizationLevel, Target, Threads,
+    codegen::CodegenContext, linker::LinkerType, output::FormatOption, ConfigFormat, DebugLevel,
+    ErrorFormat, OptimizationLevel, Target, Threads,
 };
 
 use plc_diagnostics::{diagnostician::Diagnostician, diagnostics::Diagnostic};
@@ -50,6 +50,8 @@ pub struct CompileOptions {
     /// The name of the resulting compiled file
     pub output: String,
     pub output_format: FormatOption,
+    pub got_layout_file: Option<String>,
+    pub got_layout_format: Option<ConfigFormat>,
     pub optimization: OptimizationLevel,
     pub error_format: ErrorFormat,
     pub debug_level: DebugLevel,
@@ -63,6 +65,8 @@ impl Default for CompileOptions {
             build_location: None,
             output: String::new(),
             output_format: Default::default(),
+            got_layout_file: None,
+            got_layout_format: None,
             optimization: OptimizationLevel::None,
             error_format: ErrorFormat::None,
             debug_level: DebugLevel::None,
@@ -172,6 +176,8 @@ pub fn get_compilation_context<T: AsRef<str> + AsRef<OsStr> + Debug>(
         build_location: compile_parameters.get_build_location(),
         output: project.get_output_name(),
         output_format,
+        got_layout_file: compile_parameters.got_layout_file.clone(),
+        got_layout_format: compile_parameters.got_layout_format(),
         optimization: compile_parameters.optimization,
         error_format: compile_parameters.error_format,
         debug_level: compile_parameters.debug_level(),

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -273,6 +273,7 @@ impl<T: SourceContainer + Sync> AnnotatedProject<T> {
             context,
             compile_options.root.as_deref(),
             &unit.file_name,
+            compile_options.got_layout_file.clone().zip(compile_options.got_layout_format),
             compile_options.optimization,
             compile_options.debug_level,
         );


### PR DESCRIPTION
This commit contains changes that are required to generate a global variable which will be used to store an array of addresses of other global variables in the program. The location of the globals within this array should be stable after a recompilation to support online change, so we support loading a pre-existing layout to ensure that for all globals that we see in both the current program and the pre-existing layout, their positions remain the same. Otherwise, any new globals will be placed in any empty spaces left by old globals, or appended on to the end of the array. The layout will then be saved back the the file used for saving and loading.

Currently, to use this feature the flag `--got-layout-file=<file>` must be provided, which should specify the name of either a TOML or JSON file to use to save, and optionally load if the file already exists, the GOT layout. In future we will integrate this with a generic online change flag, whereby it will not be necessary to ask for a GOT layout file when we already know that we need it for online change.