### PR TITLE
fix: Debug locations of CASE statement

### DIFF
--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -533,9 +533,6 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
         self.register_debug_location(selector);
         builder.build_switch(selector_statement.into_int_value(), else_block, &cases);
 
-        // TODO: Not entirely sure if we have to register the debug location of every node in the else-body
-        // or some callee takes care of this...
-
         builder.position_at_end(continue_block);
         Ok(())
     }

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -484,7 +484,6 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
 
         let basic_block = builder.get_insert_block().expect(INTERNAL_LLVM_ERROR);
         let exp_gen = self.create_expr_generator();
-        self.register_debug_location(selector);
         let selector_statement = exp_gen.generate_expression(selector)?;
 
         let mut cases = Vec::new();
@@ -530,7 +529,12 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
 
         // now that we collected all cases, go back to the initial block and generate the switch-statement
         builder.position_at_end(basic_block);
+
+        self.register_debug_location(selector);
         builder.build_switch(selector_statement.into_int_value(), else_block, &cases);
+
+        // TODO: Not entirely sure if we have to register the debug location of every node in the else-body
+        // or some callee takes care of this...
 
         builder.position_at_end(continue_block);
         Ok(())

--- a/src/codegen/tests/debug_tests.rs
+++ b/src/codegen/tests/debug_tests.rs
@@ -186,3 +186,157 @@ fn test_dwarf_version_override() {
 
     assert_snapshot!(codegen)
 }
+
+#[test]
+fn switch_case_debug_info() {
+    let codegen = codegen_with_debug_version(
+        r#"
+        FUNCTION main : DINT
+            VAR
+                x1 : INT;
+                x2 : INT;
+                x3 : INT;
+            END_VAR
+            
+            WHILE TRUE DO
+            x1 := x1 + 1;
+
+            CASE x1 OF
+                1: x2 := 1;
+                2: x2 := 2;
+                3: x2 := 3;
+                ELSE
+                    x1 := 0;
+                    x2 := 1;
+                    x3 := 2;
+            END_CASE
+
+            END_WHILE
+
+        END_FUNCTION
+        "#,
+        4,
+    );
+
+    assert_snapshot!(codegen, @r###"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+
+    define i32 @main() section "fn-$RUSTY$main:i32" !dbg !4 {
+    entry:
+      %main = alloca i32, align 4, !dbg !9
+      %x1 = alloca i16, align 2, !dbg !9
+      %x2 = alloca i16, align 2, !dbg !9
+      %x3 = alloca i16, align 2, !dbg !9
+      call void @llvm.dbg.declare(metadata i16* %x1, metadata !10, metadata !DIExpression()), !dbg !12
+      store i16 0, i16* %x1, align 2, !dbg !9
+      call void @llvm.dbg.declare(metadata i16* %x2, metadata !13, metadata !DIExpression()), !dbg !14
+      store i16 0, i16* %x2, align 2, !dbg !9
+      call void @llvm.dbg.declare(metadata i16* %x3, metadata !15, metadata !DIExpression()), !dbg !16
+      store i16 0, i16* %x3, align 2, !dbg !9
+      call void @llvm.dbg.declare(metadata i32* %main, metadata !17, metadata !DIExpression()), !dbg !19
+      store i32 0, i32* %main, align 4, !dbg !9
+      br label %condition_check, !dbg !20
+
+    condition_check:                                  ; preds = %entry, %continue1
+      br i1 true, label %while_body, label %continue, !dbg !21
+
+    while_body:                                       ; preds = %condition_check
+      %load_x1 = load i16, i16* %x1, align 2, !dbg !22
+      %0 = sext i16 %load_x1 to i32, !dbg !22
+      %tmpVar = add i32 %0, 1, !dbg !22
+      %1 = trunc i32 %tmpVar to i16, !dbg !22
+      store i16 %1, i16* %x1, align 2, !dbg !22
+      %load_x12 = load i16, i16* %x1, align 2, !dbg !22
+      switch i16 %load_x12, label %else [
+        i16 1, label %case
+        i16 2, label %case3
+        i16 3, label %case4
+      ], !dbg !20
+
+    continue:                                         ; preds = %condition_check
+      %main_ret = load i32, i32* %main, align 4, !dbg !20
+      ret i32 %main_ret, !dbg !20
+
+    case:                                             ; preds = %while_body
+      store i16 1, i16* %x2, align 2, !dbg !23
+      br label %continue1, !dbg !23
+
+    case3:                                            ; preds = %while_body
+      store i16 2, i16* %x2, align 2, !dbg !24
+      br label %continue1, !dbg !24
+
+    case4:                                            ; preds = %while_body
+      store i16 3, i16* %x2, align 2, !dbg !25
+      br label %continue1, !dbg !25
+
+    else:                                             ; preds = %while_body
+      store i16 0, i16* %x1, align 2, !dbg !26
+      store i16 1, i16* %x2, align 2, !dbg !27
+      store i16 2, i16* %x3, align 2, !dbg !28
+      br label %continue1, !dbg !28
+
+    continue1:                                        ; preds = %else, %case4, %case3, %case
+      br label %condition_check, !dbg !20
+    }
+
+    ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+    declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+    attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
+
+    !llvm.module.flags = !{!0, !1}
+    !llvm.dbg.cu = !{!2}
+
+    !0 = !{i32 2, !"Dwarf Version", i32 4}
+    !1 = !{i32 2, !"Debug Info Version", i32 3}
+    !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+    !3 = !DIFile(filename: "<internal>", directory: "src")
+    !4 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !5, file: !5, line: 2, type: !6, scopeLine: 9, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !8)
+    !5 = !DIFile(filename: "<internal>", directory: "")
+    !6 = !DISubroutineType(flags: DIFlagPublic, types: !7)
+    !7 = !{null}
+    !8 = !{}
+    !9 = !DILocation(line: 9, column: 12, scope: !4)
+    !10 = !DILocalVariable(name: "x1", scope: !4, file: !5, line: 4, type: !11, align: 16)
+    !11 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !12 = !DILocation(line: 4, column: 16, scope: !4)
+    !13 = !DILocalVariable(name: "x2", scope: !4, file: !5, line: 5, type: !11, align: 16)
+    !14 = !DILocation(line: 5, column: 16, scope: !4)
+    !15 = !DILocalVariable(name: "x3", scope: !4, file: !5, line: 6, type: !11, align: 16)
+    !16 = !DILocation(line: 6, column: 16, scope: !4)
+    !17 = !DILocalVariable(name: "main", scope: !4, file: !5, line: 2, type: !18, align: 32)
+    !18 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !19 = !DILocation(line: 2, column: 17, scope: !4)
+    !20 = !DILocation(line: 12, column: 17, scope: !4)
+    !21 = !DILocation(line: 9, column: 18, scope: !4)
+    !22 = !DILocation(line: 10, column: 12, scope: !4)
+    !23 = !DILocation(line: 13, column: 19, scope: !4)
+    !24 = !DILocation(line: 14, column: 19, scope: !4)
+    !25 = !DILocation(line: 15, column: 19, scope: !4)
+    !26 = !DILocation(line: 17, column: 20, scope: !4)
+    !27 = !DILocation(line: 18, column: 20, scope: !4)
+    !28 = !DILocation(line: 19, column: 20, scope: !4)
+    ; ModuleID = '__init___testproject'
+    source_filename = "__init___testproject"
+
+    define void @__init___testproject() section "fn-$RUSTY$__init___testproject:v" !dbg !4 {
+    entry:
+      ret void, !dbg !9
+    }
+
+    !llvm.module.flags = !{!0, !1}
+    !llvm.dbg.cu = !{!2}
+
+    !0 = !{i32 2, !"Dwarf Version", i32 4}
+    !1 = !{i32 2, !"Debug Info Version", i32 3}
+    !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+    !3 = !DIFile(filename: "__init___testproject", directory: "src")
+    !4 = distinct !DISubprogram(name: "__init___testproject", linkageName: "__init___testproject", scope: !5, file: !5, type: !6, scopeLine: 1, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !8)
+    !5 = !DIFile(filename: "<internal>", directory: "")
+    !6 = !DISubroutineType(flags: DIFlagPublic, types: !7)
+    !7 = !{null}
+    !8 = !{}
+    !9 = !DILocation(line: 0, scope: !4)
+    "###);
+}

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
@@ -10,23 +10,23 @@ entry:
   %myFunc = alloca i32, align 4, !dbg !9
   call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !10, metadata !DIExpression()), !dbg !12
   store i32 0, i32* %myFunc, align 4, !dbg !9
