### PR TITLE
Add online-change CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -16,6 +16,7 @@ plc_index = { path = "../plc_index" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+toml = "0.5"
 clap = { version = "3.0", features = ["derive"] }
 rayon = "1.6.1"
 tempfile = "3"

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -328,7 +328,9 @@ pub fn get_config_format(name: &str) -> Option<ConfigFormat> {
 
 impl CompileParameters {
     pub fn parse<T: AsRef<OsStr> + AsRef<str>>(args: &[T]) -> Result<CompileParameters, ParameterError> {
-        CompileParameters::try_parse_from(args).and_then(|result| {
+        CompileParameters::try_parse_from(args).and_then(|mut result| {
+            result.got_layout_file = Some(String::from("tmp.json"));
+
             if result.sysroot.len() > result.target.len() {
                 let mut cmd = CompileParameters::command();
                 Err(cmd.error(

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -109,6 +109,18 @@ pub struct CompileParameters {
     pub hardware_config: Option<String>,
 
     #[clap(
+        name = "got-layout-file",
+        long,
+        global = true,
+        help = "Obtain information about the current custom GOT layout from the given file if it exists.
+    Save information about the generated custom GOT layout to the given file.
+    Format is detected by extension.
+    Supported formats : json, toml",
+    parse(try_from_str = validate_config)
+    ) ]
+    pub got_layout_file: Option<String>,
+
+    #[clap(
         name = "optimization",
         long,
         short = 'O',
@@ -385,6 +397,10 @@ impl CompileParameters {
 
     pub fn config_format(&self) -> Option<ConfigFormat> {
         self.hardware_config.as_deref().and_then(get_config_format)
+    }
+
+    pub fn got_layout_format(&self) -> Option<ConfigFormat> {
+        self.got_layout_file.as_deref().and_then(get_config_format)
     }
 
     /// Returns the location where the build artifacts should be stored / output

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -213,6 +213,12 @@ pub struct CompileParameters {
     #[clap(name = "check", long, help = "Check only, do not generate any output", global = true)]
     pub check_only: bool,
 
+    #[clap(
+        long,
+        help = "Emit a binary with specific compilation information, suitable for online changes when ran under a conforming runtime"
+    )]
+    pub online_change: bool,
+
     #[clap(subcommand)]
     pub commands: Option<SubCommands>,
 }

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -19,8 +19,8 @@ use std::{
 use cli::{CompileParameters, ParameterError, SubCommands};
 use pipelines::AnnotatedProject;
 use plc::{
-    codegen::CodegenContext, linker::LinkerType, output::FormatOption, ConfigFormat, DebugLevel,
-    ErrorFormat, OptimizationLevel, Target, Threads,
+    codegen::CodegenContext, linker::LinkerType, output::FormatOption, ConfigFormat, DebugLevel, ErrorFormat,
+    OnlineChange, OptimizationLevel, Target, Threads,
 };
 
 use plc_diagnostics::{diagnostician::Diagnostician, diagnostics::Diagnostic};
@@ -56,6 +56,7 @@ pub struct CompileOptions {
     pub error_format: ErrorFormat,
     pub debug_level: DebugLevel,
     pub single_module: bool,
+    pub online_change: OnlineChange,
 }
 
 impl Default for CompileOptions {
@@ -71,6 +72,7 @@ impl Default for CompileOptions {
             error_format: ErrorFormat::None,
             debug_level: DebugLevel::None,
             single_module: false,
+            online_change: OnlineChange::Disabled,
         }
     }
 }
@@ -182,6 +184,11 @@ pub fn get_compilation_context<T: AsRef<str> + AsRef<OsStr> + Debug>(
         error_format: compile_parameters.error_format,
         debug_level: compile_parameters.debug_level(),
         single_module: compile_parameters.single_module,
+        online_change: if compile_parameters.online_change {
+            OnlineChange::Enabled
+        } else {
+            OnlineChange::Disabled
+        },
     };
 
     let libraries =

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -19,8 +19,8 @@ use std::{
 use cli::{CompileParameters, ParameterError, SubCommands};
 use pipelines::AnnotatedProject;
 use plc::{
-    codegen::CodegenContext, linker::LinkerType, output::FormatOption, DebugLevel, ErrorFormat,
-    OptimizationLevel, Target, Threads,
+    codegen::CodegenContext, linker::LinkerType, output::FormatOption, ConfigFormat, DebugLevel,
+    ErrorFormat, OptimizationLevel, Target, Threads,
 };
 
 use plc_diagnostics::{diagnostician::Diagnostician, diagnostics::Diagnostic};
@@ -50,6 +50,8 @@ pub struct CompileOptions {
     /// The name of the resulting compiled file
     pub output: String,
     pub output_format: FormatOption,
+    pub got_layout_file: Option<String>,
+    pub got_layout_format: Option<ConfigFormat>,
     pub optimization: OptimizationLevel,
     pub error_format: ErrorFormat,
     pub debug_level: DebugLevel,
@@ -63,6 +65,8 @@ impl Default for CompileOptions {
             build_location: None,
             output: String::new(),
             output_format: Default::default(),
+            got_layout_file: None,
+            got_layout_format: None,
             optimization: OptimizationLevel::None,
             error_format: ErrorFormat::None,
             debug_level: DebugLevel::None,
@@ -172,6 +176,8 @@ pub fn get_compilation_context<T: AsRef<str> + AsRef<OsStr> + Debug>(
         build_location: compile_parameters.get_build_location(),
         output: project.get_output_name(),
         output_format,
+        got_layout_file: compile_parameters.got_layout_file.clone(),
+        got_layout_format: compile_parameters.got_layout_format(),
         optimization: compile_parameters.optimization,
         error_format: compile_parameters.error_format,
         debug_level: compile_parameters.debug_level(),

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -274,6 +274,7 @@ impl<T: SourceContainer + Sync> AnnotatedProject<T> {
             context,
             compile_options.root.as_deref(),
             &unit.file_name,
+            compile_options.got_layout_file.clone().zip(compile_options.got_layout_format),
             compile_options.optimization,
             compile_options.debug_level,
         );

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -330,6 +330,7 @@ impl<T: SourceContainer + Sync> AnnotatedProject<T> {
             compile_options.got_layout_file.clone().zip(compile_options.got_layout_format),
             compile_options.optimization,
             compile_options.debug_level,
+            compile_options.online_change,
         );
         //Create a types codegen, this contains all the type declarations
         //Associate the index type with LLVM types

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_function_call.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_function_call.snap
@@ -5,7 +5,7 @@ expression: "results.join(\"\\n\")"
 ; ModuleID = 'main.st'
 source_filename = "main.st"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -14,9 +14,9 @@ entry:
   ret i16 %main_ret
 }
 
-declare i16 @external() section "fn-$RUSTY$external:i16"
+declare i16 @external()
 
 ; ModuleID = 'external.st'
 source_filename = "external.st"
 
-declare i16 @external() section "fn-$RUSTY$external:i16"
+declare i16 @external()

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_global_var.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__external_files__external_file_global_var.snap
@@ -8,7 +8,7 @@ source_filename = "main.st"
 @x = external global i16, section "var-$RUSTY$x:i16"
 @y = external global i16, section "var-$RUSTY$y:i16"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -19,7 +19,7 @@ entry:
   ret i16 %main_ret
 }
 
-declare i16 @external() section "fn-$RUSTY$external:i16"
+declare i16 @external()
 
 ; ModuleID = 'external.st'
 source_filename = "external.st"
@@ -27,4 +27,4 @@ source_filename = "external.st"
 @x = external global i16, section "var-$RUSTY$x:i16"
 @y = external global i16, section "var-$RUSTY$y:i16"
 
-declare i16 @external() section "fn-$RUSTY$external:i16"
+declare i16 @external()

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_in_different_locations_with_debug_info.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_in_different_locations_with_debug_info.snap
@@ -9,7 +9,7 @@ source_filename = "app/file1.st"
 
 @mainProg_instance = external global %mainProg, section "var-$RUSTY$mainProg_instance:r0", !dbg !0
 
-define i16 @main() section "fn-$RUSTY$main:i16" !dbg !10 {
+define i16 @main() !dbg !10 {
 entry:
   %main = alloca i16, align 2, !dbg !14
   call void @llvm.dbg.declare(metadata i16* %main, metadata !15, metadata !DIExpression()), !dbg !17
@@ -19,7 +19,7 @@ entry:
   ret i16 %main_ret, !dbg !14
 }
 
-declare !dbg !18 void @mainProg(%mainProg*) section "fn-$RUSTY$mainProg:v"
+declare !dbg !18 void @mainProg(%mainProg*)
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
@@ -56,7 +56,7 @@ source_filename = "lib/file2.st"
 
 @mainProg_instance = global %mainProg zeroinitializer, section "var-$RUSTY$mainProg_instance:r0", !dbg !0
 
-define void @mainProg(%mainProg* %0) section "fn-$RUSTY$mainProg:v" !dbg !10 {
+define void @mainProg(%mainProg* %0) !dbg !10 {
 entry:
   call void @llvm.dbg.declare(metadata %mainProg* %0, metadata !13, metadata !DIExpression()), !dbg !14
   ret void, !dbg !14

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_with_debug_info.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_with_debug_info.snap
@@ -9,7 +9,7 @@ source_filename = "file1.st"
 
 @mainProg_instance = external global %mainProg, section "var-$RUSTY$mainProg_instance:r0", !dbg !0
 
-define i16 @main() section "fn-$RUSTY$main:i16" !dbg !10 {
+define i16 @main() !dbg !10 {
 entry:
   %main = alloca i16, align 2, !dbg !14
   call void @llvm.dbg.declare(metadata i16* %main, metadata !15, metadata !DIExpression()), !dbg !17
@@ -19,7 +19,7 @@ entry:
   ret i16 %main_ret, !dbg !14
 }
 
-declare !dbg !18 void @mainProg(%mainProg*) section "fn-$RUSTY$mainProg:v"
+declare !dbg !18 void @mainProg(%mainProg*)
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
@@ -56,7 +56,7 @@ source_filename = "file2.st"
 
 @mainProg_instance = global %mainProg zeroinitializer, section "var-$RUSTY$mainProg_instance:r0", !dbg !0
 
-define void @mainProg(%mainProg* %0) section "fn-$RUSTY$mainProg:v" !dbg !10 {
+define void @mainProg(%mainProg* %0) !dbg !10 {
 entry:
   call void @llvm.dbg.declare(metadata %mainProg* %0, metadata !13, metadata !DIExpression()), !dbg !14
   ret void, !dbg !14

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_source_files_generated.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_source_files_generated.snap
@@ -9,7 +9,7 @@ source_filename = "external_file1.st"
 
 @mainProg_instance = external global %mainProg, section "var-$RUSTY$mainProg_instance:r0"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -18,7 +18,7 @@ entry:
   ret i16 %main_ret
 }
 
-declare void @mainProg(%mainProg*) section "fn-$RUSTY$mainProg:v"
+declare void @mainProg(%mainProg*)
 
 ; ModuleID = 'external_file2.st'
 source_filename = "external_file2.st"
@@ -27,7 +27,7 @@ source_filename = "external_file2.st"
 
 @mainProg_instance = global %mainProg zeroinitializer, section "var-$RUSTY$mainProg_instance:r0"
 
-define void @mainProg(%mainProg* %0) section "fn-$RUSTY$mainProg:v" {
+define void @mainProg(%mainProg* %0) {
 entry:
   ret void
 }

--- a/compiler/section_mangler/src/parser.rs
+++ b/compiler/section_mangler/src/parser.rs
@@ -228,4 +228,11 @@ mod tests {
     fn parse_function_invalid_no_arguments() {
         let _ = SectionMangler::from("$RUSTY$fn-no_arguments:u16u8");
     }
+
+    #[test]
+    fn parse_qualified_var_name() {
+        let mangled = SectionMangler::from("$RUSTY$var-Color.red:e4i32");
+
+        assert_eq!(mangled.name(), "Color.red");
+    }
 }

--- a/compiler/section_mangler/src/parser.rs
+++ b/compiler/section_mangler/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::{FunctionArgument, SectionMangler, Type};
+use crate::{FunctionArgument, SectionMangler, StringEncoding, Type};
 
 use std::str;
 
@@ -21,7 +21,7 @@ fn parse_prefix(input: &str) -> ParseResult<Prefix> {
     let fn_prefix = tag("fn").map(|_| Prefix::Fn);
     let var_prefix = tag("var").map(|_| Prefix::Var);
 
-    let (input, _) = tag(crate::PREFIX)(input)?;
+    let (input, _) = tag(crate::RUSTY_PREFIX)(input)?;
     let (input, prefix) = alt((fn_prefix, var_prefix))(input)?;
 
     Ok((input, prefix))
@@ -75,8 +75,29 @@ fn type_enum(input: &str) -> ParseResult<Type> {
         .parse(input)
 }
 
+fn string_encoding(input: &str) -> ParseResult<StringEncoding> {
+    let utf8 = tag("8u").map(|_| StringEncoding::Utf8);
+    let utf16 = tag("16u").map(|_| StringEncoding::Utf16);
+
+    alt((utf8, utf16))(input)
+}
+
+fn type_string(input: &str) -> ParseResult<Type> {
+    char('s')
+        .and(string_encoding)
+        .and(number::<usize>)
+        .map(|((_, encoding), size)| Type::String { size, encoding })
+        .parse(input)
+}
+
+fn type_array(input: &str) -> ParseResult<Type> {
+    char('a').and(parse_type).map(|(_, inner_ty)| Type::Array { inner: Box::new(inner_ty) }).parse(input)
+}
+
 fn parse_type(input: &str) -> ParseResult<Type> {
-    alt((type_void, type_integer, type_float, type_pointer, type_struct, type_enum))(input)
+    alt((type_void, type_integer, type_float, type_pointer, type_struct, type_enum, type_string, type_array))(
+        input,
+    )
 }
 
 fn parse_var_content<'i>(input: &'i str, name: &str) -> ParseResult<'i, SectionMangler> {
@@ -188,6 +209,7 @@ mod tests {
         // this needs to be handled by the toplevel parse function
         assert!(type_struct("r0u8u8").is_ok());
         assert!(type_struct("r1u8u8").is_ok());
+        assert!(type_struct("r5s8u1025s8u2049s8u3u64s8u3").is_ok());
 
         // invalid number of elements
         assert!(type_struct("r15u8").is_err());
@@ -234,5 +256,68 @@ mod tests {
         let mangled = SectionMangler::from("$RUSTY$var-Color.red:e4i32");
 
         assert_eq!(mangled.name(), "Color.red");
+    }
+
+    #[test]
+    fn parse_complex1() {
+        let mangled = SectionMangler::from("$RUSTY$var-__File__init:r5s8u1025s8u2049s8u3u64s8u3");
+
+        assert_eq!(mangled.name(), "__File__init");
+    }
+
+    #[test]
+    fn parse_complex2() {
+        let inputs = [
+            "$RUSTY$var-__CosineSignal__init:r4f64i32f64f64",
+            "$RUSTY$var-__File__init:r5s8u1025s8u2049s8u3u64s8u3",
+            "$RUSTY$var-__SineSignal__init:r4f64i32f64f64",
+            "$RUSTY$var-__mainProg_state.Init:e3i32",
+            "$RUSTY$var-__mainProg_state.Running:e3i32",
+            "$RUSTY$var-__mainProg_state.Stopped:e3i32",
+            "$RUSTY$var-__SR__init:r3u8u8u8",
+            "$RUSTY$var-__RS__init:r3u8u8u8",
+            "$RUSTY$var-__CTU__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTU_INT__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTU_DINT__init:r6u8u8i32u8i32u8",
+            "$RUSTY$var-__CTU_UDINT__init:r6u8u8u32u8u32u8",
+            "$RUSTY$var-__CTU_LINT__init:r6u8u8i64u8i64u8",
+            "$RUSTY$var-__CTU_ULINT__init:r6u8u8u64u8u64u8",
+            "$RUSTY$var-__CTD__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTD_INT__init:r6u8u8i16u8i16u8",
+            "$RUSTY$var-__CTD_DINT__init:r6u8u8i32u8i32u8",
+            "$RUSTY$var-__CTD_UDINT__init:r6u8u8u32u8u32u8",
+            "$RUSTY$var-__CTD_LINT__init:r6u8u8i64u8i64u8",
+            "$RUSTY$var-__CTD_ULINT__init:r6u8u8u64u8u64u8",
+            "$RUSTY$var-__CTUD__init:r10u8u8u8u8i16u8u8i16u8u8",
+            "$RUSTY$var-__CTUD_INT__init:r10u8u8u8u8i16u8u8i16u8u8",
+            "$RUSTY$var-__CTUD_DINT__init:r10u8u8u8u8i32u8u8i32u8u8",
+            "$RUSTY$var-__CTUD_UDINT__init:r10u8u8u8u8u32u8u8u32u8u8",
+            "$RUSTY$var-__CTUD_LINT__init:r10u8u8u8u8i64u8u8i64u8u8",
+            "$RUSTY$var-__CTUD_ULINT__init:r10u8u8u8u8u64u8u8u64u8u8",
+            "$RUSTY$var-__R_TRIG__init:r3u8u8u8",
+            "$RUSTY$var-__F_TRIG__init:r3u8u8u8",
+            "$RUSTY$var-__TP__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TP_TIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TP_LTIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TON__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TON_TIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TON_LTIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TOF__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TOF_TIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$var-__TOF_LTIME__init:r7u8i64u8i64u8u8au8",
+            "$RUSTY$fn-CosineSignal:v[f64][i32][f64]",
+            "$RUSTY$fn-File:v[s8u1025][s8u2049][s8u3]",
+            "$RUSTY$fn-File.Open:v",
+            "$RUSTY$fn-File.Write:v",
+            "$RUSTY$fn-File.Close:v",
+            "$RUSTY$fn-File.Clear:v",
+            "$RUSTY$fn-SineSignal:v[f64][i32][f64]",
+            "$RUSTY$fn-mainProg:v",
+            "$RUSTY$var-mainProg:r7i32r4f64i32f64f64r4f64i32f64f64e3i32r5s8u1025s8u2049s8u3u64s8u3r5s8u1025s8u2049s8u3u64s8u3r5s8u1025s8u2049s8u3u64s8u3"
+        ];
+
+        inputs.into_iter().for_each(|input| {
+            let _ = SectionMangler::from(dbg!(input));
+        });
     }
 }

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -2,10 +2,10 @@
 
 use inkwell::{
     builder::Builder,
-    types::{BasicType, BasicTypeEnum},
+    types::{BasicType, BasicTypeEnum, FunctionType},
     values::{
-        ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, FloatValue, IntValue, PointerValue,
-        StructValue, VectorValue,
+        ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallSiteValue, CallableValue,
+        FloatValue, IntValue, PointerValue, StructValue, VectorValue,
     },
     AddressSpace, FloatPredicate, IntPredicate,
 };
@@ -328,10 +328,9 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
     ) -> Result<Option<CallSiteValue<'ink>>, Diagnostic> {
         // We will generate a GEP, which has as its base address the magic constant which
         // will eventually be replaced by the location of the GOT.
-        let base =
-            self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
-                llvm_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
-            );
+        let base = self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
+            function_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
+        );
 
         self.llvm_index
             .find_got_index(qualified_name)

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -298,14 +298,10 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             Some(StatementAnnotation::Variable { qualified_name, .. }) => {
                 // We will generate a GEP, which has as its base address the magic constant which
                 // will eventually be replaced by the location of the GOT.
-                let base = self
-                    .llvm
-                    .context
-                    .i64_type()
-                    .const_int(0xdeadbeef00000000, false)
-                    .const_to_pointer(llvm_type
-                        .ptr_type(AddressSpace::default())
-                        .ptr_type(AddressSpace::default()));
+                let base =
+                    self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
+                        llvm_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
+                    );
 
                 self.llvm_index
                     .find_got_index(qualified_name)
@@ -321,6 +317,37 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             }
             _ => Ok(None),
         }
+    }
+
+    /// Generate an access to the appropriate GOT entry to achieve a call to the given function.
+    pub fn generate_got_call(
+        &self,
+        qualified_name: &str,
+        function_type: &FunctionType<'ink>,
+        args: &[BasicMetadataValueEnum<'ink>],
+    ) -> Result<Option<CallSiteValue<'ink>>, Diagnostic> {
+        // We will generate a GEP, which has as its base address the magic constant which
+        // will eventually be replaced by the location of the GOT.
+        let base =
+            self.llvm.context.i64_type().const_int(0xdeadbeef00000000, false).const_to_pointer(
+                llvm_type.ptr_type(AddressSpace::default()).ptr_type(AddressSpace::default()),
+            );
+
+        self.llvm_index
+            .find_got_index(qualified_name)
+            .map(|idx| {
+                let mut ptr = self.llvm.load_array_element(
+                    base,
+                    &[self.llvm.context.i32_type().const_int(idx, false)],
+                    "",
+                )?;
+                ptr = self.llvm.load_pointer(&ptr, "").into_pointer_value();
+                let callable = CallableValue::try_from(ptr)
+                    .map_err(|_| Diagnostic::new("Pointer was not a function pointer"))?;
+
+                Ok(self.llvm.builder.build_call(callable, args, "call"))
+            })
+            .transpose()
     }
 
     /// generates a binary expression (e.g. a + b, x AND y, etc.) and returns the resulting `BasicValueEnum`
@@ -520,9 +547,20 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             None
         };
 
+        // Check for the function within the GOT. If it's there, we need to generate an indirect
+        // call to its location within the GOT, which should contain a function pointer.
+        // First get the function type so our function pointer can have the correct type.
+        let qualified_name = self
+            .annotations
+            .get_qualified_name(operator)
+            .expect("Shouldn't have got this far without a name for the function");
+        let function_type = function.get_type();
+        let call = self
+            .generate_got_call(qualified_name, &function_type, &arguments_list)?
+            .unwrap_or_else(|| self.llvm.builder.build_call(function, &arguments_list, "call"));
+
         // if the target is a function, declare the struct locally
         // assign all parameters into the struct values
-        let call = &self.llvm.builder.build_call(function, &arguments_list, "call");
 
         // so grab either:
         // - the out-pointer if we generated one in by_ref_func_out
@@ -1412,17 +1450,19 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             }
         }
 
-        let ctx_type =
-            self.annotations.get_type_or_void(context, self.index).get_type_information();
+        let ctx_type = self.annotations.get_type_or_void(context, self.index).get_type_information();
 
         // no context ... so just something like 'x'
         match self.annotations.get(context) {
             Some(StatementAnnotation::Variable { qualified_name, .. })
-            | Some(StatementAnnotation::Program { qualified_name, .. }) =>
-                self.generate_got_access(context, &self.llvm_index.get_associated_type(ctx_type.get_name())?)?.map_or(self
-                    .llvm_index
-                    .find_loaded_associated_variable_value(qualified_name)
-                    .ok_or_else(|| Diagnostic::unresolved_reference(name, offset.clone())), Ok),
+            | Some(StatementAnnotation::Program { qualified_name, .. }) => self
+                .generate_got_access(context, &self.llvm_index.get_associated_type(ctx_type.get_name())?)?
+                .map_or(
+                    self.llvm_index
+                        .find_loaded_associated_variable_value(qualified_name)
+                        .ok_or_else(|| Diagnostic::unresolved_reference(name, offset.clone())),
+                    Ok,
+                ),
             _ => Err(Diagnostic::unresolved_reference(name, offset.clone())),
         }
     }

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -133,6 +133,7 @@ pub fn generate_global_constants_for_pou_members<'ink>(
                         .make_constant()
                         .set_initial_value(Some(value), variable_type);
                     local_llvm_index.associate_global(&name, global_value)?;
+                    local_llvm_index.insert_new_got_index(&name)?;
                 }
             }
         }
@@ -154,7 +155,7 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
     }
 
     fn mangle_function(&self, implementation: &ImplementationIndexEntry) -> Result<String, Diagnostic> {
-        let ctx = SectionMangler::function(implementation.get_call_name());
+        let ctx = SectionMangler::function(implementation.get_call_name().to_lowercase());
 
         let params = self.index.get_declared_parameters(implementation.get_call_name());
 

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -16,6 +16,7 @@ use crate::{
     index::{self, ImplementationType},
     resolver::{AstAnnotations, Dependency},
     typesystem::{DataType, DataTypeInformation, VarArgs, DINT_TYPE},
+    OnlineChange,
 };
 
 /// The pou_generator contains functions to generate the code for POUs (PROGRAM, FUNCTION, FUNCTION_BLOCK)
@@ -49,6 +50,7 @@ pub struct PouGenerator<'ink, 'cg> {
     index: &'cg Index,
     annotations: &'cg AstAnnotations,
     llvm_index: &'cg LlvmTypedIndex<'ink>,
+    online_change: OnlineChange,
 }
 
 /// Creates opaque implementations for all callable items in the index
@@ -61,9 +63,10 @@ pub fn generate_implementation_stubs<'ink>(
     annotations: &AstAnnotations,
     types_index: &LlvmTypedIndex<'ink>,
     debug: &mut DebugBuilderEnum<'ink>,
+    online_change: OnlineChange,
 ) -> Result<LlvmTypedIndex<'ink>, Diagnostic> {
     let mut llvm_index = LlvmTypedIndex::default();
-    let pou_generator = PouGenerator::new(llvm, index, annotations, types_index);
+    let pou_generator = PouGenerator::new(llvm, index, annotations, types_index, online_change);
     let implementations = dependencies
         .into_iter()
         .filter_map(|it| {
@@ -150,8 +153,9 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
         index: &'cg Index,
         annotations: &'cg AstAnnotations,
         llvm_index: &'cg LlvmTypedIndex<'ink>,
+        online_change: OnlineChange,
     ) -> PouGenerator<'ink, 'cg> {
-        PouGenerator { llvm, index, annotations, llvm_index }
+        PouGenerator { llvm, index, annotations, llvm_index, online_change }
     }
 
     fn mangle_function(&self, implementation: &ImplementationIndexEntry) -> Result<String, Diagnostic> {
@@ -286,8 +290,10 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
 
         let curr_f = module.add_function(implementation.get_call_name(), function_declaration, None);
 
-        let section_name = self.mangle_function(implementation)?;
-        curr_f.set_section(Some(&section_name));
+        if self.online_change == OnlineChange::Enabled {
+            let section_name = self.mangle_function(implementation)?;
+            curr_f.set_section(Some(&section_name));
+        }
 
         let pou_name = implementation.get_call_name();
         if let Some(pou) = self.index.find_pou(pou_name) {

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -172,7 +172,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         }
 
         let section = section_mangler::SectionMangler::variable(
-            global_variable.get_name(),
+            global_variable.get_qualified_name(),
             section_names::mangle_type(
                 self.global_index,
                 self.global_index.get_effective_type_by_name(global_variable.get_type_name())?,

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -5,15 +5,11 @@ use crate::{
     codegen::{debug::Debug, llvm_index::LlvmTypedIndex, llvm_typesystem::cast_if_needed},
     index::{get_initializer_name, Index, PouIndexEntry, VariableIndexEntry},
     resolver::{AnnotationMap, AstAnnotations, Dependency},
-    ConfigFormat,
 };
 use indexmap::IndexSet;
-use inkwell::{module::Module, types::BasicTypeEnum, values::GlobalValue};
+use inkwell::{module::Module, values::GlobalValue};
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
-use std::collections::HashMap;
-use std::fs::{read_to_string, write};
-use std::path::Path;
 
 use super::{
     data_type_generator::get_default_for,
@@ -24,40 +20,6 @@ use super::{
 use crate::codegen::debug::DebugBuilderEnum;
 use crate::index::FxIndexSet;
 
-pub fn read_got_layout(location: &str, format: ConfigFormat) -> Result<HashMap<String, u64>, Diagnostic> {
-    if !Path::new(location).is_file() {
-        // Assume if the file doesn't exist that there is no existing GOT layout yet. write_got_layout will handle
-        // creating our file when we want to.
-        return Ok(HashMap::new());
-    }
-
-    let s =
-        read_to_string(location).map_err(|_| Diagnostic::new("GOT layout could not be read from file"))?;
-    match format {
-        ConfigFormat::JSON => serde_json::from_str(&s)
-            .map_err(|_| Diagnostic::new("Could not deserialize GOT layout from JSON")),
-        ConfigFormat::TOML => {
-            toml::de::from_str(&s).map_err(|_| Diagnostic::new("Could not deserialize GOT layout from TOML"))
-        }
-    }
-}
-
-pub fn write_got_layout(
-    got_entries: HashMap<String, u64>,
-    location: &str,
-    format: ConfigFormat,
-) -> Result<(), Diagnostic> {
-    let s = match format {
-        ConfigFormat::JSON => serde_json::to_string(&got_entries)
-            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to JSON"))?,
-        ConfigFormat::TOML => toml::ser::to_string(&got_entries)
-            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to TOML"))?,
-    };
-
-    write(location, s).map_err(|_| Diagnostic::new("GOT layout could not be written to file"))?;
-    Ok(())
-}
-
 pub struct VariableGenerator<'ctx, 'b> {
     module: &'b Module<'ctx>,
     llvm: &'b Llvm<'ctx>,
@@ -65,7 +27,6 @@ pub struct VariableGenerator<'ctx, 'b> {
     annotations: &'b AstAnnotations,
     types_index: &'b LlvmTypedIndex<'ctx>,
     debug: &'b mut DebugBuilderEnum<'ctx>,
-    got_layout_file: Option<(String, ConfigFormat)>,
 }
 
 impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
@@ -76,9 +37,8 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         annotations: &'b AstAnnotations,
         types_index: &'b LlvmTypedIndex<'ctx>,
         debug: &'b mut DebugBuilderEnum<'ctx>,
-        got_layout_file: Option<(String, ConfigFormat)>,
     ) -> Self {
-        VariableGenerator { module, llvm, global_index, annotations, types_index, debug, got_layout_file }
+        VariableGenerator { module, llvm, global_index, annotations, types_index, debug }
     }
 
     pub fn generate_global_variables(
@@ -137,48 +97,6 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
                 &variable.data_type_name,
                 global_variable,
                 &variable.source_location,
-            );
-        }
-
-        if let Some((location, format)) = &self.got_layout_file {
-            let got_entries = read_got_layout(location.as_str(), *format)?;
-            let mut new_globals = Vec::new();
-            let mut new_got_entries = HashMap::new();
-            let mut new_got = HashMap::new();
-
-            for (name, _) in &globals {
-                if let Some(idx) = got_entries.get(&name.to_string()) {
-                    new_got_entries.insert(name.to_string(), *idx);
-                    index.associate_got_index(name, *idx);
-                    new_got.insert(*idx, name.to_string());
-                } else {
-                    new_globals.push(name.to_string());
-                }
-            }
-
-            // Put any globals that weren't there last time in any free space in the GOT.
-            let mut idx: u64 = 0;
-            for name in &new_globals {
-                while new_got.contains_key(&idx) {
-                    idx += 1;
-                }
-                new_got_entries.insert(name.to_string(), idx);
-                index.associate_got_index(name, idx);
-                new_got.insert(idx, name.to_string());
-            }
-
-            // Now we can write new_got_entries back out to a file.
-            write_got_layout(new_got_entries, location.as_str(), *format)?;
-
-            // Construct our GOT as a new global array. We initialise this array in the loader code.
-            let got_size = new_got.keys().max().map_or(0, |m| *m + 1);
-            let _got = self.llvm.create_global_variable(
-                self.module,
-                "__custom_got",
-                BasicTypeEnum::ArrayType(Llvm::get_array_type(
-                    BasicTypeEnum::PointerType(self.llvm.context.i8_type().ptr_type(0.into())),
-                    got_size.try_into().expect("the computed custom GOT size is too large"),
-                )),
             );
         }
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -5,11 +5,15 @@ use crate::{
     codegen::{debug::Debug, llvm_index::LlvmTypedIndex, llvm_typesystem::cast_if_needed},
     index::{get_initializer_name, Index, PouIndexEntry, VariableIndexEntry},
     resolver::{AnnotationMap, AstAnnotations, Dependency},
+    ConfigFormat,
 };
-
-use inkwell::{module::Module, values::GlobalValue};
+use indexmap::IndexSet;
+use inkwell::{module::Module, types::BasicTypeEnum, values::GlobalValue};
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
+use std::collections::HashMap;
+use std::fs::{read_to_string, write};
+use std::path::Path;
 
 use super::{
     data_type_generator::get_default_for,
@@ -20,6 +24,40 @@ use super::{
 use crate::codegen::debug::DebugBuilderEnum;
 use crate::index::FxIndexSet;
 
+pub fn read_got_layout(location: &str, format: ConfigFormat) -> Result<HashMap<String, u64>, Diagnostic> {
+    if !Path::new(location).is_file() {
+        // Assume if the file doesn't exist that there is no existing GOT layout yet. write_got_layout will handle
+        // creating our file when we want to.
+        return Ok(HashMap::new());
+    }
+
+    let s =
+        read_to_string(location).map_err(|_| Diagnostic::new("GOT layout could not be read from file"))?;
+    match format {
+        ConfigFormat::JSON => serde_json::from_str(&s)
+            .map_err(|_| Diagnostic::new("Could not deserialize GOT layout from JSON")),
+        ConfigFormat::TOML => {
+            toml::de::from_str(&s).map_err(|_| Diagnostic::new("Could not deserialize GOT layout from TOML"))
+        }
+    }
+}
+
+pub fn write_got_layout(
+    got_entries: HashMap<String, u64>,
+    location: &str,
+    format: ConfigFormat,
+) -> Result<(), Diagnostic> {
+    let s = match format {
+        ConfigFormat::JSON => serde_json::to_string(&got_entries)
+            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to JSON"))?,
+        ConfigFormat::TOML => toml::ser::to_string(&got_entries)
+            .map_err(|_| Diagnostic::new("Could not serialize GOT layout to TOML"))?,
+    };
+
+    write(location, s).map_err(|_| Diagnostic::new("GOT layout could not be written to file"))?;
+    Ok(())
+}
+
 pub struct VariableGenerator<'ctx, 'b> {
     module: &'b Module<'ctx>,
     llvm: &'b Llvm<'ctx>,
@@ -27,6 +65,7 @@ pub struct VariableGenerator<'ctx, 'b> {
     annotations: &'b AstAnnotations,
     types_index: &'b LlvmTypedIndex<'ctx>,
     debug: &'b mut DebugBuilderEnum<'ctx>,
+    got_layout_file: Option<(String, ConfigFormat)>,
 }
 
 impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
@@ -37,8 +76,9 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         annotations: &'b AstAnnotations,
         types_index: &'b LlvmTypedIndex<'ctx>,
         debug: &'b mut DebugBuilderEnum<'ctx>,
+        got_layout_file: Option<(String, ConfigFormat)>,
     ) -> Self {
-        VariableGenerator { module, llvm, global_index, annotations, types_index, debug }
+        VariableGenerator { module, llvm, global_index, annotations, types_index, debug, got_layout_file }
     }
 
     pub fn generate_global_variables(
@@ -76,7 +116,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
             }
         });
 
-        for (name, variable) in globals {
+        for (name, variable) in &globals {
             let linkage =
                 if !variable.is_in_unit(location) { LinkageType::External } else { variable.get_linkage() };
             let global_variable = self.generate_global_variable(variable, linkage).map_err(|err| {
@@ -97,6 +137,46 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
                 &variable.data_type_name,
                 global_variable,
                 &variable.source_location,
+            );
+        }
+
+        if let Some((location, format)) = &self.got_layout_file {
+            let got_entries = read_got_layout(location.as_str(), *format)?;
+            let mut new_globals = Vec::new();
+            let mut new_got_entries = HashMap::new();
+            let mut new_got = HashMap::new();
+
+            for (name, _) in &globals {
+                if let Some(idx) = got_entries.get(&name.to_string()) {
+                    new_got_entries.insert(name.to_string(), *idx);
+                    new_got.insert(*idx, name.to_string());
+                } else {
+                    new_globals.push(name.to_string());
+                }
+            }
+
+            // Put any globals that weren't there last time in any free space in the GOT.
+            let mut idx: u64 = 0;
+            for name in &new_globals {
+                while new_got.contains_key(&idx) {
+                    idx += 1;
+                }
+                new_got_entries.insert(name.to_string(), idx);
+                new_got.insert(idx, name.to_string());
+            }
+
+            // Now we can write new_got_entries back out to a file.
+            write_got_layout(new_got_entries, location.as_str(), *format)?;
+
+            // Construct our GOT as a new global array. We initialise this array in the loader code.
+            let got_size = new_got.keys().max().map_or(0, |m| *m + 1);
+            let _got = self.llvm.create_global_variable(
+                self.module,
+                "__custom_got",
+                BasicTypeEnum::ArrayType(Llvm::get_array_type(
+                    BasicTypeEnum::PointerType(self.llvm.context.i8_type().ptr_type(0.into())),
+                    got_size.try_into().expect("the computed custom GOT size is too large"),
+                )),
             );
         }
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -149,6 +149,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
             for (name, _) in &globals {
                 if let Some(idx) = got_entries.get(&name.to_string()) {
                     new_got_entries.insert(name.to_string(), *idx);
+                    index.associate_got_index(name, *idx);
                     new_got.insert(*idx, name.to_string());
                 } else {
                     new_globals.push(name.to_string());
@@ -162,6 +163,7 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
                     idx += 1;
                 }
                 new_got_entries.insert(name.to_string(), idx);
+                index.associate_got_index(name, idx);
                 new_got.insert(idx, name.to_string());
             }
 

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -6,10 +6,10 @@ use crate::{
     index::{get_initializer_name, Index, PouIndexEntry, VariableIndexEntry},
     resolver::{AnnotationMap, AstAnnotations, Dependency},
 };
-use indexmap::IndexSet;
 use inkwell::{module::Module, values::GlobalValue};
 use plc_ast::ast::LinkageType;
 use plc_diagnostics::diagnostics::Diagnostic;
+use section_mangler::SectionMangler;
 
 use super::{
     data_type_generator::get_default_for,
@@ -171,8 +171,15 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
             }
         }
 
-        let section = section_mangler::SectionMangler::variable(
-            global_variable.get_qualified_name(),
+        let global_name = if global_variable.get_name().ends_with("instance") {
+            global_variable.get_name()
+        } else {
+            global_variable.get_qualified_name()
+        };
+        let global_name = global_name.to_lowercase();
+
+        let section = SectionMangler::variable(
+            global_name,
             section_names::mangle_type(
                 self.global_index,
                 self.global_index.get_effective_type_by_name(global_variable.get_type_name())?,

--- a/src/codegen/llvm_index.rs
+++ b/src/codegen/llvm_index.rs
@@ -14,6 +14,7 @@ pub struct LlvmTypedIndex<'ink> {
     type_associations: FxHashMap<String, BasicTypeEnum<'ink>>,
     pou_type_associations: FxHashMap<String, BasicTypeEnum<'ink>>,
     global_values: FxHashMap<String, GlobalValue<'ink>>,
+    // TODO: Should this be an Option?
     got_indices: FxHashMap<String, u64>,
     initial_value_associations: FxHashMap<String, BasicValueEnum<'ink>>,
     loaded_variable_associations: FxHashMap<String, PointerValue<'ink>>,
@@ -162,15 +163,22 @@ impl<'ink> LlvmTypedIndex<'ink> {
         self.global_values.insert(variable_name.to_lowercase(), global_variable);
         self.initial_value_associations
             .insert(variable_name.to_lowercase(), global_variable.as_pointer_value().into());
+
+        // FIXME: Do we want to call .insert_new_got_index() here?
+
         Ok(())
     }
 
-    pub fn associate_got_index(
-        &mut self,
-        variable_name: &str,
-        index: u64,
-    ) -> Result<(), Diagnostic> {
+    pub fn associate_got_index(&mut self, variable_name: &str, index: u64) -> Result<(), Diagnostic> {
         self.got_indices.insert(variable_name.to_lowercase(), index);
+        Ok(())
+    }
+
+    pub fn insert_new_got_index(&mut self, variable_name: &str) -> Result<(), Diagnostic> {
+        let idx = self.got_indices.values().max().copied().unwrap_or(0);
+
+        self.got_indices.insert(variable_name.to_lowercase(), idx);
+
         Ok(())
     }
 

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__aggregate_return_value_variable_in_function.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__aggregate_return_value_variable_in_function.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define void @myFunc([81 x i8]* %0) section "fn-$RUSTY$myFunc:s8u81" !dbg !4 {
+define void @myFunc([81 x i8]* %0) !dbg !4 {
 entry:
   %myFunc = alloca [81 x i8]*, align 8, !dbg !8
   store [81 x i8]* %0, [81 x i8]** %myFunc, align 8, !dbg !8

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__array_size_correctly_set_in_dwarf_info.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__array_size_correctly_set_in_dwarf_info.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @foo() section "fn-$RUSTY$foo:i32" !dbg !4 {
+define i32 @foo() !dbg !4 {
 entry:
   %foo = alloca i32, align 4, !dbg !8
   %a = alloca [64 x i32], align 4, !dbg !8

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__assignment_statement_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__assignment_statement_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__exit_statement_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__exit_statement_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
@@ -11,11 +11,11 @@ source_filename = "main"
 @myPrg_instance = external global %myPrg, section "var-$RUSTY$myPrg_instance:r0", !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, section "var-$RUSTY$__myFb__init:r0", !dbg !5
 
-declare i32 @myFunc() section "fn-$RUSTY$myFunc:i32"
+declare i32 @myFunc()
 
-declare void @myPrg(%myPrg*) section "fn-$RUSTY$myPrg:v"
+declare void @myPrg(%myPrg*)
 
-declare void @myFb(%myFb*) section "fn-$RUSTY$myFb:v"
+declare void @myFb(%myFb*)
 
 !llvm.module.flags = !{!8, !9}
 !llvm.dbg.cu = !{!10}

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__for_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__for_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_in_expressions_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__function_calls_in_expressions_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__if_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__if_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__implementation_added_as_subroutine.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__implementation_added_as_subroutine.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @myPrg_instance = global %myPrg zeroinitializer, section "var-$RUSTY$myPrg_instance:r0", !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, section "var-$RUSTY$__myFb__init:r0", !dbg !5
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !12 {
+define i32 @myFunc() !dbg !12 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !15
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !16, metadata !DIExpression()), !dbg !18
@@ -20,13 +20,13 @@ entry:
   ret i32 %myFunc_ret, !dbg !15
 }
 
-define void @myPrg(%myPrg* %0) section "fn-$RUSTY$myPrg:v" !dbg !19 {
+define void @myPrg(%myPrg* %0) !dbg !19 {
 entry:
   call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !20, metadata !DIExpression()), !dbg !21
   ret void, !dbg !21
 }
 
-define void @myFb(%myFb* %0) section "fn-$RUSTY$myFb:v" !dbg !22 {
+define void @myFb(%myFb* %0) !dbg !22 {
 entry:
   call void @llvm.dbg.declare(metadata %myFb* %0, metadata !23, metadata !DIExpression()), !dbg !24
   ret void, !dbg !24

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__nested_function_calls_get_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__nested_function_calls_get_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc(i32 %0) section "fn-$RUSTY$myFunc:i32[i32]" !dbg !4 {
+define i32 @myFunc(i32 %0) !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !9
   %x = alloca i32, align 4, !dbg !9

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_callable_expressions_have_no_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_callable_expressions_have_no_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_function_pous_have_struct_as_param.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_function_pous_have_struct_as_param.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @myProg_instance = global %myProg zeroinitializer, section "var-$RUSTY$myProg_instance:r1i32", !dbg !0
 @__fb__init = unnamed_addr constant %fb zeroinitializer, section "var-$RUSTY$__fb__init:r1i32", !dbg !7
 
-define void @myProg(%myProg* %0) section "fn-$RUSTY$myProg:v[i32]" !dbg !16 {
+define void @myProg(%myProg* %0) !dbg !16 {
 entry:
   call void @llvm.dbg.declare(metadata %myProg* %0, metadata !20, metadata !DIExpression()), !dbg !21
   %x = getelementptr inbounds %myProg, %myProg* %0, i32 0, i32 0, !dbg !21
@@ -21,7 +21,7 @@ entry:
   ret void, !dbg !21
 }
 
-define void @fb(%fb* %0) section "fn-$RUSTY$fb:v[i32]" !dbg !22 {
+define void @fb(%fb* %0) !dbg !22 {
 entry:
   call void @llvm.dbg.declare(metadata %fb* %0, metadata !23, metadata !DIExpression()), !dbg !24
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0, !dbg !24

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__repeat_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__repeat_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__return_statement_have_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__return_statement_have_location.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @myPrg_instance = global %myPrg zeroinitializer, section "var-$RUSTY$myPrg_instance:r3i32i32i32", !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, section "var-$RUSTY$__myFb__init:r3i32i32i32", !dbg !9
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !20 {
+define i32 @myFunc() !dbg !20 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !24
   %a = alloca i32, align 4, !dbg !24
@@ -29,7 +29,7 @@ entry:
   ret i32 %myFunc_ret, !dbg !24
 }
 
-define void @myPrg(%myPrg* %0) section "fn-$RUSTY$myPrg:v" !dbg !33 {
+define void @myPrg(%myPrg* %0) !dbg !33 {
 entry:
   call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !34, metadata !DIExpression()), !dbg !35
   %a = alloca i32, align 4, !dbg !35
@@ -44,7 +44,7 @@ entry:
   ret void, !dbg !35
 }
 
-define void @myFb(%myFb* %0) section "fn-$RUSTY$myFb:v" !dbg !42 {
+define void @myFb(%myFb* %0) !dbg !42 {
 entry:
   call void @llvm.dbg.declare(metadata %myFb* %0, metadata !43, metadata !DIExpression()), !dbg !44
   %a = alloca i32, align 4, !dbg !44

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_in_out_inout_in_function_added_as_params.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_in_out_inout_in_function_added_as_params.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc(i16* %0) section "fn-$RUSTY$myFunc:i32[pi16]" !dbg !4 {
+define i32 @myFunc(i16* %0) !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !10
   %x = alloca i16*, align 8, !dbg !10

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__while_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__while_conditions_location_marked.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @myFunc() section "fn-$RUSTY$myFunc:i32" !dbg !4 {
+define i32 @myFunc() !dbg !4 {
 entry:
   %myFunc = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !9, metadata !DIExpression()), !dbg !11

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_declared_initializer.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_declared_initializer.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__commands__init = unnamed_addr constant %commands { i8 1, i8 0 }, section "var-$RUSTY$__commands__init:r2u8u8"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %cmd1 = alloca %commands, align 8

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_default_initializer.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__global_constant_without_initializer_gets_default_initializer.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @__commands__init = unnamed_addr constant %commands zeroinitializer, section "var-$RUSTY$__commands__init:r2u8u8"
 @__main.myStr1__init = unnamed_addr constant [81 x i8] zeroinitializer
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %cmd1 = alloca %commands, align 8

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__initial_values_in_global_variables_out_of_order.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__global_initializers__initial_values_in_global_variables_out_of_order.snap
@@ -12,13 +12,13 @@ source_filename = "main"
 @__MyFB__init = unnamed_addr constant %MyFB { i16 77 }, section "var-$RUSTY$__MyFB__init:r1i16"
 @prg_instance = global %prg { %MyFB { i16 77 } }, section "var-$RUSTY$prg_instance:r1r1i16"
 
-define void @MyFB(%MyFB* %0) section "fn-$RUSTY$MyFB:v" {
+define void @MyFB(%MyFB* %0) {
 entry:
   %x = getelementptr inbounds %MyFB, %MyFB* %0, i32 0, i32 0
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__class_struct_initialized_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__class_struct_initialized_in_function.snap
@@ -11,13 +11,13 @@ source_filename = "main"
 @__fb__init = unnamed_addr constant %fb { i16 9 }, section "var-$RUSTY$__fb__init:r1i16"
 @main_instance = global %main { %fb { i16 9 } }, section "var-$RUSTY$main_instance:r1r1i16"
 
-define void @fb(%fb* %0) section "fn-$RUSTY$fb:v" {
+define void @fb(%fb* %0) {
 entry:
   %a = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
 }
 
-define i32 @func(%fb* %0) section "fn-$RUSTY$func:i32[r1i16]" {
+define i32 @func(%fb* %0) {
 entry:
   %func = alloca i32, align 4
   %in = alloca %fb, align 8
@@ -32,7 +32,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %fb0 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %call = call i32 @func(%fb* %fb0)

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__default_values_for_not_initialized_function_vars.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__default_values_for_not_initialized_function_vars.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @func() section "fn-$RUSTY$func:i16" {
+define i16 @func() {
 entry:
   %func = alloca i16, align 2
   %int_var = alloca i16, align 2

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__enum_variants_have_precedence_over_global_variables_in_inline_assignment.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__enum_variants_have_precedence_over_global_variables_in_inline_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @__foo_position.y = unnamed_addr constant i32 2, section "var-$RUSTY$y:e2i32"
 @__bar_position.y = unnamed_addr constant i32 4, section "var-$RUSTY$y:e2i32"
 
-define i32 @foo() section "fn-$RUSTY$foo:i32" {
+define i32 @foo() {
 entry:
   %foo = alloca i32, align 4
   %position = alloca i32, align 4
@@ -21,7 +21,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define i32 @bar() section "fn-$RUSTY$bar:i32" {
+define i32 @bar() {
 entry:
   %bar = alloca i32, align 4
   %position = alloca i32, align 4

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_block_struct_initialized_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_block_struct_initialized_in_function.snap
@@ -11,12 +11,12 @@ source_filename = "main"
 @__fb__init = unnamed_addr constant %fb zeroinitializer, section "var-$RUSTY$__fb__init:r0"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1r0"
 
-define void @fb(%fb* %0) section "fn-$RUSTY$fb:v" {
+define void @fb(%fb* %0) {
 entry:
   ret void
 }
 
-define i32 @func(%fb* %0) section "fn-$RUSTY$func:i32[r0]" {
+define i32 @func(%fb* %0) {
 entry:
   %func = alloca i32, align 4
   %in = alloca %fb, align 8
@@ -31,7 +31,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %fb0 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %call = call i32 @func(%fb* %fb0)

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__MyStruct__init = unnamed_addr constant %MyStruct zeroinitializer, section "var-$RUSTY$__MyStruct__init:r2i32i16"
 
-define i16 @foo_int() section "fn-$RUSTY$foo_int:i16" {
+define i16 @foo_int() {
 entry:
   %foo_int = alloca i16, align 2
   store i16 0, i16* %foo_int, align 2
@@ -17,7 +17,7 @@ entry:
   ret i16 %foo_int_ret
 }
 
-define void @foo_str([11 x i8]* %0) section "fn-$RUSTY$foo_str:s8u11" {
+define void @foo_str([11 x i8]* %0) {
 entry:
   %foo_str = alloca [11 x i8]*, align 8
   store [11 x i8]* %0, [11 x i8]** %foo_str, align 8
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @foo_arr([10 x float]* %0) section "fn-$RUSTY$foo_arr:af32" {
+define void @foo_arr([10 x float]* %0) {
 entry:
   %foo_arr = alloca [10 x float]*, align 8
   store [10 x float]* %0, [10 x float]** %foo_arr, align 8
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-define void @foo_struct(%MyStruct* %0) section "fn-$RUSTY$foo_struct:r2i32i16" {
+define void @foo_struct(%MyStruct* %0) {
 entry:
   %foo_struct = alloca %MyStruct*, align 8
   store %MyStruct* %0, %MyStruct** %foo_struct, align 8

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized_with_type_initializer.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_is_initialized_with_type_initializer.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2ai32ai32"
 @__myArray__init = unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4], section "var-$RUSTY$__myArray__init:ai32"
 
-define void @target([4 x i32]* %0) section "fn-$RUSTY$target:ai32" {
+define void @target([4 x i32]* %0) {
 entry:
   %target = alloca [4 x i32]*, align 8
   store [4 x i32]* %0, [4 x i32]** %target, align 8
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_with_initializers_is_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_with_initializers_is_initialized.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @__MyArr__init = unnamed_addr constant [10 x float] [float 0.000000e+00, float 0x3FF19999A0000000, float 0x40019999A0000000, float 0x400A666660000000, float 0x40119999A0000000, float 5.500000e+00, float 0x401A666660000000, float 0x401ECCCCC0000000, float 0x40219999A0000000, float 0x4023CCCCC0000000], section "var-$RUSTY$__MyArr__init:af32"
 @__MyStrct__init = unnamed_addr constant %MyStrct { i32 1, i32 2, i32 3 }, section "var-$RUSTY$__MyStrct__init:r3i32i32i32"
 
-define i16 @foo_int() section "fn-$RUSTY$foo_int:i16" {
+define i16 @foo_int() {
 entry:
   %foo_int = alloca i16, align 2
   store i16 7, i16* %foo_int, align 2
@@ -19,7 +19,7 @@ entry:
   ret i16 %foo_int_ret
 }
 
-define void @foo_str([11 x i8]* %0) section "fn-$RUSTY$foo_str:s8u11" {
+define void @foo_str([11 x i8]* %0) {
 entry:
   %foo_str = alloca [11 x i8]*, align 8
   store [11 x i8]* %0, [11 x i8]** %foo_str, align 8
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-define void @foo_arr([10 x float]* %0) section "fn-$RUSTY$foo_arr:af32" {
+define void @foo_arr([10 x float]* %0) {
 entry:
   %foo_arr = alloca [10 x float]*, align 8
   store [10 x float]* %0, [10 x float]** %foo_arr, align 8
@@ -39,7 +39,7 @@ entry:
   ret void
 }
 
-define void @foo_strct(%MyStrct* %0) section "fn-$RUSTY$foo_strct:r3i32i32i32" {
+define void @foo_strct(%MyStrct* %0) {
 entry:
   %foo_strct = alloca %MyStrct*, align 8
   store %MyStrct* %0, %MyStrct** %foo_strct, align 8

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_without_initializers_is_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__function_return_value_without_initializers_is_initialized.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__MyStrct__init = unnamed_addr constant %MyStrct zeroinitializer, section "var-$RUSTY$__MyStrct__init:r3i32i32i32"
 
-define i16 @foo_int() section "fn-$RUSTY$foo_int:i16" {
+define i16 @foo_int() {
 entry:
   %foo_int = alloca i16, align 2
   store i16 0, i16* %foo_int, align 2
@@ -17,7 +17,7 @@ entry:
   ret i16 %foo_int_ret
 }
 
-define void @foo_str([11 x i8]* %0) section "fn-$RUSTY$foo_str:s8u11" {
+define void @foo_str([11 x i8]* %0) {
 entry:
   %foo_str = alloca [11 x i8]*, align 8
   store [11 x i8]* %0, [11 x i8]** %foo_str, align 8
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @foo_arr([10 x float]* %0) section "fn-$RUSTY$foo_arr:af32" {
+define void @foo_arr([10 x float]* %0) {
 entry:
   %foo_arr = alloca [10 x float]*, align 8
   store [10 x float]* %0, [10 x float]** %foo_arr, align 8
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-define void @foo_strct(%MyStrct* %0) section "fn-$RUSTY$foo_strct:r3i32i32i32" {
+define void @foo_strct(%MyStrct* %0) {
 entry:
   %foo_strct = alloca %MyStrct*, align 8
   store %MyStrct* %0, %MyStrct** %foo_strct, align 8

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_constant_values_in_pou_variables.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_constant_values_in_pou_variables.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @LEN = unnamed_addr constant i16 20, section "var-$RUSTY$LEN:i16"
 @prg_instance = global %prg { i16 24, i16 89 }, section "var-$RUSTY$prg_instance:r2i16i16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v[i16][i16]" {
+define void @prg(%prg* %0) {
 entry:
   %my_len = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %my_size = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_function_block_pou.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_function_block_pou.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @__FB__init = unnamed_addr constant %FB { i16 7, i16 0, i8 1, i8 0, float 0x400921CAC0000000, float 0.000000e+00 }, section "var-$RUSTY$__FB__init:r6i16i16u8u8f32f32"
 @main_instance = global %main { %FB { i16 7, i16 0, i8 1, i8 0, float 0x400921CAC0000000, float 0.000000e+00 } }, section "var-$RUSTY$main_instance:r1r6i16i16u8u8f32f32"
 
-define void @FB(%FB* %0) section "fn-$RUSTY$FB:v" {
+define void @FB(%FB* %0) {
 entry:
   %x = getelementptr inbounds %FB, %FB* %0, i32 0, i32 0
   %xx = getelementptr inbounds %FB, %FB* %0, i32 0, i32 1
@@ -22,7 +22,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %fb = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_program_pou.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initial_values_in_program_pou.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @Main_instance = global %Main { i16 7, i16 0, i8 1, i8 0, float 0x400921CAC0000000, float 0.000000e+00 }, section "var-$RUSTY$Main_instance:r6i16i16u8u8f32f32"
 
-define void @Main(%Main* %0) section "fn-$RUSTY$Main:v" {
+define void @Main(%Main* %0) {
 entry:
   %x = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %xx = getelementptr inbounds %Main, %Main* %0, i32 0, i32 1

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_in_function.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @__func.arr_var__init = unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4]
 
-define i16 @func() section "fn-$RUSTY$func:i16" {
+define i16 @func() {
 entry:
   %func = alloca i16, align 2
   %arr_var = alloca [4 x i32], align 4

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_type_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__initialized_array_type_in_function.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @__arr__init = unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4], section "var-$RUSTY$__arr__init:ai32"
 
-define i16 @func() section "fn-$RUSTY$func:i16" {
+define i16 @func() {
 entry:
   %func = alloca i16, align 2
   %arr_var = alloca [4 x i32], align 4

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__memcpy_for_struct_initialization_in_function.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__memcpy_for_struct_initialization_in_function.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____func_a__init = unnamed_addr constant %__func_a zeroinitializer, section "var-$RUSTY$____func_a__init:r1i16"
 
-define i16 @func() section "fn-$RUSTY$func:i16" {
+define i16 @func() {
 entry:
   %func = alloca i16, align 2
   %a = alloca %__func_a, align 8

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__no_memcpy_for_struct_initialization_in_program.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__no_memcpy_for_struct_initialization_in_program.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r1r1i16"
 @____prog_a__init = unnamed_addr constant %__prog_a zeroinitializer, section "var-$RUSTY$____prog_a__init:r1i16"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   %a = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_are_referenced_correctly.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_are_referenced_correctly.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @__foo_position.y = unnamed_addr constant i32 2, section "var-$RUSTY$y:e2i32"
 @__bar_position.y = unnamed_addr constant i32 4, section "var-$RUSTY$y:e2i32"
 
-define i32 @foo() section "fn-$RUSTY$foo:i32" {
+define i32 @foo() {
 entry:
   %foo = alloca i32, align 4
   %position = alloca i32, align 4
@@ -20,7 +20,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define i32 @bar() section "fn-$RUSTY$bar:i32" {
+define i32 @bar() {
 entry:
   %bar = alloca i32, align 4
   %position = alloca i32, align 4

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_with_similar_names_are_referenced_correctly.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__pou_initializers__two_identical_enums_in_different_functions_with_similar_names_are_referenced_correctly.snap
@@ -14,7 +14,7 @@ source_filename = "main"
 @__bb_position.y = unnamed_addr constant i32 5, section "var-$RUSTY$y:e2i32"
 @__b_position.y = unnamed_addr constant i32 5, section "var-$RUSTY$y:e2i32"
 
-define i32 @a() section "fn-$RUSTY$a:i32" {
+define i32 @a() {
 entry:
   %a = alloca i32, align 4
   %position = alloca i32, align 4
@@ -24,7 +24,7 @@ entry:
   ret i32 %a_ret
 }
 
-define i32 @aa() section "fn-$RUSTY$aa:i32" {
+define i32 @aa() {
 entry:
   %aa = alloca i32, align 4
   %position = alloca i32, align 4
@@ -34,7 +34,7 @@ entry:
   ret i32 %aa_ret
 }
 
-define i32 @bb() section "fn-$RUSTY$bb:i32" {
+define i32 @bb() {
 entry:
   %bb = alloca i32, align 4
   %position = alloca i32, align 4
@@ -44,7 +44,7 @@ entry:
   ret i32 %bb_ret
 }
 
-define i32 @b() section "fn-$RUSTY$b:i32" {
+define i32 @b() {
 entry:
   %b = alloca i32, align 4
   %position = alloca i32, align 4

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__array_of_struct_initialization.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__array_of_struct_initialization.snap
@@ -16,7 +16,7 @@ source_filename = "main"
 @__main.arr__init = unnamed_addr constant [2 x %myStruct] [%myStruct { i32 10, i32 20, [2 x i32] [i32 30, i32 40] }, %myStruct { i32 50, i32 60, [2 x i32] [i32 70, i32 80] }]
 @__main.alias_arr__init = unnamed_addr constant [2 x %myStruct] [%myStruct { i32 10, i32 20, [2 x i32] [i32 30, i32 40] }, %myStruct { i32 50, i32 60, [2 x i32] [i32 70, i32 80] }]
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %arr = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %alias_arr = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__enums_with_inline_initializer_are_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__enums_with_inline_initializer_are_initialized.snap
@@ -21,7 +21,7 @@ source_filename = "main"
 @__global_x.red = unnamed_addr constant i32 0, section "var-$RUSTY$red:e3i32"
 @__global_x.green = unnamed_addr constant i32 2, section "var-$RUSTY$green:e3i32"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %y = alloca i32, align 4

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__initial_values_in_fb_variable.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__initial_values_in_fb_variable.snap
@@ -13,14 +13,14 @@ source_filename = "main"
 @__main.struct1__init = unnamed_addr constant %TON { i16 10, i16 17 }
 @__main.struct2__init = unnamed_addr constant %TON { i16 17, i16 10 }
 
-define void @TON(%TON* %0) section "fn-$RUSTY$TON:v[i16][i16]" {
+define void @TON(%TON* %0) {
 entry:
   %a = getelementptr inbounds %TON, %TON* %0, i32 0, i32 0
   %b = getelementptr inbounds %TON, %TON* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %TEN = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %struct1 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__skipped_field_members_for_array_of_structs_are_zero_initialized.snap
+++ b/src/codegen/tests/initialization_test/snapshots/rusty__codegen__tests__initialization_test__type_initializers__skipped_field_members_for_array_of_structs_are_zero_initialized.snap
@@ -14,7 +14,7 @@ source_filename = "main"
 @__STRUCT2__init = unnamed_addr constant %STRUCT2 zeroinitializer, section "var-$RUSTY$__STRUCT2__init:r2i32i32"
 @__main.var_init1__init = unnamed_addr constant [3 x %STRUCT1] [%STRUCT1 { i32 0, [2 x %STRUCT2] [%STRUCT2 { i32 1, i32 0 }, %STRUCT2 zeroinitializer] }, %STRUCT1 { i32 2, [2 x %STRUCT2] [%STRUCT2 { i32 1, i32 1 }, %STRUCT2 zeroinitializer] }, %STRUCT1 { i32 1, [2 x %STRUCT2] [%STRUCT2 { i32 1, i32 0 }, %STRUCT2 { i32 0, i32 2 }] }]
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var_init1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/parameters_tests.rs
+++ b/src/codegen/tests/parameters_tests.rs
@@ -711,7 +711,7 @@ fn by_value_function_arg_builtin_type_strings_are_memcopied() {
     ; ModuleID = 'main'
     source_filename = "main"
 
-    define i32 @main() section "fn-$RUSTY$main:i32" {
+    define i32 @main() {
     entry:
       %main = alloca i32, align 4
       %str = alloca [81 x i8], align 1
@@ -724,7 +724,7 @@ fn by_value_function_arg_builtin_type_strings_are_memcopied() {
       ret i32 %main_ret
     }
 
-    define i32 @foo(i8* %0) section "fn-$RUSTY$foo:i32[s8u81]" {
+    define i32 @foo(i8* %0) {
     entry:
       %foo = alloca i32, align 4
       %val = alloca [81 x i8], align 1
@@ -770,7 +770,7 @@ fn by_value_function_arg_user_type_strings_are_memcopied() {
     ; ModuleID = 'main'
     source_filename = "main"
 
-    define i32 @main() section "fn-$RUSTY$main:i32" {
+    define i32 @main() {
     entry:
       %main = alloca i32, align 4
       %str = alloca [65537 x i8], align 1
@@ -783,7 +783,7 @@ fn by_value_function_arg_user_type_strings_are_memcopied() {
       ret i32 %main_ret
     }
 
-    define i32 @foo(i8* %0) section "fn-$RUSTY$foo:i32[s8u65537]" {
+    define i32 @foo(i8* %0) {
     entry:
       %foo = alloca i32, align 4
       %val = alloca [65537 x i8], align 1
@@ -829,7 +829,7 @@ fn by_value_function_arg_arrays_are_memcopied() {
     ; ModuleID = 'main'
     source_filename = "main"
 
-    define i32 @main() section "fn-$RUSTY$main:i32" {
+    define i32 @main() {
     entry:
       %main = alloca i32, align 4
       %arr = alloca [65537 x i32], align 4
@@ -842,7 +842,7 @@ fn by_value_function_arg_arrays_are_memcopied() {
       ret i32 %main_ret
     }
 
-    define i32 @foo(i32* %0) section "fn-$RUSTY$foo:i32[ai32]" {
+    define i32 @foo(i32* %0) {
     entry:
       %foo = alloca i32, align 4
       %val = alloca [65537 x i32], align 4
@@ -899,7 +899,7 @@ fn by_value_function_arg_structs_are_memcopied() {
 
     @__S_TY__init = unnamed_addr constant %S_TY zeroinitializer, section "var-$RUSTY$__S_TY__init:r2u8u8"
 
-    define i32 @foo(%S_TY* %0) section "fn-$RUSTY$foo:i32[r2u8u8]" {
+    define i32 @foo(%S_TY* %0) {
     entry:
       %foo = alloca i32, align 4
       %val = alloca %S_TY, align 8
@@ -911,7 +911,7 @@ fn by_value_function_arg_structs_are_memcopied() {
       ret i32 %foo_ret
     }
 
-    define i32 @main() section "fn-$RUSTY$main:i32" {
+    define i32 @main() {
     entry:
       %main = alloca i32, align 4
       %s = alloca %S_TY, align 8
@@ -972,7 +972,7 @@ fn by_value_function_arg_structs_with_aggregate_members_are_memcopied() {
     @__AGGREGATE_COLLECTOR_TY__init = unnamed_addr constant %AGGREGATE_COLLECTOR_TY zeroinitializer, section "var-$RUSTY$__AGGREGATE_COLLECTOR_TY__init:r3ai32s8u65537r2u8u8"
     @__S_TY__init = unnamed_addr constant %S_TY zeroinitializer, section "var-$RUSTY$__S_TY__init:r2u8u8"
 
-    define i32 @foo(%AGGREGATE_COLLECTOR_TY* %0) section "fn-$RUSTY$foo:i32[r3ai32s8u65537r2u8u8]" {
+    define i32 @foo(%AGGREGATE_COLLECTOR_TY* %0) {
     entry:
       %foo = alloca i32, align 4
       %val = alloca %AGGREGATE_COLLECTOR_TY, align 8
@@ -984,7 +984,7 @@ fn by_value_function_arg_structs_with_aggregate_members_are_memcopied() {
       ret i32 %foo_ret
     }
 
-    define i32 @main() section "fn-$RUSTY$main:i32" {
+    define i32 @main() {
     entry:
       %main = alloca i32, align 4
       %s = alloca %AGGREGATE_COLLECTOR_TY, align 8
@@ -1033,7 +1033,7 @@ fn by_value_fb_arg_aggregates_are_memcopied() {
 
     @__FOO__init = unnamed_addr constant %FOO zeroinitializer, section "var-$RUSTY$__FOO__init:r2s8u65537ai32"
 
-    define i32 @main() section "fn-$RUSTY$main:i32" {
+    define i32 @main() {
     entry:
       %main = alloca i32, align 4
       %str = alloca [65537 x i8], align 1
@@ -1059,7 +1059,7 @@ fn by_value_fb_arg_aggregates_are_memcopied() {
       ret i32 %main_ret
     }
 
-    define void @FOO(%FOO* %0) section "fn-$RUSTY$FOO:v[s8u65537][ai32]" {
+    define void @FOO(%FOO* %0) {
     entry:
       %val = getelementptr inbounds %FOO, %FOO* %0, i32 0, i32 0
       %field = getelementptr inbounds %FOO, %FOO* %0, i32 0, i32 1
@@ -1125,7 +1125,7 @@ fn var_output_aggregate_types_are_memcopied() {
     @__OUT_TYPE__init = unnamed_addr constant %OUT_TYPE zeroinitializer, section "var-$RUSTY$__OUT_TYPE__init:r1u8"
     @PRG_instance = global %PRG zeroinitializer, section "var-$RUSTY$PRG_instance:r6r1u8ai32ar1u8s8u81s16u81r5r1u8ai32ar1u8s8u81s16u81"
 
-    define void @FB(%FB* %0) section "fn-$RUSTY$FB:v[r1u8][ai32][ar1u8][s8u81][s16u81]" {
+    define void @FB(%FB* %0) {
     entry:
       %output = getelementptr inbounds %FB, %FB* %0, i32 0, i32 0
       %output2 = getelementptr inbounds %FB, %FB* %0, i32 0, i32 1
@@ -1135,7 +1135,7 @@ fn var_output_aggregate_types_are_memcopied() {
       ret void
     }
 
-    define void @PRG(%PRG* %0) section "fn-$RUSTY$PRG:v" {
+    define void @PRG(%PRG* %0) {
     entry:
       %out = getelementptr inbounds %PRG, %PRG* %0, i32 0, i32 0
       %out2 = getelementptr inbounds %PRG, %PRG* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__a_global_variables_generates_in_separate_global_variables.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__a_global_variables_generates_in_separate_global_variables.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @gY = global i8 0, section "var-$RUSTY$gY:u8"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_array_in_struct.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_array_in_struct.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @Main_instance = global %Main zeroinitializer, section "var-$RUSTY$Main_instance:r1r1ai16"
 @__MyStruct__init = unnamed_addr constant %MyStruct zeroinitializer, section "var-$RUSTY$__MyStruct__init:r1ai16"
 
-define void @Main(%Main* %0) section "fn-$RUSTY$Main:v" {
+define void @Main(%Main* %0) {
 entry:
   %m = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %field1 = getelementptr inbounds %MyStruct, %MyStruct* %m, i32 0, i32 0

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_structs.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__accessing_nested_structs.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @__OuterStruct__init = unnamed_addr constant %OuterStruct zeroinitializer, section "var-$RUSTY$__OuterStruct__init:r2r2i16i16r2i16i16"
 @__InnerStruct__init = unnamed_addr constant %InnerStruct zeroinitializer, section "var-$RUSTY$__InnerStruct__init:r2i16i16"
 
-define void @Main(%Main* %0) section "fn-$RUSTY$Main:v" {
+define void @Main(%Main* %0) {
 entry:
   %m = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %out1 = getelementptr inbounds %OuterStruct, %OuterStruct* %m, i32 0, i32 0

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__action_called_in_program.snap
@@ -9,14 +9,14 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   call void @prg.foo(%prg* %0)
   ret void
 }
 
-define void @prg.foo(%prg* %0) section "fn-$RUSTY$prg.foo:v" {
+define void @prg.foo(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_cast_int_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_cast_int_type_generated.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_negative_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_negative_type_generated.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_non_zero_type_generated.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_generated.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_used.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_used.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [4 x i32], [4 x i32]* %x, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_negative_start_used.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_negative_start_used.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [6 x i32], [6 x i32]* %x, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_start_used.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_int_type_with_non_zero_start_used.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [3 x i32], [3 x i32]* %x, i32 0, i32 0

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initialized.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_and_variable_declaration_is_initialized.snap
@@ -14,7 +14,7 @@ source_filename = "main"
 @__STRUCT2__init = unnamed_addr constant %STRUCT2 zeroinitializer, section "var-$RUSTY$__STRUCT2__init:r2u8i32"
 @__mainProg.var_str1__init = unnamed_addr constant [5 x %STRUCT1] [%STRUCT1 { i16 1, [5 x %STRUCT2] [%STRUCT2 { i8 1, i32 128 }, %STRUCT2 { i8 0, i32 1024 }, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer] }, %STRUCT1 { i16 2, [5 x %STRUCT2] [%STRUCT2 { i8 1, i32 256 }, %STRUCT2 { i8 0, i32 2048 }, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer] }, %STRUCT1 zeroinitializer, %STRUCT1 zeroinitializer, %STRUCT1 zeroinitializer]
 
-define void @mainProg(%mainProg* %0) section "fn-$RUSTY$mainProg:v" {
+define void @mainProg(%mainProg* %0) {
 entry:
   %var_str1 = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_is_initialized.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__array_of_struct_as_member_of_another_struct_is_initialized.snap
@@ -14,7 +14,7 @@ source_filename = "main"
 @__STRUCT2__init = unnamed_addr constant %STRUCT2 zeroinitializer, section "var-$RUSTY$__STRUCT2__init:r2u8i32"
 @__mainProg.var_str1__init = unnamed_addr constant %STRUCT1 { i16 10, [11 x %STRUCT2] [%STRUCT2 { i8 1, i32 128 }, %STRUCT2 { i8 0, i32 1024 }, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer, %STRUCT2 zeroinitializer] }
 
-define void @mainProg(%mainProg* %0) section "fn-$RUSTY$mainProg:v" {
+define void @mainProg(%mainProg* %0) {
 entry:
   %var_str1 = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_constant_expressions_in_case_selectors.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_constant_expressions_in_case_selectors.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 @UP = unnamed_addr constant i32 8, section "var-$RUSTY$UP:i32"
 @DOWN = unnamed_addr constant i32 15, section "var-$RUSTY$DOWN:i32"
 
-define i32 @drive() section "fn-$RUSTY$drive:i32" {
+define i32 @drive() {
 entry:
   %drive = alloca i32, align 4
   %input = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_enum_expressions_in_case_selectors.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_enum_expressions_in_case_selectors.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @Direction.UP = unnamed_addr constant i32 8, section "var-$RUSTY$UP:e3i32"
 @Direction.DOWN = unnamed_addr constant i32 28, section "var-$RUSTY$DOWN:e3i32"
 
-define i32 @drive() section "fn-$RUSTY$drive:i32" {
+define i32 @drive() {
 entry:
   %drive = alloca i32, align 4
   %input = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_multiple_labels_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_multiple_labels_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_ranges_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__case_with_ranges_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_bool_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_bool_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i8 1, i8* %z, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i16i16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i16i16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_ints_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_hex_ints_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 -1, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_lreal_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_lreal_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2f32f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_real_code_gen_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__casted_literals_real_code_gen_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i16f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_member_access_from_method.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_member_access_from_method.snap
@@ -10,14 +10,14 @@ source_filename = "main"
 
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer, section "var-$RUSTY$__MyClass__init:r2i16i16"
 
-define void @MyClass(%MyClass* %0) section "fn-$RUSTY$MyClass:v" {
+define void @MyClass(%MyClass* %0) {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-$RUSTY$MyClass.testMethod:v[i16]" {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_method_in_pou.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__class_method_in_pou.snap
@@ -12,14 +12,14 @@ source_filename = "main"
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer, section "var-$RUSTY$__MyClass__init:r2i16i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2r2i16i16i16"
 
-define void @MyClass(%MyClass* %0) section "fn-$RUSTY$MyClass:v" {
+define void @MyClass(%MyClass* %0) {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-$RUSTY$MyClass.testMethod:v[i16]" {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
@@ -38,7 +38,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %cl = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__complex_pointers.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__complex_pointers.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r4i16ai16api16pai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %X = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %arrX = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expression_in_function_blocks_are_propagated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expression_in_function_blocks_are_propagated.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__fbWithConstant__init = unnamed_addr constant %fbWithConstant { i16 0, i16 2 }, section "var-$RUSTY$__fbWithConstant__init:r2i16i16"
 
-define void @fbWithConstant(%fbWithConstant* %0) section "fn-$RUSTY$fbWithConstant:v" {
+define void @fbWithConstant(%fbWithConstant* %0) {
 entry:
   %x = getelementptr inbounds %fbWithConstant, %fbWithConstant* %0, i32 0, i32 0
   %const = getelementptr inbounds %fbWithConstant, %fbWithConstant* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expressions_in_ranged_type_declaration_are_propagated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_expressions_in_ranged_type_declaration_are_propagated.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @MIN = unnamed_addr constant i16 7, section "var-$RUSTY$MIN:i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i16"
 
-define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) section "fn-$RUSTY$CheckRangeSigned:i16[i16][i16][i16]" {
+define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) {
 entry:
   %CheckRangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -26,7 +26,7 @@ entry:
   ret i16 %CheckRangeSigned_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i16 @CheckRangeSigned(i16 5, i16 0, i16 8)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_propagation_of_struct_fields_on_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__constant_propagation_of_struct_fields_on_assignment.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @MyStruct = unnamed_addr constant %STRUCT1 { i32 99 }, section "var-$RUSTY$MyStruct:r1i32"
 @__STRUCT1__init = unnamed_addr constant %STRUCT1 zeroinitializer, section "var-$RUSTY$__STRUCT1__init:r1i32"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %local_value = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__contants_in_case_statements_resolved.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__contants_in_case_statements_resolved.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i32 0, i32 60 }, section "var-$RUSTY$main_instance:r2i32i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %DAYS_IN_MONTH = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %SIXTY = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_addition_in_var_output.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_addition_in_var_output.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @func(i64* %0, i64* %1) section "fn-$RUSTY$func:i32[pi64][pi64]" {
+define i32 @func(i64* %0, i64* %1) {
 entry:
   %func = alloca i32, align 4
   %d_and_t = alloca i64*, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_global_constants_initialize.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_and_time_global_constants_initialize.snap
@@ -25,7 +25,7 @@ source_filename = "main"
 @cLDT_SHORT = unnamed_addr constant i64 172799123000000, section "var-$RUSTY$cLDT_SHORT:i64"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r16i64i64i64i64i64i64i64i64i64i64i64i64i64i64i64i64"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %t1 = alloca i64, align 8
   %t2 = alloca i64, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_comparisons.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__date_comparisons.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r4i64i64i64i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__default_values_for_not_initialized_function_vars.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__default_values_for_not_initialized_function_vars.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @func() section "fn-$RUSTY$func:i16" {
+define i16 @func() {
 entry:
   %func = alloca i16, align 2
   %int_var = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__different_case_references.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__different_case_references.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg { i16 0, i16 1, i32 2 }, section "var-$RUSTY$prg_instance:r3i16i16i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_function_with_name_generates_int_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_function_with_name_generates_int_function.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @foo() section "fn-$RUSTY$foo:i16" {
+define i16 @foo() {
 entry:
   %foo = alloca i16, align 2
   store i16 0, i16* %foo, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_global_variable_list_generates_nothing.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_global_variable_list_generates_nothing.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_program_with_name_generates_void_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_program_with_name_generates_void_function.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_statements_dont_generate_anything.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__empty_statements_dont_generate_anything.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enum_members_can_be_used_in_asignments.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enum_members_can_be_used_in_asignments.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @MyEnum.yellow = unnamed_addr constant i32 1, section "var-$RUSTY$yellow:e3i32"
 @MyEnum.green = unnamed_addr constant i32 2, section "var-$RUSTY$green:e3i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %color = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   store i32 0, i32* %color, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enums_custom_type_are_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__enums_custom_type_are_generated.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @TrafficLight.Yellow = unnamed_addr constant i32 2, section "var-$RUSTY$Yellow:e4i32"
 @TrafficLight.Green = unnamed_addr constant i32 3, section "var-$RUSTY$Green:e4i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %tf1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_function_called_in_program.snap
@@ -9,9 +9,9 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-declare i32 @foo() section "fn-$RUSTY$foo:i32"
+declare i32 @foo()
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %call = call i32 @foo()
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_global_variable_generates_as_external.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_global_variable_generates_as_external.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @gY = external global i8, section "var-$RUSTY$gY:u8"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_program_global_var_is_external.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__external_program_global_var_is_external.snap
@@ -9,4 +9,4 @@ source_filename = "main"
 
 @prg_instance = external global %prg, section "var-$RUSTY$prg_instance:r2i32i32"
 
-declare void @prg(%prg*) section "fn-$RUSTY$prg:v"
+declare void @prg(%prg*)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__fb_method_in_pou.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__fb_method_in_pou.snap
@@ -12,14 +12,14 @@ source_filename = "main"
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer, section "var-$RUSTY$__MyClass__init:r2i16i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2r2i16i16i16"
 
-define void @MyClass(%MyClass* %0) section "fn-$RUSTY$MyClass:v" {
+define void @MyClass(%MyClass* %0) {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-$RUSTY$MyClass.testMethod:v[i16]" {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
 entry:
   %x = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 0
   %y = getelementptr inbounds %MyClass, %MyClass* %0, i32 0, i32 1
@@ -38,7 +38,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %cl = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_continue.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_continue.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_int.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_int.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i16 3, i16* %x, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_lint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_lint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 3, i64* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_sint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_sint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i8 3, i8* %x, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_continue.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_continue.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_exit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_exit.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_references_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_references_steps_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r4i32i32i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %step = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_with_steps_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_without_steps_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__for_statement_without_steps_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 3, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_instance_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_instance_call.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @__foo__init = unnamed_addr constant %foo zeroinitializer, section "var-$RUSTY$__foo__init:r2i16i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1r2i16i16"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[i16][i16]" {
+define void @foo(%foo* %0) {
 entry:
   %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %y = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %fb_inst = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   call void @foo(%foo* %fb_inst)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_qualified_instance_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_block_qualified_instance_call.snap
@@ -13,18 +13,18 @@ source_filename = "main"
 @__bar__init = unnamed_addr constant %bar zeroinitializer, section "var-$RUSTY$__bar__init:r0"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1r1r0"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v" {
+define void @foo(%foo* %0) {
 entry:
   %bar_inst = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   ret void
 }
 
-define void @bar(%bar* %0) section "fn-$RUSTY$bar:v" {
+define void @bar(%bar* %0) {
 entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %foo_inst = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %bar_inst = getelementptr inbounds %foo, %foo* %foo_inst, i32 0, i32 0

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_call_with_same_name_as_return_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_call_with_same_name_as_return_type.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define i64 @TIME() section "fn-$RUSTY$TIME:i64" {
+define i64 @TIME() {
 entry:
   %TIME = alloca i64, align 8
   store i64 0, i64* %TIME, align 4
@@ -17,7 +17,7 @@ entry:
   ret i64 %TIME_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %call = call i64 @TIME()
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define i32 @foo() section "fn-$RUSTY$foo:i32" {
+define i32 @foo() {
 entry:
   %foo = alloca i32, align 4
   store i32 0, i32* %foo, align 4
@@ -18,7 +18,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo()

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_when_shadowed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_called_when_shadowed.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define i32 @foo() section "fn-$RUSTY$foo:i32" {
+define i32 @foo() {
 entry:
   %foo = alloca i32, align 4
   store i32 0, i32* %foo, align 4
@@ -18,7 +18,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %froo = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo()

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_temp_var_initialization.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_temp_var_initialization.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define i32 @foo(i32 %0) section "fn-$RUSTY$foo:i32[i32]" {
+define i32 @foo(i32 %0) {
 entry:
   %foo = alloca i32, align 4
   %in1 = alloca i32, align 4
@@ -30,7 +30,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %call = call i32 @foo(i32 5)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_var_initialization_and_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_local_var_initialization_and_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define i32 @foo(i32 %0) section "fn-$RUSTY$foo:i32[i32]" {
+define i32 @foo(i32 %0) {
 entry:
   %foo = alloca i32, align 4
   %in1 = alloca i32, align 4
@@ -26,7 +26,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %call = call i32 @foo(i32 5)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_parameters_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define i32 @foo(i32 %0) section "fn-$RUSTY$foo:i32[i32]" {
+define i32 @foo(i32 %0) {
 entry:
   %foo = alloca i32, align 4
   %bar = alloca i32, align 4
@@ -20,7 +20,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo(i32 2)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_two_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__function_with_two_parameters_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define i32 @foo(i32 %0, i8 %1) section "fn-$RUSTY$foo:i32[i32][u8]" {
+define i32 @foo(i32 %0, i8 %1) {
 entry:
   %foo = alloca i32, align 4
   %bar = alloca i32, align 4
@@ -22,7 +22,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @foo(i32 2, i8 1)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__global_variable_reference_is_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__global_variable_reference_is_generated.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @gX = global i16 0, section "var-$RUSTY$gX:i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i16 20, i16* @gX, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_elsif_else_generator_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_elsif_else_generator_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r7i32i32i32i32u8u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_generator_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_generator_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_with_expression_generator_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_with_expression_generator_test.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__inlined_array_size_from_local_scoped_constants.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__inlined_array_size_from_local_scoped_constants.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @c = unnamed_addr constant i16 5, section "var-$RUSTY$c:i16"
 @aaa_instance = global %aaa { i16 3, i16 7, [5 x i8] zeroinitializer, [3 x i8] zeroinitializer }, section "var-$RUSTY$aaa_instance:r4i16i16au8au8"
 
-define void @aaa(%aaa* %0) section "fn-$RUSTY$aaa:v" {
+define void @aaa(%aaa* %0) {
 entry:
   %a = getelementptr inbounds %aaa, %aaa* %0, i32 0, i32 0
   %b = getelementptr inbounds %aaa, %aaa* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_return.snap
@@ -10,12 +10,12 @@ source_filename = "main"
 
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer, section "var-$RUSTY$__MyClass__init:r0"
 
-define void @MyClass(%MyClass* %0) section "fn-$RUSTY$MyClass:v" {
+define void @MyClass(%MyClass* %0) {
 entry:
   ret void
 }
 
-define i16 @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-$RUSTY$MyClass.testMethod:i16[i16]" {
+define i16 @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
 entry:
   %myMethodArg = getelementptr inbounds %MyClass.testMethod, %MyClass.testMethod* %1, i32 0, i32 0
   %testMethod = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_void.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__method_codegen_void.snap
@@ -10,12 +10,12 @@ source_filename = "main"
 
 @__MyClass__init = unnamed_addr constant %MyClass zeroinitializer, section "var-$RUSTY$__MyClass__init:r0"
 
-define void @MyClass(%MyClass* %0) section "fn-$RUSTY$MyClass:v" {
+define void @MyClass(%MyClass* %0) {
 entry:
   ret void
 }
 
-define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) section "fn-$RUSTY$MyClass.testMethod:v[i16]" {
+define void @MyClass.testMethod(%MyClass* %0, %MyClass.testMethod* %1) {
 entry:
   %myMethodArg = getelementptr inbounds %MyClass.testMethod, %MyClass.testMethod* %1, i32 0, i32 0
   %myMethodLocalVar = getelementptr inbounds %MyClass.testMethod, %MyClass.testMethod* %1, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__min_max_real_and_lreal_values_do_not_result_in_an_under_or_overflow.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__min_max_real_and_lreal_values_do_not_result_in_an_under_or_overflow.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { float 0xC7EFFFFFE0000000, float 0x47EFFFFFE0000000, double 0xFFEFFFFFFFFFFFFF, double 0x7FEFFFFFFFFFFFFF }, section "var-$RUSTY$main_instance:r4f32f32f64f64"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %F32_MIN = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %F32_MAX = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [8 x i32], [8 x i32]* %x, i32 0, i32 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_declaration.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__multidim_array_declaration.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1aai32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %tmpVar = getelementptr inbounds [4 x [2 x i32]], [4 x [2 x i32]]* %x, i32 0, i32 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r4i16i16i16ai32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes_negative_start.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_cube_writes_negative_start.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r4i16i16i16ai32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_declaration.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_array_declaration.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1aai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__nested_function_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define i32 @bar() section "fn-$RUSTY$bar:i32" {
+define i32 @bar() {
 entry:
   %bar = alloca i32, align 4
   store i32 0, i32* %bar, align 4
@@ -18,7 +18,7 @@ entry:
   ret i32 %bar_ret
 }
 
-define i32 @foo(i32 %0) section "fn-$RUSTY$foo:i32[i32]" {
+define i32 @foo(i32 %0) {
 entry:
   %foo = alloca i32, align 4
   %in = alloca i32, align 4
@@ -29,7 +29,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call i32 @bar()

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__order_var_and_var_temp_block.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__order_var_and_var_temp_block.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2i16i16"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %temp = alloca i16, align 2
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pass_inout_to_inout.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pass_inout_to_inout.snap
@@ -13,14 +13,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r1pi32"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @foo2(%foo2* %0) section "fn-$RUSTY$foo2:v[pi32][i32]" {
+define void @foo2(%foo2* %0) {
 entry:
   %inout = getelementptr inbounds %foo2, %foo2* %0, i32 0, i32 0
   %in = getelementptr inbounds %foo2, %foo2* %0, i32 0, i32 1
   ret void
 }
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[pi32]" {
+define void @foo(%foo* %0) {
 entry:
   %inout = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %deref = load i32*, i32** %inout, align 8
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32* %baz, i32** getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointer_and_array_access_to_in_out.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointer_and_array_access_to_in_out.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main(i16** %0, i16* %1) section "fn-$RUSTY$main:i16[ppi16][pai16]" {
+define i16 @main(i16** %0, i16* %1) {
 entry:
   %main = alloca i16, align 2
   %a = alloca i16**, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointers_generated.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__pointers_generated.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u8pu8pu8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %X = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %pX = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_called_in_program.snap
@@ -11,12 +11,12 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r0"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v" {
+define void @foo(%foo* %0) {
 entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   call void @foo(%foo* @foo_instance)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_and_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_and_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_bool_variables_and_references_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_bool_variables_and_references_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_boolean_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_boolean_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i8 1, i8* %y, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_casted_chars_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_casted_chars_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"B\00"
 @utf16_literal_0 = private unnamed_addr constant [2 x i16] [i16 65, i16 0]
 
-define void @mainPROG(%mainPROG* %0) section "fn-$RUSTY$mainPROG:v" {
+define void @mainPROG(%mainPROG* %0) {
 entry:
   %x = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 0
   %y = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_chars.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_chars.snap
@@ -15,7 +15,7 @@ source_filename = "main"
 @utf16_literal_2 = private unnamed_addr constant [2 x i16] [i16 39, i16 0]
 @utf16_literal_3 = private unnamed_addr constant [2 x i16] [i16 65, i16 0]
 
-define void @mainPROG(%mainPROG* %0) section "fn-$RUSTY$mainPROG:v" {
+define void @mainPROG(%mainPROG* %0) {
 entry:
   %x = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 0
   %y = getelementptr inbounds %mainPROG, %mainPROG* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r4i64i64i64i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %w = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment_whit_short_datatype_names.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_date_assignment_whit_short_datatype_names.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r4i64i64i64i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %w = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_floats_variable_and_comparison_assignment_generates_correctly.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_floats_variable_and_comparison_assignment_generates_correctly.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2f32u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_local_temp_var_initialization.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_local_temp_var_initialization.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @foo_instance = global %foo { i16 7 }, section "var-$RUSTY$foo_instance:r3i16i16i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v" {
+define void @foo(%foo* %0) {
 entry:
   %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %y = alloca i16, align 2
@@ -26,7 +26,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   call void @foo(%foo* @foo_instance)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_long_date_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_long_date_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r4i64i64i64i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %w = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_combined_expressions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_combined_expressions_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_expressions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_expressions_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_or_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_or_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_additions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_additions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3f32f32f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store float 1.562500e-01, float* %y, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_cast_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_real_cast_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2f32i16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_signed_combined_expressions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_signed_combined_expressions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_special_chars_in_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_special_chars_in_string.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf16_literal_0 = private unnamed_addr constant [19 x i16] [i16 36, i16 52, i16 51, i16 32, i16 36, i16 39, i16 110, i16 111, i16 32, i16 114, i16 101, i16 112, i16 108, i16 97, i16 99, i16 101, i16 36, i16 39, i16 0]
 @utf16_literal_1 = private unnamed_addr constant [41 x i16] [i16 97, i16 10, i16 10, i16 32, i16 98, i16 10, i16 10, i16 32, i16 99, i16 12, i16 12, i16 32, i16 100, i16 13, i16 13, i16 32, i16 101, i16 9, i16 9, i16 32, i16 36, i16 32, i16 34, i16 100, i16 111, i16 117, i16 98, i16 108, i16 101, i16 34, i16 32, i16 87, i16 -10179, i16 -9066, i16 -10179, i16 -9066, i16 0, i16 0, i16 0, i16 0, i16 0]
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %should_replace_s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %should_not_replace_s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_string_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_string_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [12 x i8] c"im a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [18 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 117, i16 116, i16 102, i16 49, i16 54, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 0, i64* %y, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_of_day_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_time_of_day_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 0, i64* %y, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_explicit_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_explicit_parameters_called_in_program.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r2i32u8"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[i32][u8]" {
+define void @foo(%foo* %0) {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   store i8 1, i8* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 1), align 1
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_parameters_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_two_parameters_called_in_program.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r2i32u8"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r0"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[i32][u8]" {
+define void @foo(%foo* %0) {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4
   store i8 1, i8* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 1), align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_inout_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_inout_called_in_program.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r1pi32"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[pi32]" {
+define void @foo(%foo* %0) {
 entry:
   %inout = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %deref = load i32*, i32** %inout, align 8
@@ -22,7 +22,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 7, i32* %baz, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_in_program.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r2i32u8"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1u8"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[i32][u8]" {
+define void @foo(%foo* %0) {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_mixed_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_var_out_called_mixed_in_program.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r2i32u8"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1u8"
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[i32][u8]" {
+define void @foo(%foo* %0) {
 entry:
   %bar = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %buz = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %baz = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_addition_literal_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_addition_literal_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_arithmatic_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_arithmatic_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_comparison_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_and_comparison_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_assignment_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variable_assignment_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 7, i32* %y, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_additions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_additions_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_references_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_and_references_generates_void_function_and_struct_and_body.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_generates_void_function_and_struct.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_variables_generates_void_function_and_struct.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_xor_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_xor_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u8u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_action_from_fb_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_action_from_fb_called_in_program.snap
@@ -11,20 +11,20 @@ source_filename = "main"
 @bar_instance = global %bar zeroinitializer, section "var-$RUSTY$bar_instance:r1r1i32"
 @__fb__init = unnamed_addr constant %fb zeroinitializer, section "var-$RUSTY$__fb__init:r1i32"
 
-define void @bar(%bar* %0) section "fn-$RUSTY$bar:v" {
+define void @bar(%bar* %0) {
 entry:
   %fb_inst = getelementptr inbounds %bar, %bar* %0, i32 0, i32 0
   call void @fb.foo(%fb* %fb_inst)
   ret void
 }
 
-define void @fb(%fb* %0) section "fn-$RUSTY$fb:v" {
+define void @fb(%fb* %0) {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
 }
 
-define void @fb.foo(%fb* %0) section "fn-$RUSTY$fb.foo:v" {
+define void @fb.foo(%fb* %0) {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_foreign_action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_foreign_action_called_in_program.snap
@@ -11,19 +11,19 @@ source_filename = "main"
 @bar_instance = global %bar zeroinitializer, section "var-$RUSTY$bar_instance:r0"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @bar(%bar* %0) section "fn-$RUSTY$bar:v" {
+define void @bar(%bar* %0) {
 entry:
   call void @prg.foo(%prg* @prg_instance)
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
 }
 
-define void @prg.foo(%prg* %0) section "fn-$RUSTY$prg.foo:v" {
+define void @prg.foo(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_local_action_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__qualified_local_action_called_in_program.snap
@@ -9,14 +9,14 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   call void @prg.foo(%prg* @prg_instance)
   ret void
 }
 
-define void @prg.foo(%prg* %0) section "fn-$RUSTY$prg.foo:v" {
+define void @prg.foo(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 2, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__real_function_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__real_function_called_in_program.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define float @foo() section "fn-$RUSTY$foo:f32" {
+define float @foo() {
 entry:
   %foo = alloca float, align 4
   store float 0.000000e+00, float* %foo, align 4
@@ -18,7 +18,7 @@ entry:
   ret float %foo_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %call = call float @foo()

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_qualified_name.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_qualified_name.snap
@@ -13,13 +13,13 @@ source_filename = "main"
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r3i32i32r1i32"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @fb(%fb* %0) section "fn-$RUSTY$fb:v[i32]" {
+define void @fb(%fb* %0) {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
 }
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v[i32][i32][r1i32]" {
+define void @foo(%foo* %0) {
 entry:
   %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
   %y = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* getelementptr inbounds (%foo, %foo* @foo_instance, i32 0, i32 0), align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_to_reference_assignments_in_function_arguments.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__reference_to_reference_assignments_in_function_arguments.snap
@@ -19,14 +19,14 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r2pr3u8u8u8pr3u8u8u8"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[pr3u8u8u8][pr3u8u8u8]" {
+define void @prog(%prog* %0) {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %input2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   store %STRUCT_params* @global1, %STRUCT_params** getelementptr inbounds (%prog, %prog* @prog_instance, i32 0, i32 0), align 8
   store %STRUCT_params* @global2, %STRUCT_params** getelementptr inbounds (%prog, %prog* @prog_instance, i32 0, i32 1), align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__repeat_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__repeat_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %while_body

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @smaller_than_ten(i8 %0) section "fn-$RUSTY$smaller_than_ten:i16[i8]" {
+define i16 @smaller_than_ten(i8 %0) {
 entry:
   %smaller_than_ten = alloca i16, align 2
   %n = alloca i8, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function_block.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__returning_early_in_function_block.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__abcdef__init = unnamed_addr constant %abcdef zeroinitializer, section "var-$RUSTY$__abcdef__init:r1i8"
 
-define void @abcdef(%abcdef* %0) section "fn-$RUSTY$abcdef:v[i8]" {
+define void @abcdef(%abcdef* %0) {
 entry:
   %n = getelementptr inbounds %abcdef, %abcdef* %0, i32 0, i32 0
   %load_n = load i8, i8* %n, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_i8_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_i8_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__simple_case_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sizeof_works_in_binary_expression_with_different_size.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sizeof_works_in_binary_expression_with_different_size.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %i = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__structs_members_can_be_referenced.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__structs_members_can_be_referenced.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @MainProg_instance = global %MainProg zeroinitializer, section "var-$RUSTY$MainProg_instance:r1r2i32i32"
 @__MyStruct__init = unnamed_addr constant %MyStruct zeroinitializer, section "var-$RUSTY$__MyStruct__init:r2i32i32"
 
-define void @MainProg(%MainProg* %0) section "fn-$RUSTY$MainProg:v" {
+define void @MainProg(%MainProg* %0) {
 entry:
   %Cord = getelementptr inbounds %MainProg, %MainProg* %0, i32 0, i32 0
   %a = getelementptr inbounds %MyStruct, %MyStruct* %Cord, i32 0, i32 0

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_check_functions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_check_functions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r10u8i8u8u16i16u16i32u32i64u64"
 
-define i32 @CheckRangeSigned(i32 %0, i32 %1, i32 %2) section "fn-$RUSTY$CheckRangeSigned:i32[i32][i32][i32]" {
+define i32 @CheckRangeSigned(i32 %0, i32 %1, i32 %2) {
 entry:
   %CheckRangeSigned = alloca i32, align 4
   %v = alloca i32, align 4
@@ -24,7 +24,7 @@ entry:
   ret i32 %CheckRangeSigned_ret
 }
 
-define i32 @CheckRangeUnsigned(i32 %0, i32 %1, i32 %2) section "fn-$RUSTY$CheckRangeUnsigned:u32[u32][u32][u32]" {
+define i32 @CheckRangeUnsigned(i32 %0, i32 %1, i32 %2) {
 entry:
   %CheckRangeUnsigned = alloca i32, align 4
   %v = alloca i32, align 4
@@ -39,7 +39,7 @@ entry:
   ret i32 %CheckRangeUnsigned_ret
 }
 
-define i64 @CheckLRangeSigned(i64 %0, i64 %1, i64 %2) section "fn-$RUSTY$CheckLRangeSigned:i64[i64][i64][i64]" {
+define i64 @CheckLRangeSigned(i64 %0, i64 %1, i64 %2) {
 entry:
   %CheckLRangeSigned = alloca i64, align 8
   %v = alloca i64, align 8
@@ -54,7 +54,7 @@ entry:
   ret i64 %CheckLRangeSigned_ret
 }
 
-define i64 @CheckLRangeUnsigned(i64 %0, i64 %1, i64 %2) section "fn-$RUSTY$CheckLRangeUnsigned:u64[u64][u64][u64]" {
+define i64 @CheckLRangeUnsigned(i64 %0, i64 %1, i64 %2) {
 entry:
   %CheckLRangeUnsigned = alloca i64, align 8
   %v = alloca i64, align 8
@@ -69,7 +69,7 @@ entry:
   ret i64 %CheckLRangeUnsigned_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_missing.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_missing.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @Main_instance = global %Main zeroinitializer, section "var-$RUSTY$Main_instance:r1i16"
 
-define i16 @Check_XX_RangeSigned(i16 %0, i16 %1, i16 %2) section "fn-$RUSTY$Check_XX_RangeSigned:i16[i16][i16][i16]" {
+define i16 @Check_XX_RangeSigned(i16 %0, i16 %1, i16 %2) {
 entry:
   %Check_XX_RangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -25,7 +25,7 @@ entry:
   ret i16 %Check_XX_RangeSigned_ret
 }
 
-define void @Main(%Main* %0) section "fn-$RUSTY$Main:v" {
+define void @Main(%Main* %0) {
 entry:
   %x = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   store i16 7, i16* %x, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_on_assigment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__sub_range_type_calls_check_function_on_assigment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @Main_instance = global %Main zeroinitializer, section "var-$RUSTY$Main_instance:r1i16"
 
-define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) section "fn-$RUSTY$CheckRangeSigned:i16[i16][i16][i16]" {
+define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) {
 entry:
   %CheckRangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -25,7 +25,7 @@ entry:
   ret i16 %CheckRangeSigned_ret
 }
 
-define void @Main(%Main* %0) section "fn-$RUSTY$Main:v" {
+define void @Main(%Main* %0) {
 entry:
   %x = getelementptr inbounds %Main, %Main* %0, i32 0, i32 0
   %call = call i16 @CheckRangeSigned(i16 7, i16 0, i16 100)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__time_variables_have_nano_seconds_resolution.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__time_variables_have_nano_seconds_resolution.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i64 1000000, i64* %y, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__two_global_variables_generates_in_separate_global_variables.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__two_global_variables_generates_in_separate_global_variables.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @gA = global i16 0, section "var-$RUSTY$gA:i16"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__typed_enums_are_used_properly.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__typed_enums_are_used_properly.snap
@@ -18,7 +18,7 @@ source_filename = "main"
 @MyEnum3.yellow = unnamed_addr constant i32 26, section "var-$RUSTY$yellow:e3i32"
 @MyEnum3.green = unnamed_addr constant i32 27, section "var-$RUSTY$green:e3i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_cast_statement_as_const_expression.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_cast_statement_as_const_expression.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1ai16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_const_expression_in_range_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_const_expression_in_range_type.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @MIN = global i16 7, section "var-$RUSTY$MIN:i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i16"
 
-define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) section "fn-$RUSTY$CheckRangeSigned:i16[i16][i16][i16]" {
+define i16 @CheckRangeSigned(i16 %0, i16 %1, i16 %2) {
 entry:
   %CheckRangeSigned = alloca i16, align 2
   %value = alloca i16, align 2
@@ -27,7 +27,7 @@ entry:
   ret i16 %CheckRangeSigned_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_MIN = load i16, i16* @MIN, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_global_consts_in_expressions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__using_global_consts_in_expressions.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @cC = unnamed_addr constant i16 3, section "var-$RUSTY$cC:i16"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   store i32 6, i32* %z, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__variable_with_same_name_as_data_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__variable_with_same_name_as_data_type.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r1i64"
 
-define i64 @func() section "fn-$RUSTY$func:i64" {
+define i64 @func() {
 entry:
   %func = alloca i64, align 8
   %TIME = alloca i64, align 8
@@ -19,7 +19,7 @@ entry:
   ret i64 %func_ret
 }
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   %TIME = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_loop_with_if_exit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_loop_with_if_exit.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %condition_check

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %condition_check

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_with_expression_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__while_with_expression_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   br label %condition_check

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_number_type_comparing_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_number_type_comparing_test.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %x = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_ranged_number_type_comparing_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__aliased_ranged_number_type_comparing_test.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %x = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_datetime_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_datetime_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r4i64i64i64i64"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var_time = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var_time_of_day = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instruction_functions_with_different_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instruction_functions_with_different_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r13pf32i16i32f32f64i8i16i32i64u8u16u32u64"
 
-define float @foo() section "fn-$RUSTY$foo:f32" {
+define float @foo() {
 entry:
   %foo = alloca float, align 4
   store float 0.000000e+00, float* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret float %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %ptr_float = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instructions_with_different_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instructions_with_different_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r11pi16i16i32i8i16i32i64u8u16u32u64"
 
-define i64 @foo() section "fn-$RUSTY$foo:i64" {
+define i64 @foo() {
 entry:
   %foo = alloca i64, align 8
   store i64 0, i64* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret i64 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %ptr_int = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_compare_instructions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_compare_instructions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i16 10, i16 20, i16* null, i8 0 }, section "var-$RUSTY$main_instance:r4i16i16pi16u8"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_function_call_compare_instructions.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__pointer_function_call_compare_instructions.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3pi16i16u8"
 
-define i64 @foo() section "fn-$RUSTY$foo:i64" {
+define i64 @foo() {
 entry:
   %foo = alloca i64, align 8
   store i64 0, i64* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret i64 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %pt = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__ranged_number_type_comparing_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__ranged_number_type_comparing_test.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %x = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_comparison_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_comparison_test.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"a\00"
 @utf08_literal_1 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-$RUSTY$STRING_EQUAL:u8[s8u1025][s8u1025]" {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -24,7 +24,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_equal_with_constant_test.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"a\00"
 @utf08_literal_1 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-$RUSTY$STRING_EQUAL:u8[s8u1025][s8u1025]" {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -24,7 +24,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_or_equal_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_GREATER(i8* %0, i8* %1) section "fn-$RUSTY$STRING_GREATER:u8[s8u1025][s8u1025]" {
+define i8 @STRING_GREATER(i8* %0, i8* %1) {
 entry:
   %STRING_GREATER = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   ret i8 %STRING_GREATER_ret
 }
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-$RUSTY$STRING_EQUAL:u8[s8u1025][s8u1025]" {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -39,7 +39,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_GREATER(i8* %0, i8* %1) section "fn-$RUSTY$STRING_GREATER:u8[s8u1025][s8u1025]" {
+define i8 @STRING_GREATER(i8* %0, i8* %1) {
 entry:
   %STRING_GREATER = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   ret i8 %STRING_GREATER_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_less_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_less_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_LESS(i8* %0, i8* %1) section "fn-$RUSTY$STRING_LESS:u8[s8u1025][s8u1025]" {
+define i8 @STRING_LESS(i8* %0, i8* %1) {
 entry:
   %STRING_LESS = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   ret i8 %STRING_LESS_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_not_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_not_equal_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-$RUSTY$STRING_EQUAL:u8[s8u1025][s8u1025]" {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_smaller_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_smaller_or_equal_with_constant_test.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"b\00"
 
-define i8 @STRING_LESS(i8* %0, i8* %1) section "fn-$RUSTY$STRING_LESS:u8[s8u1025][s8u1025]" {
+define i8 @STRING_LESS(i8* %0, i8* %1) {
 entry:
   %STRING_LESS = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   ret i8 %STRING_LESS_ret
 }
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-$RUSTY$STRING_EQUAL:u8[s8u1025][s8u1025]" {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -39,7 +39,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %a = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_array_variable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_array_variable.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @const_arr = unnamed_addr constant [4 x i16] [i16 1, i16 2, i16 3, i16 4], section "var-$RUSTY$const_arr:ai16"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1ai16"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %arr = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast [4 x i16]* %arr to i8*

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_string_variable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_string_variable.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @const_str = unnamed_addr constant [81 x i8] c"global constant string\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", section "var-$RUSTY$const_str:s8u81"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1s8u81"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %str = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast [81 x i8]* %str to i8*

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_struct_variable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__constants_tests__assigning_const_struct_variable.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @__Point__init = unnamed_addr constant %Point zeroinitializer, section "var-$RUSTY$__Point__init:r2i16i16"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1r2i16i16"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %strct = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast %Point* %strct to i8*

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__bitaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__bitaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   %a = alloca i8, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__byteaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__byteaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   %b = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__chained_bit_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__chained_bit_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   %d = alloca i64, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__dwordaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__dwordaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   %d = alloca i64, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__lwordaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__lwordaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   %d = alloca i64, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__qualified_reference_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__qualified_reference_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__myStruct__init = unnamed_addr constant %myStruct { i8 1 }, section "var-$RUSTY$__myStruct__init:r1u8"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   %str = alloca %myStruct, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__wordaccess_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__directaccess_test__wordaccess_assignment.snap
@@ -5,7 +5,7 @@ expression: prog
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   %c = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__access_string_via_byte_array.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__access_string_via_byte_array.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @baz_instance = global %baz zeroinitializer, section "var-$RUSTY$baz_instance:r3s8u11pu8pau8"
 
-define void @baz(%baz* %0) section "fn-$RUSTY$baz:v" {
+define void @baz(%baz* %0) {
 entry:
   %str = getelementptr inbounds %baz, %baz* %0, i32 0, i32 0
   %ptr = getelementptr inbounds %baz, %baz* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__allowed_assignable_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__allowed_assignable_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r4i16ai16pi16pai16"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %v = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_add_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_div_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_adr.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_adr.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2pi32i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_lower_bound.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_lower_bound.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2ai32i32"
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai32ai32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-define i32 @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:i32[pr2pai32ai32]" {
+define i32 @foo(%__foo_vla* %0) {
 entry:
   %foo = alloca i32, align 4
   %vla = alloca %__foo_vla*, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_move.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_move.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2i32i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r5i32i32i32i32i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux_with_aggregate_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_mux_with_aggregate_type.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf08_literal_2 = private unnamed_addr constant [6 x i8] c"lorem\00"
 @utf08_literal_3 = private unnamed_addr constant [4 x i8] c"sit\00"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %str1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_ref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_ref.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2pi32i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel_as_expression.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sel_as_expression.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sizeof.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_sizeof.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2i32i64"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2ai32i32"
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai32ai32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-define i32 @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:i32[pr2pai32ai32]" {
+define i32 @foo(%__foo_vla* %0) {
 entry:
   %foo = alloca i32, align 4
   %vla = alloca %__foo_vla*, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound_expr.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_function_call_upper_bound_expr.snap
@@ -12,7 +12,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2ai32i32"
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai32ai32"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %b = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-define i32 @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:i32[pr2pai32ai32]" {
+define i32 @foo(%__foo_vla* %0) {
 entry:
   %foo = alloca i32, align 4
   %vla = alloca %__foo_vla*, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_mul_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_float.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_ints.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_mixed.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__builtin_sub_mixed.snap
@@ -5,7 +5,7 @@ expression: res
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__calling_strings_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__calling_strings_in_function_return.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1s8u81"
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define void @func([81 x i8]* %0) section "fn-$RUSTY$func:s8u81" {
+define void @func([81 x i8]* %0) {
 entry:
   %func = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %func, align 8
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_between_pointer_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_between_pointer_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @baz_instance = global %baz zeroinitializer, section "var-$RUSTY$baz_instance:r2pu8u16"
 
-define void @baz(%baz* %0) section "fn-$RUSTY$baz:v" {
+define void @baz(%baz* %0) {
 entry:
   %ptr_x = getelementptr inbounds %baz, %baz* %0, i32 0, i32 0
   %y = getelementptr inbounds %baz, %baz* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_lword_to_pointer.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_lword_to_pointer.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %ptr_x = alloca i16*, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_pointer_to_lword.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__cast_pointer_to_lword.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   %ptr_x = alloca i16*, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__compare_date_time_literals.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__compare_date_time_literals.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r8u8u8u8u8u8u8u8u8"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %cmp1 = alloca i8, align 1
   %cmp2 = alloca i8, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_assign_codegen.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_assign_codegen.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u8u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_codegen.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__hardware_access_codegen.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u8u8u8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__max_int.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__max_int.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @main() section "fn-$RUSTY$main:i16" {
+define i16 @main() {
 entry:
   %main = alloca i16, align 2
   store i16 0, i16* %main, align 2
@@ -31,4 +31,4 @@ entry:
   ret i16 %main_ret
 }
 
-declare i16 @MAX__INT(i32, i16*) section "fn-$RUSTY$MAX__INT:i16"
+declare i16 @MAX__INT(i32, i16*)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__nested_call_statements.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__nested_call_statements.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define i32 @foo(i32 %0) section "fn-$RUSTY$foo:i32[i32]" {
+define i32 @foo(i32 %0) {
 entry:
   %foo = alloca i32, align 4
   %a = alloca i32, align 4
@@ -19,7 +19,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %call = call i32 @foo(i32 2)
   %call1 = call i32 @foo(i32 %call)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i16 10, i16 20, i16* null }, section "var-$RUSTY$main_instance:r3i16i16pi16"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointer_arithmetics_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2pi16i16"
 
-define i64 @foo() section "fn-$RUSTY$foo:i64" {
+define i64 @foo() {
 entry:
   %foo = alloca i64, align 8
   store i64 0, i64* %foo, align 4
@@ -17,7 +17,7 @@ entry:
   ret i64 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %pt = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointers_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__pointers_in_function_return.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16* @func() section "fn-$RUSTY$func:pi16" {
+define i16* @func() {
 entry:
   %func = alloca i16*, align 8
   store i16* null, i16** %func, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__strings_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__strings_in_function_return.snap
@@ -7,7 +7,7 @@ source_filename = "main"
 
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define void @func([81 x i8]* %0, [81 x i8]* %1) section "fn-$RUSTY$func:s8u81[ps8u81]" {
+define void @func([81 x i8]* %0, [81 x i8]* %1) {
 entry:
   %func = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %func, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__structs_in_function_return.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__structs_in_function_return.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer, section "var-$RUSTY$__myStruct__init:r1i16"
 
-define void @func(%myStruct* %0, %myStruct* %1) section "fn-$RUSTY$func:r1i16[pr1i16]" {
+define void @func(%myStruct* %0, %myStruct* %1) {
 entry:
   %func = alloca %myStruct*, align 8
   store %myStruct* %0, %myStruct** %func, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__type_mix_in_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__type_mix_in_call.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i16 @foo(i16 %0) section "fn-$RUSTY$foo:i16[i16]" {
+define i16 @foo(i16 %0) {
 entry:
   %foo = alloca i16, align 2
   %in = alloca i16, align 2
@@ -15,7 +15,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i16 @baz() section "fn-$RUSTY$baz:i16" {
+define i16 @baz() {
 entry:
   %baz = alloca i16, align 2
   store i16 0, i16* %baz, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unary_expressions_can_be_real.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unary_expressions_can_be_real.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2f32f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unnecessary_casts_between_pointer_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__expression_tests__unnecessary_casts_between_pointer_types.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @baz_instance = global %baz zeroinitializer, section "var-$RUSTY$baz_instance:r4pu8u8i8u8"
 
-define void @baz(%baz* %0) section "fn-$RUSTY$baz:v" {
+define void @baz(%baz* %0) {
 entry:
   %ptr = getelementptr inbounds %baz, %baz* %0, i32 0, i32 0
   %b = getelementptr inbounds %baz, %baz* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__argument_fed_by_ref_then_by_val.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__argument_fed_by_ref_then_by_val.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [5 x i32], align 4
@@ -18,7 +18,7 @@ entry:
   ret i32 %main_ret
 }
 
-define i32 @fn_by_ref(i32* %0) section "fn-$RUSTY$fn_by_ref:i32[pau32]" {
+define i32 @fn_by_ref(i32* %0) {
 entry:
   %fn_by_ref = alloca i32, align 4
   %arg_by_ref = alloca i32*, align 8
@@ -30,7 +30,7 @@ entry:
   ret i32 %fn_by_ref_ret
 }
 
-define i32 @fn_by_val(i32* %0) section "fn-$RUSTY$fn_by_val:i32[au32]" {
+define i32 @fn_by_val(i32* %0) {
 entry:
   %fn_by_val = alloca i32, align 4
   %arg_by_val = alloca [5 x i32], align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__autocast_argument_literals_for_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__autocast_argument_literals_for_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define i32 @func(i8* %0, i16* %1, i32* %2, i64* %3, float* %4, double* %5) section "fn-$RUSTY$func:i32[pi8][pi16][pi32][pi64][pf32][pf64]" {
+define i32 @func(i8* %0, i16* %1, i32* %2, i64* %3, float* %4, double* %5) {
 entry:
   %func = alloca i32, align 4
   %byInt1 = alloca i8*, align 8
@@ -30,7 +30,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %1 = alloca i8, align 1
   store i8 1, i8* %1, align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__bitcast_argument_references_for_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__bitcast_argument_references_for_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i8 1, i8 1, i16 2, i16 2, i32 3, i32 3, i64 4, i64 4, float 5.000000e+00, float 5.000000e+00, double 6.000000e+00, double 6.000000e+00 }, section "var-$RUSTY$main_instance:r12i8i8i16i16i32i32i64i64f32f32f64f64"
 
-define i8 @fn_sint(i8* %0, i8* %1) section "fn-$RUSTY$fn_sint:i8[pi8][pi8]" {
+define i8 @fn_sint(i8* %0, i8* %1) {
 entry:
   %fn_sint = alloca i8, align 1
   %in_ref = alloca i8*, align 8
@@ -21,7 +21,7 @@ entry:
   ret i8 %fn_sint_ret
 }
 
-define i64 @fn_lint(i64* %0, i64* %1) section "fn-$RUSTY$fn_lint:i64[pi64][pi64]" {
+define i64 @fn_lint(i64* %0, i64* %1) {
 entry:
   %fn_lint = alloca i64, align 8
   %in_ref = alloca i64*, align 8
@@ -33,7 +33,7 @@ entry:
   ret i64 %fn_lint_ret
 }
 
-define i64 @fn_real(float* %0, float* %1) section "fn-$RUSTY$fn_real:i64[pf32][pf32]" {
+define i64 @fn_real(float* %0, float* %1) {
 entry:
   %fn_real = alloca i64, align 8
   %in_ref = alloca float*, align 8
@@ -45,7 +45,7 @@ entry:
   ret i64 %fn_real_ret
 }
 
-define i64 @fn_lreal(double* %0, double* %1) section "fn-$RUSTY$fn_lreal:i64[pf64][pf64]" {
+define i64 @fn_lreal(double* %0, double* %1) {
 entry:
   %fn_lreal = alloca i64, align 8
   %in_ref = alloca double*, align 8
@@ -57,7 +57,7 @@ entry:
   ret i64 %fn_lreal_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1_sint = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2_sint = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_ref_sized_string_varargs_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_ref_sized_string_varargs_called_in_program.snap
@@ -12,9 +12,9 @@ source_filename = "main"
 @utf08_literal_1 = private unnamed_addr constant [4 x i8] c"abc\00"
 @utf08_literal_2 = private unnamed_addr constant [7 x i8] c"abcdef\00"
 
-declare i32 @foo(i32, i8**) section "fn-$RUSTY$foo:i32"
+declare i32 @foo(i32, i8**)
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %1 = alloca [3 x i8*], align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_sized_varargs_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_sized_varargs_called_in_program.snap
@@ -9,9 +9,9 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-declare i32 @foo(i32, i32*) section "fn-$RUSTY$foo:i32"
+declare i32 @foo(i32, i32*)
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_varargs_called_in_program.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_with_varargs_called_in_program.snap
@@ -9,9 +9,9 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-declare i32 @foo(...) section "fn-$RUSTY$foo:i32"
+declare i32 @foo(...)
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %load_x = load i32, i32* %x, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__literal_string_argument_passed_by_ref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__literal_string_argument_passed_by_ref.snap
@@ -10,9 +10,9 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1s8u81"
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-declare void @func([81 x i8]*, i8*) section "fn-$RUSTY$func:s8u81[ps8u81]"
+declare void @func([81 x i8]*, i8*)
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %res = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__member_variables_in_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__member_variables_in_body.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @func(i16 %0, i8* %1, i64* %2) section "fn-$RUSTY$func:i32[i16][pi8][pi64]" {
+define i32 @func(i16 %0, i8* %1, i64* %2) {
 entry:
   %func = alloca i32, align 4
   %i = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__on_functions_var_output_should_be_passed_as_a_pointer.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__on_functions_var_output_should_be_passed_as_a_pointer.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @bump(i8* %0) section "fn-$RUSTY$bump:i32[pi8]" {
+define i32 @bump(i8* %0) {
 entry:
   %bump = alloca i32, align 4
   %v = alloca i8*, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1s8u6"
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"12345\00"
 
-define i32 @func(i8* %0) section "fn-$RUSTY$func:i32[s8u6]" {
+define i32 @func(i8* %0) {
 entry:
   %func = alloca i32, align 4
   %x = alloca [6 x i8], align 1
@@ -22,7 +22,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast [6 x i8]* %a to i8*

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function_as_reference.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_a_string_to_a_function_as_reference.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1s8u6"
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"12345\00"
 
-define i32 @func(i8* %0) section "fn-$RUSTY$func:i32[ps8u6]" {
+define i32 @func(i8* %0) {
 entry:
   %func = alloca i32, align 4
   %x = alloca i8*, align 8
@@ -20,7 +20,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = bitcast [6 x i8]* %a to i8*

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_arguments_to_functions_by_ref_and_val.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__passing_arguments_to_functions_by_ref_and_val.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define i32 @func(i16* %0, i32* %1, i16 %2, i32 %3) section "fn-$RUSTY$func:i32[pi16][pi32][i16][i32]" {
+define i32 @func(i16* %0, i32* %1, i16 %2, i32 %3) {
 entry:
   %func = alloca i32, align 4
   %byRef1 = alloca i16*, align 8
@@ -38,7 +38,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %1 = alloca i16, align 2
   store i16 1, i16* %1, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__return_variable_in_nested_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__return_variable_in_nested_call.snap
@@ -5,7 +5,7 @@ expression: codegen(src)
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x1 = alloca i32, align 4
@@ -20,7 +20,7 @@ entry:
   ret i32 %main_ret
 }
 
-define i32 @SMC_Read(i64 %0) section "fn-$RUSTY$SMC_Read:i32[u64]" {
+define i32 @SMC_Read(i64 %0) {
 entry:
   %SMC_Read = alloca i32, align 4
   %ValAddr = alloca i64, align 8

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__simple_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__simple_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1i32"
 
-define i32 @func(i32 %0) section "fn-$RUSTY$func:i32[i32]" {
+define i32 @func(i32 %0) {
 entry:
   %func = alloca i32, align 4
   %x = alloca i32, align 4
@@ -19,7 +19,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %load_a = load i32, i32* %a, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__var_output_in_function_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__var_output_in_function_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main { i16 4 }, section "var-$RUSTY$main_instance:r1i16"
 
-define i32 @func(i16* %0) section "fn-$RUSTY$func:i32[pi16]" {
+define i32 @func(i16* %0) {
 entry:
   %func = alloca i32, align 4
   %o = alloca i16*, align 8
@@ -22,7 +22,7 @@ entry:
   ret i32 %func_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %call = call i32 @func(i16* %x)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__any_real_function_called_with_ints.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__any_real_function_called_with_ints.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r10f32f32f32f64f32f32f32f64i32i32"
 
-define float @foo__REAL(float %0) section "fn-$RUSTY$foo__REAL:f32[f32]" {
+define float @foo__REAL(float %0) {
 entry:
   %foo__REAL = alloca float, align 4
   %in1 = alloca float, align 4
@@ -19,7 +19,7 @@ entry:
   ret float %foo__REAL_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %res_sint = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %res_int = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -56,4 +56,4 @@ entry:
   ret void
 }
 
-declare double @foo__LREAL(double) section "fn-$RUSTY$foo__LREAL:f64[f64]"
+declare double @foo__LREAL(double)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_call_gets_cast_to_biggest_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_call_gets_cast_to_biggest_type.snap
@@ -5,7 +5,7 @@ expression: codegen(src)
 ; ModuleID = 'main'
 source_filename = "main"
 
-define double @main() section "fn-$RUSTY$main:f64" {
+define double @main() {
 entry:
   %main = alloca double, align 8
   store double 0.000000e+00, double* %main, align 8
@@ -25,4 +25,4 @@ entry:
   ret double %main_ret
 }
 
-declare double @MAX__LREAL(i32, double*) section "fn-$RUSTY$MAX__LREAL:f64"
+declare double @MAX__LREAL(i32, double*)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_function_call_generates_real_type_call.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_function_call_generates_real_type_call.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i16i16"
 
-define i32 @MAX__DINT(i32 %0, i32 %1) section "fn-$RUSTY$MAX__DINT:i32[i32][i32]" {
+define i32 @MAX__DINT(i32 %0, i32 %1) {
 entry:
   %MAX__DINT = alloca i32, align 4
   %in1 = alloca i32, align 4
@@ -21,7 +21,7 @@ entry:
   ret i32 %MAX__DINT_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -32,4 +32,4 @@ entry:
   ret void
 }
 
-declare i16 @MAX__INT(i16, i16) section "fn-$RUSTY$MAX__INT:i16[i16][i16]"
+declare i16 @MAX__INT(i16, i16)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_output_parameter.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__generics_test__generic_output_parameter.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3i16i16i64"
 
-define i16 @foo__INT(i64 %0, i16* %1) section "fn-$RUSTY$foo__INT:i16[i64][pi16]" {
+define i16 @foo__INT(i64 %0, i16* %1) {
 entry:
   %foo__INT = alloca i16, align 2
   %in1 = alloca i64, align 8
@@ -21,7 +21,7 @@ entry:
   ret i16 %foo__INT_ret
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %theInt = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %iResult = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_in_module.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_in_module.snap
@@ -18,7 +18,7 @@ source_filename = "prog.st"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r1r2i32pi16"
 @__myStruct__init = external global %myStruct.1, section "var-$RUSTY$__myStruct__init:r2i32pi16"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_no_deps_in_module.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_no_deps_in_module.snap
@@ -16,7 +16,7 @@ source_filename = "prog.st"
 
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r1i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_initialized_in_external_file_in_module.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_initialized_in_external_file_in_module.snap
@@ -12,7 +12,7 @@ source_filename = "prog.st"
 
 @prog_instance = global %prog { i16 5 }, section "var-$RUSTY$prog_instance:r1i16"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__enum_referenced_in_fb_nested.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__enum_referenced_in_fb_nested.snap
@@ -16,7 +16,7 @@ source_filename = "fb.st"
 
 @__fb__init = unnamed_addr constant %fb zeroinitializer, section "var-$RUSTY$__fb__init:r1e3i32"
 
-define void @fb(%fb* %0) section "fn-$RUSTY$fb:v" {
+define void @fb(%fb* %0) {
 entry:
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
   ret void
@@ -31,7 +31,7 @@ source_filename = "myStruct.st"
 @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer, section "var-$RUSTY$__myStruct__init:r1r1e3i32"
 @__fb__init = external global %fb.2, section "var-$RUSTY$__fb__init:r1e3i32"
 
-declare void @fb(%fb.2*) section "fn-$RUSTY$fb:v"
+declare void @fb(%fb.2*)
 
 ; ModuleID = 'fb2.st'
 source_filename = "fb2.st"
@@ -44,13 +44,13 @@ source_filename = "fb2.st"
 @__myStruct__init = external global %myStruct.4, section "var-$RUSTY$__myStruct__init:r1r1e3i32"
 @__fb__init = external global %fb.5, section "var-$RUSTY$__fb__init:r1e3i32"
 
-define void @fb2(%fb2* %0) section "fn-$RUSTY$fb2:v" {
+define void @fb2(%fb2* %0) {
 entry:
   %x = getelementptr inbounds %fb2, %fb2* %0, i32 0, i32 0
   ret void
 }
 
-declare void @fb(%fb.5*) section "fn-$RUSTY$fb:v"
+declare void @fb(%fb.5*)
 
 ; ModuleID = 'fb3.st'
 source_filename = "fb3.st"
@@ -59,7 +59,7 @@ source_filename = "fb3.st"
 
 @__fb3__init = unnamed_addr constant %fb3 zeroinitializer, section "var-$RUSTY$__fb3__init:r0"
 
-define void @fb3(%fb3* %0) section "fn-$RUSTY$fb3:v" {
+define void @fb3(%fb3* %0) {
 entry:
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__function_defined_in_external_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__function_defined_in_external_file.snap
@@ -5,7 +5,7 @@ expression: "codegen_multi(units, crate::DebugLevel::None).join(\"\\n\")"
 ; ModuleID = 'func.st'
 source_filename = "func.st"
 
-define i32 @func() section "fn-$RUSTY$func:i32" {
+define i32 @func() {
 entry:
   %func = alloca i32, align 4
   store i32 0, i32* %func, align 4
@@ -20,7 +20,7 @@ source_filename = "fb.st"
 
 @__fb__init = unnamed_addr constant %fb zeroinitializer, section "var-$RUSTY$__fb__init:r0"
 
-define void @fb(%fb* %0) section "fn-$RUSTY$fb:v" {
+define void @fb(%fb* %0) {
 entry:
   ret void
 }
@@ -32,7 +32,7 @@ source_filename = "prg.st"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   ret void
@@ -45,7 +45,7 @@ source_filename = "prg2.st"
 
 @prg2_instance = global %prg2 zeroinitializer, section "var-$RUSTY$prg2_instance:r1i32"
 
-define void @prg2(%prg2* %0) section "fn-$RUSTY$prg2:v" {
+define void @prg2(%prg2* %0) {
 entry:
   %b = getelementptr inbounds %prg2, %prg2* %0, i32 0, i32 0
   ret void
@@ -64,7 +64,7 @@ source_filename = "prog.st"
 @prg_instance = external global %prg.5, section "var-$RUSTY$prg_instance:r1i32"
 @prg2_instance = external global %prg2.6, section "var-$RUSTY$prg2_instance:r1i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   %myFb = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %load_a = load i32, i32* getelementptr inbounds (%prg.5, %prg.5* @prg_instance, i32 0, i32 0), align 4
@@ -74,10 +74,10 @@ entry:
   ret void
 }
 
-declare void @fb(%fb.4*) section "fn-$RUSTY$fb:v"
+declare void @fb(%fb.4*)
 
-declare void @prg(%prg.5*) section "fn-$RUSTY$prg:v"
+declare void @prg(%prg.5*)
 
-declare void @prg2(%prg2.6*) section "fn-$RUSTY$prg2:v"
+declare void @prg2(%prg2.6*)
 
-declare i32 @func() section "fn-$RUSTY$func:i32"
+declare i32 @func()

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__global_value_from_different_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__global_value_from_different_file.snap
@@ -26,7 +26,7 @@ source_filename = "prog.st"
 @c = external global i32, section "var-$RUSTY$c:i32"
 @x = external global i32, section "var-$RUSTY$x:i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   store i32 7, i32* @x, align 4
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__struct_with_custom_init_in_different_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__struct_with_custom_init_in_different_file.snap
@@ -28,7 +28,7 @@ source_filename = "prog.st"
 @__myStruct2__init = external global %myStruct2.3, section "var-$RUSTY$__myStruct2__init:r2i32i16"
 @__prog.x__init = unnamed_addr constant %myStruct.2 { i32 5, i16 2 }
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v" {
+define void @prog(%prog* %0) {
 entry:
   %x = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %y = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_input_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_input_param.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @__fb_t__init = unnamed_addr constant %fb_t zeroinitializer, section "var-$RUSTY$__fb_t__init:r2i32i32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1r2i32i32"
 
-define void @fb_t(%fb_t* %0) section "fn-$RUSTY$fb_t:v[i32][i32]" {
+define void @fb_t(%fb_t* %0) {
 entry:
   %in1 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %in2 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %fb = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = getelementptr inbounds %fb_t, %fb_t* %fb, i32 0, i32 0

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_output_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__fb_accepts_empty_statement_as_output_param.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @__fb_t__init = unnamed_addr constant %fb_t zeroinitializer, section "var-$RUSTY$__fb_t__init:r2i32i32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2r2i32i32i32"
 
-define void @fb_t(%fb_t* %0) section "fn-$RUSTY$fb_t:v[i32][i32]" {
+define void @fb_t(%fb_t* %0) {
 entry:
   %out1 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %out2 = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %fb = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_input_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_input_param.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define void @foo(i32 %0, i32 %1) section "fn-$RUSTY$foo:v[i32][i32]" {
+define void @foo(i32 %0, i32 %1) {
 entry:
   %in1 = alloca i32, align 4
   store i32 %0, i32* %in1, align 4
@@ -18,7 +18,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %1 = alloca i32, align 4
   %2 = load i32, i32* %1, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_output_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_accepts_empty_statement_as_output_param.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1i32"
 
-define void @foo(i32* %0, i32* %1) section "fn-$RUSTY$foo:v[pi32][pi32]" {
+define void @foo(i32* %0, i32* %1) {
 entry:
   %out1 = alloca i32*, align 8
   store i32* %0, i32** %out1, align 8
@@ -18,7 +18,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca i32, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_all_parameters_assigned.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_all_parameters_assigned.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_default_value_parameter_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_default_value_parameter_type.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2, i32* %3) section "fn-$RUSTY$foo:i32[i32][pi32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2, i32* %3) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -25,7 +25,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_inout_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_inout_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_input_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_input_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_default_value_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_empty_output_default_value_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_inout_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_inout_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_default_value_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_input_default_value_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_default_value_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__function_missing_output_default_value_assignment.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define i32 @foo(i32 %0, i32* %1, i32* %2) section "fn-$RUSTY$foo:i32[i32][pi32][pi32]" {
+define i32 @foo(i32 %0, i32* %1, i32* %2) {
 entry:
   %foo = alloca i32, align 4
   %input1 = alloca i32, align 4
@@ -23,7 +23,7 @@ entry:
   ret i32 %foo_ret
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__parameters_behind_function_block_pointer_are_assigned_to.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__parameters_behind_function_block_pointer_are_assigned_to.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2r2u8u8pr2u8u8"
 @__file_t__init = unnamed_addr constant %file_t zeroinitializer, section "var-$RUSTY$__file_t__init:r2u8u8"
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %file = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %FileOpen = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @file_t(%file_t* %0) section "fn-$RUSTY$file_t:v[u8][u8]" {
+define void @file_t(%file_t* %0) {
 entry:
   %var1 = getelementptr inbounds %file_t, %file_t* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %file_t, %file_t* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_input_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_input_param.snap
@@ -11,14 +11,14 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r2i32i32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r0"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[i32][i32]" {
+define void @prog(%prog* %0) {
 entry:
   %in1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %in2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   store i32 1, i32* getelementptr inbounds (%prog, %prog* @prog_instance, i32 0, i32 0), align 4
   call void @prog(%prog* @prog_instance)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_output_param.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_accepts_empty_statement_as_output_param.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r2i32i32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[i32][i32]" {
+define void @prog(%prog* %0) {
 entry:
   %out1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %out2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -20,7 +20,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   call void @prog(%prog* @prog_instance)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_explicit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_explicit.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r3i32i32pi32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[i32][i32][pi32]" {
+define void @prog(%prog* %0) {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_implicit.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_all_parameters_assigned_implicit.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r3i32i32pi32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[i32][i32][pi32]" {
+define void @prog(%prog* %0) {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_empty_inout_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_empty_inout_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r3i32i32pi32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[i32][i32][pi32]" {
+define void @prog(%prog* %0) {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_input_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_input_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r3i32i32pi32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[i32][i32][pi32]" {
+define void @prog(%prog* %0) {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_output_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__program_missing_output_assignment.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @prog_instance = global %prog zeroinitializer, section "var-$RUSTY$prog_instance:r3i32i32pi32"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r3i32i32i32"
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[i32][i32][pi32]" {
+define void @prog(%prog* %0) {
 entry:
   %input1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -19,7 +19,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %var1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %var2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__var_in_out_params_can_be_out_of_order.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__parameters_tests__var_in_out_params_can_be_out_of_order.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @mainProg_instance = global %mainProg zeroinitializer, section "var-$RUSTY$mainProg_instance:r3r5u8u8pu8u8pu8u8u8"
 @__fb_t__init = unnamed_addr constant %fb_t zeroinitializer, section "var-$RUSTY$__fb_t__init:r5u8u8pu8u8pu8"
 
-define void @mainProg(%mainProg* %0) section "fn-$RUSTY$mainProg:v" {
+define void @mainProg(%mainProg* %0) {
 entry:
   %fb = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 0
   %out1 = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 1
@@ -35,7 +35,7 @@ entry:
   ret void
 }
 
-define void @fb_t(%fb_t* %0) section "fn-$RUSTY$fb_t:v[u8][pu8][u8][pu8]" {
+define void @fb_t(%fb_t* %0) {
 entry:
   %myVar = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %myInput = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1
@@ -45,7 +45,7 @@ entry:
   ret void
 }
 
-define void @fb_t.foo(%fb_t* %0) section "fn-$RUSTY$fb_t.foo:v" {
+define void @fb_t.foo(%fb_t* %0) {
 entry:
   %myVar = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 0
   %myInput = getelementptr inbounds %fb_t, %fb_t* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__bitaccess_generated_as_rsh_and_trunc_i1.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__bitaccess_generated_as_rsh_and_trunc_i1.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u8u32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__byteaccess_generated_as_rsh_and_trunc_i8.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__byteaccess_generated_as_rsh_and_trunc_i8.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u8u32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__dwordaccess_generated_as_rsh_and_trunc_i32.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__dwordaccess_generated_as_rsh_and_trunc_i32.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u32u64i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__floating_point_type_casting.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__floating_point_type_casting.snap
@@ -5,7 +5,7 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-define i32 @fn() section "fn-$RUSTY$fn:i32" {
+define i32 @fn() {
 entry:
   %fn = alloca i32, align 4
   %a = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_aliased_string.snap
@@ -5,9 +5,9 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-declare void @CONCAT([1025 x i8]*, i8*, i8*) section "fn-$RUSTY$CONCAT:s8u1025[s8u1025][s8u1025]"
+declare void @CONCAT([1025 x i8]*, i8*, i8*)
 
-define i8 @LIST_ADD(i8* %0, i8* %1) section "fn-$RUSTY$LIST_ADD:u8[s8u1001][s8u2]" {
+define i8 @LIST_ADD(i8* %0, i8* %1) {
 entry:
   %LIST_ADD = alloca i8, align 1
   %INS = alloca [1001 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__function_result_assignment_on_string.snap
@@ -5,9 +5,9 @@ expression: result
 ; ModuleID = 'main'
 source_filename = "main"
 
-declare void @CONCAT([1025 x i8]*, i8*, i8*) section "fn-$RUSTY$CONCAT:s8u1025[s8u1025][s8u1025]"
+declare void @CONCAT([1025 x i8]*, i8*, i8*)
 
-define i8 @LIST_ADD(i8* %0, i8* %1) section "fn-$RUSTY$LIST_ADD:u8[s8u1001][s8u2]" {
+define i8 @LIST_ADD(i8* %0, i8* %1) {
 entry:
   %LIST_ADD = alloca i8, align 1
   %INS = alloca [1001 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__nested_bitwise_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__nested_bitwise_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2u8u64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__variable_based_bitwise_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__variable_based_bitwise_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r4u8u8i16i16"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__wordaccess_generated_as_rsh_and_trunc_i16.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__statement_codegen_test__wordaccess_generated_as_rsh_and_trunc_i16.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u16u32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__casted_string_assignment_uses_memcpy.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__casted_string_assignment_uses_memcpy.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [4 x i8] c"abc\00"
 @utf16_literal_0 = private unnamed_addr constant [4 x i16] [i16 97, i16 98, i16 99, i16 0]
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returning_generic_string_should_return_by_ref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returning_generic_string_should_return_by_ref.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2s8u61s8u81"
 @utf08_literal_0 = private unnamed_addr constant [4 x i8] c"abc\00"
 
-define void @MID__STRING([81 x i8]* %0, i8* %1, i32 %2, i32 %3) section "fn-$RUSTY$MID__STRING:s8u81[ps8u81][i32][i32]" {
+define void @MID__STRING([81 x i8]* %0, i8* %1, i32 %2, i32 %3) {
 entry:
   %MID__STRING = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %MID__STRING, align 8
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v[s8u61][s8u81]" {
+define void @main(%main* %0) {
 entry:
   %fmt = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returns_a_literal_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_returns_a_literal_string.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1s8u81"
 @utf08_literal_0 = private unnamed_addr constant [4 x i8] c"abc\00"
 
-define void @ret([81 x i8]* %0) section "fn-$RUSTY$ret:s8u81" {
+define void @ret([81 x i8]* %0) {
 entry:
   %ret = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %ret, align 8
@@ -23,7 +23,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %str = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_takes_string_paramter_and_returns_string.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_takes_string_paramter_and_returns_string.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1s8u81"
 @utf08_literal_0 = private unnamed_addr constant [154 x i8] c"abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc\00"
 
-define void @read_string([81 x i8]* %0, i8* %1) section "fn-$RUSTY$read_string:s8u81[s8u81]" {
+define void @read_string([81 x i8]* %0, i8* %1) {
 entry:
   %read_string = alloca [81 x i8]*, align 8
   store [81 x i8]* %0, [81 x i8]** %read_string, align 8
@@ -28,7 +28,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %text1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %1 = alloca [81 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_var_constant_strings_should_be_collected_as_literals.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__function_var_constant_strings_should_be_collected_as_literals.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [2 x i8] c"#\00"
 @utf08_literal_1 = private unnamed_addr constant [2 x i8] c"*\00"
 
-define i64 @FSTRING_TO_DT() section "fn-$RUSTY$FSTRING_TO_DT:i64" {
+define i64 @FSTRING_TO_DT() {
 entry:
   %FSTRING_TO_DT = alloca i64, align 8
   %ignore = alloca [2 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_string_output.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_string_output.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [7 x i8] c"string\00"
 @utf16_literal_0 = private unnamed_addr constant [8 x i16] [i16 119, i16 115, i16 116, i16 114, i16 105, i16 110, i16 103, i16 0]
 
-define void @prog(%prog* %0) section "fn-$RUSTY$prog:v[s8u81][s16u81]" {
+define void @prog(%prog* %0) {
 entry:
   %output1 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
   %output2 = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
@@ -24,7 +24,7 @@ entry:
   ret void
 }
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0
   %y = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_casted_string_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_casted_string_assignment.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf16_literal_0 = private unnamed_addr constant [12 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 @utf16_literal_1 = private unnamed_addr constant [18 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 117, i16 116, i16 102, i16 49, i16 54, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_string_type_assignment.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__program_with_string_type_assignment.snap
@@ -14,7 +14,7 @@ source_filename = "main"
 @utf08_literal_1 = private unnamed_addr constant [17 x i8] c"im also a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [17 x i16] [i16 105, i16 109, i16 32, i16 97, i16 108, i16 115, i16 111, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__string_function_parameters.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__string_function_parameters.snap
@@ -11,7 +11,7 @@ source_filename = "main"
 @__prg.s__init = unnamed_addr constant [11 x i8] c"hello\00\00\00\00\00\00"
 @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
-define i16 @foo(i8* %0) section "fn-$RUSTY$foo:i16[s8u81]" {
+define i16 @foo(i8* %0) {
 entry:
   %foo = alloca i16, align 2
   %s = alloca [81 x i8], align 1
@@ -27,7 +27,7 @@ buffer_block:                                     ; No predecessors!
   ret i16 %foo_ret1
 }
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @__FSTRING_TO_DT.ignore__init = unnamed_addr constant [2 x i8] c"*\00"
 @__FSTRING_TO_DT.fchar__init = unnamed_addr constant [2 x i8] c"#\00"
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-$RUSTY$STRING_EQUAL:u8[ps8u1025][ps8u1025]" {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca i8*, align 8
@@ -20,7 +20,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i64 @FSTRING_TO_DT() section "fn-$RUSTY$FSTRING_TO_DT:i64" {
+define i64 @FSTRING_TO_DT() {
 entry:
   %FSTRING_TO_DT = alloca i64, align 8
   %ignore = alloca [2 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable_nonref.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__using_a_constant_var_string_should_be_memcpyable_nonref.snap
@@ -8,7 +8,7 @@ source_filename = "main"
 @__FSTRING_TO_DT.ignore__init = unnamed_addr constant [2 x i8] c"*\00"
 @__FSTRING_TO_DT.fchar__init = unnamed_addr constant [2 x i8] c"#\00"
 
-define i8 @STRING_EQUAL(i8* %0, i8* %1) section "fn-$RUSTY$STRING_EQUAL:u8[s8u1025][s8u1025]" {
+define i8 @STRING_EQUAL(i8* %0, i8* %1) {
 entry:
   %STRING_EQUAL = alloca i8, align 1
   %op1 = alloca [1025 x i8], align 1
@@ -24,7 +24,7 @@ entry:
   ret i8 %STRING_EQUAL_ret
 }
 
-define i64 @FSTRING_TO_DT() section "fn-$RUSTY$FSTRING_TO_DT:i64" {
+define i64 @FSTRING_TO_DT() {
 entry:
   %FSTRING_TO_DT = alloca i64, align 8
   %ignore = alloca [2 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_can_be_created.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_can_be_created.snap
@@ -13,7 +13,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [12 x i8] c"im a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [12 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_using_constants_can_be_created.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_length_strings_using_constants_can_be_created.snap
@@ -15,7 +15,7 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [12 x i8] c"im a genius\00"
 @utf16_literal_0 = private unnamed_addr constant [12 x i16] [i16 105, i16 109, i16 32, i16 97, i16 32, i16 103, i16 101, i16 110, i16 105, i16 117, i16 115, i16 0]
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_string_assignment_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__variable_string_assignment_test.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @prg_instance = global %prg { [16 x i8] zeroinitializer, [31 x i8] c"xyz\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00" }, section "var-$RUSTY$prg_instance:r2s8u16s8u31"
 @__prg.z__init = unnamed_addr constant [31 x i8] c"xyz\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__vartmp_string_init_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__string_tests__vartmp_string_init_test.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2s8u16s8u31"
 @__prg.z__init = unnamed_addr constant [31 x i8] c"xyz\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %y = alloca [16 x i8], align 1
   %z = alloca [31 x i8], align 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__aliased_datatypes_respect_conversion_rules.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__aliased_datatypes_respect_conversion_rules.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3i8i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_larger_than_int_promote_the_second_operand.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_larger_than_int_promote_the_second_operand.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3i32i64i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_smaller_than_dint_promoted_to_dint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__datatypes_smaller_than_dint_promoted_to_dint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3i8i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__even_all_sint_expressions_fallback_to_dint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__even_all_sint_expressions_fallback_to_dint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3i8i8i8"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_and_double_mix_converted_to_double.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_and_double_mix_converted_to_double.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3f32f64f64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assigned_to_int_is_cast.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assigned_to_int_is_cast.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3i16u16f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assinged_to_double_to_double.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__float_assinged_to_double_to_double.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2f32f64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_assigned_to_float_is_cast.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_assigned_to_float_is_cast.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3i16u16f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_byte_promoted_on_compare_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_byte_promoted_on_compare_statement.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2u8i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_float_converted_to_double.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_bigger_than_float_converted_to_double.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2f32i64"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_smaller_or_equal_to_float_converted_to_float.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__int_smaller_or_equal_to_float_converted_to_float.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3f32i16f32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__numerical_promotion_for_variadic_functions_without_declaration.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__numerical_promotion_for_variadic_functions_without_declaration.snap
@@ -10,9 +10,9 @@ source_filename = "main"
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r4s8u81f32f64i16"
 @__main.s__init = unnamed_addr constant [81 x i8] c"\0A numbers: %f %f %f %d \0A \0A\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 
-declare i32 @printf(i8*, ...) section "fn-$RUSTY$printf:i32[ps8u81]"
+declare i32 @printf(i8*, ...)
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+define void @main(%main* %0) {
 entry:
   %s = alloca [81 x i8], align 1
   %float = alloca float, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__small_int_varargs_get_promoted_while_32bit_and_higher_keep_their_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__small_int_varargs_get_promoted_while_32bit_and_higher_keep_their_type.snap
@@ -8,9 +8,9 @@ source_filename = "main"
 @utf08_literal_0 = private unnamed_addr constant [26 x i8] c"(d) result : %d %d %d %u\0A\00"
 @utf08_literal_1 = private unnamed_addr constant [27 x i8] c"(hd) result : %hd %hd %hd\0A\00"
 
-declare i32 @printf(i8*, ...) section "fn-$RUSTY$printf:i32[ps8u81]"
+declare i32 @printf(i8*, ...)
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %out1 = alloca i16, align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__unsingned_datatypes_smaller_than_dint_promoted_to_dint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__typesystem_test__unsingned_datatypes_smaller_than_dint_promoted_to_dint.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r3u8i32i32"
 
-define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+define void @prg(%prg* %0) {
 entry:
   %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
   %c = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__consecutive_calls_with_differently_sized_arrays.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__consecutive_calls_with_differently_sized_arrays.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai16ai32"
 
-define i16 @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:i16[r2pai16ai32]" {
+define i16 @foo(%__foo_vla* %0) {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -57,7 +57,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [60 x i16], align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__global_variable_passed_to_function_as_vla.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__global_variable_passed_to_function_as_vla.snap
@@ -10,7 +10,7 @@ source_filename = "main"
 @arr = global [2 x i16] zeroinitializer, section "var-$RUSTY$arr:ai16"
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai16ai32"
 
-define i16 @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:i16[r2pai16ai32]" {
+define i16 @foo(%__foo_vla* %0) {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -32,7 +32,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   store i32 0, i32* %main, align 4

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__internal_vla_struct_is_generated_for_call_statements.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__internal_vla_struct_is_generated_for_call_statements.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai16ai32"
 
-define void @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:v[r2pai16ai32]" {
+define void @foo(%__foo_vla* %0) {
 entry:
   %vla = alloca %__foo_vla, align 8
   %1 = bitcast %__foo_vla* %vla to i8*
@@ -18,7 +18,7 @@ entry:
   ret void
 }
 
-define void @bar() section "fn-$RUSTY$bar:v" {
+define void @bar() {
 entry:
   %arr = alloca [2 x i16], align 2
   %0 = bitcast [2 x i16]* %arr to i8*

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__multi_dimensional_vla.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__multi_dimensional_vla.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai16ai32"
 
-define i16 @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:i16[r2pai16ai32]" {
+define i16 @foo(%__foo_vla* %0) {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -57,7 +57,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [20 x i16], align 2

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access.snap
@@ -9,7 +9,7 @@ source_filename = "main"
 
 @____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer, section "var-$RUSTY$____foo_vla__init:r2pai16ai32"
 
-define i16 @foo(%__foo_vla* %0) section "fn-$RUSTY$foo:i16[r2pai16ai32]" {
+define i16 @foo(%__foo_vla* %0) {
 entry:
   %foo = alloca i16, align 2
   %vla = alloca %__foo_vla, align 8
@@ -32,7 +32,7 @@ entry:
   ret i16 %foo_ret
 }
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %arr = alloca [2 x i16], align 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,12 @@ pub enum DebugLevel {
     Full(usize),
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum OnlineChange {
+    Enabled,
+    Disabled,
+}
+
 impl From<OptimizationLevel> for inkwell::OptimizationLevel {
     fn from(val: OptimizationLevel) -> Self {
         match val {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -164,6 +164,7 @@ pub mod tests {
             None,
             crate::OptimizationLevel::None,
             debug_level,
+            crate::OnlineChange::Disabled,
         );
         let annotations = AstAnnotations::new(annotations, id_provider.next_id());
 
@@ -239,6 +240,7 @@ pub mod tests {
                     None,
                     crate::OptimizationLevel::None,
                     debug_level,
+                    crate::OnlineChange::Disabled,
                 );
                 let got_layout = Mutex::new(None);
 

--- a/src/tests/adr/arrays_adr.rs
+++ b/src/tests/adr/arrays_adr.rs
@@ -73,7 +73,7 @@ fn assigning_full_arrays() {
     @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9] }, section "var-$RUSTY$prg_instance:r2ai32ai32"
     @__Data__init = unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], section "var-$RUSTY$__Data__init:ai32"
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -126,7 +126,7 @@ fn accessing_array_elements() {
     @__Data__init = unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], section "var-$RUSTY$__Data__init:ai32"
     @__prg.b__init = unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/enum_adr.rs
+++ b/src/tests/adr/enum_adr.rs
@@ -129,7 +129,7 @@ fn using_enums() {
     @Door.open = unnamed_addr constant i32 8, section "var-$RUSTY$open:e2i32"
     @Door.closed = unnamed_addr constant i32 16, section "var-$RUSTY$closed:e2i32"
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %y = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/pou_adr.rs
+++ b/src/tests/adr/pou_adr.rs
@@ -235,7 +235,7 @@ fn codegen_of_a_program_pou() {
 
     @main_prg_instance = global %main_prg zeroinitializer, section "var-$RUSTY$main_prg_instance:r5i16pi16i16i16i16"
 
-    define void @main_prg(%main_prg* %0) section "fn-$RUSTY$main_prg:v[i16][pi16][i16]" {
+    define void @main_prg(%main_prg* %0) {
     entry:
       %i = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 1
@@ -273,7 +273,7 @@ fn calling_a_program() {
 
     @main_prg_instance = global %main_prg zeroinitializer, section "var-$RUSTY$main_prg_instance:r5i16pi16i16i16i16"
 
-    define i16 @foo() section "fn-$RUSTY$foo:i16" {
+    define i16 @foo() {
     entry:
       %foo = alloca i16, align 2
       %x = alloca i16, align 2
@@ -290,7 +290,7 @@ fn calling_a_program() {
       ret i16 %foo_ret
     }
 
-    define void @main_prg(%main_prg* %0) section "fn-$RUSTY$main_prg:v[i16][pi16][i16]" {
+    define void @main_prg(%main_prg* %0) {
     entry:
       %i = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_prg, %main_prg* %0, i32 0, i32 1
@@ -337,7 +337,7 @@ fn function_blocks_get_a_method_with_a_self_parameter() {
 
     @__main_fb__init = unnamed_addr constant %main_fb { i16 6, i16* null, i16 0, i16 1 }, section "var-$RUSTY$__main_fb__init:r5i16pi16i16i16i16"
 
-    define void @main_fb(%main_fb* %0) section "fn-$RUSTY$main_fb:v[i16][pi16][i16]" {
+    define void @main_fb(%main_fb* %0) {
     entry:
       %i = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 1
@@ -378,7 +378,7 @@ fn calling_a_function_block() {
     @foo_instance = global %foo { i16 0, i16 0, %main_fb { i16 6, i16* null, i16 0, i16 1 } }, section "var-$RUSTY$foo_instance:r3i16i16r5i16pi16i16i16i16"
     @__main_fb__init = unnamed_addr constant %main_fb { i16 6, i16* null, i16 0, i16 1 }, section "var-$RUSTY$__main_fb__init:r5i16pi16i16i16i16"
 
-    define void @foo(%foo* %0) section "fn-$RUSTY$foo:v" {
+    define void @foo(%foo* %0) {
     entry:
       %x = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
       %y = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
@@ -394,7 +394,7 @@ fn calling_a_function_block() {
       ret void
     }
 
-    define void @main_fb(%main_fb* %0) section "fn-$RUSTY$main_fb:v[i16][pi16][i16]" {
+    define void @main_fb(%main_fb* %0) {
     entry:
       %i = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 0
       %io = getelementptr inbounds %main_fb, %main_fb* %0, i32 0, i32 1
@@ -431,7 +431,7 @@ fn function_get_a_method_with_by_ref_parameters() {
     ; ModuleID = 'main'
     source_filename = "main"
 
-    define i32 @main_fun(i16 %0, i8* %1, i64* %2) section "fn-$RUSTY$main_fun:i32[i16][pi8][pi64]" {
+    define i32 @main_fun(i16 %0, i8* %1, i64* %2) {
     entry:
       %main_fun = alloca i32, align 4
       %i = alloca i16, align 2
@@ -477,7 +477,7 @@ fn calling_a_function() {
 
     @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2i16i8"
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %x = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %z = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -487,7 +487,7 @@ fn calling_a_function() {
       ret void
     }
 
-    define i32 @main_fun(i16 %0, i8* %1, i64* %2) section "fn-$RUSTY$main_fun:i32[i16][pi8][pi64]" {
+    define i32 @main_fun(i16 %0, i8* %1, i64* %2) {
     entry:
       %main_fun = alloca i32, align 4
       %i = alloca i16, align 2
@@ -540,7 +540,7 @@ fn return_a_complex_type_from_function() {
     @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r1s8u81"
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
-    define void @foo([81 x i8]* %0) section "fn-$RUSTY$foo:s8u81" {
+    define void @foo([81 x i8]* %0) {
     entry:
       %foo = alloca [81 x i8]*, align 8
       store [81 x i8]* %0, [81 x i8]** %foo, align 8
@@ -553,7 +553,7 @@ fn return_a_complex_type_from_function() {
       ret void
     }
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %s = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %1 = alloca [81 x i8], align 1
@@ -623,7 +623,7 @@ fn passing_aggregate_types_to_functions_by_value() {
     @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer, section "var-$RUSTY$__myStruct__init:r4i32i32i32s8u81"
     @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r4s8u81s16u81ai32r4i32i32i32s8u81"
 
-    define void @foo(i8* %0, i16* %1, i32* %2, %myStruct* %3) section "fn-$RUSTY$foo:v[s8u81][s16u81][ai32][r4i32i32i32s8u81]" {
+    define void @foo(i8* %0, i16* %1, i32* %2, %myStruct* %3) {
     entry:
       %s = alloca [81 x i8], align 1
       %bitcast = bitcast [81 x i8]* %s to i8*
@@ -648,7 +648,7 @@ fn passing_aggregate_types_to_functions_by_value() {
       ret void
     }
 
-    define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+    define void @main(%main* %0) {
     entry:
       %string1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
       %string2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1
@@ -707,7 +707,7 @@ fn passing_by_ref_to_functions() {
 
     @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2s8u81s8u81"
 
-    define i8 @StrEqual(i8* %0, i8* %1) section "fn-$RUSTY$StrEqual:u8[ps8u81][ps8u81]" {
+    define i8 @StrEqual(i8* %0, i8* %1) {
     entry:
       %StrEqual = alloca i8, align 1
       %o1 = alloca i8*, align 8
@@ -719,7 +719,7 @@ fn passing_by_ref_to_functions() {
       ret i8 %StrEqual_ret
     }
 
-    define void @main(%main* %0) section "fn-$RUSTY$main:v" {
+    define void @main(%main* %0) {
     entry:
       %str1 = getelementptr inbounds %main, %main* %0, i32 0, i32 0
       %str2 = getelementptr inbounds %main, %main* %0, i32 0, i32 1

--- a/src/tests/adr/strings_adr.rs
+++ b/src/tests/adr/strings_adr.rs
@@ -70,7 +70,7 @@ fn assigning_strings() {
 
     @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2s8u11s8u11"
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -113,7 +113,7 @@ fn assigning_string_literals() {
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %a = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %b = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/structs_adr.rs
+++ b/src/tests/adr/structs_adr.rs
@@ -103,7 +103,7 @@ fn initializing_a_struct() {
     @__prg.rect1__init = unnamed_addr constant %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }
     @__prg.rect2__init = unnamed_addr constant %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } }
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %rect1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %rect2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -146,7 +146,7 @@ fn assigning_structs() {
     @prg_instance = global %prg zeroinitializer, section "var-$RUSTY$prg_instance:r2r2i16i16r2i16i16"
     @__Point__init = unnamed_addr constant %Point zeroinitializer, section "var-$RUSTY$__Point__init:r2i16i16"
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %p1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %p2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1
@@ -204,7 +204,7 @@ fn accessing_struct_members() {
     @__Rect__init = unnamed_addr constant %Rect zeroinitializer, section "var-$RUSTY$__Rect__init:r2r2i16i16r2i16i16"
     @__Point__init = unnamed_addr constant %Point zeroinitializer, section "var-$RUSTY$__Point__init:r2i16i16"
 
-    define void @prg(%prg* %0) section "fn-$RUSTY$prg:v" {
+    define void @prg(%prg* %0) {
     entry:
       %rect1 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 0
       %rect2 = getelementptr inbounds %prg, %prg* %0, i32 0, i32 1

--- a/src/tests/adr/vla_adr.rs
+++ b/src/tests/adr/vla_adr.rs
@@ -318,7 +318,7 @@ fn pass() {
 
     @____foo_arr__init = unnamed_addr constant %__foo_arr zeroinitializer, section "var-$RUSTY$____foo_arr__init:r2pai32ai32"
 
-    define i32 @main() section "fn-$RUSTY$main:i32" {
+    define i32 @main() {
     entry:
       %main = alloca i32, align 4
       %local = alloca [6 x i32], align 4
@@ -340,7 +340,7 @@ fn pass() {
       ret i32 %main_ret
     }
 
-    define i32 @foo(%__foo_arr* %0) section "fn-$RUSTY$foo:i32[pr2pai32ai32]" {
+    define i32 @foo(%__foo_arr* %0) {
     entry:
       %foo = alloca i32, align 4
       %arr = alloca %__foo_arr*, align 8
@@ -384,7 +384,7 @@ fn access() {
 
     @____foo_arr__init = unnamed_addr constant %__foo_arr zeroinitializer, section "var-$RUSTY$____foo_arr__init:r2pai32ai32"
 
-    define i32 @foo(%__foo_arr* %0) section "fn-$RUSTY$foo:i32[pr2pai32ai32]" {
+    define i32 @foo(%__foo_arr* %0) {
     entry:
       %foo = alloca i32, align 4
       %arr = alloca %__foo_arr*, align 8
@@ -442,7 +442,7 @@ fn multi_dimensional() {
 
     @____foo_arr__init = unnamed_addr constant %__foo_arr zeroinitializer, section "var-$RUSTY$____foo_arr__init:r2pai32ai32"
 
-    define i32 @foo(%__foo_arr* %0) section "fn-$RUSTY$foo:i32[pr2pai32ai32]" {
+    define i32 @foo(%__foo_arr* %0) {
     entry:
       %foo = alloca i32, align 4
       %arr = alloca %__foo_arr*, align 8

--- a/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r2i32i32", !dbg !0
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" !dbg !12 {
+define void @main(%main* %0) !dbg !12 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !16, metadata !DIExpression()), !dbg !17
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !18
@@ -17,7 +17,7 @@ entry:
   ret void, !dbg !20
 }
 
-define void @main.newAction(%main* %0) section "fn-$RUSTY$main.newAction:v" !dbg !21 {
+define void @main.newAction(%main* %0) !dbg !21 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !16, metadata !DIExpression()), !dbg !22
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !23
@@ -28,7 +28,7 @@ entry:
   ret void, !dbg !22
 }
 
-define void @main.newAction2(%main* %0) section "fn-$RUSTY$main.newAction2:v" !dbg !24 {
+define void @main.newAction2(%main* %0) !dbg !24 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !16, metadata !DIExpression()), !dbg !25
   %a = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !26

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @__conditional_return__init = unnamed_addr constant %conditional_return zeroinitializer, section "var-$RUSTY$__conditional_return__init:r1i32"
 
-define void @conditional_return(%conditional_return* %0) section "fn-$RUSTY$conditional_return:v[i32]" {
+define void @conditional_return(%conditional_return* %0) {
 entry:
   %val = getelementptr inbounds %conditional_return, %conditional_return* %0, i32 0, i32 0
   %load_val = load i32, i32* %val, align 4

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_debug.snap
@@ -2,7 +2,7 @@
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
 ---
-define i32 @foo(i32 %0) section "fn-$RUSTY$foo:i32[i32]" !dbg !4 {
+define i32 @foo(i32 %0) !dbg !4 {
 entry:
   %foo = alloca i32, align 4, !dbg !9
   %val = alloca i32, align 4, !dbg !9

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @__conditional_return__init = constant %conditional_return zeroinitializer, section "var-$RUSTY$__conditional_return__init:r1i32"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %my_val = alloca i32, align 4
@@ -29,7 +29,7 @@ entry:
 ; Function Attrs: argmemonly nofree nounwind willreturn
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
-define void @conditional_return(%conditional_return* %0) section "fn-$RUSTY$conditional_return:v[i32]" {
+define void @conditional_return(%conditional_return* %0) {
 entry:
   %val = getelementptr inbounds %conditional_return, %conditional_return* %0, i32 0, i32 0
   %load_val = load i32, i32* %val, align 4

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @__conditional_return__init = constant %conditional_return zeroinitializer, section "var-$RUSTY$__conditional_return__init:r1i32"
 
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %my_val = alloca i32, align 4
@@ -29,7 +29,7 @@ entry:
 ; Function Attrs: argmemonly nofree nounwind willreturn
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
-define void @conditional_return(%conditional_return* %0) section "fn-$RUSTY$conditional_return:v[i32]" {
+define void @conditional_return(%conditional_return* %0) {
 entry:
   %val = getelementptr inbounds %conditional_return, %conditional_return* %0, i32 0, i32 0
   %load_val = load i32, i32* %val, align 4

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @foo_instance = global %foo zeroinitializer, section "var-$RUSTY$foo_instance:r1i32", !dbg !0
 
-define void @foo(%foo* %0) section "fn-$RUSTY$foo:v" !dbg !11 {
+define void @foo(%foo* %0) !dbg !11 {
 entry:
   call void @llvm.dbg.declare(metadata %foo* %0, metadata !15, metadata !DIExpression()), !dbg !16
   %val = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0, !dbg !17

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_false.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_false.snap
@@ -2,7 +2,7 @@
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
 ---
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x = alloca i8, align 1

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_true.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_to_label_with_true.snap
@@ -2,7 +2,7 @@
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
 ---
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %x = alloca i8, align 1

--- a/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
@@ -6,7 +6,7 @@ expression: output_file_content_without_headers
 
 @main_instance = global %main zeroinitializer, section "var-$RUSTY$main_instance:r1i32", !dbg !0
 
-define void @main(%main* %0) section "fn-$RUSTY$main:v" !dbg !11 {
+define void @main(%main* %0) !dbg !11 {
 entry:
   call void @llvm.dbg.declare(metadata %main* %0, metadata !15, metadata !DIExpression()), !dbg !16
   %x = getelementptr inbounds %main, %main* %0, i32 0, i32 0, !dbg !17

--- a/tests/integration/snapshots/tests__integration__cfc__ir__variable_source_to_variable_and_block_sink.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__variable_source_to_variable_and_block_sink.snap
@@ -2,7 +2,7 @@
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
 ---
-define i32 @main() section "fn-$RUSTY$main:i32" {
+define i32 @main() {
 entry:
   %main = alloca i32, align 4
   %value = alloca i32, align 4
@@ -15,7 +15,7 @@ entry:
   ret i32 %main_ret
 }
 
-define i32 @myAdd(i32 %0, i32 %1) section "fn-$RUSTY$myAdd:i32[i32][i32]" {
+define i32 @myAdd(i32 %0, i32 %1) {
 entry:
   %myAdd = alloca i32, align 4
   %a = alloca i32, align 4
@@ -31,7 +31,7 @@ entry:
   ret i32 %myAdd_ret
 }
 
-define i32 @myConnection(i32 %0) section "fn-$RUSTY$myConnection:i32[i32]" {
+define i32 @myConnection(i32 %0) {
 entry:
   %myConnection = alloca i32, align 4
   %x = alloca i32, align 4

--- a/tests/integration/snapshots/tests__integration__command_line_compile__ir_generation_full_pass.snap
+++ b/tests/integration/snapshots/tests__integration__command_line_compile__ir_generation_full_pass.snap
@@ -2,4 +2,4 @@
 source: tests/integration/command_line_compile.rs
 expression: content
 ---
-define i32 @myFunc(i32 %0, i32 %1, i32 %2) section "fn-$RUSTY$myFunc:i32[i32][i32][i32]" {entry:  %myFunc = alloca i32, align 4  %a = alloca i32, align 4  store i32 %0, i32* %a, align 4  %b = alloca i32, align 4  store i32 %1, i32* %b, align 4  %c = alloca i32, align 4  store i32 %2, i32* %c, align 4  store i32 0, i32* %myFunc, align 4  %myFunc_ret = load i32, i32* %myFunc, align 4  ret i32 %myFunc_ret}
+define i32 @myFunc(i32 %0, i32 %1, i32 %2) {entry:  %myFunc = alloca i32, align 4  %a = alloca i32, align 4  store i32 %0, i32* %a, align 4  %b = alloca i32, align 4  store i32 %1, i32* %b, align 4  %c = alloca i32, align 4  store i32 %2, i32* %c, align 4  store i32 0, i32* %myFunc, align 4  %myFunc_ret = load i32, i32* %myFunc, align 4  ret i32 %myFunc_ret}


### PR DESCRIPTION
This change allows the user to not be burdened by online-change specific behavior when using the compiler in a regular environment. Depends on #1268 as the flag needs to interact with whether or not the custom GOT is generated. Only review the last two commits, as the others are on #1268 