### PR TITLE
fix: Pattern match Option value in alias variable

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1132,7 +1132,12 @@ fn parse_variable_line(lexer: &mut ParseSession) -> Vec<Variable> {
                 address = parse_hardware_access(lexer, direction, access_type)
             }
 
-            Identifier => return vec![parse_aliasing(lexer, &var_names[0]).unwrap()],
+            Identifier => {
+                return match parse_aliasing(lexer, &var_names[0]) {
+                    Some(aliased_variable) => vec![aliased_variable],
+                    None => vec![],
+                };
+            }
 
             _ => {
                 lexer.accept_diagnostic(Diagnostic::missing_token(


### PR DESCRIPTION
Fixes an issue where omitting a data-type in an alias variable would cause a panic in the parser. For example

```
FUNCTION main
    VAR
        s AT str; // omitted data-type
    END_VAR
END_FUNCTION
```