### PR TITLE
test: add alias to run `cargo t --workspace` on a single thread

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,7 @@
 xtask = "run --release --package xtask --"
 metrics = "run --release --package xtask -- metrics"
 metrics-sql = "run --release --package xtask --features=sql -- metrics"
+tw1 = "test --workspace -- --test-threads=1"
 
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]


### PR DESCRIPTION
Sometimes running `cargo t --workspace` can result in a lock-up of the machine it is being run on, which is a big problem when working remotely via ssh, since the only way to get your machine back to a working state is a soft-reset. This commit provides a convenient alias to run workspace tests on a single thread.