### PR TITLE
Allow compiling online-change-example for reloadable runtime 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -16,6 +16,7 @@ plc_index = { path = "../plc_index" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+toml = "0.5"
 clap = { version = "3.0", features = ["derive"] }
 rayon = "1.6.1"
 tempfile = "3"

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -328,7 +328,9 @@ pub fn get_config_format(name: &str) -> Option<ConfigFormat> {
 
 impl CompileParameters {
     pub fn parse<T: AsRef<OsStr> + AsRef<str>>(args: &[T]) -> Result<CompileParameters, ParameterError> {
-        CompileParameters::try_parse_from(args).and_then(|result| {
+        CompileParameters::try_parse_from(args).and_then(|mut result| {
+            result.got_layout_file = Some(String::from("tmp.json"));
+
             if result.sysroot.len() > result.target.len() {
                 let mut cmd = CompileParameters::command();
                 Err(cmd.error(

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -109,6 +109,18 @@ pub struct CompileParameters {
     pub hardware_config: Option<String>,
 
     #[clap(
+        name = "got-layout-file",
+        long,
+        global = true,
+        help = "Obtain information about the current custom GOT layout from the given file if it exists.
+    Save information about the generated custom GOT layout to the given file.
+    Format is detected by extension.
+    Supported formats : json, toml",
+    parse(try_from_str = validate_config)
+    ) ]
+    pub got_layout_file: Option<String>,
+
+    #[clap(
         name = "optimization",
         long,
         short = 'O',
@@ -385,6 +397,10 @@ impl CompileParameters {
 
     pub fn config_format(&self) -> Option<ConfigFormat> {
         self.hardware_config.as_deref().and_then(get_config_format)
+    }
+
+    pub fn got_layout_format(&self) -> Option<ConfigFormat> {
+        self.got_layout_file.as_deref().and_then(get_config_format)
     }
 
     /// Returns the location where the build artifacts should be stored / output

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -19,8 +19,8 @@ use std::{
 use cli::{CompileParameters, ParameterError, SubCommands};
 use pipelines::AnnotatedProject;
 use plc::{
-    codegen::CodegenContext, linker::LinkerType, output::FormatOption, DebugLevel, ErrorFormat,
-    OptimizationLevel, Target, Threads,
+    codegen::CodegenContext, linker::LinkerType, output::FormatOption, ConfigFormat, DebugLevel,
+    ErrorFormat, OptimizationLevel, Target, Threads,
 };
 
 use plc_diagnostics::{diagnostician::Diagnostician, diagnostics::Diagnostic};
@@ -50,6 +50,8 @@ pub struct CompileOptions {
     /// The name of the resulting compiled file
     pub output: String,
     pub output_format: FormatOption,
+    pub got_layout_file: Option<String>,
+    pub got_layout_format: Option<ConfigFormat>,
     pub optimization: OptimizationLevel,
     pub error_format: ErrorFormat,
     pub debug_level: DebugLevel,
@@ -63,6 +65,8 @@ impl Default for CompileOptions {
             build_location: None,
             output: String::new(),
             output_format: Default::default(),
+            got_layout_file: None,
+            got_layout_format: None,
             optimization: OptimizationLevel::None,
             error_format: ErrorFormat::None,
             debug_level: DebugLevel::None,
@@ -172,6 +176,8 @@ pub fn get_compilation_context<T: AsRef<str> + AsRef<OsStr> + Debug>(
         build_location: compile_parameters.get_build_location(),
         output: project.get_output_name(),
         output_format,
+        got_layout_file: compile_parameters.got_layout_file.clone(),
+        got_layout_format: compile_parameters.got_layout_format(),
         optimization: compile_parameters.optimization,
         error_format: compile_parameters.error_format,
         debug_level: compile_parameters.debug_level(),

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -274,6 +274,7 @@ impl<T: SourceContainer + Sync> AnnotatedProject<T> {
             context,
             compile_options.root.as_deref(),
             &unit.file_name,
+            compile_options.got_layout_file.clone().zip(compile_options.got_layout_format),
             compile_options.optimization,
             compile_options.debug_level,
         );

--- a/compiler/section_mangler/src/parser.rs
+++ b/compiler/section_mangler/src/parser.rs
@@ -228,4 +228,11 @@ mod tests {
     fn parse_function_invalid_no_arguments() {
         let _ = SectionMangler::from("$RUSTY$fn-no_arguments:u16u8");
     }
+
+    #[test]
+    fn parse_qualified_var_name() {
+        let mangled = SectionMangler::from("$RUSTY$var-Color.red:e4i32");
+
+        assert_eq!(mangled.name(), "Color.red");
+    }
 }

--- a/compiler/section_mangler/src/parser.rs
+++ b/compiler/section_mangler/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::{FunctionArgument, SectionMangler, Type};
+use crate::{FunctionArgument, SectionMangler, StringEncoding, Type};
 
 use std::str;
 
@@ -21,7 +21,7 @@ fn parse_prefix(input: &str) -> ParseResult<Prefix> {
     let fn_prefix = tag("fn").map(|_| Prefix::Fn);
     let var_prefix = tag("var").map(|_| Prefix::Var);
 
-    let (input, _) = tag(crate::PREFIX)(input)?;
+    let (input, _) = tag(crate::RUSTY_PREFIX)(input)?;
     let (input, prefix) = alt((fn_prefix, var_prefix))(input)?;
 
     Ok((input, prefix))
@@ -75,8 +75,29 @@ fn type_enum(input: &str) -> ParseResult<Type> {
         .parse(input)
 }
 
+fn string_encoding(input: &str) -> ParseResult<StringEncoding> {
+    let utf8 = tag("8u").map(|_| StringEncoding::Utf8);
+    let utf16 = tag("16u").map(|_| StringEncoding::Utf16);
+
+    alt((utf8, utf16))(input)
+}
+
+fn type_string(input: &str) -> ParseResult<Type> {
+    char('s')
+        .and(string_encoding)
+        .and(number::<usize>)
+        .map(|((_, encoding), size)| Type::String { size, encoding })
+        .parse(input)
+}
+
+fn type_array(input: &str) -> ParseResult<Type> {
+    char('a').and(parse_type).map(|(_, inner_ty)| Type::Array { inner: Box::new(inner_ty) }).parse(input)
+}
+
 fn parse_type(input: &str) -> ParseResult<Type> {
-    alt((type_void, type_integer, type_float, type_pointer, type_struct, type_enum))(input)
+    alt((type_void, type_integer, type_float, type_pointer, type_struct, type_enum, type_string, type_array))(
+        input,
+    )
 }
 
 fn parse_var_content<'i>(input: &'i str, name: &str) -> ParseResult<'i, SectionMangler> {
@@ -188,6 +209,7 @@ mod tests {
         // this needs to be handled by the toplevel parse function
         assert!(type_struct("r0u8u8").is_ok());
         assert!(type_struct("r1u8u8").is_ok());
+        assert!(type_struct("r5s8u1025s8u2049s8u3u64s8u3").is_ok());
 
         // invalid number of elements
         assert!(type_struct("r15u8").is_err());
@@ -234,5 +256,68 @@ mod tests {
         let mangled = SectionMangler::from("$RUSTY$var-Color.red:e4i32");
 
         assert_eq!(mangled.name(), "Color.red");
+    }
+
+    #[test]
+    fn parse_complex1() {
+        let mangled = SectionMangler::from("$RUSTY$var-__File__init:r5s8u1025s8u2049s8u3u64s8u3");
+
+        assert_eq!(mangled.name(), "__File__init");
+    }
+
+    #[test]
+    fn parse_complex2() {
+        let inputs = [
+            "$RUSTY$var-__CosineSignal__init:r4f64i32f64f64",
+            "$RUSTY$var-__File__init:r5s8u1025s8u2049s8u3u64s8u3",
+            "$RUSTY$var-__SineSignal__init:r4f64i32f64f64",
+            "$RUSTY$var-__mainProg_state.Init:e3i32",
+            "$RUSTY$var-__mainProg_state.Running:e3i32",
+            "$RUSTY$var-__mainProg_state.Stopped:e3i32",
+            "$RUSTY$var-__SR__init:r3u8u8u8",
+            "$RUSTY$var-__RS__init:r3u8u8u8",
+            "$RUSTY$var-__CTU__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTU_INT__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTU_DINT__init:r6u8u8i32u8i32u8",
+            "$RUSTY$var-__CTU_UDINT__init:r6u8u8u32u8u32u8",
+            "$RUSTY$var-__CTU_LINT__init:r6u8u8i64u8i64u8",
+            "$RUSTY$var-__CTU_ULINT__init:r6u8u8u64u8u64u8",
+            "$RUSTY$var-__CTD__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTD_INT__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTD_DINT__init:r6u8u8i32u8i32u8",
+            "$RUSTY$var-__CTD_UDINT__init:r6u8u8u32u8u32u8",
+            "$RUSTY$var-__CTD_LINT__init:r6u8u8i64u8i64u8",
+            "$RUSTY$var-__CTD_ULINT__init:r6u8u8u64u8u64u8",
+            "$RUSTY$var-__CTUD__init:r10u8u8u8u8i16u8u8i16u8u8",
+            "$RUSTY$var-__CTUD_INT__init:r10u8u8u8u8i16u8u8i16u8u8",
+            "$RUSTY$var-__CTUD_DINT__init:r10u8u8u8u8i32u8u8i32u8u8",
+            "$RUSTY$var-__CTUD_UDINT__init:r10u8u8u8u8u32u8u8u32u8u8",
+            "$RUSTY$var-__CTUD_LINT__init:r10u8u8u8u8i64u8u8i64u8u8",
+            "$RUSTY$var-__CTUD_ULINT__init:r10u8u8u8u8u64u8u8u64u8u8",
+            "$RUSTY$var-__R_TRIG__init:r3u8u8u8",
+            "$RUSTY$var-__F_TRIG__init:r3u8u8u8",
+            "$RUSTY$var-__TP__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TP_TIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TP_LTIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TON__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TON_TIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TON_LTIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TOF__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TOF_TIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TOF_LTIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$fn-CosineSignal:v[f64][i32][f64]",
+            "$RUSTY$fn-File:v[s8u1025][s8u2049][s8u3]",
+            "$RUSTY$fn-File.Open:v",
+            "$RUSTY$fn-File.Write:v",
+            "$RUSTY$fn-File.Close:v",
+            "$RUSTY$fn-File.Clear:v",
+            "$RUSTY$fn-SineSignal:v[f64][i32][f64]",
+            "$RUSTY$fn-mainProg:v",
+            "$RUSTY$var-mainProg:r7i32r4f64i32f64f64r4f64i32f64f64e3i32r5s8u1025s8u2049s8u3u64s8u3r5s8u1025s8u2049s8u3u64s8u3r5s8u1025s8u2049s8u3u64s8u3"
+        ];
+
+        inputs.into_iter().for_each(|input| {
+            let _ = SectionMangler::from(dbg!(input));
+        });
     }
 }

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -2,10 +2,10 @@
 
 use inkwell::{
     builder::Builder,
-    types::{BasicType, BasicTypeEnum},
+    types::{BasicType, BasicTypeEnum, FunctionType},
     values::{
-        ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, FloatValue, IntValue, PointerValue,
-        StructValue, VectorValue,
+        ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallSiteValue, CallableValue,
+        FloatValue, IntValue, PointerValue, StructValue, VectorValue,
     },
     AddressSpace, FloatPredicate, IntPredicate,
 };
@@ -328,10 +328,9 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
     ) -> Result<Option<CallSiteValue<'ink>>, Diagnostic> {
         // We will generate a GEP, which has as its base address the magic constant which
         // will eventually be replaced by the location of the GOT.
-        let base =
-            self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
-                llvm_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
-            );
+        let base = self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
+            function_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
+        );
 
         self.llvm_index
             .find_got_index(qualified_name)

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -298,14 +298,10 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             Some(StatementAnnotation::Variable { qualified_name, .. }) => {
                 // We will generate a GEP, which has as its base address the magic constant which
                 // will eventually be replaced by the location of the GOT.
-                let base = self
-                    .llvm
-                    .context
-                    .i64_type()
-                    .const_int(0xdeadbeef00000000, false)
-                    .const_to_pointer(llvm_type
-                        .ptr_type(AddressSpace::default())
-                        .ptr_type(AddressSpace::default()));
+                let base =
+                    self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
+                        llvm_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
+                    );
 
                 self.llvm_index
                     .find_got_index(qualified_name)
@@ -321,6 +317,37 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             }
             _ => Ok(None),
         }
+    }
+
+    /// Generate an access to the appropriate GOT entry to achieve a call to the given function.
+    pub fn generate_got_call(
+        &self,
+        qualified_name: &str,
+        function_type: &FunctionType<'ink>,
+        args: &[BasicMetadataValueEnum<'ink>],
+    ) -> Result<Option<CallSiteValue<'ink>>, Diagnostic> {
+        // We will generate a GEP, which has as its base address the magic constant which
+        // will eventually be replaced by the location of the GOT.
+        let base =
+            self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
+                llvm_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
+            );
+
+        self.llvm_index
+            .find_got_index(qualified_name)
+            .map(|idx| {
+                let mut ptr = self.llvm.load_array_element(
+                    base,
+                    &[self.llvm.context.i32_type().const_int(idx, false)],
+                    "",
+                )?;
+                ptr = self.llvm.load_pointer(&ptr, "").into_pointer_value();
+                let callable = CallableValue::try_from(ptr)
+                    .map_err(|_| Diagnostic::new("Pointer was not a function pointer"))?;
+
+                Ok(self.llvm.builder.build_call(callable, args, "call"))
+            })
+            .transpose()
     }
 
     /// generates a binary expression (e.g. a + b, x AND y, etc.) and returns the resulting `BasicValueEnum`
@@ -520,9 +547,20 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             None
         };
 
+        // Check for the function within the GOT. If it's there, we need to generate an indirect
+        // call to its location within the GOT, which should contain a function pointer.
+        // First get the function type so our function pointer can have the correct type.
+        let qualified_name = self
+            .annotations
+            .get_qualified_name(operator)
+            .expect("Shouldn't have got this far without a name for the function");
+        let function_type = function.get_type();
+        let call = self
+            .generate_got_call(qualified_name, &function_type, &arguments_list)?
+            .unwrap_or_else(|| self.llvm.builder.build_call(function, &arguments_list, "call"));
+
         // if the target is a function, declare the struct locally
         // assign all parameters into the struct values
-        let call = &self.llvm.builder.build_call(function, &arguments_list, "call");
 
         // so grab either:
         // - the out-pointer if we generated one in by_ref_func_out
@@ -1412,17 +1450,19 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             }
         }
 
-        let ctx_type =
-            self.annotations.get_type_or_void(context, self.index).get_type_information();
+        let ctx_type = self.annotations.get_type_or_void(context, self.index).get_type_information();
 
         // no context ... so just something like 'x'
         match self.annotations.get(context) {
             Some(StatementAnnotation::Variable { qualified_name, .. })
-            | Some(StatementAnnotation::Program { qualified_name, .. }) =>
-                self.generate_got_access(context, &self.llvm_index.get_associated_type(ctx_type.get_name())?)?.map_or(self
-                    .llvm_index
-                    .find_loaded_associated_variable_value(qualified_name)
-                    .ok_or_else(|| Diagnostic::unresolved_reference(name, offset.clone())), Ok),
+            | Some(StatementAnnotation::Program { qualified_name, .. }) => self
+                .generate_got_access(context, &self.llvm_index.get_associated_type(ctx_type.get_name())?)?
+                .map_or(
+                    self.llvm_index
+                        .find_loaded_associated_variable_value(qualified_name)
+                        .ok_or_else(|| Diagnostic::unresolved_reference(name, offset.clone())),
+                    Ok,
+                ),
             _ => Err(Diagnostic::unresolved_reference(name, offset.clone())),
         }
     }

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -133,6 +133,7 @@ pub fn generate_global_constants_for_pou_members<'ink>(
                         .make_constant()
                         .set_initial_value(Some(value), variable_type);
                     local_llvm_index.associate_global(&name, global_value)?;
+                    local_llvm_index.insert_new_got_index(&name)?;
                 }
             }
         }
@@ -154,7 +155,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
     }
 
     fn mangle_function(&self, implementation: &ImplementationIndexEntry) -> Result<String, Diagnostic> {
-        let ctx = SectionMangler::function(implementation.get_call_name());
+        let ctx = SectionMangler::function(implementation.get_call_name().to_lowercase());
 
         let params = self.index.get_declared_parameters(implementation.get_call_name());
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -172,7 +172,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         }
 
         let section = section_mangler::SectionMangler::variable(
-            global_variable.get_name(),
+            global_variable.get_qualified_name(),
             section_names::mangle_type(
                 self.global_index,
                 self.global_index.get_effective_type_by_name(global_variable.get_type_name())?,

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -5,15 +5,11 @@ use crate::{
     codegen::{debug::Debug, llvm_index::LlvmTypedIndex, llvm_typesystem::cast_if_needed},
     index::{get_initializer_name, Index, PouIndexEntry, VariableIndexEntry},
     resolver::{AnnotationMap, AstAnnotations, Dependency},
-    ConfigFormat,
 };
 use indexmap::IndexSet;
-use inkwell::{module::Module, types::BasicTypeEnum, values::GlobalValue};
+use inkwell::{module::Module, values::GlobalValue};
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
-use std::collections::HashMap;
-use std::fs::{read_to_string, write};
-use std::path::Path;
 
 use super::{
     data_type_generator::get_default_for,
@@ -24,40 +20,6 @@ use super::{
 use crate::codegen::debug::DebugBuilderEnum;
 use crate::index::FxIndexSet;
 
-pub fn read_got_layout(location: &str, format: ConfigFormat) -> Result<HashMap<String, u64>, Diagnostic> {
-    if !Path::new(location).is_file() {
-        // Assume if the file doesn't exist that there is no existing GOT layout yet. write_got_layout will handle
-        // creating our file when we want to.
-        return Ok(HashMap::new());
-    }
-
-    let s =
-        read_to_string(location).map_err(|_| Diagnostic::new("GOT layout could not be read from file"))?;
-    match format {
-        ConfigFormat::JSON => serde_json::from_str(&s)
-            .map_err(|_| Diagnostic::new("Could not deserialize GOT layout from JSON")),
-        ConfigFormat::TOML => {
-            toml::de::from_str(&s).map_err(|_| Diagnostic::new("Could not deserialize GOT layout from TOML"))
-        }
-    }
-}
-
-pub fn write_got_layout(
-    got_entries: HashMap<String, u64>,
-    location: &str,
-    format: ConfigFormat,
-) -> Result<(), Diagnostic> {
-    let s = match format {
-        ConfigFormat::JSON => serde_json::to_string(&got_entries)
-            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to JSON"))?,
-        ConfigFormat::TOML => toml::ser::to_string(&got_entries)
-            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to TOML"))?,
-    };
-
-    write(location, s).map_err(|_| Diagnostic::new("GOT layout could not be written to file"))?;
-    Ok(())
-}
-
 pub struct VariableGenerator<'ctx, 'b> {
     module: &'b Module<'ctx>,
     llvm: &'b Llvm<'ctx>,
@@ -65,7 +27,6 @@ pub struct VariableGenerator<'ctx, 'b> {
     annotations: &'b AstAnnotations,
     types_index: &'b LlvmTypedIndex<'ctx>,
     debug: &'b mut DebugBuilderEnum<'ctx>,
-    got_layout_file: Option<(String, ConfigFormat)>,
 }
 
 impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
@@ -76,9 +37,8 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         annotations: &'b AstAnnotations,
         types_index: &'b LlvmTypedIndex<'ctx>,
         debug: &'b mut DebugBuilderEnum<'ctx>,
-        got_layout_file: Option<(String, ConfigFormat)>,
     ) -> Self {
-        VariableGenerator { module, llvm, global_index, annotations, types_index, debug, got_layout_file }
+        VariableGenerator { module, llvm, global_index, annotations, types_index, debug }
     }
 
     pub fn generate_global_variables(
@@ -137,48 +97,6 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
                 &variable.data_type_name,
                 global_variable,
                 &variable.source_location,
-            );
-        }
-
-        if let Some((location, format)) = &self.got_layout_file {
-            let got_entries = read_got_layout(location.as_str(), *format)?;
-            let mut new_globals = Vec::new();
-            let mut new_got_entries = HashMap::new();
-            let mut new_got = HashMap::new();
-
-            for (name, _) in &globals {
-                if let Some(idx) = got_entries.get(&name.to_string()) {
-                    new_got_entries.insert(name.to_string(), *idx);
-                    index.associate_got_index(name, *idx);
-                    new_got.insert(*idx, name.to_string());
-                } else {
-                    new_globals.push(name.to_string());
-                }
-            }
-
-            // Put any globals that weren't there last time in any free space in the GOT.
-            let mut idx: u64 = 0;
-            for name in &new_globals {
-                while new_got.contains_key(&idx) {
-                    idx += 1;
-                }
-                new_got_entries.insert(name.to_string(), idx);
-                index.associate_got_index(name, idx);
-                new_got.insert(idx, name.to_string());
-            }
-
-            // Now we can write new_got_entries back out to a file.
-            write_got_layout(new_got_entries, location.as_str(), *format)?;
-
-            // Construct our GOT as a new global array. We initialise this array in the loader code.
-            let got_size = new_got.keys().max().map_or(0, |m| *m + 1);
-            let _got = self.llvm.create_global_variable(
-                self.module,
-                "__custom_got",
-                BasicTypeEnum::ArrayType(Llvm::get_array_type(
-                    BasicTypeEnum::PointerType(self.llvm.context.i8_type().ptr_type(0.into())),
-                    got_size.try_into().expect("the computed custom GOT size is too large"),
-                )),
             );
         }
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -5,11 +5,15 @@ use crate::{
     codegen::{debug::Debug, llvm_index::LlvmTypedIndex, llvm_typesystem::cast_if_needed},
     index::{get_initializer_name, Index, PouIndexEntry, VariableIndexEntry},
     resolver::{AnnotationMap, AstAnnotations, Dependency},
+    ConfigFormat,
 };
-
-use inkwell::{module::Module, values::GlobalValue};
+use indexmap::IndexSet;
+use inkwell::{module::Module, types::BasicTypeEnum, values::GlobalValue};
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
+use std::collections::HashMap;
+use std::fs::{read_to_string, write};
+use std::path::Path;
 
 use super::{
     data_type_generator::get_default_for,
@@ -20,6 +24,40 @@ use super::{
 use crate::codegen::debug::DebugBuilderEnum;
 use crate::index::FxIndexSet;
 
+pub fn read_got_layout(location: &str, format: ConfigFormat) -> Result<HashMap<String, u64>, Diagnostic> {
+    if !Path::new(location).is_file() {
+        // Assume if the file doesn't exist that there is no existing GOT layout yet. write_got_layout will handle
+        // creating our file when we want to.
+        return Ok(HashMap::new());
+    }
+
+    let s =
+        read_to_string(location).map_err(|_| Diagnostic::new("GOT layout could not be read from file"))?;
+    match format {
+        ConfigFormat::JSON => serde_json::from_str(&s)
+            .map_err(|_| Diagnostic::new("Could not deserialize GOT layout from JSON")),
+        ConfigFormat::TOML => {
+            toml::de::from_str(&s).map_err(|_| Diagnostic::new("Could not deserialize GOT layout from TOML"))
+        }
+    }
+}
+
+pub fn write_got_layout(
+    got_entries: HashMap<String, u64>,
+    location: &str,
+    format: ConfigFormat,
+) -> Result<(), Diagnostic> {
+    let s = match format {
+        ConfigFormat::JSON => serde_json::to_string(&got_entries)
+            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to JSON"))?,
+        ConfigFormat::TOML => toml::ser::to_string(&got_entries)
+            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to TOML"))?,
+    };
+
+    write(location, s).map_err(|_| Diagnostic::new("GOT layout could not be written to file"))?;
+    Ok(())
+}
+
 pub struct VariableGenerator<'ctx, 'b> {
     module: &'b Module<'ctx>,
     llvm: &'b Llvm<'ctx>,
@@ -27,6 +65,7 @@ pub struct VariableGenerator<'ctx, 'b> {
     annotations: &'b AstAnnotations,
     types_index: &'b LlvmTypedIndex<'ctx>,
     debug: &'b mut DebugBuilderEnum<'ctx>,
+    got_layout_file: Option<(String, ConfigFormat)>,
 }
 
 impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
@@ -37,8 +76,9 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         annotations: &'b AstAnnotations,
         types_index: &'b LlvmTypedIndex<'ctx>,
         debug: &'b mut DebugBuilderEnum<'ctx>,
+        got_layout_file: Option<(String, ConfigFormat)>,
     ) -> Self {
-        VariableGenerator { module, llvm, global_index, annotations, types_index, debug }
+        VariableGenerator { module, llvm, global_index, annotations, types_index, debug, got_layout_file }
     }
 
     pub fn generate_global_variables(
@@ -76,7 +116,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
             }
         });
 
-        for (name, variable) in globals {
+        for (name, variable) in &globals {
             let linkage =
                 if !variable.is_in_unit(location) { LinkageType::External } else { variable.get_linkage() };
             let global_variable = self.generate_global_variable(variable, linkage).map_err(|err| {
@@ -97,6 +137,46 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
                 &variable.data_type_name,
                 global_variable,
                 &variable.source_location,
+            );
+        }
+
+        if let Some((location, format)) = &self.got_layout_file {
+            let got_entries = read_got_layout(location.as_str(), *format)?;
+            let mut new_globals = Vec::new();
+            let mut new_got_entries = HashMap::new();
+            let mut new_got = HashMap::new();
+
+            for (name, _) in &globals {
+                if let Some(idx) = got_entries.get(&name.to_string()) {
+                    new_got_entries.insert(name.to_string(), *idx);
+                    new_got.insert(*idx, name.to_string());
+                } else {
+                    new_globals.push(name.to_string());
+                }
+            }
+
+            // Put any globals that weren't there last time in any free space in the GOT.
+            let mut idx: u64 = 0;
+            for name in &new_globals {
+                while new_got.contains_key(&idx) {
+                    idx += 1;
+                }
+                new_got_entries.insert(name.to_string(), idx);
+                new_got.insert(idx, name.to_string());
+            }
+
+            // Now we can write new_got_entries back out to a file.
+            write_got_layout(new_got_entries, location.as_str(), *format)?;
+
+            // Construct our GOT as a new global array. We initialise this array in the loader code.
+            let got_size = new_got.keys().max().map_or(0, |m| *m + 1);
+            let _got = self.llvm.create_global_variable(
+                self.module,
+                "__custom_got",
+                BasicTypeEnum::ArrayType(Llvm::get_array_type(
+                    BasicTypeEnum::PointerType(self.llvm.context.i8_type().ptr_type(0.into())),
+                    got_size.try_into().expect("the computed custom GOT size is too large"),
+                )),
             );
         }
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -149,6 +149,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
             for (name, _) in &globals {
                 if let Some(idx) = got_entries.get(&name.to_string()) {
                     new_got_entries.insert(name.to_string(), *idx);
+                    index.associate_got_index(name, *idx);
                     new_got.insert(*idx, name.to_string());
                 } else {
                     new_globals.push(name.to_string());
@@ -162,6 +163,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
                     idx += 1;
                 }
                 new_got_entries.insert(name.to_string(), idx);
+                index.associate_got_index(name, idx);
                 new_got.insert(idx, name.to_string());
             }
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -6,10 +6,10 @@ use crate::{
     index::{get_initializer_name, Index, PouIndexEntry, VariableIndexEntry},
     resolver::{AnnotationMap, AstAnnotations, Dependency},
 };
-use indexmap::IndexSet;
 use inkwell::{module::Module, values::GlobalValue};
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
+use section_mangler::SectionMangler;
 
 use super::{
     data_type_generator::get_default_for,
@@ -171,8 +171,15 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
             }
         }
 
-        let section = section_mangler::SectionMangler::variable(
-            global_variable.get_qualified_name(),
+        let global_name = if global_variable.get_name().ends_with("instance") {
+            global_variable.get_name()
+        } else {
+            global_variable.get_qualified_name()
+        };
+        let global_name = global_name.to_lowercase();
+
+        let section = SectionMangler::variable(
+            global_name,
             section_names::mangle_type(
                 self.global_index,
                 self.global_index.get_effective_type_by_name(global_variable.get_type_name())?,

--- a/src/codegen/llvm_index.rs
+++ b/src/codegen/llvm_index.rs
@@ -14,6 +14,7 @@ pub struct LlvmTypedIndex<'ink> {
     type_associations: FxHashMap<String, BasicTypeEnum<'ink>>,
     pou_type_associations: FxHashMap<String, BasicTypeEnum<'ink>>,
     global_values: FxHashMap<String, GlobalValue<'ink>>,
+    // TODO: Should this be an Option?
     got_indices: FxHashMap<String, u64>,
     initial_value_associations: FxHashMap<String, BasicValueEnum<'ink>>,
     loaded_variable_associations: FxHashMap<String, PointerValue<'ink>>,
@@ -162,15 +163,22 @@ impl<'ink> LlvmTypedIndex<'ink> {
         self.global_values.insert(variable_name.to_lowercase(), global_variable);
         self.initial_value_associations
             .insert(variable_name.to_lowercase(), global_variable.as_pointer_value().into());
+
+        // FIXME: Do we want to call .insert_new_got_index() here?
+
         Ok(())
     }
 
-    pub fn associate_got_index(
-        &mut self,
-        variable_name: &str,
-        index: u64,
-    ) -> Result<(), Diagnostic> {
+    pub fn associate_got_index(&mut self, variable_name: &str, index: u64) -> Result<(), Diagnostic> {
         self.got_indices.insert(variable_name.to_lowercase(), index);
+        Ok(())
+    }
+
+    pub fn insert_new_got_index(&mut self, variable_name: &str) -> Result<(), Diagnostic> {
+        let idx = self.got_indices.values().max().copied().unwrap_or(0);
+
+        self.got_indices.insert(variable_name.to_lowercase(), idx);
+
         Ok(())
     }
 


### PR DESCRIPTION
Hi everyone, here is the PR containing all of the changes we had to make to the compiler in order to try and get online-change-example to work with our runtime. I will self-review the PR and add notes concerning certain workarounds we had to make