### PR TITLE
ci: Split the windows and linux workflows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -17,7 +17,9 @@ rustflags = [
 linker = "clang"
 
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = [
+"-C", "link-arg=-fuse-ld=lld",
+"-C", "link-arg=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"]
 
 [profile.profiling]
 inherits = "release"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,9 @@ rustflags = [
 ]
 linker = "clang"
 
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,11 +16,6 @@ rustflags = [
 ]
 linker = "clang"
 
-[target.x86_64-pc-windows-msvc]
-rustflags = [
-"-C", "link-arg=-fuse-ld=lld",
-"-C", "link-arg=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"]
-
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Linux
 
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
@@ -62,44 +62,6 @@ jobs:
         with:
           name: stdlib
           path: output
-
-  test-windows:
-    name: Test Windows
-    runs-on: windows-2022
-    env:
-      toolchain-version: 1.77.0
-      llvm-version: 14.0.6
-    steps:
-
-      - uses: actions/checkout@v3
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.toolchain-version }}
-
-      - name: Install LLVM
-        uses: ghaith/install-llvm-action@latest
-        with:
-          version: ${{ env.llvm-version }}
-          directory: "./llvm"
-
-      - name: Cargo test (Unit)
-        run: cargo test --lib -- --nocapture
-
-      - name: Cargo test (Correctness)
-        run: cargo test correctness -- --nocapture --test-threads=1
-
-      - name: Cargo test (Integration)
-        run: cargo test integration -- --nocapture --test-threads=1
-
-      - name: Release Build
-        run: cargo build --release --workspace
-
-      - uses: actions/upload-artifact@master
-        with:
-          name: plc.exe
-          path: target/release/plc.exe
 
   style:
     name: Check Style

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,50 @@
+name: Build Windows
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Windows Build
+    runs-on: windows-2022
+    env:
+      toolchain-version: 1.77.0
+      llvm-version: 14.0.6
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.toolchain-version }}
+
+      - name: Install LLVM
+        uses: ghaith/install-llvm-action@latest
+        with:
+          version: ${{ env.llvm-version }}
+          directory: "./llvm"
+
+      - name: Cargo test (Unit)
+        run: cargo test --lib -- --nocapture
+
+      - name: Cargo test (Correctness)
+        run: cargo test correctness -- --nocapture --test-threads=1
+
+      - name: Cargo test (Integration)
+        run: cargo test integration -- --nocapture --test-threads=1
+
+      - name: Release Build
+        run: cargo build --release --workspace
+
+      - uses: actions/upload-artifact@master
+        with:
+          name: plc.exe
+          path: target/release/plc.exe
+


### PR DESCRIPTION
The windows and linux workflows are now split into 2 files
Each workflow can be enabled/disabled manually and reported manually.