### PR TITLE
fix: mut_visitor no longer clones

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -2,7 +2,6 @@
 
 use std::{
     fmt::{Debug, Display, Formatter},
-    hash::Hash,
     ops::Range,
 };
 
@@ -722,8 +721,14 @@ pub struct AstNode {
     pub location: SourceLocation,
 }
 
+impl Default for AstNode {
+    fn default() -> Self {
+        AstFactory::create_empty_statement(SourceLocation::internal(), usize::MAX)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, TryInto)]
-#[try_into(ref)]
+#[try_into(ref, ref_mut, owned)]
 pub enum AstStatement {
     EmptyStatement(EmptyStatement),
 
@@ -780,6 +785,20 @@ macro_rules! try_from {
     };
     ($($ex:tt)*, $t:ty) => {
         try_from!($($ex)*, $t).ok()
+    };
+}
+
+#[macro_export]
+/// A `try_from` convenience wrapper for `AstNode`, passed as the `ex:expr` argument.
+/// Will try to return a reference to the variants inner type, specified via the `t:ty` parameter.
+/// Converts the `try_from`-`Result` into an `Option`
+macro_rules! try_from_mut {
+    () => { None };
+    ($ex:expr, $t:ty) => {
+        <&mut $t>::try_from($ex.get_stmt_mut()).ok()
+    };
+    ($($ex:tt)*, $t:ty) => {
+        try_from_mut!($($ex)*, $t).ok()
     };
 }
 
@@ -930,6 +949,10 @@ impl AstNode {
 
     pub fn get_stmt(&self) -> &AstStatement {
         &self.stmt
+    }
+
+    pub fn get_stmt_mut(&mut self) -> &mut AstStatement {
+        &mut self.stmt
     }
 
     /// Similar to [`AstNode::get_stmt`] with the exception of peeling parenthesized expressions.


### PR DESCRIPTION
Cherry-picked changes to `mut_visitor.rs` and `ast.rs` from #1379. 
- the mutating ast-visitor no longer clones nodes when visiting
- `try_from_mut` macro implementation