### PR TITLE
feat: validate comparison operand types

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -199,6 +199,7 @@ lazy_static! {
         E095,   Error,      include_str!("./error_codes/E095.md"),  // Action call without `()`
         E096,   Warning,    include_str!("./error_codes/E096.md"),  // Integer Condition
         E097,   Error,      include_str!("./error_codes/E097.md"),  // Invalid Array Range
+        E098,   Error,      include_str!("./error_codes/E098.md"),  // Types Must Match For Comparison
     );
 }
 

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E098.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E098.md
@@ -1,0 +1,4 @@
+# Types Must Match for Comparison
+
+You cannot compare values that are of different types even if they are both numbers (ie. DINT and INT).
+You must explicitly convert one of values so that the types match (ie. INT_TO_DINT)

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -678,14 +678,14 @@ fn validate_comparison_operator<T: AnnotationMap>(
     // if the type is a subrange, check if the intrinsic type is numerical
     let is_numerical = context.index.find_intrinsic_type(left_type).is_numerical();
 
-    if discriminant(left_type) != discriminant(right_type) {
+    if left_type != right_type {
         validator.push_diagnostic(
             Diagnostic::new(format!(
-                "Cannot compare {} with {}",
+                "Types do not match. Cannot compare {} with {}",
                 left_type.get_name(),
                 right_type.get_name()
             ))
-            .with_error_code("E0XX")
+            .with_error_code("E098")
             .with_location(statement.get_location()),
         );
     }


### PR DESCRIPTION
Fixes #1026.

My read of the IEC spec is that comparison is not defined when the operands data types do not match. So this adds a validation that disallows all comparisons where the data types of the two operands are not the same.