### PR TITLE
perf: Use FxHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,6 +2485,7 @@ dependencies = [
  "chrono",
  "plc_source",
  "plc_util",
+ "rustc-hash",
  "serde",
 ]
 
@@ -2506,6 +2507,7 @@ dependencies = [
  "log",
  "plc_ast",
  "plc_source",
+ "rustc-hash",
  "serde",
  "serde_json",
  "toml",
@@ -2545,6 +2547,7 @@ dependencies = [
  "plc_ast",
  "plc_diagnostics",
  "plc_source",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -2591,6 +2594,7 @@ dependencies = [
  "plc_diagnostics",
  "plc_source",
  "quick-xml",
+ "rustc-hash",
  "rusty",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -2897,6 +2897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2968,7 @@ dependencies = [
  "plc_xml",
  "pretty_assertions",
  "regex",
+ "rustc-hash",
  "section_mangler",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ shell-words = "1.1.0"
 plc_derive = { path = "./compiler/plc_derive" }
 lld_rs = "140.0.0"
 which = "4.2.5"
-rustc-hash = "1.1.0"
 log.workspace = true
 inkwell.workspace = true
 chrono.workspace = true
@@ -43,6 +42,7 @@ lazy_static.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 toml.workspace = true
+rustc-hash.workspace = true
 
 [dev-dependencies]
 num = "0.4"
@@ -91,3 +91,4 @@ lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"
+rustc-hash = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ shell-words = "1.1.0"
 plc_derive = { path = "./compiler/plc_derive" }
 lld_rs = "140.0.0"
 which = "4.2.5"
+rustc-hash = "1.1.0"
 log.workspace = true
 inkwell.workspace = true
 chrono.workspace = true
@@ -48,7 +49,7 @@ num = "0.4"
 insta = "1.31.0"
 pretty_assertions = "1.3.0"
 driver = { path = "./compiler/plc_driver/", package = "plc_driver" }
-project = { path = "./compiler/plc_project/", package = "plc_project", features = ["integration"]}
+project = { path = "./compiler/plc_project/", package = "plc_project", features = ["integration"] }
 plc_xml = { path = "./compiler/plc_xml" }
 serial_test = "*"
 tempfile = "3"

--- a/compiler/plc_ast/Cargo.toml
+++ b/compiler/plc_ast/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 plc_util = { path = "../plc_util" }
-plc_source = {path = "../plc_source"}
+plc_source = { path = "../plc_source" }
 chrono = { version = "0.4", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
+rustc-hash.workspace = true

--- a/compiler/plc_ast/src/pre_processor.rs
+++ b/compiler/plc_ast/src/pre_processor.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use plc_util::convention::internal_type_name;
 
@@ -176,7 +176,7 @@ fn build_enum_initializer(
 }
 
 fn preprocess_generic_structs(pou: &mut Pou) -> Vec<UserTypeDeclaration> {
-    let mut generic_types = HashMap::new();
+    let mut generic_types = FxHashMap::default();
     let mut types = vec![];
     for binding in &pou.generics {
         let new_name = format!("__{}__{}", pou.name, binding.name); // TODO: Naming convention (see plc_util/src/convention.rs)
@@ -269,7 +269,7 @@ fn add_nested_datatypes(
     }
 }
 
-fn replace_generic_type_name(dt: &mut DataTypeDeclaration, generics: &HashMap<String, String>) {
+fn replace_generic_type_name(dt: &mut DataTypeDeclaration, generics: &FxHashMap<String, String>) {
     match dt {
         DataTypeDeclaration::DataTypeDefinition { data_type, .. } => match data_type {
             DataType::ArrayType { referenced_type, .. }

--- a/compiler/plc_diagnostics/Cargo.toml
+++ b/compiler/plc_diagnostics/Cargo.toml
@@ -15,3 +15,4 @@ toml.workspace = true
 anyhow.workspace = true
 lazy_static.workspace = true
 log.workspace = true
+rustc-hash.workspace = true

--- a/compiler/plc_diagnostics/src/diagnostician.rs
+++ b/compiler/plc_diagnostics/src/diagnostician.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::{
     diagnostics::{
@@ -16,7 +16,7 @@ use crate::{
 pub struct Diagnostician {
     reporter: Box<dyn DiagnosticReporter>,
     assessor: Box<dyn DiagnosticAssessor>,
-    filename_fileid_mapping: HashMap<String, usize>,
+    filename_fileid_mapping: FxHashMap<String, usize>,
 }
 
 impl Diagnostician {
@@ -75,7 +75,7 @@ impl Diagnostician {
         Diagnostician {
             assessor: Box::<DiagnosticsRegistry>::default(),
             reporter: Box::<NullDiagnosticReporter>::default(),
-            filename_fileid_mapping: HashMap::new(),
+            filename_fileid_mapping: FxHashMap::default(),
         }
     }
 
@@ -84,7 +84,7 @@ impl Diagnostician {
         Diagnostician {
             assessor: Box::<DiagnosticsRegistry>::default(),
             reporter: Box::new(CodeSpanDiagnosticReporter::buffered()),
-            filename_fileid_mapping: HashMap::new(),
+            filename_fileid_mapping: FxHashMap::default(),
         }
     }
 
@@ -93,7 +93,7 @@ impl Diagnostician {
         Diagnostician {
             reporter: Box::<ClangFormatDiagnosticReporter>::default(),
             assessor: Box::<DiagnosticsRegistry>::default(),
-            filename_fileid_mapping: HashMap::new(),
+            filename_fileid_mapping: FxHashMap::default(),
         }
     }
 
@@ -151,7 +151,7 @@ impl Default for Diagnostician {
         Self {
             reporter: Box::<CodeSpanDiagnosticReporter>::default(),
             assessor: Box::<DiagnosticsRegistry>::default(),
-            filename_fileid_mapping: HashMap::new(),
+            filename_fileid_mapping: FxHashMap::default(),
         }
     }
 }

--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -1,7 +1,6 @@
 /// Returns a diagnostics map with the error code, default severity and a description
-use std::collections::HashMap;
-
 use lazy_static::lazy_static;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::diagnostician::DiagnosticAssessor;
@@ -13,7 +12,7 @@ use super::{
 
 macro_rules! add_diagnostic {
     ($($number:ident, $severity:expr, $desc:expr,)*) => {
-        { let mut m : HashMap<&str, DiagnosticEntry> = HashMap::new();
+        { let mut m : FxHashMap<&str, DiagnosticEntry> = FxHashMap::default();
             $(
                 {
                     let code = stringify!($number);
@@ -24,7 +23,7 @@ macro_rules! add_diagnostic {
         }}
 }
 
-pub struct DiagnosticsRegistry(HashMap<&'static str, DiagnosticEntry>);
+pub struct DiagnosticsRegistry(FxHashMap<&'static str, DiagnosticEntry>);
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DiagnosticEntry {
@@ -41,7 +40,7 @@ impl Default for DiagnosticsRegistry {
 
 impl DiagnosticsRegistry {
     /// Creates an empty registry.
-    fn new(map: HashMap<&'static str, DiagnosticEntry>) -> Self {
+    fn new(map: FxHashMap<&'static str, DiagnosticEntry>) -> Self {
         DiagnosticsRegistry(map)
     }
 
@@ -87,7 +86,7 @@ impl DiagnosticAssessor for DiagnosticsRegistry {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(transparent)]
-pub struct DiagnosticsConfiguration(HashMap<Severity, Vec<String>>);
+pub struct DiagnosticsConfiguration(FxHashMap<Severity, Vec<String>>);
 
 impl From<&DiagnosticsRegistry> for DiagnosticsConfiguration {
     fn from(registry: &DiagnosticsRegistry) -> Self {
@@ -101,7 +100,7 @@ impl From<&DiagnosticsRegistry> for DiagnosticsConfiguration {
 }
 
 lazy_static! {
-    static ref DIAGNOSTICS: HashMap<&'static str, DiagnosticEntry> = add_diagnostic!(
+    static ref DIAGNOSTICS: FxHashMap<&'static str, DiagnosticEntry> = add_diagnostic!(
     E001,
     Error,
     include_str!("./error_codes/E001.md"), //General Error

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -10,7 +10,8 @@ use ast::{
     ast::{pre_process, CompilationUnit, LinkageType},
     provider::IdProvider,
 };
-use indexmap::IndexSet;
+
+use plc::index::FxIndexSet;
 use plc::{
     codegen::{CodegenContext, GeneratedModule},
     index::Index,
@@ -192,7 +193,7 @@ impl<T: SourceContainer + Sync> IndexedProject<T> {
 /// A project that has been annotated with information about different types and used units
 pub struct AnnotatedProject<T: SourceContainer + Sync> {
     pub project: Project<T>,
-    pub units: Vec<(CompilationUnit, IndexSet<Dependency>, StringLiterals)>,
+    pub units: Vec<(CompilationUnit, FxIndexSet<Dependency>, StringLiterals)>,
     pub index: Index,
     pub annotations: AstAnnotations,
 }
@@ -266,7 +267,7 @@ impl<T: SourceContainer + Sync> AnnotatedProject<T> {
         context: &'ctx CodegenContext,
         compile_options: &CompileOptions,
         unit: &CompilationUnit,
-        dependencies: &IndexSet<Dependency>,
+        dependencies: &FxIndexSet<Dependency>,
         literals: &StringLiterals,
     ) -> Result<GeneratedModule<'ctx>, Diagnostic> {
         let mut code_generator = plc::codegen::CodeGen::new(

--- a/compiler/plc_index/Cargo.toml
+++ b/compiler/plc_index/Cargo.toml
@@ -10,5 +10,6 @@ plc_ast = { path = "../plc_ast" }
 plc_source = { path = "../plc_source" }
 plc_diagnostics = { path = "../plc_diagnostics" }
 #plc_project = { path = "../plc_project" } # TODO: This will create a circular dependency
+rustc-hash.workspace = true
 
 encoding_rs = "0.8"

--- a/compiler/plc_index/src/lib.rs
+++ b/compiler/plc_index/src/lib.rs
@@ -3,13 +3,13 @@ use plc_ast::provider::IdProvider;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 use plc_source::{SourceCode, SourceContainer};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 #[derive(Debug, Default)]
 pub struct GlobalContext {
     /// HashMap containing all read, i.e. parsed, sources where the key represents
     /// the relative file path and the value some [`SourceCode`]
-    sources: HashMap<&'static str, SourceCode>,
+    sources: FxHashMap<&'static str, SourceCode>,
 
     /// [`IdProvider`] used during the parsing session
     provider: IdProvider,
@@ -24,7 +24,7 @@ pub struct GlobalContext {
 
 impl GlobalContext {
     pub fn new() -> Self {
-        Self { sources: HashMap::new(), provider: IdProvider::default() }
+        Self { sources: FxHashMap::default(), provider: IdProvider::default() }
     }
 
     /// Inserts a single [`SourceCode`] to the internal source map

--- a/compiler/plc_xml/Cargo.toml
+++ b/compiler/plc_xml/Cargo.toml
@@ -16,6 +16,7 @@ ast = { path = "../plc_ast/", package = "plc_ast" }
 plc_diagnostics = { path = "../plc_diagnostics" }
 plc_source = { path = "../plc_source" }
 itertools.workspace = true
+rustc-hash.workspace = true
 
 [features]
 default = []

--- a/compiler/plc_xml/src/extensions.rs
+++ b/compiler/plc_xml/src/extensions.rs
@@ -1,8 +1,9 @@
 //! In this file extension traits are defined to be used within the `plc_xml` crate.
 
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use quick_xml::name::QName;
+use rustc_hash::FxHashMap;
 
 use crate::error::Error;
 
@@ -34,7 +35,7 @@ impl TryToString for Cow<'_, [u8]> {
     }
 }
 
-impl GetOrErr for HashMap<String, String> {
+impl GetOrErr for FxHashMap<String, String> {
     fn get_or_err(&self, key: &str) -> Result<String, Error> {
         self.get(key).map(|it| it.to_owned()).ok_or(Error::MissingAttribute(key.to_string()))
     }

--- a/compiler/plc_xml/src/model/block.rs
+++ b/compiler/plc_xml/src/model/block.rs
@@ -1,6 +1,7 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use quick_xml::events::{BytesStart, Event};
+use rustc_hash::FxHashMap;
 
 use crate::{
     error::Error,
@@ -21,7 +22,7 @@ pub(crate) struct Block<'xml> {
 }
 
 impl<'xml> Block<'xml> {
-    pub fn new(mut hm: HashMap<String, String>, variables: Vec<BlockVariable>) -> Result<Self, Error> {
+    pub fn new(mut hm: FxHashMap<String, String>, variables: Vec<BlockVariable>) -> Result<Self, Error> {
         Ok(Self {
             local_id: hm.get_or_err("localId").map(|it| it.parse())??,
             type_name: Cow::from(hm.get_or_err("typeName")?),

--- a/compiler/plc_xml/src/model/connector.rs
+++ b/compiler/plc_xml/src/model/connector.rs
@@ -1,6 +1,7 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use quick_xml::events::Event;
+use rustc_hash::FxHashMap;
 
 use crate::{
     error::Error,
@@ -19,7 +20,7 @@ pub(crate) struct Connector<'xml> {
 }
 
 impl<'xml> Connector<'xml> {
-    pub fn new(mut hm: HashMap<String, String>, kind: ConnectorKind) -> Result<Self, Error> {
+    pub fn new(mut hm: FxHashMap<String, String>, kind: ConnectorKind) -> Result<Self, Error> {
         Ok(Self {
             kind,
             name: Cow::from(hm.get_or_err("name")?),

--- a/compiler/plc_xml/src/model/control.rs
+++ b/compiler/plc_xml/src/model/control.rs
@@ -1,6 +1,7 @@
-use std::{borrow::Cow, collections::HashMap, str::FromStr};
+use std::{borrow::Cow, str::FromStr};
 
 use quick_xml::events::Event;
+use rustc_hash::FxHashMap;
 
 use crate::{
     error::Error,
@@ -20,7 +21,7 @@ pub(crate) struct Control<'xml> {
 }
 
 impl<'xml> Control<'xml> {
-    pub fn new(mut hm: HashMap<String, String>, kind: ControlKind) -> Result<Self, Error> {
+    pub fn new(mut hm: FxHashMap<String, String>, kind: ControlKind) -> Result<Self, Error> {
         Ok(Self {
             kind,
             name: hm.remove("label").map(Cow::from),

--- a/compiler/plc_xml/src/model/fbd.rs
+++ b/compiler/plc_xml/src/model/fbd.rs
@@ -1,4 +1,5 @@
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexSet;
+use plc::index::FxIndexMap;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocationFactory;
 use quick_xml::events::{BytesStart, Event};
@@ -15,7 +16,7 @@ use super::{
 
 /// Represent either a `localId` or `refLocalId`
 pub(crate) type NodeId = usize;
-pub(crate) type NodeIndex<'xml> = IndexMap<NodeId, Node<'xml>>;
+pub(crate) type NodeIndex<'xml> = FxIndexMap<NodeId, Node<'xml>>;
 
 #[derive(Debug, Default)]
 pub(crate) struct FunctionBlockDiagram<'xml> {
@@ -113,7 +114,7 @@ impl<'xml> Node<'xml> {
 
 impl<'xml> Parseable for FunctionBlockDiagram<'xml> {
     fn visit(reader: &mut Reader, _tag: Option<BytesStart>) -> Result<Self, Error> {
-        let mut nodes = IndexMap::new();
+        let mut nodes = FxIndexMap::default();
 
         loop {
             match reader.read_event().map_err(Error::ReadEvent)? {
@@ -304,6 +305,7 @@ mod tests {
         xml_parser::Parseable,
     };
     use insta::assert_debug_snapshot;
+    use plc::index::FxIndexMap;
     use plc_source::source_location::SourceLocationFactory;
 
     use super::Node;
@@ -336,7 +338,7 @@ mod tests {
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
 
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -359,8 +361,7 @@ mod tests {
                         ref_local_id: Some(1),
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -375,7 +376,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -418,8 +419,7 @@ mod tests {
                         formal_parameter: None,
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -434,7 +434,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -498,8 +498,7 @@ mod tests {
                         ref_local_id: Some(5),
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -514,7 +513,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -577,8 +576,7 @@ mod tests {
                         formal_parameter: None,
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -593,7 +591,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -626,8 +624,7 @@ mod tests {
                         formal_parameter: None,
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -642,7 +639,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -675,8 +672,7 @@ mod tests {
                         formal_parameter: None,
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -693,7 +689,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -756,8 +752,7 @@ mod tests {
                         formal_parameter: None,
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -773,7 +768,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -816,8 +811,7 @@ mod tests {
                         formal_parameter: None,
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);
@@ -834,7 +828,7 @@ mod tests {
         let mut model = Project::default();
         let mut pou = Pou { name: "TestProg".into(), ..Default::default() };
         let fbd = FunctionBlockDiagram {
-            nodes: [
+            nodes: FxIndexMap::from_iter([
                 (
                     1,
                     Node::FunctionBlockVariable(FunctionBlockVariable {
@@ -919,8 +913,7 @@ mod tests {
                         formal_parameter: None,
                     }),
                 ),
-            ]
-            .into(),
+            ]),
         };
         pou.body.function_block_diagram = fbd;
         model.pous.push(pou);

--- a/compiler/plc_xml/src/model/pou.rs
+++ b/compiler/plc_xml/src/model/pou.rs
@@ -1,7 +1,8 @@
-use std::{borrow::Cow, collections::HashMap, str::FromStr};
+use std::{borrow::Cow, str::FromStr};
 
 use plc_diagnostics::diagnostics::Diagnostic;
 use quick_xml::events::{BytesStart, Event};
+use rustc_hash::FxHashMap;
 
 use crate::{
     error::Error,
@@ -22,7 +23,7 @@ pub(crate) struct Pou<'xml> {
 }
 
 impl<'xml> Pou<'xml> {
-    fn with_attributes(self, attributes: HashMap<String, String>) -> Result<Self, Error> {
+    fn with_attributes(self, attributes: FxHashMap<String, String>) -> Result<Self, Error> {
         Ok(Pou {
             name: Cow::from(attributes.get_or_err("name")?),
             pou_type: attributes.get_or_err("pouType").map(|it| it.parse())??,

--- a/compiler/plc_xml/src/model/variables.rs
+++ b/compiler/plc_xml/src/model/variables.rs
@@ -4,8 +4,9 @@ use crate::error::Error;
 use crate::extensions::GetOrErr;
 use crate::reader::Reader;
 use crate::xml_parser::{get_attributes, Parseable};
+use rustc_hash::FxHashMap;
 use std::borrow::Cow;
-use std::{collections::HashMap, str::FromStr};
+use std::str::FromStr;
 
 use super::fbd::NodeId;
 
@@ -33,7 +34,7 @@ pub(crate) enum Storage {
 }
 
 impl BlockVariable {
-    pub fn new(hm: HashMap<String, String>, kind: VariableKind) -> Result<Self, Error> {
+    pub fn new(hm: FxHashMap<String, String>, kind: VariableKind) -> Result<Self, Error> {
         Ok(Self {
             kind,
             formal_parameter: hm.get_or_err("formalParameter")?,
@@ -75,7 +76,7 @@ pub(crate) struct FunctionBlockVariable<'xml> {
 }
 
 impl<'xml> FunctionBlockVariable<'xml> {
-    pub fn new(hm: HashMap<String, String>, kind: VariableKind) -> Result<Self, Error> {
+    pub fn new(hm: FxHashMap<String, String>, kind: VariableKind) -> Result<Self, Error> {
         Ok(Self {
             kind,
             local_id: hm.get_or_err("localId").map(|it| it.parse())??,

--- a/compiler/plc_xml/src/serializer.rs
+++ b/compiler/plc_xml/src/serializer.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_without_default)]
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 #[derive(Clone)]
 pub struct Node {
@@ -12,7 +12,7 @@ pub struct Node {
     /// Design Note: We use a HashMap here to avoid duplicates but also update existing values in case of
     /// repeated function calls, e.g. `with_attribute("x", 1)` and `with_attribute("x", 2)` where the value of
     /// x has been updated from 1 to 2.
-    attributes: HashMap<&'static str, &'static str>,
+    attributes: FxHashMap<&'static str, &'static str>,
 
     /// Indicates if an element has a closed form, e.g. `<position x="1" y="2"/>`
     closed: bool,
@@ -27,7 +27,7 @@ pub trait IntoNode {
 
 impl Node {
     fn new(name: &'static str) -> Self {
-        Self { name, attributes: HashMap::new(), children: Vec::new(), closed: false, content: None }
+        Self { name, attributes: FxHashMap::default(), children: Vec::new(), closed: false, content: None }
     }
 
     fn attribute(mut self, key: &'static str, value: &'static str) -> Self {

--- a/compiler/plc_xml/src/xml_parser.rs
+++ b/compiler/plc_xml/src/xml_parser.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use ast::{
     ast::{AstId, AstNode, CompilationUnit, Implementation, LinkageType, PouType as AstPouType},
     provider::IdProvider,
@@ -15,6 +13,7 @@ use plc_source::{
     SourceCode, SourceContainer,
 };
 use quick_xml::events::{attributes::Attributes, BytesStart, Event};
+use rustc_hash::FxHashMap;
 
 use crate::{
     error::Error,
@@ -35,11 +34,11 @@ mod pou;
 mod tests;
 mod variables;
 
-pub(crate) fn get_attributes(attributes: Attributes) -> Result<HashMap<String, String>, Error> {
+pub(crate) fn get_attributes(attributes: Attributes) -> Result<FxHashMap<String, String>, Error> {
     attributes
         .flatten()
         .map(|it| Ok((it.key.try_to_string()?, it.value.try_to_string()?)))
-        .collect::<Result<HashMap<_, _>, Error>>()
+        .collect::<Result<FxHashMap<_, _>, Error>>()
 }
 
 pub(crate) trait Parseable

--- a/compiler/plc_xml/src/xml_parser/fbd.rs
+++ b/compiler/plc_xml/src/xml_parser/fbd.rs
@@ -1,5 +1,6 @@
 use ast::ast::{AstFactory, AstNode, AstStatement};
-use indexmap::IndexMap;
+
+use plc::index::FxIndexMap;
 use plc_source::source_location::SourceLocation;
 
 use crate::model::fbd::{FunctionBlockDiagram, Node, NodeId};
@@ -10,7 +11,7 @@ impl<'xml> FunctionBlockDiagram<'xml> {
     /// Transforms the body of a function block diagram to their AST-equivalent, in order of execution.
     /// Only statements that are necessary for execution logic will be selected.
     pub(crate) fn transform(&self, session: &mut ParseSession) -> Vec<AstNode> {
-        let mut ast_association = IndexMap::new();
+        let mut ast_association = FxIndexMap::default();
 
         // transform each node to an ast-statement. since we might see and transform a node multiple times, we use an
         // ast-association map to keep track of the latest statement for each id
@@ -36,7 +37,7 @@ impl<'xml> FunctionBlockDiagram<'xml> {
         &self,
         id: NodeId,
         session: &mut ParseSession,
-        ast_association: &IndexMap<usize, AstNode>,
+        ast_association: &FxIndexMap<usize, AstNode>,
     ) -> (AstNode, Option<NodeId>) {
         let Some(current_node) = self.nodes.get(&id) else { unreachable!() };
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -14,8 +14,8 @@ use plc_ast::{
 };
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::{SourceLocation, SourceLocationFactory};
+use rustc_hash::FxHashMap;
 
-use crate::index::FxHashMap;
 use crate::{
     codegen::generators::expression_generator::{self, ExpressionCodeGenerator, ExpressionValue},
     index::Index,

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use inkwell::{
     basic_block::BasicBlock,
     types::BasicType,
@@ -17,6 +15,7 @@ use plc_ast::{
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::{SourceLocation, SourceLocationFactory};
 
+use crate::index::FxHashMap;
 use crate::{
     codegen::generators::expression_generator::{self, ExpressionCodeGenerator, ExpressionValue},
     index::Index,
@@ -32,7 +31,7 @@ use crate::{
 
 // Defines a set of functions that are always included in a compiled application
 lazy_static! {
-    static ref BUILTIN: HashMap<&'static str, BuiltIn> = HashMap::from([
+    static ref BUILTIN: FxHashMap<&'static str, BuiltIn> = FxHashMap::from_iter([
         (
             "ADR",
             BuiltIn {
@@ -893,7 +892,7 @@ fn generate_variable_length_array_bound_function<'ink>(
 }
 
 type AnnotationFunction = fn(&mut TypeAnnotator, &AstNode, &AstNode, Option<&AstNode>, VisitorContext);
-type GenericNameResolver = fn(&str, &[GenericBinding], &HashMap<String, GenericType>) -> String;
+type GenericNameResolver = fn(&str, &[GenericBinding], &FxHashMap<String, GenericType>) -> String;
 type CodegenFunction = for<'ink, 'b> fn(
     &'b ExpressionCodeGenerator<'ink, 'b>,
     &[&AstNode],

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::index::*;
-use indexmap::IndexSet;
+
 use inkwell::{
     context::Context,
     execution_engine::{ExecutionEngine, JitFunction},
@@ -102,7 +102,7 @@ impl<'ink> CodeGen<'ink> {
         context: &'ink CodegenContext,
         annotations: &AstAnnotations,
         literals: &StringLiterals,
-        dependencies: &IndexSet<Dependency>,
+        dependencies: &FxIndexSet<Dependency>,
         global_index: &Index,
     ) -> Result<LlvmTypedIndex<'ink>, Diagnostic> {
         let llvm = Llvm::new(context, context.create_builder());

--- a/src/codegen/debug.rs
+++ b/src/codegen/debug.rs
@@ -11,12 +11,12 @@ use inkwell::{
     module::Module,
     values::{BasicMetadataValueEnum, FunctionValue, GlobalValue, PointerValue},
 };
+use rustc_hash::FxHashMap;
 
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 
-use crate::index::FxHashMap;
 use crate::{
     datalayout::{Bytes, DataLayout, MemoryLocation},
     index::{ImplementationType, Index, PouIndexEntry, VariableIndexEntry},

--- a/src/codegen/debug.rs
+++ b/src/codegen/debug.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Range, path::Path};
+use std::{ops::Range, path::Path};
 
 use inkwell::{
     basic_block::BasicBlock,
@@ -16,6 +16,7 @@ use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 
+use crate::index::FxHashMap;
 use crate::{
     datalayout::{Bytes, DataLayout, MemoryLocation},
     index::{ImplementationType, Index, PouIndexEntry, VariableIndexEntry},
@@ -147,10 +148,10 @@ pub struct DebugBuilder<'ink> {
     context: &'ink Context,
     debug_info: DebugInfoBuilder<'ink>,
     compile_unit: DICompileUnit<'ink>,
-    types: HashMap<String, DebugType<'ink>>,
-    variables: HashMap<String, DILocalVariable<'ink>>,
+    types: FxHashMap<String, DebugType<'ink>>,
+    variables: FxHashMap<String, DILocalVariable<'ink>>,
     optimization: OptimizationLevel,
-    files: HashMap<&'static str, DIFile<'ink>>,
+    files: FxHashMap<&'static str, DIFile<'ink>>,
 }
 
 /// A wrapper that redirects to correct debug builder implementation based on the debug context.

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -21,13 +21,14 @@ use plc_ast::ast::{AstNode, AstStatement};
 use plc_ast::literals::AstLiteral;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
+use rustc_hash::FxHashMap;
 /// the data_type_generator generates user defined data-types
 /// - Structures
 /// - Enum types
 /// - SubRange types
 /// - Alias types
 /// - sized Strings
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 
 use super::ADDRESS_SPACE_GENERIC;
 use super::{expression_generator::ExpressionCodeGenerator, llvm::Llvm};
@@ -117,7 +118,7 @@ pub fn generate_data_types<'ink>(
     }
 
     let mut tries = 0;
-    let mut errors = HashMap::new();
+    let mut errors = FxHashMap::default();
     // If the tries are equal to the number of types remaining, it means we failed to resolve
     // anything
     while tries < types_to_init.len() {

--- a/src/codegen/generators/data_type_generator.rs
+++ b/src/codegen/generators/data_type_generator.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use crate::codegen::debug::Debug;
-use crate::index::{Index, VariableIndexEntry, VariableType};
+use crate::index::{FxIndexSet, Index, VariableIndexEntry, VariableType};
 use crate::resolver::{AstAnnotations, Dependency};
 use crate::typesystem::{self, DataTypeInformation, Dimension, StringEncoding, StructSource};
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
     },
     typesystem::DataType,
 };
-use indexmap::IndexSet;
+
 use inkwell::{
     types::{BasicType, BasicTypeEnum},
     values::{BasicValue, BasicValueEnum},
@@ -50,7 +50,7 @@ pub struct DataTypeGenerator<'ink, 'b> {
 pub fn generate_data_types<'ink>(
     llvm: &Llvm<'ink>,
     debug: &mut DebugBuilderEnum<'ink>,
-    dependencies: &IndexSet<Dependency>,
+    dependencies: &FxIndexSet<Dependency>,
     index: &Index,
     annotations: &AstAnnotations,
 ) -> Result<LlvmTypedIndex<'ink>, Diagnostic> {

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::index::FxHashSet;
 use crate::{
     codegen::{
         debug::{Debug, DebugBuilderEnum},
@@ -35,6 +34,7 @@ use plc_ast::{
 use plc_diagnostics::diagnostics::{Diagnostic, INTERNAL_LLVM_ERROR};
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::qualified_name;
+use rustc_hash::FxHashSet;
 use std::vec;
 
 use super::{llvm::Llvm, statement_generator::FunctionContext, ADDRESS_SPACE_CONST, ADDRESS_SPACE_GENERIC};

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use crate::index::FxHashSet;
 use crate::{
     codegen::{
         debug::{Debug, DebugBuilderEnum},
@@ -34,7 +35,7 @@ use plc_ast::{
 use plc_diagnostics::diagnostics::{Diagnostic, INTERNAL_LLVM_ERROR};
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::qualified_name;
-use std::{collections::HashSet, vec};
+use std::vec;
 
 use super::{llvm::Llvm, statement_generator::FunctionContext, ADDRESS_SPACE_CONST, ADDRESS_SPACE_GENERIC};
 /// the generator for expressions
@@ -1870,7 +1871,7 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
         if let DataTypeInformation::Struct { name: struct_name, members, .. } =
             self.get_type_hint_info_for(assignments)?
         {
-            let mut uninitialized_members: HashSet<&VariableIndexEntry> = HashSet::from_iter(members);
+            let mut uninitialized_members: FxHashSet<&VariableIndexEntry> = FxHashSet::from_iter(members);
             let mut member_values: Vec<(u32, BasicValueEnum<'ink>)> = Vec::new();
             for assignment in flatten_expression_list(assignments) {
                 if let AstStatement::Assignment(data) = assignment.get_stmt() {

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -17,18 +17,19 @@ use crate::{
     resolver::{AstAnnotations, Dependency},
     typesystem::{DataType, DataTypeInformation, VarArgs, DINT_TYPE},
 };
-use std::collections::HashMap;
 
 /// The pou_generator contains functions to generate the code for POUs (PROGRAM, FUNCTION, FUNCTION_BLOCK)
 /// # responsibilities
 /// - generates a struct-datatype for the POU's members
 /// - generates a function for the pou
 /// - declares a global instance if the POU is a PROGRAM
-use crate::index::{ArgumentType, ImplementationIndexEntry, VariableIndexEntry};
+use crate::index::{
+    ArgumentType, FxHashMap, FxIndexMap, FxIndexSet, ImplementationIndexEntry, VariableIndexEntry,
+};
 
 use crate::index::Index;
 use index::VariableType;
-use indexmap::{IndexMap, IndexSet};
+
 use inkwell::{
     module::Module,
     types::{BasicMetadataTypeEnum, BasicTypeEnum, FunctionType},
@@ -56,7 +57,7 @@ pub struct PouGenerator<'ink, 'cg> {
 pub fn generate_implementation_stubs<'ink>(
     module: &Module<'ink>,
     llvm: Llvm<'ink>,
-    dependencies: &IndexSet<Dependency>,
+    dependencies: &FxIndexSet<Dependency>,
     index: &Index,
     annotations: &AstAnnotations,
     types_index: &LlvmTypedIndex<'ink>,
@@ -73,7 +74,7 @@ pub fn generate_implementation_stubs<'ink>(
                 None
             }
         })
-        .collect::<IndexMap<_, _>>();
+        .collect::<FxIndexMap<_, _>>();
     for (name, implementation) in implementations {
         if !implementation.is_generic() {
             let curr_f =
@@ -92,7 +93,7 @@ pub fn generate_implementation_stubs<'ink>(
 pub fn generate_global_constants_for_pou_members<'ink>(
     module: &Module<'ink>,
     llvm: &Llvm<'ink>,
-    dependencies: &IndexSet<Dependency>,
+    dependencies: &FxIndexSet<Dependency>,
     index: &Index,
     annotations: &AstAnnotations,
     llvm_index: &LlvmTypedIndex<'ink>,
@@ -372,7 +373,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
         let block = context.append_basic_block(current_function, "entry");
 
         //Create all labels this function will have
-        let mut blocks = HashMap::new();
+        let mut blocks = FxHashMap::default();
         if let Some(labels) = self.index.get_labels(&implementation.name) {
             for name in labels.keys() {
                 blocks.insert(name.to_string(), self.llvm.context.append_basic_block(current_function, name));

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -23,9 +23,7 @@ use crate::{
 /// - generates a struct-datatype for the POU's members
 /// - generates a function for the pou
 /// - declares a global instance if the POU is a PROGRAM
-use crate::index::{
-    ArgumentType, FxHashMap, FxIndexMap, FxIndexSet, ImplementationIndexEntry, VariableIndexEntry,
-};
+use crate::index::{ArgumentType, FxIndexMap, FxIndexSet, ImplementationIndexEntry, VariableIndexEntry};
 
 use crate::index::Index;
 use index::VariableType;
@@ -43,6 +41,7 @@ use inkwell::{
 use plc_ast::ast::{AstNode, Implementation, PouType};
 use plc_diagnostics::diagnostics::{Diagnostic, INTERNAL_LLVM_ERROR};
 use plc_source::source_location::SourceLocation;
+use rustc_hash::FxHashMap;
 use section_mangler::{FunctionArgument, SectionMangler};
 
 pub struct PouGenerator<'ink, 'cg> {

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use super::{
     expression_generator::{to_i1, ExpressionCodeGenerator},
     llvm::Llvm,
 };
+use crate::index::FxHashMap;
 use crate::{
     codegen::{debug::Debug, llvm_typesystem::cast_if_needed},
     codegen::{debug::DebugBuilderEnum, LlvmTypedIndex},
@@ -35,7 +34,7 @@ pub struct FunctionContext<'ink, 'b> {
     /// the llvm function to generate statements into
     pub function: FunctionValue<'ink>,
     /// The blocks/labels this function can use
-    pub blocks: HashMap<String, BasicBlock<'ink>>,
+    pub blocks: FxHashMap<String, BasicBlock<'ink>>,
 }
 
 /// the StatementCodeGenerator is used to generate statements (For, If, etc.) or expressions (references, literals, etc.)

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -3,7 +3,6 @@ use super::{
     expression_generator::{to_i1, ExpressionCodeGenerator},
     llvm::Llvm,
 };
-use crate::index::FxHashMap;
 use crate::{
     codegen::{debug::Debug, llvm_typesystem::cast_if_needed},
     codegen::{debug::DebugBuilderEnum, LlvmTypedIndex},
@@ -26,6 +25,7 @@ use plc_ast::{
 };
 use plc_diagnostics::diagnostics::{Diagnostic, INTERNAL_LLVM_ERROR};
 use plc_source::source_location::SourceLocation;
+use rustc_hash::FxHashMap;
 
 /// the full context when generating statements inside a POU
 pub struct FunctionContext<'ink, 'b> {

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -6,7 +6,7 @@ use crate::{
     index::{get_initializer_name, Index, PouIndexEntry, VariableIndexEntry},
     resolver::{AnnotationMap, AstAnnotations, Dependency},
 };
-use indexmap::IndexSet;
+
 use inkwell::{module::Module, values::GlobalValue};
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
@@ -17,6 +17,7 @@ use super::{
     llvm::{GlobalValueExt, Llvm},
 };
 use crate::codegen::debug::DebugBuilderEnum;
+use crate::index::FxIndexSet;
 
 pub struct VariableGenerator<'ctx, 'b> {
     module: &'b Module<'ctx>,
@@ -41,7 +42,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
 
     pub fn generate_global_variables(
         &mut self,
-        dependencies: &IndexSet<Dependency>,
+        dependencies: &FxIndexSet<Dependency>,
         location: &'b str,
     ) -> Result<LlvmTypedIndex<'ctx>, Diagnostic> {
         let mut index = LlvmTypedIndex::default();

--- a/src/codegen/llvm_index.rs
+++ b/src/codegen/llvm_index.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
-use crate::index::FxHashMap;
 use inkwell::types::BasicTypeEnum;
 use inkwell::values::{BasicValueEnum, FunctionValue, GlobalValue, PointerValue};
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::qualified_name;
+use rustc_hash::FxHashMap;
 
 /// Index view containing declared values for the current context
 /// Parent Index is the a fallback lookup index for values not declared locally

--- a/src/codegen/llvm_index.rs
+++ b/src/codegen/llvm_index.rs
@@ -1,40 +1,40 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+use crate::index::FxHashMap;
 use inkwell::types::BasicTypeEnum;
 use inkwell::values::{BasicValueEnum, FunctionValue, GlobalValue, PointerValue};
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::qualified_name;
-use std::collections::HashMap;
 
 /// Index view containing declared values for the current context
 /// Parent Index is the a fallback lookup index for values not declared locally
 #[derive(Debug, Clone, Default)]
 pub struct LlvmTypedIndex<'ink> {
     parent_index: Option<&'ink LlvmTypedIndex<'ink>>,
-    type_associations: HashMap<String, BasicTypeEnum<'ink>>,
-    pou_type_associations: HashMap<String, BasicTypeEnum<'ink>>,
-    global_values: HashMap<String, GlobalValue<'ink>>,
-    initial_value_associations: HashMap<String, BasicValueEnum<'ink>>,
-    loaded_variable_associations: HashMap<String, PointerValue<'ink>>,
-    implementations: HashMap<String, FunctionValue<'ink>>,
-    constants: HashMap<String, BasicValueEnum<'ink>>,
-    utf08_literals: HashMap<String, GlobalValue<'ink>>,
-    utf16_literals: HashMap<String, GlobalValue<'ink>>,
+    type_associations: FxHashMap<String, BasicTypeEnum<'ink>>,
+    pou_type_associations: FxHashMap<String, BasicTypeEnum<'ink>>,
+    global_values: FxHashMap<String, GlobalValue<'ink>>,
+    initial_value_associations: FxHashMap<String, BasicValueEnum<'ink>>,
+    loaded_variable_associations: FxHashMap<String, PointerValue<'ink>>,
+    implementations: FxHashMap<String, FunctionValue<'ink>>,
+    constants: FxHashMap<String, BasicValueEnum<'ink>>,
+    utf08_literals: FxHashMap<String, GlobalValue<'ink>>,
+    utf16_literals: FxHashMap<String, GlobalValue<'ink>>,
 }
 
 impl<'ink> LlvmTypedIndex<'ink> {
     pub fn create_child(parent: &'ink LlvmTypedIndex<'ink>) -> LlvmTypedIndex<'ink> {
         LlvmTypedIndex {
             parent_index: Some(parent),
-            type_associations: HashMap::new(),
-            pou_type_associations: HashMap::new(),
-            global_values: HashMap::new(),
-            initial_value_associations: HashMap::new(),
-            loaded_variable_associations: HashMap::new(),
-            implementations: HashMap::new(),
-            constants: HashMap::new(),
-            utf08_literals: HashMap::new(),
-            utf16_literals: HashMap::new(),
+            type_associations: FxHashMap::default(),
+            pou_type_associations: FxHashMap::default(),
+            global_values: FxHashMap::default(),
+            initial_value_associations: FxHashMap::default(),
+            loaded_variable_associations: FxHashMap::default(),
+            implementations: FxHashMap::default(),
+            constants: FxHashMap::default(),
+            utf08_literals: FxHashMap::default(),
+            utf16_literals: FxHashMap::default(),
         }
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,11 +1,9 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 
-use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 
-use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
-use rustc_hash::FxHasher;
+use rustc_hash::{FxHashSet, FxHasher};
 
 use plc_ast::ast::{
     AstId, AstNode, AstStatement, DirectAccessType, GenericBinding, HardwareAccessType, LinkageType, PouType,
@@ -30,21 +28,16 @@ use self::{
 pub mod const_expressions;
 mod instance_iterator;
 pub mod symbol;
-#[cfg(test)]
-mod tests;
 pub mod visitor;
 
-/// Type alias for a HashMap using the `fx` hashing algorithm, see https://github.com/rust-lang/rustc-hash
-pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
-
-/// Type alias for a HashSet using the `fx` hashing algorithm, see https://github.com/rust-lang/rustc-hash
-pub type FxHashSet<K> = HashSet<K, BuildHasherDefault<FxHasher>>;
+#[cfg(test)]
+mod tests;
 
 /// Type alias for an IndexMap using the `fx` hashing algorithm, see https://github.com/rust-lang/rustc-hash
-pub type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FxIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 
 /// Type alias for a IndexSet using the `fx` hashing algorithm, see https://github.com/rust-lang/rustc-hash
-pub type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
+pub type FxIndexSet<K> = indexmap::IndexSet<K, BuildHasherDefault<FxHasher>>;
 
 /// A label represents a possible jump point in the source.
 /// It can be referenced by jump elements in the same unit

--- a/src/index/symbol.rs
+++ b/src/index/symbol.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022 Ghaith Hachem and Mathias Rieder
 
-use indexmap::{Equivalent, IndexMap};
+use crate::index::FxIndexMap;
+use indexmap::Equivalent;
 use std::hash::Hash;
 
 /// A multi-map implementation with a stable order of elements. When iterating
@@ -9,7 +10,7 @@ use std::hash::Hash;
 pub struct SymbolMap<K, V> {
     /// internal storage of the SymbolMap that uses an *
     /// IndexMap of Vectors
-    inner_map: IndexMap<K, Vec<V>>,
+    inner_map: FxIndexMap<K, Vec<V>>,
 }
 
 impl<K, V> Default for SymbolMap<K, V> {
@@ -47,7 +48,7 @@ where
     }
 
     /// removes and returns all elements in the SymbolMap
-    pub fn drain(&mut self, range: std::ops::RangeFull) -> indexmap::map::Drain<'_, K, std::vec::Vec<V>> {
+    pub fn drain(&mut self, range: std::ops::RangeFull) -> indexmap::map::Drain<'_, K, Vec<V>> {
         self.inner_map.drain(range)
     }
 

--- a/src/parser/tests/misc_parser_tests.rs
+++ b/src/parser/tests/misc_parser_tests.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
 use core::panic;
-use std::collections::HashSet;
 
 use crate::test_utils::tests::parse;
 use insta::assert_debug_snapshot;
@@ -12,6 +11,7 @@ use plc_ast::{
     control_statements::{AstControlStatement, CaseStatement, ForLoopStatement, IfStatement, LoopStatement},
 };
 use pretty_assertions::*;
+use rustc_hash::FxHashSet;
 
 #[test]
 fn empty_returns_empty_compilation_unit() {
@@ -66,7 +66,7 @@ fn ids_are_assigned_to_parsed_literals() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
     assert!(ids.insert(implementation.statements[0].get_id()));
     assert!(ids.insert(implementation.statements[1].get_id()));
     assert!(ids.insert(implementation.statements[2].get_id()));
@@ -87,7 +87,7 @@ fn ids_are_assigned_to_parsed_assignments() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
 
     if let AstStatement::Assignment(Assignment { left, right }) = &implementation.statements[0].get_stmt() {
         assert!(ids.insert(left.get_id()));
@@ -110,7 +110,7 @@ fn ids_are_assigned_to_callstatements() {
 
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
     if let AstStatement::CallStatement(CallStatement { operator, .. }, ..) =
         &implementation.statements[0].get_stmt()
     {
@@ -188,7 +188,7 @@ fn ids_are_assigned_to_expressions() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
 
     if let AstNode {
         id, stmt: AstStatement::BinaryExpression(BinaryExpression { left, right, .. }), ..
@@ -304,7 +304,7 @@ fn ids_are_assigned_to_if_statements() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
     match &implementation.statements[0] {
         AstNode {
             stmt:
@@ -335,7 +335,7 @@ fn ids_are_assigned_to_for_statements() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
     match &implementation.statements[0] {
         AstNode {
             stmt:
@@ -374,7 +374,7 @@ fn ids_are_assigned_to_while_statements() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
     match &implementation.statements[0] {
         AstNode {
             stmt:
@@ -406,7 +406,7 @@ fn ids_are_assigned_to_repeat_statements() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
 
     match &implementation.statements[0] {
         AstNode {
@@ -444,7 +444,7 @@ fn ids_are_assigned_to_case_statements() {
     ";
     let parse_result = parse(src).0;
     let implementation = &parse_result.implementations[0];
-    let mut ids = HashSet::new();
+    let mut ids = FxHashSet::default();
     match &implementation.statements[0] {
         AstNode {
             stmt:

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -5,12 +5,7 @@
 //! Recursively visits all statements and expressions of a `CompilationUnit` and
 //! records all resulting types associated with the statement's id.
 
-use std::{
-    collections::{HashMap, HashSet},
-    hash::Hash,
-};
-
-use indexmap::{IndexMap, IndexSet};
+use std::{collections::HashSet, hash::Hash};
 
 use plc_ast::{
     ast::{
@@ -26,6 +21,7 @@ use plc_ast::{
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::internal_type_name;
 
+use crate::index::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use crate::typesystem::VOID_INTERNAL_NAME;
 use crate::{
     builtins::{self, BuiltIn},
@@ -151,10 +147,10 @@ pub struct TypeAnnotator<'i> {
     pub(crate) index: &'i Index,
     pub(crate) annotation_map: AnnotationMapImpl,
     string_literals: StringLiterals,
-    dependencies: IndexSet<Dependency>,
+    dependencies: FxIndexSet<Dependency>,
     /// A map containing every jump encountered in a file, and the label of where this jump should
     /// point. This is later used to annotate all jumps after the initial visit is done.
-    jumps_to_annotate: HashMap<String, HashMap<String, Vec<AstId>>>,
+    jumps_to_annotate: FxHashMap<String, FxHashMap<String, Vec<AstId>>>,
 }
 
 impl TypeAnnotator<'_> {
@@ -163,16 +159,18 @@ impl TypeAnnotator<'_> {
             StatementAnnotation::Function { return_type, qualified_name, call_name } => {
                 let name = call_name.as_ref().unwrap_or(qualified_name);
                 self.dependencies.insert(Dependency::Call(name.to_string()));
-                self.dependencies.extend(self.get_datatype_dependencies(name, IndexSet::new()));
-                self.dependencies.extend(self.get_datatype_dependencies(return_type, IndexSet::new()));
+                self.dependencies.extend(self.get_datatype_dependencies(name, FxIndexSet::default()));
+                self.dependencies.extend(self.get_datatype_dependencies(return_type, FxIndexSet::default()));
             }
             StatementAnnotation::Program { qualified_name } => {
                 self.dependencies.insert(Dependency::Call(qualified_name.to_string()));
-                self.dependencies.extend(self.get_datatype_dependencies(qualified_name, IndexSet::new()));
+                self.dependencies
+                    .extend(self.get_datatype_dependencies(qualified_name, FxIndexSet::default()));
             }
             StatementAnnotation::Variable { resulting_type, qualified_name, argument_type, .. } => {
                 if matches!(argument_type.get_inner(), VariableType::Global) {
-                    self.dependencies.extend(self.get_datatype_dependencies(resulting_type, IndexSet::new()));
+                    self.dependencies
+                        .extend(self.get_datatype_dependencies(resulting_type, FxIndexSet::default()));
                     self.dependencies.insert(Dependency::Variable(qualified_name.to_string()));
                 }
             }
@@ -276,7 +274,7 @@ impl TypeAnnotator<'_> {
         };
         let operator_qualifier = &self.get_call_name(operator);
 
-        let mut generics_candidates: HashMap<String, Vec<String>> = HashMap::new();
+        let mut generics_candidates: FxHashMap<String, Vec<String>> = FxHashMap::default();
         let mut params = vec![];
         let mut parameters = parameters.into_iter();
 
@@ -608,16 +606,16 @@ impl AstAnnotations {
 #[derive(Default, Debug)]
 pub struct AnnotationMapImpl {
     /// maps a statement to the type it resolves to
-    type_map: IndexMap<AstId, StatementAnnotation>,
+    type_map: FxIndexMap<AstId, StatementAnnotation>,
 
     /// maps a statement to the target-type it should eventually resolve to
     /// example:
     /// x : BYTE := 1;  //1's actual type is DINT, 1's target type is BYTE
     /// x : INT := 1;   //1's actual type is DINT, 1's target type is INT
-    type_hint_map: IndexMap<AstId, StatementAnnotation>,
+    type_hint_map: FxIndexMap<AstId, StatementAnnotation>,
 
     /// A map from a call to the generic function name of that call
-    generic_nature_map: IndexMap<AstId, TypeNature>,
+    generic_nature_map: FxIndexMap<AstId, TypeNature>,
 
     /// maps a function to a statement
     ///
@@ -628,7 +626,7 @@ pub struct AnnotationMapImpl {
     /// ...
     /// x : BYTE(0..100);
     /// x := 10; // a call to `CheckRangeUnsigned` is maped to `10`
-    hidden_function_calls: IndexMap<AstId, AstNode>,
+    hidden_function_calls: FxIndexMap<AstId, AstNode>,
 
     //An index of newly created types
     pub new_index: Index,
@@ -702,8 +700,8 @@ impl AnnotationMap for AnnotationMapImpl {
 
 #[derive(Default)]
 pub struct StringLiterals {
-    pub utf08: HashSet<String>,
-    pub utf16: HashSet<String>,
+    pub utf08: FxHashSet<String>,
+    pub utf16: FxHashSet<String>,
 }
 
 impl StringLiterals {
@@ -719,9 +717,9 @@ impl<'i> TypeAnnotator<'i> {
         TypeAnnotator {
             annotation_map: AnnotationMapImpl::new(),
             index,
-            dependencies: IndexSet::new(),
-            string_literals: StringLiterals { utf08: HashSet::new(), utf16: HashSet::new() },
-            jumps_to_annotate: HashMap::new(),
+            dependencies: FxIndexSet::default(),
+            string_literals: StringLiterals { utf08: HashSet::default(), utf16: HashSet::default() },
+            jumps_to_annotate: FxHashMap::default(),
         }
     }
 
@@ -731,7 +729,7 @@ impl<'i> TypeAnnotator<'i> {
         index: &Index,
         unit: &'i CompilationUnit,
         id_provider: IdProvider,
-    ) -> (AnnotationMapImpl, IndexSet<Dependency>, StringLiterals) {
+    ) -> (AnnotationMapImpl, FxIndexSet<Dependency>, StringLiterals) {
         let mut visitor = TypeAnnotator::new(index);
         let ctx = &VisitorContext {
             pou: None,
@@ -759,7 +757,7 @@ impl<'i> TypeAnnotator<'i> {
 
         let body_ctx = ctx.enter_body();
         for i in &unit.implementations {
-            visitor.dependencies.extend(visitor.get_datatype_dependencies(&i.name, IndexSet::new()));
+            visitor.dependencies.extend(visitor.get_datatype_dependencies(&i.name, FxIndexSet::default()));
             i.statements.iter().for_each(|s| visitor.visit_statement(&body_ctx.with_pou(i.name.as_str()), s));
         }
 
@@ -1118,7 +1116,7 @@ impl<'i> TypeAnnotator<'i> {
 
     fn visit_data_type_declaration(&mut self, ctx: &VisitorContext, declaration: &DataTypeDeclaration) {
         if let Some(name) = declaration.get_name() {
-            let deps = self.get_datatype_dependencies(name, IndexSet::new());
+            let deps = self.get_datatype_dependencies(name, FxIndexSet::default());
             self.dependencies.extend(deps);
         }
         if let DataTypeDeclaration::DataTypeDefinition { data_type, .. } = declaration {
@@ -1129,8 +1127,8 @@ impl<'i> TypeAnnotator<'i> {
     fn get_datatype_dependencies(
         &self,
         datatype_name: &str,
-        resolved: IndexSet<Dependency>,
-    ) -> IndexSet<Dependency> {
+        resolved: FxIndexSet<Dependency>,
+    ) -> FxIndexSet<Dependency> {
         let mut resolved_names = resolved;
         let Some(datatype) = self
             .index

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -5,7 +5,8 @@
 //! Recursively visits all statements and expressions of a `CompilationUnit` and
 //! records all resulting types associated with the statement's id.
 
-use std::{collections::HashSet, hash::Hash};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::hash::Hash;
 
 use plc_ast::{
     ast::{
@@ -21,7 +22,7 @@ use plc_ast::{
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::internal_type_name;
 
-use crate::index::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
+use crate::index::{FxIndexMap, FxIndexSet};
 use crate::typesystem::VOID_INTERNAL_NAME;
 use crate::{
     builtins::{self, BuiltIn},
@@ -718,7 +719,7 @@ impl<'i> TypeAnnotator<'i> {
             annotation_map: AnnotationMapImpl::new(),
             index,
             dependencies: FxIndexSet::default(),
-            string_literals: StringLiterals { utf08: HashSet::default(), utf16: HashSet::default() },
+            string_literals: StringLiterals { utf08: FxHashSet::default(), utf16: FxHashSet::default() },
             jumps_to_annotate: FxHashMap::default(),
         }
     }

--- a/src/resolver/generics.rs
+++ b/src/resolver/generics.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
-
 use plc_ast::ast::{flatten_expression_list, AstNode, AstStatement, GenericBinding, LinkageType, TypeNature};
 use plc_source::source_location::SourceLocation;
 
+use crate::index::FxHashMap;
 use crate::{
     builtins,
     codegen::generators::expression_generator::get_implicit_call_parameter,
@@ -62,7 +61,7 @@ impl<'i> TypeAnnotator<'i> {
     /// then chooses the best fitting function signature and reannotates the function with the found information.
     pub(crate) fn update_generic_call_statement(
         &mut self,
-        generics_candidates: HashMap<String, Vec<String>>,
+        generics_candidates: FxHashMap<String, Vec<String>>,
         implementation_name: &str,
         operator: &AstNode,
         parameters: Option<&AstNode>,
@@ -128,7 +127,7 @@ impl<'i> TypeAnnotator<'i> {
         generic_function: &PouIndexEntry,
         return_type: &str,
         new_name: &str,
-        generics: &HashMap<String, GenericType>,
+        generics: &FxHashMap<String, GenericType>,
     ) {
         // the generic implementation
         if let Some(generic_implementation) = generic_function.find_implementation(self.index) {
@@ -191,7 +190,7 @@ impl<'i> TypeAnnotator<'i> {
     fn find_or_create_datatype(
         &mut self,
         member_name: &str,
-        generics: &HashMap<String, GenericType>,
+        generics: &FxHashMap<String, GenericType>,
     ) -> String {
         match self.index.find_effective_type_info(member_name) {
             Some(DataTypeInformation::Generic { generic_symbol, .. }) => {
@@ -233,7 +232,7 @@ impl<'i> TypeAnnotator<'i> {
         &mut self,
         s: &AstNode,
         function_name: &str,
-        generic_map: &HashMap<String, GenericType>,
+        generic_map: &FxHashMap<String, GenericType>,
     ) {
         /// An internal struct used to hold the type and nature of a generic parameter
         struct TypeAndNature<'a> {
@@ -322,7 +321,7 @@ impl<'i> TypeAnnotator<'i> {
         generics: &[GenericBinding],
         generic_qualified_name: &str,
         generic_return_type: &str,
-        generic_map: &HashMap<String, GenericType>,
+        generic_map: &FxHashMap<String, GenericType>,
         generic_name_resolver: GenericNameResolver,
     ) -> (String, StatementAnnotation) {
         let call_name = generic_name_resolver(generic_qualified_name, generics, generic_map);
@@ -356,9 +355,9 @@ impl<'i> TypeAnnotator<'i> {
     pub fn derive_generic_types(
         &self,
         generics: &[GenericBinding],
-        generics_candidates: HashMap<String, Vec<String>>,
-    ) -> HashMap<String, GenericType> {
-        let mut generic_map: HashMap<String, GenericType> = HashMap::new();
+        generics_candidates: FxHashMap<String, Vec<String>>,
+    ) -> FxHashMap<String, GenericType> {
+        let mut generic_map: FxHashMap<String, GenericType> = FxHashMap::default();
         for GenericBinding { name, nature } in generics {
             let smallest_possible_type =
                 self.index.find_effective_type_info(get_smallest_possible_type(nature));
@@ -425,13 +424,13 @@ impl<'i> TypeAnnotator<'i> {
     }
 }
 
-type GenericNameResolver = fn(&str, &[GenericBinding], &HashMap<String, GenericType>) -> String;
+type GenericNameResolver = fn(&str, &[GenericBinding], &FxHashMap<String, GenericType>) -> String;
 
 /// Builds the correct generic name from the given information
 pub fn generic_name_resolver(
     qualified_name: &str,
     generics: &[GenericBinding],
-    generic_map: &HashMap<String, GenericType>,
+    generic_map: &FxHashMap<String, GenericType>,
 ) -> String {
     generics
         .iter()
@@ -445,9 +444,9 @@ pub fn generic_name_resolver(
 pub fn no_generic_name_resolver(
     qualified_name: &str,
     _: &[GenericBinding],
-    _: &HashMap<String, GenericType>,
+    _: &FxHashMap<String, GenericType>,
 ) -> String {
-    generic_name_resolver(qualified_name, &[], &HashMap::new())
+    generic_name_resolver(qualified_name, &[], &FxHashMap::default())
 }
 
 pub fn get_smallest_possible_type(nature: &TypeNature) -> &str {

--- a/src/resolver/generics.rs
+++ b/src/resolver/generics.rs
@@ -1,7 +1,7 @@
 use plc_ast::ast::{flatten_expression_list, AstNode, AstStatement, GenericBinding, LinkageType, TypeNature};
 use plc_source::source_location::SourceLocation;
+use rustc_hash::FxHashMap;
 
-use crate::index::FxHashMap;
 use crate::{
     builtins,
     codegen::generators::expression_generator::get_implicit_call_parameter,

--- a/src/validation/global.rs
+++ b/src/validation/global.rs
@@ -1,8 +1,9 @@
 use plc_ast::ast::PouType;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
+use rustc_hash::FxHashMap;
 
-use crate::index::{FxHashMap, VariableIndexEntry};
+use crate::index::VariableIndexEntry;
 use crate::{
     index::{symbol::SymbolMap, Index, PouIndexEntry},
     typesystem::{DataTypeInformation, StructSource},

--- a/src/validation/global.rs
+++ b/src/validation/global.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-
 use plc_ast::ast::PouType;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 
-use crate::index::VariableIndexEntry;
+use crate::index::{FxHashMap, VariableIndexEntry};
 use crate::{
     index::{symbol::SymbolMap, Index, PouIndexEntry},
     typesystem::{DataTypeInformation, StructSource},
@@ -95,7 +93,7 @@ impl GlobalValidator {
 
         // Report name conflicts between any member variables in the VAR block
         for ty in index.get_types().values().chain(index.get_pou_types().values()) {
-            let mut groups: HashMap<&str, Vec<&VariableIndexEntry>> = HashMap::new();
+            let mut groups: FxHashMap<&str, Vec<&VariableIndexEntry>> = FxHashMap::default();
             for variable in ty.get_members() {
                 let group = groups.entry(variable.get_qualified_name()).or_default();
                 group.push(variable);
@@ -109,7 +107,7 @@ impl GlobalValidator {
 
         // Report name conflicts between enum variants and any other member variable in the VAR block
         for pou in index.get_pou_types().values() {
-            let mut groups: HashMap<&str, Vec<&VariableIndexEntry>> = HashMap::new();
+            let mut groups: FxHashMap<&str, Vec<&VariableIndexEntry>> = FxHashMap::default();
             let variants = index.get_enum_variants_in_pou(pou.get_name());
 
             for variant in variants {

--- a/src/validation/recursive.rs
+++ b/src/validation/recursive.rs
@@ -1,9 +1,9 @@
-use indexmap::IndexSet;
 use itertools::Itertools;
 
 use plc_ast::ast::PouType;
 use plc_diagnostics::diagnostics::Diagnostic;
 
+use crate::index::FxIndexSet;
 use crate::{
     index::{Index, VariableIndexEntry},
     typesystem::{DataType, DataTypeInformation, DataTypeInformationProvider, StructSource},
@@ -39,8 +39,8 @@ impl RecursiveValidator {
 
     /// Entry point of finding and reporting all recursive data structures.
     pub fn validate(&mut self, index: &Index) {
-        let mut nodes_all: IndexSet<&DataType> = IndexSet::new();
-        let mut nodes_visited = IndexSet::new();
+        let mut nodes_all: FxIndexSet<&DataType> = FxIndexSet::default();
+        let mut nodes_visited = FxIndexSet::default();
 
         // Structs (includes arrays defined in structs)
         nodes_all.extend(index.get_types().values().filter(|x| x.get_type_information().is_struct()));
@@ -60,10 +60,10 @@ impl RecursiveValidator {
     fn find_cycle<'idx>(
         &mut self,
         index: &'idx Index,
-        nodes_all: IndexSet<&'idx DataType>,
-        nodes_visited: &mut IndexSet<&'idx DataType>,
+        nodes_all: FxIndexSet<&'idx DataType>,
+        nodes_visited: &mut FxIndexSet<&'idx DataType>,
     ) {
-        let mut path = IndexSet::new();
+        let mut path = FxIndexSet::default();
 
         for node in &nodes_all {
             if !nodes_visited.contains(node) {
@@ -80,15 +80,15 @@ impl RecursiveValidator {
     fn dfs<'idx>(
         &mut self,
         index: &'idx Index,
-        path: &mut IndexSet<&'idx DataType>,
+        path: &mut FxIndexSet<&'idx DataType>,
         node_curr: &'idx DataType,
-        nodes_visited: &mut IndexSet<&'idx DataType>,
+        nodes_visited: &mut FxIndexSet<&'idx DataType>,
     ) {
         nodes_visited.insert(node_curr);
         path.insert(node_curr);
 
         for node in
-            node_curr.get_struct_members().iter().map(|x| self.get_type(index, x)).collect::<IndexSet<_>>()
+            node_curr.get_struct_members().iter().map(|x| self.get_type(index, x)).collect::<FxIndexSet<_>>()
         {
             if path.contains(node) {
                 self.report(node, path);
@@ -102,7 +102,7 @@ impl RecursiveValidator {
     /// Generates and reports the minimal path of a cycle. Specifically `path` contains all nodes visited up
     /// until a cycle, e.g. `A -> B -> C -> B`. We are only interested in `B -> C -> B` as such this method
     /// finds the first occurence of `B` to create a vector slice of `B -> C -> B` for the diagnostician.
-    fn report<'idx>(&mut self, node: &'idx DataType, path: &mut IndexSet<&'idx DataType>) {
+    fn report<'idx>(&mut self, node: &'idx DataType, path: &mut FxIndexSet<&'idx DataType>) {
         match path.get_index_of(node) {
             Some(idx) => {
                 let mut slice = path.iter().skip(idx).copied().collect::<Vec<_>>();
@@ -128,7 +128,7 @@ impl RecursiveValidator {
                 self.diagnostics.push(diagnostic);
             }
 
-            None => unreachable!("Node has to be in the IndexSet"),
+            None => unreachable!("Node has to be in the FxIndexSet"),
         }
     }
 

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, mem::discriminant};
+use std::mem::discriminant;
 
 use plc_ast::control_statements::ForLoopStatement;
 use plc_ast::{
@@ -12,7 +12,7 @@ use plc_ast::{
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 
-use crate::index::ImplementationType;
+use crate::index::{FxHashMap, FxHashSet, ImplementationType};
 use crate::validation::statement::helper::{get_datatype_name_or_slice, get_literal_int_or_const_expr_value};
 use crate::{
     builtins::{self, BuiltIn},
@@ -1259,7 +1259,7 @@ fn validate_case_statement<T: AnnotationMap>(
 ) {
     visit_statement(validator, selector, context);
 
-    let mut cases = HashSet::new();
+    let mut cases = FxHashSet::default();
     case_blocks.iter().for_each(|b| {
         let condition = b.condition.as_ref();
 
@@ -1388,14 +1388,13 @@ fn validate_assignment_type_sizes<T: AnnotationMap>(
     right: &AstNode,
     context: &ValidationContext<T>,
 ) {
-    use std::collections::HashMap;
     fn get_expression_types_and_locations<'b, T: AnnotationMap>(
         expression: &AstNode,
         context: &'b ValidationContext<T>,
         lhs_is_signed_int: bool,
         is_builtin_call: bool,
-    ) -> HashMap<&'b DataType, Vec<SourceLocation>> {
-        let mut map: HashMap<&DataType, Vec<SourceLocation>> = HashMap::new();
+    ) -> FxHashMap<&'b DataType, Vec<SourceLocation>> {
+        let mut map: FxHashMap<&DataType, Vec<SourceLocation>> = FxHashMap::default();
         match expression.get_stmt_peeled() {
             AstStatement::BinaryExpression(BinaryExpression { operator, left, right, .. })
                 if !operator.is_comparison_operator() =>

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -1,3 +1,4 @@
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::mem::discriminant;
 
 use plc_ast::control_statements::ForLoopStatement;
@@ -12,7 +13,7 @@ use plc_ast::{
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 
-use crate::index::{FxHashMap, FxHashSet, ImplementationType};
+use crate::index::ImplementationType;
 use crate::validation::statement::helper::{get_datatype_name_or_slice, get_literal_int_or_const_expr_value};
 use crate::{
     builtins::{self, BuiltIn},


### PR DESCRIPTION
This PR introduces the `FxHashMap`, `FxHashSet`, `FxIndexMap` and `FxIndexSet` types which use the non-cryptographic [fxhash](https://github.com/rust-lang/rustc-hash) algorithm also used in the Rust compiler. Doing so improves the `plc check` times by ~300 to 500 ms in a bigger internal project of ours.