### PR TITLE
docs:  add documentation for pointer initializers

### DIFF
--- a/book/src/variables.md
+++ b/book/src/variables.md
@@ -60,31 +60,58 @@ END_PROGRAM
 
 ### Pointer Initialization
 
-A pointer variable can be initialized with an address of a global reference or an IEC-address by using the `AT` or `REFERENCE TO` syntax. `REF_TO` pointers can be initialized by using the builtin `REF` function in it's initializer.
-This initialization, however, does not take place during compiletime. Instead, each pointer initialized with an address will be zero-initialized with a null-pointer by default. The compiler collects all pointer-initializations during compilation and then creates internal initializer functions for each POU. These are then called in a single overarching project-initialization function, which in turn can be called either manually in your main function or by the runtime.
-This function has a naming scheme (`__init___<project name>`) which changes slightly depending on whether or not a build config (`plc.json`) was used or not.
+A pointer variable can be initialized with the address of a global reference or an IEC-address using the `AT` or `REFERENCE TO` syntax. `REF_TO` pointers can be initialized using the built-in `REF` function in its initializer.
 
-- when using a build config (`plc.json`), the project name is used:
+This initialization, however, does not take place during compile time. Instead, each pointer initialized with an address will be zero-initialized to a null pointer by default. The compiler collects all pointer initializations during compilation and creates internal initializer functions for each POU. These functions are then called in a single overarching project-initialization function, which can be called either manually in your main function or by the runtime. Additionally, global variables — whether they are initialized pointers or POU instances containing pointer initializers — are also assigned within this overarching function.
 
-    _build config snippet:_
+This function follows a naming scheme (`__init___<project name>`) that varies slightly depending on whether a build config (`plc.json`) was used.
+
+- **When using a build config (`plc.json`)**, the project name is used:
+
+    _Build config snippet:_
     ```json
     {
         "name": "myProject",
-        "files" : [],
+        "files": []
     }
     ```
-    _resulting symbol:_
+    _Resulting symbol:_
     ```iecst
         __init___myProject()
     ```
-- when compiling without a build config, the name of the first file passed via CLI is chosen to base the name off of.
-    
+
+- **When compiling without a build config**, the name of the first file passed via CLI is used as the base for the name.
+
     _CLI command:_
     ```bash
         # build command
         plc myFile1.st myFile2.st
     ```
-    _resulting symbol:_
+    _Resulting symbol:_
     ```iecst
         __init___myFile1_st()
     ```
+
+It is important to note that if there are pointer initializations present in your project, failing to call the initialization function in your runtime or in `main` will result in **null pointer dereferences** at runtime.
+
+### Example
+_myProject.st_:
+```iecst
+VAR_GLOBAL
+    myGlobal : STRING;
+END_VAR
+
+PROGRAM prog
+VAR
+    myString : REF_TO STRING := REF(myGlobal);
+    myOtherString : REFERENCE TO STRING REF= myGlobal;
+    myAlias AT myGlobal: STRING;
+    myAnalogSignal AT %IX1.0 : REAL;
+END_VAR
+    // ...
+END_PROGRAM
+
+FUNCTION main: DINT
+    __init___myProject_st();
+    prog();
+END_FUNCTION

--- a/book/src/variables.md
+++ b/book/src/variables.md
@@ -62,7 +62,7 @@ END_PROGRAM
 
 A pointer variable can be initialized with the address of a global reference or an IEC-address using the `AT` or `REFERENCE TO` syntax. `REF_TO` pointers can be initialized using the built-in `REF` function in its initializer.
 
-This initialization, however, does not take place during compile time. Instead, each pointer initialized with an address will be zero-initialized to a null pointer by default. The compiler collects all pointer initializations during compilation and creates internal initializer functions for each POU. These functions are then called in a single overarching project-initialization function, which can be called either manually in your main function or by the runtime. Additionally, global variables — whether they are initialized pointers or POU instances containing pointer initializers — are also assigned within this overarching function.
+This initialization, however, does not take place during compile time. Instead, each pointer initialized with an address will be zero-initialized to a null pointer by default. The compiler collects all pointer initializations during compilation and creates internal initializer functions for each POU. These functions are then called in a single overarching project-initialization function, which can be called either manually in your main function or by a runtime. Additionally, global variables — whether they are initialized pointers or POU instances containing pointer initializers — are also assigned within this overarching function.
 
 This function follows a naming scheme (`__init___<project name>`) that varies slightly depending on whether a build config (`plc.json`) was used.
 

--- a/book/src/variables.md
+++ b/book/src/variables.md
@@ -57,3 +57,34 @@ PROGRAM PLC_PRG
     ...
 END_PROGRAM
 ```
+
+### Pointer Initialization
+
+A pointer variable can be initialized with an address of a global reference or an IEC-address by using the `AT` or `REFERENCE TO` syntax. `REF_TO` pointers can be initialized by using the builtin `REF` function in it's initializer.
+This initialization, however, does not take place during compiletime. Instead, each pointer initialized with an address will be zero-initialized with a null-pointer by default. The compiler collects all pointer-initializations during compilation and then creates internal initializer functions for each POU. These are then called in a single overarching project-initialization function, which in turn can be called either manually in your main function or by the runtime.
+This function has a naming scheme (`__init___<project name>`) which changes slightly depending on whether or not a build config (`plc.json`) was used or not.
+
+- when using a build config (`plc.json`), the project name is used:
+
+    _build config snippet:_
+    ```json
+    {
+        "name": "myProject",
+        "files" : [],
+    }
+    ```
+    _resulting symbol:_
+    ```iecst
+        __init___myProject()
+    ```
+- when compiling without a build config, the name of the first file passed via CLI is chosen to base the name off of.
+    
+    _CLI command:_
+    ```bash
+        # build command
+        plc myFile1.st myFile2.st
+    ```
+    _resulting symbol:_
+    ```iecst
+        __init___myFile1_st()
+    ```


### PR DESCRIPTION
Adds a new section to the `variables.md` section of our book, explaining how and why projects with pointer-initializers need to call the generated `__init___<project name>` function.