### PR TITLE
fix: generated globals are not duplicates

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -2,6 +2,7 @@
 
 use std::{
     fmt::{Debug, Display, Formatter},
+    hash::Hash,
     ops::Range,
 };
 
@@ -398,13 +399,19 @@ impl Debug for VariableBlock {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct Variable {
     pub name: String,
     pub data_type_declaration: DataTypeDeclaration,
     pub initializer: Option<AstNode>,
     pub address: Option<AstNode>,
     pub location: SourceLocation,
+}
+
+impl PartialEq for Variable {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.location == other.location
+    }
 }
 
 impl Debug for Variable {

--- a/compiler/plc_ast/src/pre_processor.rs
+++ b/compiler/plc_ast/src/pre_processor.rs
@@ -8,7 +8,7 @@ use crate::{
     ast::{
         flatten_expression_list, Assignment, AstFactory, AstNode, AstStatement, CompilationUnit, DataType,
         DataTypeDeclaration, DirectAccessType, HardwareAccess, HardwareAccessType, Operator, Pou,
-        UserTypeDeclaration, Variable, VariableBlockType,
+        UserTypeDeclaration, Variable, VariableBlock, VariableBlockType,
     },
     literals::AstLiteral,
     provider::IdProvider,
@@ -189,20 +189,26 @@ fn process_global_variables(unit: &mut CompilationUnit, id_provider: &mut IdProv
                     data_type_declaration: ref_ty.unwrap_or(global_var.data_type_declaration.clone()),
                     initializer: None,
                     address: None,
-                    location: global_var.location.clone(),
+                    location: node.location.clone(),
                 };
                 mangled_globals.push(internal_mangled_var);
             }
         }
     }
 
-    if let Some(block) =
-        unit.global_vars.iter_mut().find(|block| block.variable_block_type == VariableBlockType::Global)
-    {
-        for new_var in mangled_globals {
-            block.variables.push(new_var);
+    let mut block = if let Some(index) = unit.global_vars.iter().position(|block| {
+        block.variable_block_type == VariableBlockType::Global && block.location.is_internal()
+    }) {
+        unit.global_vars.remove(index)
+    } else {
+        VariableBlock::default().with_block_type(VariableBlockType::Global)
+    };
+    for var in mangled_globals {
+        if !block.variables.contains(&var) {
+            block.variables.push(var);
         }
     }
+    unit.global_vars.push(block);
 }
 
 fn build_enum_initializer(

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -1798,12 +1798,12 @@ fn aliased_hardware_access_variable_creates_global_var_for_address() {
             span: Range(
                 TextLocation {
                     line: 2,
-                    column: 12,
-                    offset: 36,
+                    column: 16,
+                    offset: 40,
                 }..TextLocation {
                     line: 2,
-                    column: 15,
-                    offset: 39,
+                    column: 29,
+                    offset: 53,
                 },
             ),
         },
@@ -1949,12 +1949,12 @@ fn address_used_in_2_aliases_only_created_once() {
                 span: Range(
                     TextLocation {
                         line: 2,
-                        column: 12,
-                        offset: 36,
+                        column: 16,
+                        offset: 40,
                     }..TextLocation {
                         line: 2,
-                        column: 15,
-                        offset: 39,
+                        column: 29,
+                        offset: 53,
                     },
                 ),
             },
@@ -1998,12 +1998,12 @@ fn aliased_variable_with_in_or_out_directions_create_the_same_variable() {
                 span: Range(
                     TextLocation {
                         line: 2,
-                        column: 12,
-                        offset: 36,
+                        column: 16,
+                        offset: 40,
                     }..TextLocation {
                         line: 2,
-                        column: 15,
-                        offset: 39,
+                        column: 29,
+                        offset: 53,
                     },
                 ),
             },
@@ -2029,12 +2029,12 @@ fn aliased_variable_with_in_or_out_directions_create_the_same_variable() {
                 span: Range(
                     TextLocation {
                         line: 4,
-                        column: 12,
-                        offset: 112,
+                        column: 17,
+                        offset: 117,
                     }..TextLocation {
                         line: 4,
-                        column: 16,
-                        offset: 116,
+                        column: 30,
+                        offset: 130,
                     },
                 ),
             },
@@ -2076,12 +2076,12 @@ fn if_two_aliased_var_of_different_types_use_the_same_address_the_first_wins() {
                 span: Range(
                     TextLocation {
                         line: 2,
-                        column: 12,
-                        offset: 36,
+                        column: 16,
+                        offset: 40,
                     }..TextLocation {
                         line: 2,
-                        column: 15,
-                        offset: 39,
+                        column: 29,
+                        offset: 53,
                     },
                 ),
             },

--- a/tests/lit/single/address/hardware_reference_used.st
+++ b/tests/lit/single/address/hardware_reference_used.st
@@ -1,0 +1,20 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+VAR_GLOBAL
+    a AT %IX1.2.1 : BOOL;
+    b AT %QX1.2.2 : BOOL;
+    c AT %ID1.2.3 : DWORD;
+    d AT %ID1.2.4 : DWORD;
+END_VAR
+
+FUNCTION main : DINT
+    __init___hardware_reference_used_st();
+
+    a := TRUE;
+    printf('%u$N', a); //CHECK: 1
+    b := TRUE;
+    printf('%u$N', b); //CHECK: 1
+    c := 1337;
+    printf('%d$N', c); //CHECK: 1337
+    d := 98765;
+    printf('%d$N', d); //CHECK: 98765
+END_FUNCTION


### PR DESCRIPTION
Global addresses are now added to their own section
If a global has already been added, it will not be added again