### PR TITLE
refactor(AST): introduce AstVisitor trait

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -600,7 +600,6 @@ pub enum AstStatement {
     DefaultValue(DefaultValue),
     // Literals
     Literal(AstLiteral),
-    CastStatement(CastStatement),
     MultipliedStatement(MultipliedStatement),
     // Expressions
     ReferenceExpr(ReferenceExpr),
@@ -735,9 +734,6 @@ impl Debug for AstNode {
             }
             AstStatement::ContinueStatement(..) => f.debug_struct("ContinueStatement").finish(),
             AstStatement::ExitStatement(..) => f.debug_struct("ExitStatement").finish(),
-            AstStatement::CastStatement(CastStatement { target, type_name }) => {
-                f.debug_struct("CastStatement").field("type_name", type_name).field("target", target).finish()
-            }
             AstStatement::ReferenceExpr(ReferenceExpr { access, base }) => {
                 f.debug_struct("ReferenceExpr").field("kind", access).field("base", base).finish()
             }

--- a/compiler/plc_ast/src/lib.rs
+++ b/compiler/plc_ast/src/lib.rs
@@ -7,3 +7,4 @@ pub mod control_statements;
 pub mod literals;
 mod pre_processor;
 pub mod provider;
+pub mod visitor;

--- a/compiler/plc_ast/src/visitor.rs
+++ b/compiler/plc_ast/src/visitor.rs
@@ -1,0 +1,478 @@
+/// This module defines the `AstVisitor` trait and its associated macros.
+/// The `AstVisitor` trait provides a set of methods for traversing and visiting ASTs
+use crate::ast::AstNode;
+use crate::ast::*;
+use crate::control_statements::{AstControlStatement, ConditionalBlock, ReturnStatement};
+use crate::literals::AstLiteral;
+
+/// Macro that walks through all nodes in an iterator and applies the visitor's `walk` method to each node.
+macro_rules! visit_all_nodes {
+    ($visitor:expr, $iter:expr) => {
+        for node in $iter {
+            $visitor.visit(node);
+        }
+    };
+}
+
+/// Macro that walks through a list of nodes and applies the visitor's `walk` method to each node.
+macro_rules! visit_nodes {
+    ($visitor:expr, $($node:expr),*) => {
+        $(
+            $visitor.visit($node);
+        )*
+    };
+}
+
+pub trait Walker {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default;
+}
+
+/// The `AstVisitor` trait provides a set of methods for traversing and visiting different types of AST nodes.
+/// Implementors can individually override the methods they are interested in. When overriding a method,
+/// make sure to call `walk` on the visited statement to visit its children. DO NOT call walk on
+/// the node itself (last parameter).
+///
+/// # Example
+/// ```
+/// use plc_ast::{
+///    ast::{Assignment, AstNode},
+///    visitor::{AstVisitor, Walker},
+/// };
+///
+/// struct AssignmentCounter {
+///    count: usize,
+/// }
+///
+/// impl AstVisitor<()> for AssignmentCounter {
+///    fn visit_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
+///        self.count += 1;
+///        // visit child nodes
+///        stmt.walk(self)
+///    }
+///
+///    fn visit_output_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
+///        self.count += 1;
+///        // visit child nodes
+///        stmt.walk(self)
+///    }
+/// }
+/// ```
+pub trait AstVisitor<T: Default>: Sized {
+    /// Walks through an `AstNode` and applies the visitor's `walk` method to each node.
+    fn visit(&mut self, node: &AstNode) -> T {
+        node.walk(self)
+    }
+
+    /// Visits an `EmptyStatement` node.
+    /// Make sure to call `walk` on the `EmptyStatement` node to visit its children.
+    fn visit_empty_statement(&mut self, _stmt: &EmptyStatement, _node: &AstNode) -> T {
+        Default::default()
+    }
+
+    /// Visits a `DefaultValue` node.
+    /// Make sure to call `walk` on the `DefaultValue` node to visit its children.
+    fn visit_default_value(&mut self, _stmt: &DefaultValue, _node: &AstNode) -> T {
+        Default::default()
+    }
+
+    /// Visits an `AstLiteral` node.
+    /// Make sure to call `walk` on the `AstLiteral` node to visit its children.
+    fn visit_literal(&mut self, _stmt: &AstLiteral, _node: &AstNode) -> T {
+        Default::default()
+    }
+
+    /// Visits a `CastStatement` node.
+    /// Make sure to call `walk` on the `CastStatement` node to visit its children.
+    fn visit_cast_statement(&mut self, stmt: &CastStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `MultipliedStatement` node.
+    /// Make sure to call `walk` on the `MultipliedStatement` node to visit its children.
+    fn visit_multiplied_statement(&mut self, stmt: &MultipliedStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `ReferenceExpr` node.
+    /// Make sure to call `walk` on the `ReferenceExpr` node to visit its children.
+    fn visit_reference_expr(&mut self, stmt: &ReferenceExpr, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits an `Identifier` node.
+    fn visit_identifier(&mut self, _stmt: &str, _node: &AstNode) -> T {
+        Default::default()
+    }
+
+    /// Visits a `DirectAccess` node.
+    /// Make sure to call `walk` on the `DirectAccess` node to visit its children.
+    fn visit_direct_access(&mut self, stmt: &DirectAccess, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `HardwareAccess` node.
+    /// Make sure to call `walk` on the `HardwareAccess` node to visit its children.
+    fn visit_hardware_access(&mut self, stmt: &HardwareAccess, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `BinaryExpression` node.
+    /// Make sure to call `walk` on the `BinaryExpression` node to visit its children.
+    fn visit_binary_expression(&mut self, stmt: &BinaryExpression, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `UnaryExpression` node.
+    /// Make sure to call `walk` on the `UnaryExpression` node to visit its children.
+    fn visit_unary_expression(&mut self, stmt: &UnaryExpression, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits an `ExpressionList` node.
+    /// Make sure to call `walk` on the `Vec<AstNode>` node to visit its children.
+    fn visit_expression_list(&mut self, stmt: &Vec<AstNode>, _node: &AstNode) -> T {
+        visit_all_nodes!(self, stmt);
+        Default::default()
+    }
+
+    /// Visits a `ParenExpression` node.
+    /// Make sure to call `walk` on the inner `AstNode` node to visit its children.
+    fn visit_paren_expression(&mut self, inner: &AstNode, _node: &AstNode) -> T {
+        inner.walk(self)
+    }
+
+    /// Visits a `RangeStatement` node.
+    /// Make sure to call `walk` on the `RangeStatement` node to visit its children.
+    fn visit_range_statement(&mut self, stmt: &RangeStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `VlaRangeStatement` node.
+    fn visit_vla_range_statement(&mut self, _node: &AstNode) -> T {
+        Default::default()
+    }
+
+    /// Visits an `Assignment` node.
+    /// Make sure to call `walk` on the `Assignment` node to visit its children.
+    fn visit_assignment(&mut self, stmt: &Assignment, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits an `OutputAssignment` node.
+    /// Make sure to call `walk` on the `Assignment` node to visit its children.
+    fn visit_output_assignment(&mut self, stmt: &Assignment, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `CallStatement` node.
+    /// Make sure to call `walk` on the `CallStatement` node to visit its children.
+    fn visit_call_statement(&mut self, stmt: &CallStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits an `AstControlStatement` node.
+    /// Make sure to call `walk` on the `AstControlStatement` node to visit its children.
+    fn visit_control_statement(&mut self, stmt: &AstControlStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `CaseCondition` node.
+    /// Make sure to call `walk` on the child-`AstNode` node to visit its children.
+    fn visit_case_condition(&mut self, child: &AstNode, _node: &AstNode) -> T {
+        child.walk(self)
+    }
+
+    /// Visits an `ExitStatement` node.
+    fn visit_exit_statement(&mut self, _node: &AstNode) -> T {
+        Default::default()
+    }
+
+    /// Visits a `ContinueStatement` node.
+    fn visit_continue_statement(&mut self, _node: &AstNode) -> T {
+        Default::default()
+    }
+
+    /// Visits a `ReturnStatement` node.
+    /// Make sure to call `walk` on the `ReturnStatement` node to visit its children.
+    fn visit_return_statement(&mut self, stmt: &ReturnStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `JumpStatement` node.
+    /// Make sure to call `walk` on the `JumpStatement` node to visit its children.
+    fn visit_jump_statement(&mut self, stmt: &JumpStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+
+    /// Visits a `LabelStatement` node.
+    /// Make sure to call `walk` on the `LabelStatement` node to visit its children.
+    fn visit_label_statement(&mut self, stmt: &LabelStatement, _node: &AstNode) -> T {
+        stmt.walk(self)
+    }
+}
+
+/// Walks through a slice of `ConditionalBlock` and applies the visitor's `walk` method to each node.
+fn walk_conditional_blocks<T, V>(visitor: &mut V, blocks: &[ConditionalBlock]) -> T
+where
+    V: AstVisitor<T>,
+    T: Default,
+{
+    for b in blocks {
+        visit_nodes!(visitor, &b.condition);
+        visit_all_nodes!(visitor, &b.body);
+    }
+    Default::default()
+}
+
+impl Walker for Vec<AstNode> {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_all_nodes!(visitor, self);
+        Default::default()
+    }
+}
+
+impl Walker for EmptyStatement {
+    fn walk<T, V>(&self, _visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        Default::default()
+    }
+}
+
+impl Walker for AstLiteral {
+    fn walk<T, V>(&self, _visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        Default::default()
+    }
+}
+
+impl Walker for MultipliedStatement {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visitor.visit(&self.element)
+    }
+}
+
+impl Walker for ReferenceExpr {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        if let Some(base) = &self.base {
+            visitor.visit(base);
+        }
+
+        match &self.access {
+            ReferenceAccess::Member(t) | ReferenceAccess::Index(t) | ReferenceAccess::Cast(t) => {
+                visitor.visit(t)
+            }
+            _ => Default::default(),
+        }
+    }
+}
+
+impl Walker for CastStatement {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visitor.visit(&self.target);
+        Default::default()
+    }
+}
+
+impl Walker for DirectAccess {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_nodes!(visitor, &self.index);
+        Default::default()
+    }
+}
+
+impl Walker for HardwareAccess {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_all_nodes!(visitor, &self.address);
+        Default::default()
+    }
+}
+
+impl Walker for BinaryExpression {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_nodes!(visitor, &self.left, &self.right);
+        Default::default()
+    }
+}
+
+impl Walker for UnaryExpression {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_nodes!(visitor, &self.value);
+        Default::default()
+    }
+}
+
+impl Walker for Assignment {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_nodes!(visitor, &self.left, &self.right);
+        Default::default()
+    }
+}
+
+impl Walker for RangeStatement {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_nodes!(visitor, &self.start, &self.end);
+        Default::default()
+    }
+}
+
+impl Walker for CallStatement {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_nodes!(visitor, &self.operator);
+        if let Some(params) = &self.parameters {
+            visit_nodes!(visitor, params);
+        }
+        Default::default()
+    }
+}
+
+impl Walker for AstControlStatement {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        match self {
+            AstControlStatement::If(stmt) => {
+                walk_conditional_blocks(visitor, &stmt.blocks);
+                visit_all_nodes!(visitor, &stmt.else_block);
+            }
+            AstControlStatement::WhileLoop(stmt) | AstControlStatement::RepeatLoop(stmt) => {
+                visit_nodes!(visitor, &stmt.condition);
+                visit_all_nodes!(visitor, &stmt.body);
+            }
+            AstControlStatement::ForLoop(stmt) => {
+                visit_nodes!(visitor, &stmt.counter, &stmt.start, &stmt.end);
+                visit_all_nodes!(visitor, &stmt.by_step);
+                visit_all_nodes!(visitor, &stmt.body);
+            }
+            AstControlStatement::Case(stmt) => {
+                visit_nodes!(visitor, &stmt.selector);
+                walk_conditional_blocks(visitor, &stmt.case_blocks);
+                visit_all_nodes!(visitor, &stmt.else_block);
+            }
+        }
+        Default::default()
+    }
+}
+
+impl Walker for ReturnStatement {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_all_nodes!(visitor, &self.condition);
+        Default::default()
+    }
+}
+
+impl Walker for LabelStatement {
+    fn walk<T, V>(&self, _visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        Default::default()
+    }
+}
+
+impl Walker for JumpStatement {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        visit_nodes!(visitor, &self.condition, &self.target);
+        Default::default()
+    }
+}
+
+impl Walker for AstNode {
+    fn walk<T, V>(&self, visitor: &mut V) -> T
+    where
+        V: AstVisitor<T>,
+        T: Default,
+    {
+        let node = self;
+        match &self.stmt {
+            AstStatement::EmptyStatement(stmt) => visitor.visit_empty_statement(stmt, node),
+            AstStatement::DefaultValue(stmt) => visitor.visit_default_value(stmt, node),
+            AstStatement::Literal(stmt) => visitor.visit_literal(stmt, node),
+            AstStatement::CastStatement(stmt) => visitor.visit_cast_statement(stmt, node),
+            AstStatement::MultipliedStatement(stmt) => visitor.visit_multiplied_statement(stmt, node),
+            AstStatement::ReferenceExpr(stmt) => visitor.visit_reference_expr(stmt, node),
+            AstStatement::Identifier(stmt) => visitor.visit_identifier(stmt, node),
+            AstStatement::DirectAccess(stmt) => visitor.visit_direct_access(stmt, node),
+            AstStatement::HardwareAccess(stmt) => visitor.visit_hardware_access(stmt, node),
+            AstStatement::BinaryExpression(stmt) => visitor.visit_binary_expression(stmt, node),
+            AstStatement::UnaryExpression(stmt) => visitor.visit_unary_expression(stmt, node),
+            AstStatement::ExpressionList(stmt) => visitor.visit_expression_list(stmt, node),
+            AstStatement::ParenExpression(stmt) => visitor.visit_paren_expression(stmt, node),
+            AstStatement::RangeStatement(stmt) => visitor.visit_range_statement(stmt, node),
+            AstStatement::VlaRangeStatement => visitor.visit_vla_range_statement(node),
+            AstStatement::Assignment(stmt) => visitor.visit_assignment(stmt, node),
+            AstStatement::OutputAssignment(stmt) => visitor.visit_output_assignment(stmt, node),
+            AstStatement::CallStatement(stmt) => visitor.visit_call_statement(stmt, node),
+            AstStatement::ControlStatement(stmt) => visitor.visit_control_statement(stmt, node),
+            AstStatement::CaseCondition(stmt) => visitor.visit_case_condition(stmt, node),
+            AstStatement::ExitStatement(_stmt) => visitor.visit_exit_statement(node),
+            AstStatement::ContinueStatement(_stmt) => visitor.visit_continue_statement(node),
+            AstStatement::ReturnStatement(stmt) => visitor.visit_return_statement(stmt, node),
+            AstStatement::JumpStatement(stmt) => visitor.visit_jump_statement(stmt, node),
+            AstStatement::LabelStatement(stmt) => visitor.visit_label_statement(stmt, node),
+        }
+    }
+}

--- a/compiler/plc_ast/src/visitor.rs
+++ b/compiler/plc_ast/src/visitor.rs
@@ -34,16 +34,23 @@ macro_rules! visit_nodes {
 ///
 /// # Example
 /// ```
-/// use plc_ast::{
-///   ast::{Assignment, AstNode},
-///  visitor::{AstVisitor, Walker},
-/// };
-///
-/// impl Walker for Assignment {
-///    fn walk<V>(&self, visitor: &mut V)
-///      where V: AstVisitor {
-///     visitor.visit(&self.right);
-///     visitor.visit(&self.left);
+/// use plc_ast::ast::AstNode;
+/// use plc_ast::visitor::Walker;
+/// use plc_ast::visitor::AstVisitor;
+/// 
+/// struct MyAssignment {
+///   left: AstNode,
+///  right: AstNode,
+/// }
+/// 
+/// impl Walker for MyAssignment {
+///     fn walk<V>(&self, visitor: &mut V)
+///     where
+///         V: AstVisitor,
+///     {
+///         visitor.visit(&self.right);
+///         visitor.visit(&self.left);
+///     }
 /// }
 /// ```
 ///
@@ -52,6 +59,8 @@ pub trait Walker {
     where
         V: AstVisitor;
 }
+
+
 
 /// The `AstVisitor` trait provides a set of methods for visiting different types of AST nodes.
 /// Implementors can individually override the methods they are interested in. When overriding a method,

--- a/compiler/plc_ast/src/visitor.rs
+++ b/compiler/plc_ast/src/visitor.rs
@@ -37,12 +37,12 @@ macro_rules! visit_nodes {
 /// use plc_ast::ast::AstNode;
 /// use plc_ast::visitor::Walker;
 /// use plc_ast::visitor::AstVisitor;
-/// 
+///
 /// struct MyAssignment {
 ///   left: AstNode,
 ///  right: AstNode,
 /// }
-/// 
+///
 /// impl Walker for MyAssignment {
 ///     fn walk<V>(&self, visitor: &mut V)
 ///     where
@@ -59,8 +59,6 @@ pub trait Walker {
     where
         V: AstVisitor;
 }
-
-
 
 /// The `AstVisitor` trait provides a set of methods for visiting different types of AST nodes.
 /// Implementors can individually override the methods they are interested in. When overriding a method,

--- a/compiler/plc_ast/src/visitor.rs
+++ b/compiler/plc_ast/src/visitor.rs
@@ -89,6 +89,8 @@ pub trait AstVisitor: Sized {
         variable.walk(self);
     }
 
+    /// Visits an enum element `AstNode` node.
+    /// Make sure to call `walk` on the `AstNode` node to visit its children.
     fn visit_enum_element(&mut self, element: &AstNode) {
         element.walk(self);
     }
@@ -118,20 +120,14 @@ pub trait AstVisitor: Sized {
     }
 
     /// Visits an `EmptyStatement` node.
-    /// Make sure to call `walk` on the `EmptyStatement` node to visit its children.
     fn visit_empty_statement(&mut self, _stmt: &EmptyStatement, _node: &AstNode) {}
 
     /// Visits a `DefaultValue` node.
-    /// Make sure to call `walk` on the `DefaultValue` node to visit its children.
     fn visit_default_value(&mut self, _stmt: &DefaultValue, _node: &AstNode) {}
 
     /// Visits an `AstLiteral` node.
     /// Make sure to call `walk` on the `AstLiteral` node to visit its children.
-    fn visit_literal(&mut self, _stmt: &AstLiteral, _node: &AstNode) {}
-
-    /// Visits a `CastStatement` node.
-    /// Make sure to call `walk` on the `CastStatement` node to visit its children.
-    fn visit_cast_statement(&mut self, stmt: &CastStatement, _node: &AstNode) {
+    fn visit_literal(&mut self, stmt: &AstLiteral, _node: &AstNode) {
         stmt.walk(self)
     }
 
@@ -245,10 +241,7 @@ pub trait AstVisitor: Sized {
     }
 
     /// Visits a `LabelStatement` node.
-    /// Make sure to call `walk` on the `LabelStatement` node to visit its children.
-    fn visit_label_statement(&mut self, stmt: &LabelStatement, _node: &AstNode) {
-        stmt.walk(self)
-    }
+    fn visit_label_statement(&mut self, _stmt: &LabelStatement, _node: &AstNode) {}
 }
 
 /// Walks through a slice of `ConditionalBlock` and applies the visitor's `walk` method to each node.
@@ -259,24 +252,6 @@ where
     for b in blocks {
         visit_nodes!(visitor, &b.condition);
         visit_all_nodes!(visitor, &b.body);
-    }
-}
-
-impl Walker for Vec<AstNode> {
-    fn walk<V>(&self, visitor: &mut V)
-    where
-        V: AstVisitor,
-    {
-        visit_all_nodes!(visitor, self);
-    }
-}
-
-impl Walker for EmptyStatement {
-    fn walk<V>(&self, _visitor: &mut V)
-    where
-        V: AstVisitor,
-    {
-        // do nothing
     }
 }
 
@@ -313,15 +288,6 @@ impl Walker for ReferenceExpr {
             }
             _ => {}
         }
-    }
-}
-
-impl Walker for CastStatement {
-    fn walk<V>(&self, visitor: &mut V)
-    where
-        V: AstVisitor,
-    {
-        visitor.visit(&self.target);
     }
 }
 