-  %load_myFunc = load i32, i32* %myFunc, align 4, !dbg !13
+  %load_myFunc = load i32, i32* %myFunc, align 4, !dbg !9
   switch i32 %load_myFunc, label %else [
     i32 1, label %case
     i32 2, label %case1
-  ], !dbg !14
+  ], !dbg !13
 
 case:                                             ; preds = %entry
+  store i32 1, i32* %myFunc, align 4, !dbg !14
+  br label %continue, !dbg !14
+
+case1:                                            ; preds = %entry
   store i32 1, i32* %myFunc, align 4, !dbg !15
   br label %continue, !dbg !15
 
-case1:                                            ; preds = %entry
+else:                                             ; preds = %entry
   store i32 1, i32* %myFunc, align 4, !dbg !16
   br label %continue, !dbg !16
-
-else:                                             ; preds = %entry
-  store i32 1, i32* %myFunc, align 4, !dbg !14
-  br label %continue, !dbg !14
 
 continue:                                         ; preds = %else, %case1, %case
   store i32 1, i32* %myFunc, align 4, !dbg !17
@@ -56,9 +56,9 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !11 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !12 = !DILocation(line: 2, column: 17, scope: !4)
 !13 = !DILocation(line: 3, column: 17, scope: !4)
-!14 = !DILocation(line: 9, column: 16, scope: !4)
-!15 = !DILocation(line: 5, column: 16, scope: !4)
-!16 = !DILocation(line: 7, column: 16, scope: !4)
+!14 = !DILocation(line: 5, column: 16, scope: !4)
+!15 = !DILocation(line: 7, column: 16, scope: !4)
+!16 = !DILocation(line: 9, column: 16, scope: !4)
 !17 = !DILocation(line: 11, column: 12, scope: !4)
 ; ModuleID = '__init___testproject'
 source_filename = "__init___testproject"


### PR DESCRIPTION
Fixes the debug locations line number, where previously the `switch ...` instruction would have a line number of the last case element.