### PR TITLE
tests: Add "C-unwind" to extern functions that can panic

### DIFF
--- a/libs/stdlib/src/date_time_numeric_functions.rs
+++ b/libs/stdlib/src/date_time_numeric_functions.rs
@@ -6,7 +6,7 @@ use chrono::TimeZone;
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn ADD_TIME(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn ADD_TIME(in1: i64, in2: i64) -> i64 {
     chrono::Duration::nanoseconds(in1)
         .checked_add(&chrono::Duration::nanoseconds(in2))
         .unwrap()
@@ -20,7 +20,7 @@ pub extern "C" fn ADD_TIME(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn ADD_TOD_TIME(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn ADD_TOD_TIME(in1: i64, in2: i64) -> i64 {
     add_datetime_time(in1, in2)
 }
 
@@ -30,7 +30,7 @@ pub extern "C" fn ADD_TOD_TIME(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn ADD_DT_TIME(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn ADD_DT_TIME(in1: i64, in2: i64) -> i64 {
     add_datetime_time(in1, in2)
 }
 
@@ -49,7 +49,7 @@ fn add_datetime_time(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn SUB_TIME(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn SUB_TIME(in1: i64, in2: i64) -> i64 {
     chrono::Duration::nanoseconds(in1)
         .checked_sub(&chrono::Duration::nanoseconds(in2))
         .unwrap()
@@ -63,7 +63,7 @@ pub extern "C" fn SUB_TIME(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn SUB_DATE_DATE(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn SUB_DATE_DATE(in1: i64, in2: i64) -> i64 {
     sub_datetimes(in1, in2)
 }
 
@@ -73,7 +73,7 @@ pub extern "C" fn SUB_DATE_DATE(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn SUB_TOD_TIME(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn SUB_TOD_TIME(in1: i64, in2: i64) -> i64 {
     sub_datetime_duration(in1, in2)
 }
 
@@ -83,7 +83,7 @@ pub extern "C" fn SUB_TOD_TIME(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn SUB_TOD_TOD(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn SUB_TOD_TOD(in1: i64, in2: i64) -> i64 {
     sub_datetimes(in1, in2)
 }
 
@@ -101,7 +101,7 @@ fn sub_datetimes(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn SUB_DT_TIME(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn SUB_DT_TIME(in1: i64, in2: i64) -> i64 {
     sub_datetime_duration(in1, in2)
 }
 
@@ -120,7 +120,7 @@ fn sub_datetime_duration(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn SUB_DT_DT(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn SUB_DT_DT(in1: i64, in2: i64) -> i64 {
     sub_datetimes(in1, in2)
 }
 
@@ -130,7 +130,7 @@ pub extern "C" fn SUB_DT_DT(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__SINT(in1: i64, in2: i8) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__SINT(in1: i64, in2: i8) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -140,7 +140,7 @@ pub extern "C" fn MUL__TIME__SINT(in1: i64, in2: i8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__INT(in1: i64, in2: i16) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__INT(in1: i64, in2: i16) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -150,7 +150,7 @@ pub extern "C" fn MUL__TIME__INT(in1: i64, in2: i16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__DINT(in1: i64, in2: i32) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__DINT(in1: i64, in2: i32) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -160,7 +160,7 @@ pub extern "C" fn MUL__TIME__DINT(in1: i64, in2: i32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__LINT(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__LINT(in1: i64, in2: i64) -> i64 {
     checked_mul_time_with_signed_int(in1, in2)
 }
 
@@ -170,7 +170,7 @@ pub extern "C" fn MUL__TIME__LINT(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__SINT(in1: i64, in2: i8) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__SINT(in1: i64, in2: i8) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -180,7 +180,7 @@ pub extern "C" fn MUL_TIME__SINT(in1: i64, in2: i8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__INT(in1: i64, in2: i16) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__INT(in1: i64, in2: i16) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -190,7 +190,7 @@ pub extern "C" fn MUL_TIME__INT(in1: i64, in2: i16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__DINT(in1: i64, in2: i32) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__DINT(in1: i64, in2: i32) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -200,7 +200,7 @@ pub extern "C" fn MUL_TIME__DINT(in1: i64, in2: i32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__LINT(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__LINT(in1: i64, in2: i64) -> i64 {
     checked_mul_time_with_signed_int(in1, in2)
 }
 
@@ -210,7 +210,7 @@ pub extern "C" fn MUL_TIME__LINT(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__SINT(in1: i64, in2: i8) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__SINT(in1: i64, in2: i8) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -220,7 +220,7 @@ pub extern "C" fn MUL_LTIME__SINT(in1: i64, in2: i8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__INT(in1: i64, in2: i16) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__INT(in1: i64, in2: i16) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -230,7 +230,7 @@ pub extern "C" fn MUL_LTIME__INT(in1: i64, in2: i16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__DINT(in1: i64, in2: i32) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__DINT(in1: i64, in2: i32) -> i64 {
     checked_mul_time_with_signed_int(in1, in2.into())
 }
 
@@ -240,7 +240,7 @@ pub extern "C" fn MUL_LTIME__DINT(in1: i64, in2: i32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__LINT(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__LINT(in1: i64, in2: i64) -> i64 {
     checked_mul_time_with_signed_int(in1, in2)
 }
 
@@ -258,7 +258,7 @@ fn checked_mul_time_with_signed_int(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__USINT(in1: i64, in2: u8) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__USINT(in1: i64, in2: u8) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -268,7 +268,7 @@ pub extern "C" fn MUL__TIME__USINT(in1: i64, in2: u8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__UINT(in1: i64, in2: u16) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__UINT(in1: i64, in2: u16) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -278,7 +278,7 @@ pub extern "C" fn MUL__TIME__UINT(in1: i64, in2: u16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__UDINT(in1: i64, in2: u32) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__UDINT(in1: i64, in2: u32) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -288,7 +288,7 @@ pub extern "C" fn MUL__TIME__UDINT(in1: i64, in2: u32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__ULINT(in1: i64, in2: u64) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__ULINT(in1: i64, in2: u64) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2)
 }
 
@@ -298,7 +298,7 @@ pub extern "C" fn MUL__TIME__ULINT(in1: i64, in2: u64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__USINT(in1: i64, in2: u8) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__USINT(in1: i64, in2: u8) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -308,7 +308,7 @@ pub extern "C" fn MUL_TIME__USINT(in1: i64, in2: u8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__UINT(in1: i64, in2: u16) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__UINT(in1: i64, in2: u16) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -318,7 +318,7 @@ pub extern "C" fn MUL_TIME__UINT(in1: i64, in2: u16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__UDINT(in1: i64, in2: u32) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__UDINT(in1: i64, in2: u32) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -328,7 +328,7 @@ pub extern "C" fn MUL_TIME__UDINT(in1: i64, in2: u32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__ULINT(in1: i64, in2: u64) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__ULINT(in1: i64, in2: u64) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2)
 }
 
@@ -338,7 +338,7 @@ pub extern "C" fn MUL_TIME__ULINT(in1: i64, in2: u64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__USINT(in1: i64, in2: u8) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__USINT(in1: i64, in2: u8) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -348,7 +348,7 @@ pub extern "C" fn MUL_LTIME__USINT(in1: i64, in2: u8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__UINT(in1: i64, in2: u16) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__UINT(in1: i64, in2: u16) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -358,7 +358,7 @@ pub extern "C" fn MUL_LTIME__UINT(in1: i64, in2: u16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2.into())
 }
 
@@ -368,7 +368,7 @@ pub extern "C" fn MUL_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
     checked_mul_time_with_unsigned_int(in1, in2)
 }
 
@@ -388,7 +388,7 @@ fn checked_mul_time_with_unsigned_int(in1: i64, in2: u64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__SINT(in1: i64, in2: i8) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__SINT(in1: i64, in2: i8) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -398,7 +398,7 @@ pub extern "C" fn DIV__TIME__SINT(in1: i64, in2: i8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__INT(in1: i64, in2: i16) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__INT(in1: i64, in2: i16) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -408,7 +408,7 @@ pub extern "C" fn DIV__TIME__INT(in1: i64, in2: i16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__DINT(in1: i64, in2: i32) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__DINT(in1: i64, in2: i32) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -418,7 +418,7 @@ pub extern "C" fn DIV__TIME__DINT(in1: i64, in2: i32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__LINT(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__LINT(in1: i64, in2: i64) -> i64 {
     checked_div_time_by_signed_int(in1, in2)
 }
 
@@ -428,7 +428,7 @@ pub extern "C" fn DIV__TIME__LINT(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__SINT(in1: i64, in2: i8) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__SINT(in1: i64, in2: i8) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -438,7 +438,7 @@ pub extern "C" fn DIV_TIME__SINT(in1: i64, in2: i8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__INT(in1: i64, in2: i16) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__INT(in1: i64, in2: i16) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -448,7 +448,7 @@ pub extern "C" fn DIV_TIME__INT(in1: i64, in2: i16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__DINT(in1: i64, in2: i32) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__DINT(in1: i64, in2: i32) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -458,7 +458,7 @@ pub extern "C" fn DIV_TIME__DINT(in1: i64, in2: i32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__LINT(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__LINT(in1: i64, in2: i64) -> i64 {
     checked_div_time_by_signed_int(in1, in2)
 }
 
@@ -468,7 +468,7 @@ pub extern "C" fn DIV_TIME__LINT(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__SINT(in1: i64, in2: i8) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__SINT(in1: i64, in2: i8) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -478,7 +478,7 @@ pub extern "C" fn DIV_LTIME__SINT(in1: i64, in2: i8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__INT(in1: i64, in2: i16) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__INT(in1: i64, in2: i16) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -488,7 +488,7 @@ pub extern "C" fn DIV_LTIME__INT(in1: i64, in2: i16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__DINT(in1: i64, in2: i32) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__DINT(in1: i64, in2: i32) -> i64 {
     checked_div_time_by_signed_int(in1, in2.into())
 }
 
@@ -498,7 +498,7 @@ pub extern "C" fn DIV_LTIME__DINT(in1: i64, in2: i32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__LINT(in1: i64, in2: i64) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__LINT(in1: i64, in2: i64) -> i64 {
     checked_div_time_by_signed_int(in1, in2)
 }
 
@@ -516,7 +516,7 @@ fn checked_div_time_by_signed_int(in1: i64, in2: i64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__USINT(in1: i64, in2: u8) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__USINT(in1: i64, in2: u8) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -526,7 +526,7 @@ pub extern "C" fn DIV__TIME__USINT(in1: i64, in2: u8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__UINT(in1: i64, in2: u16) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__UINT(in1: i64, in2: u16) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -536,7 +536,7 @@ pub extern "C" fn DIV__TIME__UINT(in1: i64, in2: u16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__UDINT(in1: i64, in2: u32) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__UDINT(in1: i64, in2: u32) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -546,7 +546,7 @@ pub extern "C" fn DIV__TIME__UDINT(in1: i64, in2: u32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__ULINT(in1: i64, in2: u64) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__ULINT(in1: i64, in2: u64) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2)
 }
 
@@ -556,7 +556,7 @@ pub extern "C" fn DIV__TIME__ULINT(in1: i64, in2: u64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__USINT(in1: i64, in2: u8) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__USINT(in1: i64, in2: u8) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -566,7 +566,7 @@ pub extern "C" fn DIV_TIME__USINT(in1: i64, in2: u8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__UINT(in1: i64, in2: u16) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__UINT(in1: i64, in2: u16) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -576,7 +576,7 @@ pub extern "C" fn DIV_TIME__UINT(in1: i64, in2: u16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__UDINT(in1: i64, in2: u32) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__UDINT(in1: i64, in2: u32) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -586,7 +586,7 @@ pub extern "C" fn DIV_TIME__UDINT(in1: i64, in2: u32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__ULINT(in1: i64, in2: u64) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__ULINT(in1: i64, in2: u64) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2)
 }
 
@@ -596,7 +596,7 @@ pub extern "C" fn DIV_TIME__ULINT(in1: i64, in2: u64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__USINT(in1: i64, in2: u8) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__USINT(in1: i64, in2: u8) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -606,7 +606,7 @@ pub extern "C" fn DIV_LTIME__USINT(in1: i64, in2: u8) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__UINT(in1: i64, in2: u16) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__UINT(in1: i64, in2: u16) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -616,7 +616,7 @@ pub extern "C" fn DIV_LTIME__UINT(in1: i64, in2: u16) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2.into())
 }
 
@@ -626,7 +626,7 @@ pub extern "C" fn DIV_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
     checked_div_time_by_unsigned_int(in1, in2)
 }
 
@@ -646,7 +646,7 @@ fn checked_div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__REAL(in1: i64, in2: f32) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__REAL(in1: i64, in2: f32) -> i64 {
     checked_mul_time_with_f32(in1, in2)
 }
 
@@ -656,7 +656,7 @@ pub extern "C" fn MUL__TIME__REAL(in1: i64, in2: f32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__REAL(in1: i64, in2: f32) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__REAL(in1: i64, in2: f32) -> i64 {
     checked_mul_time_with_f32(in1, in2)
 }
 
@@ -666,7 +666,7 @@ pub extern "C" fn MUL_TIME__REAL(in1: i64, in2: f32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__REAL(in1: i64, in2: f32) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__REAL(in1: i64, in2: f32) -> i64 {
     checked_mul_time_with_f32(in1, in2)
 }
 
@@ -694,7 +694,7 @@ fn checked_mul_time_with_f32(in1: i64, in2: f32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL__TIME__LREAL(in1: i64, in2: f64) -> i64 {
+pub extern "C-unwind" fn MUL__TIME__LREAL(in1: i64, in2: f64) -> i64 {
     checked_mul_time_with_f64(in1, in2)
 }
 
@@ -704,7 +704,7 @@ pub extern "C" fn MUL__TIME__LREAL(in1: i64, in2: f64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_TIME__LREAL(in1: i64, in2: f64) -> i64 {
+pub extern "C-unwind" fn MUL_TIME__LREAL(in1: i64, in2: f64) -> i64 {
     checked_mul_time_with_f64(in1, in2)
 }
 
@@ -714,7 +714,7 @@ pub extern "C" fn MUL_TIME__LREAL(in1: i64, in2: f64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn MUL_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
+pub extern "C-unwind" fn MUL_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
     checked_mul_time_with_f64(in1, in2)
 }
 
@@ -742,7 +742,7 @@ fn checked_mul_time_with_f64(in1: i64, in2: f64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__REAL(in1: i64, in2: f32) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__REAL(in1: i64, in2: f32) -> i64 {
     checked_div_time_by_f32(in1, in2)
 }
 
@@ -752,7 +752,7 @@ pub extern "C" fn DIV__TIME__REAL(in1: i64, in2: f32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__REAL(in1: i64, in2: f32) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__REAL(in1: i64, in2: f32) -> i64 {
     checked_div_time_by_f32(in1, in2)
 }
 
@@ -762,7 +762,7 @@ pub extern "C" fn DIV_TIME__REAL(in1: i64, in2: f32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__REAL(in1: i64, in2: f32) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__REAL(in1: i64, in2: f32) -> i64 {
     checked_div_time_by_f32(in1, in2)
 }
 
@@ -790,7 +790,7 @@ fn checked_div_time_by_f32(in1: i64, in2: f32) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV__TIME__LREAL(in1: i64, in2: f64) -> i64 {
+pub extern "C-unwind" fn DIV__TIME__LREAL(in1: i64, in2: f64) -> i64 {
     checked_div_time_by_f64(in1, in2)
 }
 
@@ -800,7 +800,7 @@ pub extern "C" fn DIV__TIME__LREAL(in1: i64, in2: f64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_TIME__LREAL(in1: i64, in2: f64) -> i64 {
+pub extern "C-unwind" fn DIV_TIME__LREAL(in1: i64, in2: f64) -> i64 {
     checked_div_time_by_f64(in1, in2)
 }
 
@@ -810,7 +810,7 @@ pub extern "C" fn DIV_TIME__LREAL(in1: i64, in2: f64) -> i64 {
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "C" fn DIV_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
+pub extern "C-unwind" fn DIV_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
     checked_div_time_by_f64(in1, in2)
 }
 

--- a/libs/stdlib/src/extra_functions.rs
+++ b/libs/stdlib/src/extra_functions.rs
@@ -113,7 +113,7 @@ where
 /// Uses raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn STRING_TO_LINT(src: *const u8) -> i64 {
+pub unsafe extern "C-unwind" fn STRING_TO_LINT(src: *const u8) -> i64 {
     string_to_int(src)
 }
 
@@ -146,7 +146,7 @@ where
 /// Uses raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn STRING_TO_LREAL(src: *const u8) -> f64 {
+pub unsafe extern "C-unwind" fn STRING_TO_LREAL(src: *const u8) -> f64 {
     string_to_float(src)
 }
 
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn STRING_TO_LREAL(src: *const u8) -> f64 {
 /// Uses raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn STRING_TO_REAL(src: *const u8) -> f32 {
+pub unsafe extern "C-unwind" fn STRING_TO_REAL(src: *const u8) -> f32 {
     string_to_float(src)
 }
 

--- a/libs/stdlib/src/string_functions.rs
+++ b/libs/stdlib/src/string_functions.rs
@@ -219,7 +219,7 @@ pub unsafe extern "C" fn FIND__WSTRING(src1: *const u16, src2: *const u16) -> i3
 /// longer than the base string.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
+pub unsafe extern "C-unwind" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
     if substr_len < 0 {
         panic!("Length parameter cannot be negative.");
     }
@@ -246,7 +246,7 @@ pub unsafe extern "C" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32, dest:
 /// longer than the base string.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
+pub unsafe extern "C-unwind" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
     if substr_len < 0 {
         panic!("Length parameter cannot be negative.");
     }
@@ -273,7 +273,7 @@ pub unsafe extern "C" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i32, des
 /// longer than the base string.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
+pub unsafe extern "C-unwind" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
     if substr_len < 0 {
         panic!("Length parameter cannot be negative.");
     }
@@ -300,7 +300,7 @@ pub unsafe extern "C" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i32, dest
 /// longer than the base string.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
+pub unsafe extern "C-unwind" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
     if substr_len < 0 {
         panic!("Length parameter cannot be negative.");
     }
@@ -327,7 +327,7 @@ pub unsafe extern "C" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: i32, de
 /// starting position of the base string.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn MID_EXT__STRING(
+pub unsafe extern "C-unwind" fn MID_EXT__STRING(
     src: *const u8,
     substr_len: i32,
     start_index: i32,
@@ -366,7 +366,7 @@ pub unsafe extern "C" fn MID_EXT__STRING(
 /// starting position of the base string.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn MID_EXT__WSTRING(
+pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
     src: *const u16,
     substr_len: i32,
     start_index: i32,
@@ -405,7 +405,7 @@ pub unsafe extern "C" fn MID_EXT__WSTRING(
 /// source array bounds.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn INSERT_EXT__STRING(
+pub unsafe extern "C-unwind" fn INSERT_EXT__STRING(
     src_base: *const u8,
     src_to_insert: *const u8,
     pos: i32,
@@ -438,7 +438,7 @@ pub unsafe extern "C" fn INSERT_EXT__STRING(
 /// source array bounds.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn INSERT_EXT__WSTRING(
+pub unsafe extern "C-unwind" fn INSERT_EXT__WSTRING(
     src_base: *const u16,
     src_to_insert: *const u16,
     pos: i32,
@@ -471,7 +471,7 @@ pub unsafe extern "C" fn INSERT_EXT__WSTRING(
 /// array or if trying to delete too many characters.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn DELETE_EXT__STRING(
+pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
     src: *const u8,
     num_chars_to_delete: i32,
     pos: i32,
@@ -514,7 +514,7 @@ pub unsafe extern "C" fn DELETE_EXT__STRING(
 /// array or if trying to delete too many characters.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn DELETE_EXT__WSTRING(
+pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
     src: *const u16,
     num_chars_to_delete: i32,
     pos: i32,
@@ -558,7 +558,7 @@ pub unsafe extern "C" fn DELETE_EXT__WSTRING(
 /// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn REPLACE_EXT__STRING(
+pub unsafe extern "C-unwind" fn REPLACE_EXT__STRING(
     src_base: *const u8,
     src_replacement: *const u8,
     num_chars_to_replace: i32,
@@ -606,7 +606,7 @@ pub unsafe extern "C" fn REPLACE_EXT__STRING(
 /// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn REPLACE_EXT__WSTRING(
+pub unsafe extern "C-unwind" fn REPLACE_EXT__WSTRING(
     src_base: *const u16,
     src_replacement: *const u16,
     num_chars_to_replace: i32,
@@ -671,7 +671,7 @@ pub unsafe extern "C" fn CONCAT__STRING(dest: *mut u8, argc: i32, argv: *const *
 /// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn CONCAT_EXT__STRING(dest: *mut u8, argc: i32, argv: *const *const u8) -> i32 {
+pub unsafe extern "C-unwind" fn CONCAT_EXT__STRING(dest: *mut u8, argc: i32, argv: *const *const u8) -> i32 {
     if argv.is_null() || dest.is_null() {
         panic!("Received null-pointer.")
     }
@@ -715,7 +715,11 @@ pub unsafe extern "C" fn CONCAT__WSTRING(dest: *mut u16, argc: i32, argv: *const
 /// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn CONCAT_EXT__WSTRING(dest: *mut u16, argc: i32, argv: *const *const u16) -> i32 {
+pub unsafe extern "C-unwind" fn CONCAT_EXT__WSTRING(
+    dest: *mut u16,
+    argc: i32,
+    argv: *const *const u16,
+) -> i32 {
     if argv.is_null() || dest.is_null() {
         panic!("Received null-pointer.")
     }
@@ -760,7 +764,7 @@ where
 /// Works on raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn __STRING_GREATER(argc: i32, argv: *const *const u8) -> bool {
+pub unsafe extern "C-unwind" fn __STRING_GREATER(argc: i32, argv: *const *const u8) -> bool {
     compare(argc, argv, Ordering::is_gt)
 }
 
@@ -772,7 +776,7 @@ pub unsafe extern "C" fn __STRING_GREATER(argc: i32, argv: *const *const u8) -> 
 /// Works on raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn __WSTRING_GREATER(argc: i32, argv: *const *const u16) -> bool {
+pub unsafe extern "C-unwind" fn __WSTRING_GREATER(argc: i32, argv: *const *const u16) -> bool {
     compare(argc, argv, Ordering::is_gt)
 }
 
@@ -784,7 +788,7 @@ pub unsafe extern "C" fn __WSTRING_GREATER(argc: i32, argv: *const *const u16) -
 /// Works on raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn __STRING_EQUAL(argc: i32, argv: *const *const u8) -> bool {
+pub unsafe extern "C-unwind" fn __STRING_EQUAL(argc: i32, argv: *const *const u8) -> bool {
     compare(argc, argv, Ordering::is_eq)
 }
 
@@ -796,7 +800,7 @@ pub unsafe extern "C" fn __STRING_EQUAL(argc: i32, argv: *const *const u8) -> bo
 /// Works on raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn __WSTRING_EQUAL(argc: i32, argv: *const *const u16) -> bool {
+pub unsafe extern "C-unwind" fn __WSTRING_EQUAL(argc: i32, argv: *const *const u16) -> bool {
     compare(argc, argv, Ordering::is_eq)
 }
 
@@ -808,7 +812,7 @@ pub unsafe extern "C" fn __WSTRING_EQUAL(argc: i32, argv: *const *const u16) -> 
 /// Works on raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn __STRING_LESS(argc: i32, argv: *const *const u8) -> bool {
+pub unsafe extern "C-unwind" fn __STRING_LESS(argc: i32, argv: *const *const u8) -> bool {
     compare(argc, argv, Ordering::is_lt)
 }
 
@@ -820,7 +824,7 @@ pub unsafe extern "C" fn __STRING_LESS(argc: i32, argv: *const *const u8) -> boo
 /// Works on raw pointers, inherently unsafe.
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern "C" fn __WSTRING_LESS(argc: i32, argv: *const *const u16) -> bool {
+pub unsafe extern "C-unwind" fn __WSTRING_LESS(argc: i32, argv: *const *const u16) -> bool {
     compare(argc, argv, Ordering::is_lt)
 }
 


### PR DESCRIPTION
With Rust 1.81 `extern "C"` functions are by-default not allowed to unwind and instead follow the `panic=abort` strategy. As a consequence, the `#[should_panic]` macro no longer works on `extern "C"` functions that panic. To mitigate one can change the signature from `extern "C"` to `extern "C-unwind"` to change the strategy.

This commit does this for any unit test that uses `extern "C"` functions in combination with `#[should_panic]`.