### PR TITLE
ci: Bump `upload-artifact` action from v1 to v4

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,7 +91,7 @@ jobs:
           files: lcov.info
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: lcov.info


### PR DESCRIPTION
Fixes an issue in the CI where the coverage action would not run because v1 and v2 of `upload-artifact` have been deprecated. 
See also https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/