@@ -428,14 +394,6 @@ impl Walker for ReturnStatement {
     }
 }
 
-impl Walker for LabelStatement {
-    fn walk<V>(&self, _visitor: &mut V)
-    where
-        V: AstVisitor,
-    {
-    }
-}
-
 impl Walker for JumpStatement {
     fn walk<V>(&self, visitor: &mut V)
     where
@@ -455,7 +413,6 @@ impl Walker for AstNode {
             AstStatement::EmptyStatement(stmt) => visitor.visit_empty_statement(stmt, node),
             AstStatement::DefaultValue(stmt) => visitor.visit_default_value(stmt, node),
             AstStatement::Literal(stmt) => visitor.visit_literal(stmt, node),
-            AstStatement::CastStatement(stmt) => visitor.visit_cast_statement(stmt, node),
             AstStatement::MultipliedStatement(stmt) => visitor.visit_multiplied_statement(stmt, node),
             AstStatement::ReferenceExpr(stmt) => visitor.visit_reference_expr(stmt, node),
             AstStatement::Identifier(stmt) => visitor.visit_identifier(stmt, node),

--- a/compiler/plc_ast/src/visitor.rs
+++ b/compiler/plc_ast/src/visitor.rs
@@ -24,10 +24,9 @@ macro_rules! visit_nodes {
 }
 
 pub trait Walker {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default;
+        V: AstVisitor;
 }
 
 /// The `AstVisitor` trait provides a set of methods for traversing and visiting different types of AST nodes.
@@ -46,233 +45,210 @@ pub trait Walker {
 ///    count: usize,
 /// }
 ///
-/// impl AstVisitor<()> for AssignmentCounter {
+/// impl AstVisitor for AssignmentCounter {
 ///    fn visit_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
 ///        self.count += 1;
 ///        // visit child nodes
-///        stmt.walk(self)
+///        stmt.walk(self);
 ///    }
 ///
 ///    fn visit_output_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
 ///        self.count += 1;
 ///        // visit child nodes
-///        stmt.walk(self)
+///        stmt.walk(self);
 ///    }
 /// }
 /// ```
-pub trait AstVisitor<T: Default>: Sized {
+pub trait AstVisitor: Sized {
     /// Walks through an `AstNode` and applies the visitor's `walk` method to each node.
-    fn visit(&mut self, node: &AstNode) -> T {
+    fn visit(&mut self, node: &AstNode) {
         node.walk(self)
     }
 
     /// Visits an `EmptyStatement` node.
     /// Make sure to call `walk` on the `EmptyStatement` node to visit its children.
-    fn visit_empty_statement(&mut self, _stmt: &EmptyStatement, _node: &AstNode) -> T {
-        Default::default()
-    }
+    fn visit_empty_statement(&mut self, _stmt: &EmptyStatement, _node: &AstNode) {}
 
     /// Visits a `DefaultValue` node.
     /// Make sure to call `walk` on the `DefaultValue` node to visit its children.
-    fn visit_default_value(&mut self, _stmt: &DefaultValue, _node: &AstNode) -> T {
-        Default::default()
-    }
+    fn visit_default_value(&mut self, _stmt: &DefaultValue, _node: &AstNode) {}
 
     /// Visits an `AstLiteral` node.
     /// Make sure to call `walk` on the `AstLiteral` node to visit its children.
-    fn visit_literal(&mut self, _stmt: &AstLiteral, _node: &AstNode) -> T {
-        Default::default()
-    }
+    fn visit_literal(&mut self, _stmt: &AstLiteral, _node: &AstNode) {}
 
     /// Visits a `CastStatement` node.
     /// Make sure to call `walk` on the `CastStatement` node to visit its children.
-    fn visit_cast_statement(&mut self, stmt: &CastStatement, _node: &AstNode) -> T {
+    fn visit_cast_statement(&mut self, stmt: &CastStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `MultipliedStatement` node.
     /// Make sure to call `walk` on the `MultipliedStatement` node to visit its children.
-    fn visit_multiplied_statement(&mut self, stmt: &MultipliedStatement, _node: &AstNode) -> T {
+    fn visit_multiplied_statement(&mut self, stmt: &MultipliedStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `ReferenceExpr` node.
     /// Make sure to call `walk` on the `ReferenceExpr` node to visit its children.
-    fn visit_reference_expr(&mut self, stmt: &ReferenceExpr, _node: &AstNode) -> T {
+    fn visit_reference_expr(&mut self, stmt: &ReferenceExpr, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `Identifier` node.
-    fn visit_identifier(&mut self, _stmt: &str, _node: &AstNode) -> T {
-        Default::default()
-    }
+    fn visit_identifier(&mut self, _stmt: &str, _node: &AstNode) {}
 
     /// Visits a `DirectAccess` node.
     /// Make sure to call `walk` on the `DirectAccess` node to visit its children.
-    fn visit_direct_access(&mut self, stmt: &DirectAccess, _node: &AstNode) -> T {
+    fn visit_direct_access(&mut self, stmt: &DirectAccess, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `HardwareAccess` node.
     /// Make sure to call `walk` on the `HardwareAccess` node to visit its children.
-    fn visit_hardware_access(&mut self, stmt: &HardwareAccess, _node: &AstNode) -> T {
+    fn visit_hardware_access(&mut self, stmt: &HardwareAccess, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `BinaryExpression` node.
     /// Make sure to call `walk` on the `BinaryExpression` node to visit its children.
-    fn visit_binary_expression(&mut self, stmt: &BinaryExpression, _node: &AstNode) -> T {
+    fn visit_binary_expression(&mut self, stmt: &BinaryExpression, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `UnaryExpression` node.
     /// Make sure to call `walk` on the `UnaryExpression` node to visit its children.
-    fn visit_unary_expression(&mut self, stmt: &UnaryExpression, _node: &AstNode) -> T {
+    fn visit_unary_expression(&mut self, stmt: &UnaryExpression, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `ExpressionList` node.
     /// Make sure to call `walk` on the `Vec<AstNode>` node to visit its children.
-    fn visit_expression_list(&mut self, stmt: &Vec<AstNode>, _node: &AstNode) -> T {
+    fn visit_expression_list(&mut self, stmt: &Vec<AstNode>, _node: &AstNode) {
         visit_all_nodes!(self, stmt);
-        Default::default()
     }
 
     /// Visits a `ParenExpression` node.
     /// Make sure to call `walk` on the inner `AstNode` node to visit its children.
-    fn visit_paren_expression(&mut self, inner: &AstNode, _node: &AstNode) -> T {
+    fn visit_paren_expression(&mut self, inner: &AstNode, _node: &AstNode) {
         inner.walk(self)
     }
 
     /// Visits a `RangeStatement` node.
     /// Make sure to call `walk` on the `RangeStatement` node to visit its children.
-    fn visit_range_statement(&mut self, stmt: &RangeStatement, _node: &AstNode) -> T {
+    fn visit_range_statement(&mut self, stmt: &RangeStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `VlaRangeStatement` node.
-    fn visit_vla_range_statement(&mut self, _node: &AstNode) -> T {
-        Default::default()
-    }
+    fn visit_vla_range_statement(&mut self, _node: &AstNode) {}
 
     /// Visits an `Assignment` node.
     /// Make sure to call `walk` on the `Assignment` node to visit its children.
-    fn visit_assignment(&mut self, stmt: &Assignment, _node: &AstNode) -> T {
+    fn visit_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `OutputAssignment` node.
     /// Make sure to call `walk` on the `Assignment` node to visit its children.
-    fn visit_output_assignment(&mut self, stmt: &Assignment, _node: &AstNode) -> T {
+    fn visit_output_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `CallStatement` node.
     /// Make sure to call `walk` on the `CallStatement` node to visit its children.
-    fn visit_call_statement(&mut self, stmt: &CallStatement, _node: &AstNode) -> T {
+    fn visit_call_statement(&mut self, stmt: &CallStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `AstControlStatement` node.
     /// Make sure to call `walk` on the `AstControlStatement` node to visit its children.
-    fn visit_control_statement(&mut self, stmt: &AstControlStatement, _node: &AstNode) -> T {
+    fn visit_control_statement(&mut self, stmt: &AstControlStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `CaseCondition` node.
     /// Make sure to call `walk` on the child-`AstNode` node to visit its children.
-    fn visit_case_condition(&mut self, child: &AstNode, _node: &AstNode) -> T {
+    fn visit_case_condition(&mut self, child: &AstNode, _node: &AstNode) {
         child.walk(self)
     }
 
     /// Visits an `ExitStatement` node.
-    fn visit_exit_statement(&mut self, _node: &AstNode) -> T {
-        Default::default()
-    }
+    fn visit_exit_statement(&mut self, _node: &AstNode) {}
 
     /// Visits a `ContinueStatement` node.
-    fn visit_continue_statement(&mut self, _node: &AstNode) -> T {
-        Default::default()
-    }
+    fn visit_continue_statement(&mut self, _node: &AstNode) {}
 
     /// Visits a `ReturnStatement` node.
     /// Make sure to call `walk` on the `ReturnStatement` node to visit its children.
-    fn visit_return_statement(&mut self, stmt: &ReturnStatement, _node: &AstNode) -> T {
+    fn visit_return_statement(&mut self, stmt: &ReturnStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `JumpStatement` node.
     /// Make sure to call `walk` on the `JumpStatement` node to visit its children.
-    fn visit_jump_statement(&mut self, stmt: &JumpStatement, _node: &AstNode) -> T {
+    fn visit_jump_statement(&mut self, stmt: &JumpStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `LabelStatement` node.
     /// Make sure to call `walk` on the `LabelStatement` node to visit its children.
-    fn visit_label_statement(&mut self, stmt: &LabelStatement, _node: &AstNode) -> T {
+    fn visit_label_statement(&mut self, stmt: &LabelStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 }
 
 /// Walks through a slice of `ConditionalBlock` and applies the visitor's `walk` method to each node.
-fn walk_conditional_blocks<T, V>(visitor: &mut V, blocks: &[ConditionalBlock]) -> T
+fn walk_conditional_blocks<V>(visitor: &mut V, blocks: &[ConditionalBlock])
 where
-    V: AstVisitor<T>,
-    T: Default,
+    V: AstVisitor,
 {
     for b in blocks {
         visit_nodes!(visitor, &b.condition);
         visit_all_nodes!(visitor, &b.body);
     }
-    Default::default()
 }
 
 impl Walker for Vec<AstNode> {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_all_nodes!(visitor, self);
-        Default::default()
     }
 }
 
 impl Walker for EmptyStatement {
-    fn walk<T, V>(&self, _visitor: &mut V) -> T
+    fn walk<V>(&self, _visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
-        Default::default()
+        // do nothing
     }
 }
 
 impl Walker for AstLiteral {
-    fn walk<T, V>(&self, _visitor: &mut V) -> T
+    fn walk<V>(&self, _visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
-        Default::default()
+        // do nothing
     }
 }
 
 impl Walker for MultipliedStatement {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visitor.visit(&self.element)
     }
 }
 
 impl Walker for ReferenceExpr {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         if let Some(base) = &self.base {
             visitor.visit(base);
@@ -282,107 +258,90 @@ impl Walker for ReferenceExpr {
             ReferenceAccess::Member(t) | ReferenceAccess::Index(t) | ReferenceAccess::Cast(t) => {
                 visitor.visit(t)
             }
-            _ => Default::default(),
+            _ => {}
         }
     }
 }
 
 impl Walker for CastStatement {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visitor.visit(&self.target);
-        Default::default()
     }
 }
 
 impl Walker for DirectAccess {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_nodes!(visitor, &self.index);
-        Default::default()
     }
 }
 
 impl Walker for HardwareAccess {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_all_nodes!(visitor, &self.address);
-        Default::default()
     }
 }
 
 impl Walker for BinaryExpression {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_nodes!(visitor, &self.left, &self.right);
-        Default::default()
     }
 }
 
 impl Walker for UnaryExpression {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_nodes!(visitor, &self.value);
-        Default::default()
     }
 }
 
 impl Walker for Assignment {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_nodes!(visitor, &self.left, &self.right);
-        Default::default()
     }
 }
 
 impl Walker for RangeStatement {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_nodes!(visitor, &self.start, &self.end);
-        Default::default()
     }
 }
 
 impl Walker for CallStatement {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_nodes!(visitor, &self.operator);
         if let Some(params) = &self.parameters {
             visit_nodes!(visitor, params);
         }
-        Default::default()
     }
 }
 
 impl Walker for AstControlStatement {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         match self {
             AstControlStatement::If(stmt) => {
@@ -404,47 +363,39 @@ impl Walker for AstControlStatement {
                 visit_all_nodes!(visitor, &stmt.else_block);
             }
         }
-        Default::default()
     }
 }
 
 impl Walker for ReturnStatement {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_all_nodes!(visitor, &self.condition);
-        Default::default()
     }
 }
 
 impl Walker for LabelStatement {
-    fn walk<T, V>(&self, _visitor: &mut V) -> T
+    fn walk<V>(&self, _visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
-        Default::default()
     }
 }
 
 impl Walker for JumpStatement {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         visit_nodes!(visitor, &self.condition, &self.target);
-        Default::default()
     }
 }
 
 impl Walker for AstNode {
-    fn walk<T, V>(&self, visitor: &mut V) -> T
+    fn walk<V>(&self, visitor: &mut V)
     where
-        V: AstVisitor<T>,
-        T: Default,
+        V: AstVisitor,
     {
         let node = self;
         match &self.stmt {

--- a/compiler/plc_ast/src/visitor.rs
+++ b/compiler/plc_ast/src/visitor.rs
@@ -1,11 +1,12 @@
-/// This module defines the `AstVisitor` trait and its associated macros.
-/// The `AstVisitor` trait provides a set of methods for traversing and visiting ASTs
+//! This module defines the `AstVisitor` trait and its associated macros.
+//! The `AstVisitor` trait provides a set of methods for traversing and visiting ASTs
+
 use crate::ast::AstNode;
 use crate::ast::*;
 use crate::control_statements::{AstControlStatement, ConditionalBlock, ReturnStatement};
 use crate::literals::AstLiteral;
 
-/// Macro that walks through all nodes in an iterator and applies the visitor's `walk` method to each node.
+/// Macro that calls the visitor's `visit` method for every AstNode in the passed iterator `iter`.
 macro_rules! visit_all_nodes {
     ($visitor:expr, $iter:expr) => {
         for node in $iter {
@@ -14,7 +15,7 @@ macro_rules! visit_all_nodes {
     };
 }
 
-/// Macro that walks through a list of nodes and applies the visitor's `walk` method to each node.
+/// Macro that calls the visitor's `visit` method for every AstNode in the passed sequence of nodes.
 macro_rules! visit_nodes {
     ($visitor:expr, $($node:expr),*) => {
         $(
@@ -23,16 +24,46 @@ macro_rules! visit_nodes {
     };
 }
 
+/// The `Walker` implements the traversal of the AST nodes and Ast-related objects (e.g. CompilationUnit).
+/// The `walk` method is called on the object to visit its children.
+/// If the object passed to a `AstVisitor`'s `visit` method implements the `Walker` trait,
+/// a call to the it's walk function continues the visiting process on its children.
+///
+/// Spliting the traversal logic into a separate trait allows to call the default traversal logic
+/// from the visitor while overriding the visitor's `visit` method for specific nodes.
+///
+/// # Example
+/// ```
+/// use plc_ast::{
+///   ast::{Assignment, AstNode},
+///  visitor::{AstVisitor, Walker},
+/// };
+///
+/// impl Walker for Assignment {
+///    fn walk<V>(&self, visitor: &mut V)
+///      where V: AstVisitor {
+///     visitor.visit(&self.right);
+///     visitor.visit(&self.left);
+/// }
+/// ```
+///
 pub trait Walker {
     fn walk<V>(&self, visitor: &mut V)
     where
         V: AstVisitor;
 }
 
-/// The `AstVisitor` trait provides a set of methods for traversing and visiting different types of AST nodes.
+/// The `AstVisitor` trait provides a set of methods for visiting different types of AST nodes.
 /// Implementors can individually override the methods they are interested in. When overriding a method,
 /// make sure to call `walk` on the visited statement to visit its children. DO NOT call walk on
-/// the node itself (last parameter).
+/// the node itself to avoid a recursion (last parameter). Implementors may also decide to not call
+/// the statement's `walk` method to avoid visiting the children of the statement.
+///
+/// The visitor offers strongly typed `visit_X` functions for every node type. The function's signature
+/// is `fn visit_X(&mut self, stmt: &X, node: &AstNode)`. The `stmt` parameter is the unwrapped, typed
+/// node and the `node` parameter is the `AstNode` wrapping the stmt. The `AstNode` node offers access to location
+/// information and the AstId. Note that some nodes are not wrapped in an `AstNode` node (e.g. `CompilationUnit`)
+/// and therefore only the strongly typed node is passed to the `visit_X` function.
 ///
 /// # Example
 /// ```
@@ -60,191 +91,283 @@ pub trait Walker {
 /// }
 /// ```
 pub trait AstVisitor: Sized {
-    /// visits through an `AstNode` and applies the visitor's `walk` method to each node.
+    /// Visits this `AstNode`. The default implementation calls the `walk` method on the node
+    /// and will eventually call the strongly typed `visit` method for the node (e.g. visit_assignment
+    /// if the node is an `AstStatement::Assignment`).
+    /// # Arguments
+    /// * `node` - The `AstNode` node to visit.
     fn visit(&mut self, node: &AstNode) {
         node.walk(self)
     }
 
     /// Visits a `CompilationUnit` node.
     /// Make sure to call `walk` on the `CompilationUnit` node to visit its children.
+    /// # Arguments
+    /// * `unit` - The unwraped, typed `CompilationUnit` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_compilation_unit(&mut self, unit: &CompilationUnit) {
         unit.walk(self)
     }
 
     /// Visits an `Implementation` node.
     /// Make sure to call `walk` on the `Implementation` node to visit its children.
+    /// # Arguments
+    /// * `implementation` - The unwraped, typed `Implementation` node to visit.
     fn visit_implementation(&mut self, implementation: &Implementation) {
         implementation.walk(self);
     }
 
     /// Visits a `DataTypeDeclaration` node.
     /// Make sure to call `walk` on the `VariableBlock` node to visit its children.
+    /// # Arguments
+    /// * `block` - The unwraped, typed `VariableBlock` node to visit.
     fn visit_variable_block(&mut self, block: &VariableBlock) {
         block.walk(self)
     }
 
     /// Visits a `Variable` node.
     /// Make sure to call `walk` on the `Variable` node to visit its children.
+    /// # Arguments
+    /// * `variable` - The unwraped, typed `Variable` node to visit.
     fn visit_variable(&mut self, variable: &Variable) {
         variable.walk(self);
     }
 
     /// Visits an enum element `AstNode` node.
     /// Make sure to call `walk` on the `AstNode` node to visit its children.
+    /// # Arguments
+    /// * `element` - The unwraped, typed `AstNode` node to visit.
     fn visit_enum_element(&mut self, element: &AstNode) {
         element.walk(self);
     }
 
     /// Visits a `DataTypeDeclaration` node.
     /// Make sure to call `walk` on the `DataTypeDeclaration` node to visit its children.
+    /// # Arguments
+    /// * `data_type_declaration` - The unwraped, typed `DataTypeDeclaration` node to visit.
     fn visit_data_type_declaration(&mut self, data_type_declaration: &DataTypeDeclaration) {
         data_type_declaration.walk(self);
     }
 
     /// Visits a `UserTypeDeclaration` node.
     /// Make sure to call `walk` on the `UserTypeDeclaration` node to visit its children.
+    /// # Arguments
+    /// * `user_type` - The unwraped, typed `UserTypeDeclaration` node to visit.
     fn visit_user_type_declaration(&mut self, user_type: &UserTypeDeclaration) {
         user_type.walk(self);
     }
 
     /// Visits a `UserTypeDeclaration` node.
     /// Make sure to call `walk` on the `DataType` node to visit its children.
+    /// # Arguments
+    /// * `data_type` - The unwraped, typed `DataType` node to visit.
     fn visit_data_type(&mut self, data_type: &DataType) {
         data_type.walk(self);
     }
 
     /// Visits a `Pou` node.
     /// Make sure to call `walk` on the `Pou` node to visit its children.
+    /// # Arguments
+    /// * `pou` - The unwraped, typed `Pou` node to visit.
     fn visit_pou(&mut self, pou: &Pou) {
         pou.walk(self);
     }
 
     /// Visits an `EmptyStatement` node.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `EmptyStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_empty_statement(&mut self, _stmt: &EmptyStatement, _node: &AstNode) {}
 
     /// Visits a `DefaultValue` node.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `DefaultValue` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_default_value(&mut self, _stmt: &DefaultValue, _node: &AstNode) {}
 
     /// Visits an `AstLiteral` node.
     /// Make sure to call `walk` on the `AstLiteral` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `AstLiteral` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_literal(&mut self, stmt: &AstLiteral, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `MultipliedStatement` node.
     /// Make sure to call `walk` on the `MultipliedStatement` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `MultipliedStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_multiplied_statement(&mut self, stmt: &MultipliedStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `ReferenceExpr` node.
     /// Make sure to call `walk` on the `ReferenceExpr` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `ReferenceExpr` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_reference_expr(&mut self, stmt: &ReferenceExpr, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `Identifier` node.
     /// Make sure to call `walk` on the `Identifier` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `Identifier` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_identifier(&mut self, _stmt: &str, _node: &AstNode) {}
 
     /// Visits a `DirectAccess` node.
     /// Make sure to call `walk` on the `DirectAccess` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `DirectAccess` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_direct_access(&mut self, stmt: &DirectAccess, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `HardwareAccess` node.
     /// Make sure to call `walk` on the `HardwareAccess` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `HardwareAccess` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_hardware_access(&mut self, stmt: &HardwareAccess, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `BinaryExpression` node.
     /// Make sure to call `walk` on the `BinaryExpression` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `BinaryExpression` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_binary_expression(&mut self, stmt: &BinaryExpression, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `UnaryExpression` node.
     /// Make sure to call `walk` on the `UnaryExpression` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `UnaryExpression` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_unary_expression(&mut self, stmt: &UnaryExpression, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `ExpressionList` node.
     /// Make sure to call `walk` on the `Vec<AstNode>` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `ExpressionList` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_expression_list(&mut self, stmt: &Vec<AstNode>, _node: &AstNode) {
         visit_all_nodes!(self, stmt);
     }
 
     /// Visits a `ParenExpression` node.
     /// Make sure to call `walk` on the inner `AstNode` node to visit its children.
+    /// # Arguments
+    /// * `inner` - The unwraped, typed inner `AstNode` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_paren_expression(&mut self, inner: &AstNode, _node: &AstNode) {
         inner.walk(self)
     }
 
     /// Visits a `RangeStatement` node.
     /// Make sure to call `walk` on the `RangeStatement` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `RangeStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_range_statement(&mut self, stmt: &RangeStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `VlaRangeStatement` node.
+    /// # Arguments
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_vla_range_statement(&mut self, _node: &AstNode) {}
 
     /// Visits an `Assignment` node.
     /// Make sure to call `walk` on the `Assignment` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `Assignment` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `OutputAssignment` node.
     /// Make sure to call `walk` on the `Assignment` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `Assignment` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_output_assignment(&mut self, stmt: &Assignment, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `CallStatement` node.
     /// Make sure to call `walk` on the `CallStatement` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `CallStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_call_statement(&mut self, stmt: &CallStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits an `AstControlStatement` node.
     /// Make sure to call `walk` on the `AstControlStatement` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `AstControlStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_control_statement(&mut self, stmt: &AstControlStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `CaseCondition` node.
     /// Make sure to call `walk` on the child-`AstNode` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `CaseCondition` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_case_condition(&mut self, child: &AstNode, _node: &AstNode) {
         child.walk(self)
     }
 
     /// Visits an `ExitStatement` node.
+    /// # Arguments
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_exit_statement(&mut self, _node: &AstNode) {}
 
     /// Visits a `ContinueStatement` node.
+    /// # Arguments
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_continue_statement(&mut self, _node: &AstNode) {}
 
     /// Visits a `ReturnStatement` node.
     /// Make sure to call `walk` on the `ReturnStatement` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `ReturnStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_return_statement(&mut self, stmt: &ReturnStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `JumpStatement` node.
     /// Make sure to call `walk` on the `JumpStatement` node to visit its children.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `JumpStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_jump_statement(&mut self, stmt: &JumpStatement, _node: &AstNode) {
         stmt.walk(self)
     }
 
     /// Visits a `LabelStatement` node.
+    /// # Arguments
+    /// * `stmt` - The unwraped, typed `LabelStatement` node to visit.
+    /// * `node` - The wrapped `AstNode` node to visit. Offers access to location information and AstId
     fn visit_label_statement(&mut self, _stmt: &LabelStatement, _node: &AstNode) {}
 }
 
-/// Walks through a slice of `ConditionalBlock` and applies the visitor's `walk` method to each node.
+/// Helper method that walks through a slice of `ConditionalBlock` and applies the visitor's `walk` method to each node.
 fn walk_conditional_blocks<V>(visitor: &mut V, blocks: &[ConditionalBlock])
 where
     V: AstVisitor,

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -846,20 +846,6 @@ fn generate_variable_length_array_bound_function<'ink>(
             let offset = if is_lower { (value - 1) as u64 * 2 } else { (value - 1) as u64 * 2 + 1 };
             llvm.i32_type().const_int(offset, false)
         }
-        AstStatement::CastStatement(data) => {
-            let ExpressionValue::RValue(value) = generator.generate_expression_value(&data.target)? else {
-                unreachable!()
-            };
-
-            if !value.is_int_value() {
-                return Err(Diagnostic::codegen_error(
-                    format!("Expected INT value, found {}", value.get_type()),
-                    location,
-                ));
-            };
-
-            value.into_int_value()
-        }
         // e.g. LOWER_BOUND(arr, idx + 3)
         _ => {
             let expression_value = generator.generate_expression(params[1])?;

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1751,7 +1751,6 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             }
             // if there is just one assignment, this may be an struct-initialization (TODO this is not very elegant :-/ )
             AstStatement::Assignment { .. } => self.generate_literal_struct(literal_statement),
-            AstStatement::CastStatement(data) => self.generate_expression_value(&data.target),
             _ => Err(cannot_generate_literal()),
         }
     }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5,6 +5,7 @@ use plc_ast::{
 use plc_source::source_location::SourceLocation;
 
 // Copyright (c) 2020 Ghaith Hachem and Mathias Rieder
+mod ast_visitor_tests;
 mod class_parser_tests;
 mod container_parser_tests;
 mod control_parser_tests;

--- a/src/parser/tests/ast_visitor_tests.rs
+++ b/src/parser/tests/ast_visitor_tests.rs
@@ -12,7 +12,7 @@ struct IdentifierCollector {
     identifiers: Vec<String>,
 }
 
-impl AstVisitor<()> for IdentifierCollector {
+impl AstVisitor for IdentifierCollector {
     fn visit_identifier(&mut self, stmt: &str, _node: &plc_ast::ast::AstNode) {
         self.identifiers.push(stmt.to_string());
     }
@@ -220,7 +220,7 @@ struct AssignmentCounter {
     count: usize,
 }
 
-impl AstVisitor<()> for AssignmentCounter {
+impl AstVisitor for AssignmentCounter {
     fn visit_assignment(&mut self, stmt: &plc_ast::ast::Assignment, _node: &plc_ast::ast::AstNode) {
         self.count += 1;
         stmt.walk(self)

--- a/src/parser/tests/ast_visitor_tests.rs
+++ b/src/parser/tests/ast_visitor_tests.rs
@@ -1,0 +1,260 @@
+use plc_ast::{
+    ast::LinkageType,
+    provider::IdProvider,
+    visitor::{AstVisitor, Walker},
+};
+use plc_source::source_location::SourceLocationFactory;
+
+use crate::{lexer, parser};
+
+#[derive(Default)]
+struct IdentifierCollector {
+    identifiers: Vec<String>,
+}
+
+impl AstVisitor<()> for IdentifierCollector {
+    fn visit_identifier(&mut self, stmt: &str, _node: &plc_ast::ast::AstNode) {
+        self.identifiers.push(stmt.to_string());
+    }
+}
+
+fn get_character_range(start: char, end: char) -> Vec<String> {
+    (start as u8..=end as u8).map(|c| c as char).map(|c| c.to_string()).collect()
+}
+
+fn collect_identifiers(src: &str) -> IdentifierCollector {
+    let id_provider = IdProvider::default();
+    let (compilation_unit, _) = parser::parse(
+        lexer::lex_with_ids(src, id_provider.clone(), SourceLocationFactory::internal(src)),
+        LinkageType::Internal,
+        "test.st",
+    );
+
+    let mut visitor = IdentifierCollector::default();
+
+    for st in &compilation_unit.implementations[0].statements {
+        visitor.visit(st);
+    }
+    visitor.identifiers.sort();
+    visitor
+}
+
+#[test]
+fn test_visit_arithmetic_expressions() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            a;
+            b;
+            c := NOT d;
+            e := f MOD g;
+            h := (i / j / k - (l + m)) * n;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'n'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_expression_list() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            a,b,c;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'c'), visitor.identifiers);
+}
+
+#[test]
+fn test_if_statement() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            IF a THEN
+                b := c;
+            ELSIF d THEN
+                e := f;
+            ELSE
+                g := h;
+            END_IF;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'h'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_for_loop_statement() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            FOR a := b TO c BY d DO
+                e;
+                f;
+            END_FOR;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'f'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_while_loop_statement() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            WHILE a < b DO
+                c;
+                d;
+            END_WHILE;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'd'), visitor.identifiers);
+}
+#[test]
+fn test_visit_repeat_loop_statement() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            REPEAT
+                a;
+                b;
+            UNTIL c > d;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'd'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_case_statement() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            CASE a OF
+                b:
+                    c;
+                    d;
+                e, f:
+                    g;
+                    h;
+                ELSE
+                    i;
+                    j;
+            END_CASE;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'j'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_multiplied_statement() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            3(a+b);
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'b'), visitor.identifiers);
+}
+
+#[test]
+fn test_visist_array_expressions() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            a[b];
+            c[d,e+f];
+            g[h+i][j+k];
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'k'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_range_statement() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            a..b;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'b'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_assignment_expressions() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            a := b;
+            c => d;
+            e =>;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'e'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_call_statements() {
+    let visitor = collect_identifiers(
+        "
+        PROGRAM prg
+            a();
+            b(c,d);
+            e(f:=(g), h=>i);
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'i'), visitor.identifiers);
+}
+
+#[test]
+fn test_visit_return_statement() {
+    let visitor = collect_identifiers(
+        "
+        FUNCTION prg : INT
+            RETURN a + b;
+        END_PROGRAM",
+    );
+    assert_eq!(get_character_range('a', 'b'), visitor.identifiers);
+}
+
+struct AssignmentCounter {
+    count: usize,
+}
+
+impl AstVisitor<()> for AssignmentCounter {
+    fn visit_assignment(&mut self, stmt: &plc_ast::ast::Assignment, _node: &plc_ast::ast::AstNode) {
+        self.count += 1;
+        stmt.walk(self)
+    }
+
+    fn visit_output_assignment(&mut self, stmt: &plc_ast::ast::Assignment, _node: &plc_ast::ast::AstNode) {
+        self.count += 1;
+        stmt.walk(self)
+    }
+}
+
+#[test]
+fn test_count_assignments() {
+    let id_provider = IdProvider::default();
+    let (compilation_unit, _) = parser::parse(
+        lexer::lex_with_ids(
+            "
+            PROGRAM prg
+                a := b;
+                c => d;
+                e := f;
+                foo(a := baz(x := 2, z => 3));
+            END_PROGRAM",
+            id_provider.clone(),
+            SourceLocationFactory::internal(""),
+        ),
+        LinkageType::Internal,
+        "test.st",
+    );
+
+    let mut visitor = AssignmentCounter { count: 0 };
+
+    for st in &compilation_unit.implementations[0].statements {
+        visitor.visit(st);
+    }
+    assert_eq!(6, visitor.count);
+}

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -58,18 +58,6 @@ pub fn visit_statement<T: AnnotationMap>(
         AstStatement::Literal(AstLiteral::Array(Array { elements: Some(elements) })) => {
             visit_statement(validator, elements.as_ref(), context);
         }
-        AstStatement::CastStatement(data) => {
-            if let AstStatement::Literal(literal) = data.target.get_stmt() {
-                validate_cast_literal(
-                    validator,
-                    literal,
-                    statement,
-                    &data.type_name,
-                    &statement.get_location(),
-                    context,
-                );
-            }
-        }
         AstStatement::MultipliedStatement(data) => {
             visit_statement(validator, &data.element, context);
         }


### PR DESCRIPTION
The AST-Visitor trait allows generic visiting of AST-nodes. A default Walking behavior is implemented for each AstStatement but it can be altered by any implementor. When overriding a visit_XXX method, the implementation can decide to continue with the default walking behavior (by calling the walk function on the passed AstStatement-Struct, to skip it, or to continue with an alternative walking bahavior.

The code could be improved with a derive-macro for the walker trait