### PR TITLE
fix: Parse REFERENCE TO STRING initializer

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -854,7 +854,10 @@ fn parse_string_type_definition(
         }),
         _ => Some(DataTypeDeclaration::DataTypeReference { referenced_type: text, location }),
     }
-    .zip(Some(lexer.try_consume(&KeywordAssignment).then(|| parse_expression(lexer))))
+    .zip(Some(
+        (lexer.try_consume(&KeywordAssignment) || lexer.try_consume(&KeywordReferenceAssignment))
+            .then(|| parse_expression(lexer)),
+    ))
 }
 
 fn parse_enum_type_definition(

--- a/src/parser/tests/statement_parser_tests.rs
+++ b/src/parser/tests/statement_parser_tests.rs
@@ -291,7 +291,7 @@ fn ref_assignment() {
 }
 
 #[test]
-fn reference_to_declaration() {
+fn reference_to_dint_declaration() {
     let (result, diagnostics) = parse(
         r"
         FUNCTION foo
@@ -332,6 +332,42 @@ fn reference_to_declaration() {
                 name: "qux",
                 data_type: DataTypeReference {
                     referenced_type: "DINT",
+                },
+            },
+        ],
+        variable_block_type: Local,
+    }
+    "###);
+}
+
+#[test]
+fn reference_to_string_declaration() {
+    let (result, diagnostics) = parse(
+        r"
+        FUNCTION foo
+            VAR
+                foo : REFERENCE TO STRING;
+            END_VAR
+        END_FUNCTION
+        ",
+    );
+
+    assert!(diagnostics.is_empty());
+    insta::assert_debug_snapshot!(result.units[0].variable_blocks[0], @r###"
+    VariableBlock {
+        variables: [
+            Variable {
+                name: "foo",
+                data_type: DataTypeDefinition {
+                    data_type: PointerType {
+                        name: None,
+                        referenced_type: DataTypeReference {
+                            referenced_type: "STRING",
+                        },
+                        auto_deref: Some(
+                            Reference,
+                        ),
+                    },
                 },
             },
         ],


### PR DESCRIPTION
Previously a string REFERENCE TO pointer variable would fail to parse when a REF= operator was present. This commit fixes this by checking if a REF= operator can be consumed when parsing a STRING variable (line). Specifically the parser should now be able to parse the following without any issues
```
FUNCTION main
    VAR
        foo : REFERENCE TO STRING REF= bar;
        bar : STRING;
    END_VAR
END_FUNCTION
```