### PR TITLE
refactor: Date and commit hash in --version flag

### DIFF
--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plc_driver"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/compiler/plc_driver/build.rs
+++ b/compiler/plc_driver/build.rs
@@ -1,0 +1,16 @@
+use core::str;
+use std::process::Command;
+
+fn main() {
+    let commit_date = Command::new("git").args(&["log", "-1", "--format=%cd"]).output();
+    let commit_hash = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output();
+    let package_version = env!("CARGO_PKG_VERSION");
+
+    if let (Ok(date), Ok(hash)) = (commit_date, commit_hash) {
+        let date_str = str::from_utf8(&date.stdout).expect("invalid stdout output?").trim();
+        let hash_str = str::from_utf8(&hash.stdout).expect("invalid stdout output?").trim();
+
+        let build_info = format!("{package_version} ({date_str}, {hash_str})");
+        println!("cargo:rustc-env=RUSTY_BUILD_INFO={build_info}");
+    }
+}

--- a/compiler/plc_driver/build.rs
+++ b/compiler/plc_driver/build.rs
@@ -2,8 +2,8 @@ use core::str;
 use std::process::Command;
 
 fn main() {
-    let commit_date = Command::new("git").args(&["log", "-1", "--format=%cd"]).output();
-    let commit_hash = Command::new("git").args(&["rev-parse", "--short", "HEAD"]).output();
+    let commit_date = Command::new("git").args(["log", "-1", "--format=%cd"]).output();
+    let commit_hash = Command::new("git").args(["rev-parse", "--short", "HEAD"]).output();
     let package_version = env!("CARGO_PKG_VERSION");
 
     if let (Ok(date), Ok(hash)) = (commit_date, commit_hash) {

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -13,9 +13,7 @@ pub type ParameterError = clap::Error;
 #[clap(
     group = ArgGroup::new("format"),
     about = "IEC61131-3 Structured Text compiler powered by Rust & LLVM ",
-    version,
 )]
-#[clap(propagate_version = true)]
 #[clap(subcommand_negates_reqs = true)]
 #[clap(subcommand_precedence_over_arg = true)]
 pub struct CompileParameters {
@@ -29,6 +27,9 @@ pub struct CompileParameters {
         help = "Emit AST (Abstract Syntax Tree) as output"
     )]
     pub output_ast: bool,
+
+    #[clap(long = "version", group = "format", global = true)]
+    pub build_info: bool,
 
     #[clap(
         long = "ir",
@@ -79,7 +80,7 @@ pub struct CompileParameters {
     #[clap(
         name = "input-files",
         help = "Read input from <input-files>, may be a glob expression like 'src/**/*' or a sequence of files",
-        required = true,
+        // required = true,
         min_values = 1
     )]
     // having a vec allows bash to resolve *.st itself

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -495,14 +495,6 @@ mod cli_tests {
     }
 
     #[test]
-    fn missing_parameters_results_in_error() {
-        // no arguments
-        expect_argument_error(vec_of_strings![], ErrorKind::MissingRequiredArgument);
-        // no input file
-        expect_argument_error(vec_of_strings!["--ir"], ErrorKind::MissingRequiredArgument);
-    }
-
-    #[test]
     fn multiple_output_formats_results_in_error() {
         expect_argument_error(vec_of_strings!["input.st", "--ir", "--shared"], ErrorKind::ArgumentConflict);
         expect_argument_error(
@@ -743,8 +735,8 @@ mod cli_tests {
     #[test]
     fn cli_supports_version() {
         match CompileParameters::parse(vec_of_strings!("input.st", "--version")) {
-            Ok(_) => panic!("expected version output, but found OK"),
-            Err(e) => assert_eq!(e.kind(), ErrorKind::DisplayVersion),
+            Ok(version) => assert!(version.build_info),
+            _ => panic!("expected the build info flag to be true"),
         }
     }
 

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -208,7 +208,7 @@ pub fn compile_with_options(compile_options: CompilationContext) -> Result<()> {
     }
 
     if compile_parameters.build_info {
-        println!("{}", std::env::var("RUSTY_BUILD_INFO").unwrap_or(String::from("UNKNOWN")));
+        println!("{}", option_env!("RUSTY_BUILD_INFO").unwrap_or("version information unavailable"));
         std::process::exit(0);
     }
 

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -207,6 +207,11 @@ pub fn compile_with_options(compile_options: CompilationContext) -> Result<()> {
         return print_config_options(&project, &diagnostician, options);
     }
 
+    if compile_parameters.build_info {
+        println!("{}", std::env::var("RUSTY_BUILD_INFO").unwrap_or(String::from("UNKNOWN")));
+        std::process::exit(0);
+    }
+
     if let Some(SubCommands::Explain { error }) = &compile_parameters.commands {
         //Explain the given error
         println!("{}", diagnostician.explain(error));


### PR DESCRIPTION
The `--version` flag now emits the date and hash of the latest commit in addition to the package version as specified in the `Cargo.toml` file.
