### PR TITLE
fix: Location of variables declared in VAR_CONFIG

### DIFF
--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -2124,8 +2124,8 @@ fn var_config_hardware_address_creates_global_variable() {
                     offset: 40,
                 }..TextLocation {
                     line: 2,
-                    column: 26,
-                    offset: 50,
+                    column: 23,
+                    offset: 47,
                 },
             ),
         },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1104,7 +1104,7 @@ fn try_parse_config_var(lexer: &mut ParseSession) -> Option<ConfigVariable> {
         lexer.try_consume(&KeywordDot);
     }
 
-    let location = start.span(&lexer.location());
+    let location = start.span(&lexer.last_location());
     if !lexer.try_consume(&KeywordAt) {
         lexer.accept_diagnostic(Diagnostic::missing_token("AT", lexer.location()));
     }

--- a/src/parser/tests/variable_parser_tests.rs
+++ b/src/parser/tests/variable_parser_tests.rs
@@ -304,8 +304,8 @@ fn var_config_test() {
                             offset: 24,
                         }..TextLocation {
                             line: 2,
-                            column: 24,
-                            offset: 40,
+                            column: 21,
+                            offset: 37,
                         },
                     ),
                 },
@@ -351,8 +351,8 @@ fn var_config_test() {
                             offset: 64,
                         }..TextLocation {
                             line: 3,
-                            column: 24,
-                            offset: 80,
+                            column: 21,
+                            offset: 77,
                         },
                     ),
                 },
@@ -364,4 +364,17 @@ fn var_config_test() {
         file_name: "test.st",
     }
     "###);
+}
+
+#[test]
+fn var_config_location() {
+    let src = r#"
+    VAR_CONFIG
+        main.instance.foo AT %IX3.1 : BOOL;
+    END_VAR
+    "#;
+
+    let (result, _) = parse(src);
+
+    assert_eq!("main.instance.foo", &src[result.var_config[0].location.to_range().unwrap()]);
 }


### PR DESCRIPTION
Previously the location of a variable name declared in a `VAR_CONFIG` block would include the `AT` keyword in it. With this commit the `AT` keyword is omitted such that a slice of the variable name is e.g. `main.instance.foo` instead of `main.instance.foo AT`.