### PR TITLE
feat: extensions in interfaces

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -50,13 +50,14 @@ pub struct Pou {
 
 #[derive(Debug, PartialEq)]
 pub struct Interface {
-    pub name: String,
+    pub id: AstId,
+    pub identifier: Identifier,
     pub methods: Vec<Pou>,
     pub location: SourceLocation,
-    pub location_name: SourceLocation,
+    pub extensions: Vec<Identifier>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Identifier {
     pub name: String,
     pub location: SourceLocation,
@@ -310,6 +311,22 @@ pub enum AccessModifier {
     Internal,
 }
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+pub enum DeclarationKind {
+    Abstract,
+    Concrete,
+}
+
+impl DeclarationKind {
+    pub fn is_abstract(&self) -> bool {
+        matches!(self, DeclarationKind::Abstract)
+    }
+
+    pub fn is_concrete(&self) -> bool {
+        matches!(self, DeclarationKind::Concrete)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum PouType {
     Program,
@@ -323,6 +340,8 @@ pub enum PouType {
 
         /// The fully qualified name of the property this GET or SET method represents
         property: Option<String>,
+
+        declaration_kind: DeclarationKind,
     },
     Init,
     ProjectInit,
@@ -1350,7 +1369,7 @@ impl Operator {
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::{ArgumentProperty, PouType, VariableBlockType};
+    use crate::ast::{ArgumentProperty, DeclarationKind, PouType, VariableBlockType};
 
     #[test]
     fn display_pou() {
@@ -1359,7 +1378,15 @@ mod tests {
         assert_eq!(PouType::FunctionBlock.to_string(), "FunctionBlock");
         assert_eq!(PouType::Action.to_string(), "Action");
         assert_eq!(PouType::Class.to_string(), "Class");
-        assert_eq!(PouType::Method { parent: String::new(), property: None }.to_string(), "Method");
+        assert_eq!(
+            PouType::Method {
+                parent: String::new(),
+                property: None,
+                declaration_kind: DeclarationKind::Concrete
+            }
+            .to_string(),
+            "Method"
+        );
     }
 
     #[test]

--- a/compiler/plc_lowering/src/inheritance.rs
+++ b/compiler/plc_lowering/src/inheritance.rs
@@ -1967,7 +1967,7 @@ mod units_tests {
 
         let (_, project) = parse_and_annotate("test", vec![src]).unwrap();
         let unit = &project.units[0].get_unit().units[3];
-        assert_debug_snapshot!(unit, @r###"
+        assert_debug_snapshot!(unit, @r#"
         POU {
             name: "child.foo",
             variable_blocks: [
@@ -2014,11 +2014,12 @@ mod units_tests {
             pou_type: Method {
                 parent: "child",
                 property: None,
+                declaration_kind: Concrete,
             },
             return_type: None,
             interfaces: [],
         }
-        "###);
+        "#);
     }
 
     #[test]
@@ -2040,7 +2041,7 @@ mod units_tests {
 
         let (_, project) = parse_and_annotate("test", vec![src]).unwrap();
         let unit = &project.units[0].get_unit().implementations[1];
-        assert_debug_snapshot!(unit, @r###"
+        assert_debug_snapshot!(unit, @r#"
         Implementation {
             name: "bar.set0",
             type_name: "bar.set0",
@@ -2048,6 +2049,7 @@ mod units_tests {
             pou_type: Method {
                 parent: "bar",
                 property: None,
+                declaration_kind: Concrete,
             },
             statements: [
                 Assignment {
@@ -2111,7 +2113,7 @@ mod units_tests {
                 Protected,
             ),
         }
-        "###);
+        "#);
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 use rustc_hash::{FxHashSet, FxHasher};
 
 use plc_ast::ast::{
-    AstId, AstNode, AstStatement, ConfigVariable, DirectAccessType, GenericBinding, HardwareAccessType,
-    Identifier, Interface, LinkageType, PouType, TypeNature,
+    AstId, AstNode, AstStatement, ConfigVariable, DeclarationKind, DirectAccessType, GenericBinding,
+    HardwareAccessType, Identifier, Interface, LinkageType, PouType, TypeNature,
 };
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
@@ -491,28 +491,96 @@ impl ImplementationType {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct InterfaceIndexEntry {
-    /// The interface name
-    pub name: String,
+    /// The interface identifier, consisting of its name and name-location
+    pub identifier: Identifier,
 
     /// The location of the interface as a whole
     pub location: SourceLocation,
 
-    /// The location of the interface name
-    pub location_name: SourceLocation,
-
     /// A list of qualified names of the methods in this interface; the actual methods are located in
     /// [`Index::pous`]
     pub methods: Vec<String>,
+
+    /// A list of other interfaces this interface extends
+    pub extensions: Vec<Identifier>,
 }
 
 impl InterfaceIndexEntry {
-    /// Returns a list of methods defined in this interface
-    pub fn get_methods<'idx>(&self, index: &'idx Index) -> Vec<&'idx PouIndexEntry> {
+    pub fn get_name(&self) -> &str {
+        self.identifier.name.as_str()
+    }
+
+    pub fn get_name_location(&self) -> &SourceLocation {
+        &self.identifier.location
+    }
+
+    pub fn get_location(&self) -> &SourceLocation {
+        &self.location
+    }
+
+    /// Returns a list of methods this interface declared
+    pub fn get_declared_methods<'idx>(&self, index: &'idx Index) -> Vec<&'idx PouIndexEntry> {
         self.methods
             .iter()
             .map(|name| index.find_pou(name).expect("must exist because of present InterfaceIndexEntry"))
+            .collect()
+    }
+
+    /// Returns a list of methods this interface inherited
+    pub fn get_derived_methods<'idx>(&'idx self, index: &'idx Index) -> Vec<&'idx PouIndexEntry> {
+        self.get_derived_methods_recursive(index, &mut FxHashSet::default())
+    }
+
+    /// Returns a list of methods defined in this interface, including inherited methods from derived interfaces
+    pub fn get_methods<'idx>(&'idx self, index: &'idx Index) -> Vec<&'idx PouIndexEntry> {
+        self.get_methods_recursive(index, &mut FxHashSet::default())
+    }
+
+    /// Returns a list of interfaces this interface implements
+    pub fn get_extensions(&self) -> Vec<&Identifier> {
+        self.extensions.iter().collect()
+    }
+
+    /// Returns a list of interfaces this interface inherited
+    pub fn get_derived_interfaces<'idx>(
+        &self,
+        index: &'idx Index,
+    ) -> Vec<Result<&'idx InterfaceIndexEntry, Identifier>> {
+        self.extensions
+            .iter()
+            .flat_map(|id| index.find_interface(&id.name).map(Result::Ok).or(Some(Err(id.to_owned()))))
+            .collect()
+    }
+
+    fn get_methods_recursive<'idx>(
+        &'idx self,
+        index: &'idx Index,
+        seen: &mut FxHashSet<&'idx str>,
+    ) -> Vec<&'idx PouIndexEntry> {
+        seen.insert(self.get_name());
+        self.get_declared_methods(index)
+            .into_iter()
+            .chain(self.get_derived_methods_recursive(index, seen))
+            .collect_vec()
+    }
+
+    fn get_derived_methods_recursive<'idx>(
+        &'idx self,
+        index: &'idx Index,
+        seen: &mut FxHashSet<&'idx str>,
+    ) -> Vec<&'idx PouIndexEntry> {
+        self.get_derived_interfaces(index)
+            .iter()
+            .filter_map(|it| it.as_ref().ok())
+            .flat_map(|it| {
+                if !seen.contains(it.get_name()) {
+                    it.get_methods_recursive(index, seen)
+                } else {
+                    vec![]
+                }
+            })
             .collect()
     }
 }
@@ -520,8 +588,9 @@ impl InterfaceIndexEntry {
 impl std::fmt::Debug for InterfaceIndexEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InterfaceIndexEntry")
-            .field("name", &self.name)
+            .field("name", &self.get_name())
             .field("methods", &self.methods)
+            .field("extensions", &self.extensions)
             .finish()
     }
 }
@@ -529,10 +598,10 @@ impl std::fmt::Debug for InterfaceIndexEntry {
 impl From<&Interface> for InterfaceIndexEntry {
     fn from(interface: &Interface) -> Self {
         InterfaceIndexEntry {
-            name: interface.name.clone(),
+            identifier: interface.identifier.clone(),
             location: interface.location.clone(),
-            location_name: interface.location_name.clone(),
             methods: interface.methods.iter().map(|method| method.name.clone()).collect(),
+            extensions: interface.extensions.clone(),
         }
     }
 }
@@ -574,7 +643,8 @@ pub enum PouIndexEntry {
     },
     Method {
         name: String,
-        parent_pou_name: String,
+        parent_name: String,
+        declaration_kind: DeclarationKind,
         return_type: String,
         instance_struct_name: String,
         linkage: LinkageType,
@@ -582,7 +652,7 @@ pub enum PouIndexEntry {
     },
     Action {
         name: String,
-        parent_pou_name: String,
+        parent_name: String,
         instance_struct_name: String,
         linkage: LinkageType,
         location: SourceLocation,
@@ -693,7 +763,7 @@ impl PouIndexEntry {
     ) -> PouIndexEntry {
         PouIndexEntry::Action {
             name: qualified_name.into(),
-            parent_pou_name: pou_name.into(),
+            parent_name: pou_name.into(),
             instance_struct_name: pou_name.into(),
             linkage,
             location,
@@ -729,12 +799,14 @@ impl PouIndexEntry {
         name: &str,
         return_type: &str,
         owner_class: &str,
+        declaration_kind: DeclarationKind,
         linkage: LinkageType,
         location: SourceLocation,
     ) -> PouIndexEntry {
         PouIndexEntry::Method {
             name: name.into(),
-            parent_pou_name: owner_class.into(),
+            parent_name: owner_class.into(),
+            declaration_kind,
             instance_struct_name: name.into(),
             return_type: return_type.into(),
             linkage,
@@ -775,10 +847,17 @@ impl PouIndexEntry {
 
     pub fn get_parent_pou_name(&self) -> Option<&str> {
         match self {
-            PouIndexEntry::Method { parent_pou_name, .. } | PouIndexEntry::Action { parent_pou_name, .. } => {
-                Some(parent_pou_name.as_str())
+            PouIndexEntry::Method { parent_name, .. } | PouIndexEntry::Action { parent_name, .. } => {
+                Some(parent_name.as_str())
             }
 
+            _ => None,
+        }
+    }
+
+    pub fn get_declaration_kind(&self) -> Option<DeclarationKind> {
+        match self {
+            PouIndexEntry::Method { declaration_kind, .. } => Some(*declaration_kind),
             _ => None,
         }
     }
@@ -819,8 +898,8 @@ impl PouIndexEntry {
             | PouIndexEntry::FunctionBlock { .. }
             | PouIndexEntry::Class { .. }
             | PouIndexEntry::Function { .. } => self.get_name(),
-            PouIndexEntry::Action { parent_pou_name, .. } | PouIndexEntry::Method { parent_pou_name, .. } => {
-                parent_pou_name.as_str()
+            PouIndexEntry::Action { parent_name, .. } | PouIndexEntry::Method { parent_name, .. } => {
+                parent_name.as_str()
             }
         }
     }
@@ -1925,11 +2004,11 @@ impl Index {
 
     /// Returns all methods declared on container, or its parents.
     /// If a method is declared in the container the parent method is not included
-    pub fn find_methods(&self, container: &str) -> Vec<&PouIndexEntry> {
-        self.find_method_recursive(container, vec![], &mut FxHashSet::default())
+    pub fn get_methods(&self, container: &str) -> Vec<&PouIndexEntry> {
+        self.get_methods_recursive(container, vec![], &mut FxHashSet::default())
     }
 
-    fn find_method_recursive<'b>(
+    fn get_methods_recursive<'b>(
         &'b self,
         container: &str,
         current_methods: Vec<&'b PouIndexEntry>,
@@ -1952,7 +2031,7 @@ impl Index {
                 if !seen.insert(super_class) {
                     return res;
                 };
-                self.find_method_recursive(super_class, res, seen)
+                self.get_methods_recursive(super_class, res, seen)
             } else {
                 res
             }

--- a/src/index/indexer.rs
+++ b/src/index/indexer.rs
@@ -67,6 +67,8 @@ impl AstVisitor for SymbolIndexer {
             self.visit_pou(method);
         }
 
-        self.index.interfaces.insert(interface.name.clone(), InterfaceIndexEntry::from(interface));
+        self.index
+            .interfaces
+            .insert(interface.identifier.name.to_owned(), InterfaceIndexEntry::from(interface));
     }
 }

--- a/src/index/indexer/pou_indexer.rs
+++ b/src/index/indexer/pou_indexer.rs
@@ -1,5 +1,6 @@
 use plc_ast::ast::{
-    ArgumentProperty, DataTypeDeclaration, PouType, TypeNature, VariableBlock, VariableBlockType,
+    ArgumentProperty, DataTypeDeclaration, DeclarationKind, PouType, TypeNature, VariableBlock,
+    VariableBlockType,
 };
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::internal_type_name;
@@ -74,8 +75,8 @@ impl<'i> PouIndexer<'i> {
             PouType::Function | PouType::Init | PouType::ProjectInit => {
                 self.index_function(pou, return_type_name, member_varargs, pou_struct_type);
             }
-            PouType::Method { parent, .. } => {
-                self.index_method(pou, return_type_name, parent, pou_struct_type);
+            PouType::Method { parent, declaration_kind, .. } => {
+                self.index_method(pou, return_type_name, parent, *declaration_kind, pou_struct_type);
             }
             _ => {}
         };
@@ -93,12 +94,14 @@ impl<'i> PouIndexer<'i> {
         pou: &plc_ast::ast::Pou,
         return_type_name: &str,
         owner_class: &str,
+        declaration_kind: DeclarationKind,
         pou_struct_type: typesystem::DataType,
     ) {
         self.index.register_pou(PouIndexEntry::create_method_entry(
             &pou.name,
             return_type_name,
             owner_class,
+            declaration_kind,
             pou.linkage,
             pou.name_location.clone(),
         ));

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -1412,7 +1412,7 @@ fn a_program_pou_is_indexed() {
     assert_eq!(
         Some(&PouIndexEntry::Action {
             name: "myProgram.act".into(),
-            parent_pou_name: "myProgram".into(),
+            parent_name: "myProgram".into(),
             linkage: LinkageType::Internal,
             instance_struct_name: "myProgram".into(),
             location: source_location_factory.create_range(269..272),

--- a/src/lowering/property.rs
+++ b/src/lowering/property.rs
@@ -78,9 +78,9 @@ use std::collections::HashMap;
 use helper::{create_internal_assignment, patch_prefix_to_name};
 use plc_ast::{
     ast::{
-        AccessModifier, ArgumentProperty, AstFactory, AstNode, AstStatement, CompilationUnit, Implementation,
-        LinkageType, Pou, PouType, Property, PropertyKind, ReferenceAccess, ReferenceExpr, Variable,
-        VariableBlock, VariableBlockType,
+        AccessModifier, ArgumentProperty, AstFactory, AstNode, AstStatement, CompilationUnit,
+        DeclarationKind, Implementation, LinkageType, Pou, PouType, Property, PropertyKind, ReferenceAccess,
+        ReferenceExpr, Variable, VariableBlock, VariableBlockType,
     },
     mut_visitor::{AstVisitorMut, WalkerMut},
     provider::IdProvider,
@@ -137,6 +137,7 @@ impl PropertyLowerer {
                     kind: PouType::Method {
                         parent: property.parent_name.clone(),
                         property: Some(qualified_name(&property.parent_name, &property.name)),
+                        declaration_kind: DeclarationKind::Concrete,
                     },
                     variable_blocks: Vec::new(),
                     return_type: Some(property.datatype.clone()),
@@ -505,6 +506,7 @@ mod tests {
                     property: Some(
                         "fb.myProp",
                     ),
+                    declaration_kind: Concrete,
                 },
                 statements: [
                     Assignment {
@@ -585,6 +587,7 @@ mod tests {
                     property: Some(
                         "fb.myProp",
                     ),
+                    declaration_kind: Concrete,
                 },
                 statements: [
                     Assignment {
@@ -686,6 +689,7 @@ mod tests {
                     property: Some(
                         "fb.another_prop",
                     ),
+                    declaration_kind: Concrete,
                 },
                 statements: [
                     Assignment {
@@ -769,6 +773,7 @@ mod tests {
                     property: Some(
                         "fb.another_prop",
                     ),
+                    declaration_kind: Concrete,
                 },
                 statements: [
                     Assignment {
@@ -925,6 +930,7 @@ mod tests {
                     property: Some(
                         "fb.myProp",
                     ),
+                    declaration_kind: Concrete,
                 },
                 statements: [
                     Assignment {
@@ -1005,6 +1011,7 @@ mod tests {
                     property: Some(
                         "fb.myProp",
                     ),
+                    declaration_kind: Concrete,
                 },
                 statements: [
                     Assignment {
@@ -1120,6 +1127,7 @@ mod tests {
                 property: Some(
                     "fb.foo",
                 ),
+                declaration_kind: Concrete,
             },
             return_type: Some(
                 DataTypeReference {
@@ -1153,6 +1161,7 @@ mod tests {
                 property: Some(
                     "fb.foo",
                 ),
+                declaration_kind: Concrete,
             },
             return_type: None,
             interfaces: [],
@@ -1170,6 +1179,7 @@ mod tests {
                 property: Some(
                     "fb.foo",
                 ),
+                declaration_kind: Concrete,
             },
             statements: [
                 Assignment {
@@ -1248,6 +1258,7 @@ mod tests {
                 property: Some(
                     "fb.foo",
                 ),
+                declaration_kind: Concrete,
             },
             statements: [
                 Assignment {

--- a/src/lowering/snapshots/rusty__lowering__calls__tests__method_with_string_return_is_changed-2.snap
+++ b/src/lowering/snapshots/rusty__lowering__calls__tests__method_with_string_return_is_changed-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/lowering/calls.rs
 expression: "lowerer.index.unwrap().find_pou_type(\"fb.complexMethod\").unwrap()"
+snapshot_kind: text
 ---
 DataType {
     name: "fb.complexMethod",
@@ -44,6 +45,7 @@ DataType {
             Method {
                 parent: "fb",
                 property: None,
+                declaration_kind: Concrete,
             },
         ),
     },

--- a/src/lowering/snapshots/rusty__lowering__calls__tests__method_with_string_return_is_changed.snap
+++ b/src/lowering/snapshots/rusty__lowering__calls__tests__method_with_string_return_is_changed.snap
@@ -1,6 +1,7 @@
 ---
 source: src/lowering/calls.rs
 expression: "unit.units[1]"
+snapshot_kind: text
 ---
 POU {
     name: "fb.complexMethod",
@@ -20,6 +21,7 @@ POU {
     pou_type: Method {
         parent: "fb",
         property: None,
+        declaration_kind: Concrete,
     },
     return_type: Some(
         Aggregate {

--- a/src/parser/tests/class_parser_tests.rs
+++ b/src/parser/tests/class_parser_tests.rs
@@ -1,5 +1,7 @@
 use insta::assert_snapshot;
-use plc_ast::ast::{AccessModifier, ArgumentProperty, PolymorphismMode, PouType, VariableBlockType};
+use plc_ast::ast::{
+    AccessModifier, ArgumentProperty, DeclarationKind, PolymorphismMode, PouType, VariableBlockType,
+};
 
 use crate::test_utils::tests::{parse, parse_and_validate_buffered};
 
@@ -74,7 +76,14 @@ fn method_with_defaults_can_be_parsed() {
     assert_eq!(unit.implementations.len(), 2);
 
     let method_pou = &unit.units[1];
-    assert_eq!(method_pou.kind, PouType::Method { parent: "MyClass".into(), property: None });
+    assert_eq!(
+        method_pou.kind,
+        PouType::Method {
+            parent: "MyClass".into(),
+            property: None,
+            declaration_kind: DeclarationKind::Concrete
+        }
+    );
     let method = &unit.implementations[0];
 
     assert_eq!(method_pou.name, "MyClass.testMethod");
@@ -96,7 +105,14 @@ fn method_can_be_parsed() {
     assert_eq!(unit.implementations.len(), 2);
 
     let method_pou = &unit.units[1];
-    assert_eq!(method_pou.kind, PouType::Method { parent: "MyClass".into(), property: None });
+    assert_eq!(
+        method_pou.kind,
+        PouType::Method {
+            parent: "MyClass".into(),
+            property: None,
+            declaration_kind: DeclarationKind::Concrete
+        }
+    );
     let method = &unit.implementations[0];
 
     assert_eq!(method_pou.name, "MyClass.testMethod2");
@@ -135,7 +151,14 @@ fn method_with_return_type_can_be_parsed() {
     assert_eq!(class.kind, PouType::Class);
 
     let method_pou = &unit.units[1];
-    assert_eq!(method_pou.kind, PouType::Method { parent: "MyClass".into(), property: None });
+    assert_eq!(
+        method_pou.kind,
+        PouType::Method {
+            parent: "MyClass".into(),
+            property: None,
+            declaration_kind: DeclarationKind::Concrete
+        }
+    );
     let method = &unit.implementations[0];
 
     // classes have implementation because they are treated as other POUs
@@ -281,7 +304,14 @@ fn fb_method_can_be_parsed() {
     assert_eq!(unit.implementations.len(), 2);
 
     let method_pou = &unit.units[1];
-    assert_eq!(method_pou.kind, PouType::Method { parent: "MyFb".into(), property: None });
+    assert_eq!(
+        method_pou.kind,
+        PouType::Method {
+            parent: "MyFb".into(),
+            property: None,
+            declaration_kind: DeclarationKind::Concrete
+        }
+    );
     let method = &unit.implementations[0];
 
     assert_eq!(method_pou.name, "MyFb.testMethod2");
@@ -329,7 +359,14 @@ fn fb_method_with_return_type_can_be_parsed() {
     assert_eq!(class.kind, PouType::FunctionBlock);
 
     let method_pou = &unit.units[1];
-    assert_eq!(method_pou.kind, PouType::Method { parent: "MyShinyFb".into(), property: None });
+    assert_eq!(
+        method_pou.kind,
+        PouType::Method {
+            parent: "MyShinyFb".into(),
+            property: None,
+            declaration_kind: DeclarationKind::Concrete
+        }
+    );
     let method = &unit.implementations[0];
 
     // classes have implementation because they are treated as other POUs
@@ -358,7 +395,14 @@ fn program_methods_can_be_parsed() {
     assert_eq!(unit.implementations.len(), 2);
 
     let method_pou = &unit.units[1];
-    assert_eq!(method_pou.kind, PouType::Method { parent: "prog".into(), property: None });
+    assert_eq!(
+        method_pou.kind,
+        PouType::Method {
+            parent: "prog".into(),
+            property: None,
+            declaration_kind: DeclarationKind::Concrete
+        }
+    );
     let method = &unit.implementations[0];
 
     assert_eq!(method_pou.name, "prog.testMethod2");
@@ -406,7 +450,14 @@ fn program_method_with_return_type_can_be_parsed() {
     assert_eq!(class.kind, PouType::Program);
 
     let method_pou = &unit.units[1];
-    assert_eq!(method_pou.kind, PouType::Method { parent: "prog".into(), property: None });
+    assert_eq!(
+        method_pou.kind,
+        PouType::Method {
+            parent: "prog".into(),
+            property: None,
+            declaration_kind: DeclarationKind::Concrete
+        }
+    );
     let method = &unit.implementations[0];
 
     // classes have implementation because they are treated as other POUs
@@ -476,11 +527,17 @@ fn method_variable_blocks_can_be_parsed() {
     let (unit, _) = parse(src);
     let fb_mthd = &unit.units[1];
     assert_eq!(fb_mthd.name, "fb.mthd".to_string());
-    assert_eq!(fb_mthd.kind, PouType::Method { parent: "fb".into(), property: None });
+    assert_eq!(
+        fb_mthd.kind,
+        PouType::Method { parent: "fb".into(), property: None, declaration_kind: DeclarationKind::Concrete }
+    );
 
     let prg_mthd = &unit.units[3];
     assert_eq!(prg_mthd.name, "prg.mthd".to_string());
-    assert_eq!(prg_mthd.kind, PouType::Method { parent: "prg".into(), property: None });
+    assert_eq!(
+        prg_mthd.kind,
+        PouType::Method { parent: "prg".into(), property: None, declaration_kind: DeclarationKind::Concrete }
+    );
 
     // we expect one of each of these `VariableBlockType` to be parsed
     let expected_var_blocks = vec![

--- a/src/parser/tests/interface_parser_tests.rs
+++ b/src/parser/tests/interface_parser_tests.rs
@@ -10,10 +10,26 @@ fn empty_interface() {
     let (unit, diagnostics) = parse(source);
 
     assert_eq!(diagnostics.len(), 0, "Expected no diagnostics but got {:#?}", diagnostics);
-    insta::assert_debug_snapshot!(unit.interfaces, @r###"
+    insta::assert_debug_snapshot!(unit.interfaces, @r#"
     [
         Interface {
-            name: "myInterface",
+            id: 1,
+            identifier: Identifier {
+                name: "myInterface",
+                location: SourceLocation {
+                    span: Range(
+                        TextLocation {
+                            line: 1,
+                            column: 14,
+                            offset: 15,
+                        }..TextLocation {
+                            line: 1,
+                            column: 25,
+                            offset: 26,
+                        },
+                    ),
+                },
+            },
             methods: [],
             location: SourceLocation {
                 span: Range(
@@ -28,22 +44,10 @@ fn empty_interface() {
                     },
                 ),
             },
-            location_name: SourceLocation {
-                span: Range(
-                    TextLocation {
-                        line: 1,
-                        column: 14,
-                        offset: 15,
-                    }..TextLocation {
-                        line: 1,
-                        column: 25,
-                        offset: 26,
-                    },
-                ),
-            },
+            extensions: [],
         },
     ]
-    "###);
+    "#);
 }
 
 #[test]
@@ -65,7 +69,23 @@ fn interface_with_single_method() {
     insta::assert_debug_snapshot!(unit.interfaces, @r#"
     [
         Interface {
-            name: "myInterface",
+            id: 2,
+            identifier: Identifier {
+                name: "myInterface",
+                location: SourceLocation {
+                    span: Range(
+                        TextLocation {
+                            line: 1,
+                            column: 14,
+                            offset: 15,
+                        }..TextLocation {
+                            line: 1,
+                            column: 25,
+                            offset: 26,
+                        },
+                    ),
+                },
+            },
             methods: [
                 POU {
                     name: "myInterface.foo",
@@ -93,6 +113,7 @@ fn interface_with_single_method() {
                     pou_type: Method {
                         parent: "myInterface",
                         property: None,
+                        declaration_kind: Abstract,
                     },
                     return_type: Some(
                         DataTypeReference {
@@ -115,19 +136,7 @@ fn interface_with_single_method() {
                     },
                 ),
             },
-            location_name: SourceLocation {
-                span: Range(
-                    TextLocation {
-                        line: 1,
-                        column: 14,
-                        offset: 15,
-                    }..TextLocation {
-                        line: 1,
-                        column: 25,
-                        offset: 26,
-                    },
-                ),
-            },
+            extensions: [],
         },
     ]
     "#);
@@ -162,7 +171,23 @@ fn interface_with_multiple_methods() {
     insta::assert_debug_snapshot!(unit.interfaces, @r#"
     [
         Interface {
-            name: "myInterface",
+            id: 3,
+            identifier: Identifier {
+                name: "myInterface",
+                location: SourceLocation {
+                    span: Range(
+                        TextLocation {
+                            line: 1,
+                            column: 14,
+                            offset: 15,
+                        }..TextLocation {
+                            line: 1,
+                            column: 25,
+                            offset: 26,
+                        },
+                    ),
+                },
+            },
             methods: [
                 POU {
                     name: "myInterface.foo",
@@ -190,6 +215,7 @@ fn interface_with_multiple_methods() {
                     pou_type: Method {
                         parent: "myInterface",
                         property: None,
+                        declaration_kind: Abstract,
                     },
                     return_type: Some(
                         DataTypeReference {
@@ -229,6 +255,7 @@ fn interface_with_multiple_methods() {
                     pou_type: Method {
                         parent: "myInterface",
                         property: None,
+                        declaration_kind: Abstract,
                     },
                     return_type: Some(
                         DataTypeReference {
@@ -251,19 +278,7 @@ fn interface_with_multiple_methods() {
                     },
                 ),
             },
-            location_name: SourceLocation {
-                span: Range(
-                    TextLocation {
-                        line: 1,
-                        column: 14,
-                        offset: 15,
-                    }..TextLocation {
-                        line: 1,
-                        column: 25,
-                        offset: 26,
-                    },
-                ),
-            },
+            extensions: [],
         },
     ]
     "#);
@@ -375,6 +390,180 @@ fn pou_implementing_multiple_interfaces() {
     "###);
 }
 
+#[test]
+fn interface_deriving_from_other_interface() {
+    let source = r#"
+        INTERFACE foo
+        METHOD baz
+        END_METHOD
+        END_INTERFACE
+
+        INTERFACE bar EXTENDS foo
+        METHOD qux
+        END_METHOD
+        END_INTERFACE
+    "#;
+
+    let (unit, diagnostics) = parse(source);
+
+    assert_eq!(diagnostics.len(), 0, "Expected no diagnostics but got {:#?}", diagnostics);
+    insta::assert_debug_snapshot!(unit.interfaces[1], @r#"
+    Interface {
+        id: 4,
+        identifier: Identifier {
+            name: "bar",
+            location: SourceLocation {
+                span: Range(
+                    TextLocation {
+                        line: 6,
+                        column: 18,
+                        offset: 102,
+                    }..TextLocation {
+                        line: 6,
+                        column: 21,
+                        offset: 105,
+                    },
+                ),
+            },
+        },
+        methods: [
+            POU {
+                name: "bar.qux",
+                variable_blocks: [],
+                pou_type: Method {
+                    parent: "bar",
+                    property: None,
+                    declaration_kind: Abstract,
+                },
+                return_type: None,
+                interfaces: [],
+            },
+        ],
+        location: SourceLocation {
+            span: Range(
+                TextLocation {
+                    line: 6,
+                    column: 8,
+                    offset: 92,
+                }..TextLocation {
+                    line: 10,
+                    column: 4,
+                    offset: 182,
+                },
+            ),
+        },
+        extensions: [
+            Identifier {
+                name: "foo",
+                location: SourceLocation {
+                    span: Range(
+                        TextLocation {
+                            line: 6,
+                            column: 30,
+                            offset: 114,
+                        }..TextLocation {
+                            line: 6,
+                            column: 33,
+                            offset: 117,
+                        },
+                    ),
+                },
+            },
+        ],
+    }
+    "#);
+}
+
+#[test]
+fn interface_deriving_from_multiple_interfaces() {
+    let source = r#"
+    INTERFACE foo
+    METHOD baz
+    END_METHOD
+    END_INTERFACE
+
+    INTERFACE bar
+    METHOD qux
+    END_METHOD
+    END_INTERFACE
+
+    INTERFACE quux EXTENDS foo, bar
+    END_INTERFACE
+    "#;
+
+    let (unit, diagnostics) = parse(source);
+
+    assert_eq!(diagnostics.len(), 0, "Expected no diagnostics but got {:#?}", diagnostics);
+    insta::assert_debug_snapshot!(unit.interfaces[2], @r#"
+    Interface {
+        id: 5,
+        identifier: Identifier {
+            name: "quux",
+            location: SourceLocation {
+                span: Range(
+                    TextLocation {
+                        line: 11,
+                        column: 14,
+                        offset: 149,
+                    }..TextLocation {
+                        line: 11,
+                        column: 18,
+                        offset: 153,
+                    },
+                ),
+            },
+        },
+        methods: [],
+        location: SourceLocation {
+            span: Range(
+                TextLocation {
+                    line: 11,
+                    column: 4,
+                    offset: 139,
+                }..TextLocation {
+                    line: 13,
+                    column: 4,
+                    offset: 193,
+                },
+            ),
+        },
+        extensions: [
+            Identifier {
+                name: "foo",
+                location: SourceLocation {
+                    span: Range(
+                        TextLocation {
+                            line: 11,
+                            column: 27,
+                            offset: 162,
+                        }..TextLocation {
+                            line: 11,
+                            column: 30,
+                            offset: 165,
+                        },
+                    ),
+                },
+            },
+            Identifier {
+                name: "bar",
+                location: SourceLocation {
+                    span: Range(
+                        TextLocation {
+                            line: 11,
+                            column: 32,
+                            offset: 167,
+                        }..TextLocation {
+                            line: 11,
+                            column: 35,
+                            offset: 170,
+                        },
+                    ),
+                },
+            },
+        ],
+    }
+    "#);
+}
 mod error_handling {
     use crate::test_utils::tests::{parse, parse_and_validate_buffered};
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -12,8 +12,8 @@ use plc_ast::{
     ast::{
         self, flatten_expression_list, Allocation, Assignment, AstFactory, AstId, AstNode, AstStatement,
         BinaryExpression, CompilationUnit, DataType, DataTypeDeclaration, DirectAccessType, Identifier,
-        JumpStatement, Operator, Pou, ReferenceAccess, ReferenceExpr, TypeNature, UserTypeDeclaration,
-        Variable,
+        Interface, JumpStatement, Operator, Pou, ReferenceAccess, ReferenceExpr, TypeNature,
+        UserTypeDeclaration, Variable,
     },
     control_statements::{AstControlStatement, ReturnStatement},
     literals::{Array, AstLiteral, StringValue},
@@ -23,7 +23,7 @@ use plc_ast::{
 use plc_source::source_location::SourceLocation;
 use plc_util::convention::internal_type_name;
 
-use crate::index::{FxIndexMap, FxIndexSet};
+use crate::index::{FxIndexMap, FxIndexSet, InterfaceIndexEntry};
 use crate::typesystem::VOID_INTERNAL_NAME;
 use crate::{
     builtins::{self, BuiltIn},
@@ -59,7 +59,7 @@ macro_rules! visit_all_statements {
 ///
 /// Helper methods `qualifier`, `current_pou` and `lhs_pou` copy the current context and
 /// change one field.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct VisitorContext<'s> {
     /// the type_name of the context for a reference (e.g. `a.b` where `a`'s type is the context of `b`)
     qualifier: Option<String>,
@@ -523,6 +523,117 @@ impl MethodDeclarationType {
     }
 }
 
+trait InheritanceAnnotationConverter {
+    /// Returns a [`StatementAnnotation::MethodDeclarations`] for all method declarations of this entry,
+    /// including all inherited methods.
+    fn get_method_declarations_annotation(&self, index: &Index) -> Option<StatementAnnotation> {
+        let mut declarations = FxHashMap::<String, Vec<MethodDeclarationType>>::default();
+        self.get_method_declaration_types(index).into_iter().for_each(|method| {
+            declarations.entry(method.get_flat_name().to_string()).or_default().push(method)
+        });
+        (!declarations.is_empty()).then_some(StatementAnnotation::MethodDeclarations { declarations })
+    }
+
+    /// Returns a [`StatementAnnotation::Override`] for all method overrides of this entry,
+    /// including all inherited, overridden methods.
+    fn get_method_overrides_annotation(&self, index: &Index) -> Option<StatementAnnotation> {
+        // TODO: lazy inheritance iterator
+        let definitions = self.get_method_overrides(index);
+        (!definitions.is_empty()).then_some(StatementAnnotation::create_override(definitions))
+    }
+
+    /// Returns all method declaration-types (abstract/concrete) of this entry, including all inherited methods.
+    fn get_method_declaration_types(&self, index: &Index) -> Vec<MethodDeclarationType>;
+
+    /// Returns all overridden method declaration-types (abstract/concrete) of this entry, including all inherited methods.
+    fn get_method_overrides(&self, index: &Index) -> Vec<MethodDeclarationType>;
+}
+
+impl InheritanceAnnotationConverter for InterfaceIndexEntry {
+    fn get_method_declaration_types(&self, index: &Index) -> Vec<MethodDeclarationType> {
+        self.get_methods(index)
+            .iter()
+            .map(|method| MethodDeclarationType::abstract_method(method.get_name()))
+            .collect()
+    }
+
+    fn get_method_overrides(&self, index: &Index) -> Vec<MethodDeclarationType> {
+        let derived_methods = self.get_derived_methods(index);
+        self.methods
+            .iter()
+            .filter(|method_name| {
+                derived_methods.iter().any(|derived_method| {
+                    derived_method.get_flat_reference_name()
+                        == method_name.rsplit_once(".").map(|(_, it)| it).unwrap_or_default()
+                })
+            })
+            .map(|method_name| MethodDeclarationType::abstract_method(method_name))
+            .collect()
+    }
+}
+
+impl InheritanceAnnotationConverter for PouIndexEntry {
+    fn get_method_declaration_types(&self, index: &Index) -> Vec<MethodDeclarationType> {
+        match self {
+            PouIndexEntry::Program { name, .. }
+            | PouIndexEntry::FunctionBlock { name, .. }
+            | PouIndexEntry::Class { name, .. } => {
+                //Find all declared methods
+                index
+                    .get_methods(name)
+                    .into_iter()
+                    .map(|it| MethodDeclarationType::concrete_method(it.get_name()))
+                    .chain(self.get_interfaces().iter().flat_map(|ident| {
+                        index
+                            .find_interface(ident)
+                            .into_iter()
+                            .flat_map(|interface| interface.get_method_declaration_types(index))
+                    }))
+                    .collect()
+            }
+            _ => vec![],
+        }
+    }
+
+    fn get_method_overrides(&self, index: &Index) -> Vec<MethodDeclarationType> {
+        let PouIndexEntry::Method { ref parent_name, declaration_kind: kind, .. } = self else {
+            return vec![];
+        };
+
+        let mut overrides = vec![];
+        let method_name = self.get_flat_reference_name();
+
+        // Annotate as concrete override if a super-class also defines this method
+        if let Some(inherited_method) = index
+            .find_pou(parent_name)
+            .and_then(|pou| pou.get_super_class())
+            .and_then(|super_name| index.find_method(super_name, method_name))
+        {
+            overrides.push(MethodDeclarationType::concrete_method(inherited_method.get_name()));
+        };
+
+        let interfaces = match kind {
+            ast::DeclarationKind::Abstract => index
+                .find_interface(parent_name)
+                .map(|it| it.get_extensions().iter().map(|it| it.name.as_str()).collect()),
+            ast::DeclarationKind::Concrete => index.find_pou(parent_name).map(|it| it.get_interfaces()),
+        }
+        .unwrap_or_default();
+        // Annotate all implemented methods which were inherited from interfaces
+        interfaces.iter().for_each(|interface| {
+            if let Some(interface) = index.find_interface(interface) {
+                interface
+                    .get_methods(index)
+                    .iter()
+                    .filter(|it| it.get_flat_reference_name() == method_name)
+                    .for_each(|it| overrides.push(MethodDeclarationType::abstract_method(it.get_name())));
+            }
+        });
+
+        overrides
+    }
+}
+
 impl StatementAnnotation {
     /// Constructs a new [`StatementAnnotation::Value`] with the given type name
     pub fn value(type_name: impl Into<String>) -> Self {
@@ -906,14 +1017,9 @@ impl<'i> TypeAnnotator<'i> {
     ) -> (AnnotationMapImpl, FxIndexSet<Dependency>, StringLiterals) {
         let mut visitor = TypeAnnotator::new(index);
         let ctx = &VisitorContext {
-            pou: None,
-            qualifier: None,
-            lhs: None,
-            constant: false,
-            in_body: false,
             id_provider,
             resolve_strategy: ResolvingStrategy::default_scopes(),
-            in_control: false,
+            ..Default::default()
         };
 
         for global_variable in unit.global_vars.iter().flat_map(|it| it.variables.iter()) {
@@ -925,9 +1031,8 @@ impl<'i> TypeAnnotator<'i> {
             visitor.visit_pou(ctx, pou);
         }
 
-        for _ in &unit.interfaces {
-            // Do nothing, mostly because POUs defined in interfaces are empty therefore there shouldn't be
-            // anything to annotate
+        for interface in &unit.interfaces {
+            visitor.visit_interface(interface);
         }
 
         for t in &unit.user_types {
@@ -1014,82 +1119,49 @@ impl<'i> TypeAnnotator<'i> {
         }
     }
 
+    fn visit_interface(&mut self, interface: &Interface) {
+        self.annotate_interface(interface);
+    }
+
     fn annotate_pou(&mut self, pou: &Pou) {
         if let Some(pou_entry) = self.index.find_pou(&pou.name) {
-            match pou_entry {
-                PouIndexEntry::Program { name, .. }
-                | PouIndexEntry::FunctionBlock { name, .. }
-                | PouIndexEntry::Class { name, .. } => {
-                    //Find all declared methods
-                    let mut methods = self
-                        .index
-                        .find_methods(name)
-                        .into_iter()
-                        .map(|it| {
-                            (
-                                it.get_flat_reference_name().to_string(),
-                                MethodDeclarationType::Concrete(it.get_name().to_string()),
-                            )
-                        })
-                        .collect::<Vec<_>>();
-                    //Find all methods in interfaces (possibly undeclared)
-                    for interface in pou_entry.get_interfaces() {
-                        if let Some(interface) = self.index.find_interface(interface) {
-                            methods.extend(interface.get_methods(self.index).into_iter().map(|it| {
-                                (
-                                    it.get_flat_reference_name().to_string(),
-                                    MethodDeclarationType::Abstract(it.get_name().to_string()),
-                                )
-                            }));
-                        }
-                    }
-                    let mut declarations = FxHashMap::<String, Vec<MethodDeclarationType>>::default();
-                    methods.into_iter().for_each(|(key, value)| {
-                        let entry = declarations.entry(key).or_default();
-                        entry.push(value);
-                    });
-                    self.annotation_map
-                        .annotate_with_id(pou.id, StatementAnnotation::MethodDeclarations { declarations });
-                }
-                PouIndexEntry::Method { parent_pou_name, .. } => {
-                    self.annotate_method(pou.id, parent_pou_name, pou_entry.get_qualified_name());
-                }
-                _ => {}
-            };
+            if pou_entry.is_method() {
+                self.annotate_method(pou_entry, pou.id);
+            } else {
+                let Some(annotation) = pou_entry.get_method_declarations_annotation(self.index) else {
+                    return;
+                };
+
+                self.annotation_map.annotate_with_id(pou.id, annotation);
+            }
         }
     }
 
-    fn annotate_method(&mut self, id: AstId, parent_pou_name: &str, qualified_name: Vec<&str>) {
-        let method_name = qualified_name.last().expect("Method has a name");
-        self.dependencies.insert(Dependency::Datatype(parent_pou_name.into()));
-        //If the method is overriden, annotate the method with the original method
-        //Get the method's pou index entry in the super class
-        // TODO: lazy inheritance iterator
-        if let Some(base_pou) = self.index.find_pou(parent_pou_name) {
-            let mut overrides = vec![];
-            if let Some(super_class) = base_pou.get_super_class().and_then(|it| self.index.find_pou(it)) {
-                if let Some(method) = self.index.find_method(super_class.get_name(), method_name) {
-                    overrides.push(MethodDeclarationType::concrete_method(method.get_name()));
-                }
-            }
-            // Annotate all methods with the interface methods
-            // TODO: once we implement inheritance for interfaces, we need to adjust this logic
-            base_pou.get_interfaces().iter().for_each(|interface| {
-                if let Some(interface) = self.index.find_interface(interface) {
-                    if let Some(name) = interface
-                        .methods
-                        .iter()
-                        .find(|it| it.rsplit_once('.').map(|(_, it)| it).as_ref().unwrap() == method_name)
-                    {
-                        overrides.push(MethodDeclarationType::abstract_method(name));
-                    }
-                }
-            });
+    fn annotate_method(&mut self, method: &PouIndexEntry, id: AstId) {
+        let Some(parent_pou_name) = method.get_parent_pou_name() else { return };
 
-            if !overrides.is_empty() {
-                self.annotation_map.annotate_with_id(id, StatementAnnotation::create_override(overrides));
-            }
+        if method.get_declaration_kind().is_some_and(|it| it.is_concrete()) {
+            self.dependencies.insert(Dependency::Datatype(parent_pou_name.into()));
         }
+
+        // If the method is overridden, annotate the method with every inherited method it overrides
+        if let Some(annotation) = method.get_method_overrides_annotation(self.index) {
+            self.annotation_map.annotate_with_id(id, annotation);
+        };
+    }
+
+    fn annotate_interface(&mut self, interface: &Interface) {
+        let Some(itf) = self.index.find_interface(&interface.identifier.name) else { return };
+
+        // annotate overrides of each method declared in the interface
+        interface.methods.iter().for_each(|method| {
+            self.annotate_pou(method);
+        });
+
+        // annotate all methods (declared and derived) in the interface
+        if let Some(annotation) = itf.get_method_declarations_annotation(self.index) {
+            self.annotation_map.annotate_with_id(interface.id, annotation);
+        };
     }
 
     /// updates the expected types of statement on the right side of an assignment
@@ -2191,7 +2263,7 @@ fn to_pou_annotation(p: &PouIndexEntry, index: &Index) -> Option<StatementAnnota
         PouIndexEntry::FunctionBlock { name, .. } => {
             Some(StatementAnnotation::Type { type_name: name.into() })
         }
-        PouIndexEntry::Action { name, parent_pou_name, .. } => match index.find_pou(parent_pou_name) {
+        PouIndexEntry::Action { name, parent_name, .. } => match index.find_pou(parent_name) {
             Some(PouIndexEntry::Program { .. }) => {
                 Some(StatementAnnotation::Program { qualified_name: name.into() })
             }

--- a/src/resolver/tests/resolve_declarations.rs
+++ b/src/resolver/tests/resolve_declarations.rs
@@ -245,3 +245,467 @@ fn all_available_methods_of_container_are_annotated() {
     )
     "#);
 }
+
+#[test]
+fn all_available_methods_of_interface_are_annotated() {
+    let id_provider = IdProvider::default();
+    let (unit, index, _) = index_and_lower(
+        r#"
+        INTERFACE foo
+            METHOD bar
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE baz EXTENDS foo
+            METHOD qux
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quux
+            METHOD corge
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quuz EXTENDS quux
+            METHOD grault
+            END_METHOD
+
+            METHOD garply
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quxat
+            METHOD waldo
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quxar EXTENDS quuz, baz, quxat
+            METHOD fred
+            END_METHOD
+        END_INTERFACE
+    "#,
+        id_provider.clone(),
+    );
+
+    let (annotations, _, units) = annotate_and_lower_with_ids(unit, index, id_provider);
+
+    let intf = &units[0].0.interfaces.last().unwrap();
+    assert_debug_snapshot!(annotations.get_with_id(intf.id), @r###"
+    Some(
+        MethodDeclarations {
+            declarations: {
+                "fred": [
+                    Abstract(
+                        "quxar.fred",
+                    ),
+                ],
+                "garply": [
+                    Abstract(
+                        "quuz.garply",
+                    ),
+                ],
+                "corge": [
+                    Abstract(
+                        "quux.corge",
+                    ),
+                ],
+                "waldo": [
+                    Abstract(
+                        "quxat.waldo",
+                    ),
+                ],
+                "grault": [
+                    Abstract(
+                        "quuz.grault",
+                    ),
+                ],
+                "bar": [
+                    Abstract(
+                        "foo.bar",
+                    ),
+                ],
+                "qux": [
+                    Abstract(
+                        "baz.qux",
+                    ),
+                ],
+            },
+        },
+    )
+    "###);
+}
+
+#[test]
+fn extended_interface_has_overridden_method_annotated() {
+    let id_provider = IdProvider::default();
+    let (unit, index, _) = index_and_lower(
+        r#"
+        INTERFACE foo
+            METHOD bar
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE baz EXTENDS foo
+            METHOD bar
+            END_METHOD
+            METHOD qux
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quux
+            METHOD qux
+            END_METHOD
+            METHOD corge
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quuz EXTENDS quux
+            METHOD grault
+            END_METHOD
+            METHOD corge
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE grauply EXTENDS quuz
+            METHOD qux 
+            END_METHOD
+            METHOD corge 
+            END_METHOD
+            METHOD grault
+            END_METHOD
+        END_INTERFACE
+    "#,
+        id_provider.clone(),
+    );
+
+    let (annotations, _, units) = annotate_and_lower_with_ids(unit, index, id_provider);
+    let intf_baz = &units[0].0.interfaces[1];
+    let method = &intf_baz.methods[0];
+    // for baz we only expect one override, `bar`
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "foo.bar",
+                ),
+            ],
+        },
+    )
+    "#);
+    // for grauply, we expect all 3 methods to be overrides at different inheritance levels.
+    let intf_grauply = &units[0].0.interfaces[4];
+    let method = &intf_grauply.methods[0];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quux.qux",
+                ),
+            ],
+        },
+    )
+    "#);
+    // The method `corge` is defined in each interface in the inheritance chain, so we expect 2 overrides
+    let method = &intf_grauply.methods[1];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quuz.corge",
+                ),
+                Abstract(
+                    "quux.corge",
+                ),
+            ],
+        },
+    )
+    "#);
+    let method = &intf_grauply.methods[2];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quuz.grault",
+                ),
+            ],
+        },
+    )
+    "#);
+}
+
+#[test]
+fn function_block_has_both_abstract_and_concrete_annotation_from_extended_intf() {
+    let id_provider = IdProvider::default();
+    let (unit, index, _) = index_and_lower(
+        r#"
+        INTERFACE foo
+            METHOD bar
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE baz EXTENDS foo
+            METHOD qux
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quux
+            METHOD corge
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quuz EXTENDS quux
+            METHOD grault
+            END_METHOD
+
+            METHOD garply
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quxat
+            METHOD waldo
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quxar EXTENDS quuz, baz, quxat
+            METHOD fred
+            END_METHOD
+        END_INTERFACE
+
+        FUNCTION_BLOCK fb IMPLEMENTS quxar
+            METHOD bar
+            END_METHOD
+            METHOD qux
+            END_METHOD
+            METHOD corge
+            END_METHOD
+            METHOD grault
+            END_METHOD
+            METHOD garply
+            END_METHOD
+            METHOD waldo
+            END_METHOD
+            METHOD fred
+            END_METHOD
+        END_FUNCTION_BLOCK
+    "#,
+        id_provider.clone(),
+    );
+
+    let (annotations, _, units) = annotate_and_lower_with_ids(unit, index, id_provider);
+    let units = &units[0].0.units;
+    let fb = &units[0];
+    assert_debug_snapshot!(annotations.get_with_id(fb.id), @r#"
+    Some(
+        MethodDeclarations {
+            declarations: {
+                "corge": [
+                    Concrete(
+                        "fb.corge",
+                    ),
+                    Abstract(
+                        "quux.corge",
+                    ),
+                ],
+                "garply": [
+                    Concrete(
+                        "fb.garply",
+                    ),
+                    Abstract(
+                        "quuz.garply",
+                    ),
+                ],
+                "waldo": [
+                    Concrete(
+                        "fb.waldo",
+                    ),
+                    Abstract(
+                        "quxat.waldo",
+                    ),
+                ],
+                "fred": [
+                    Concrete(
+                        "fb.fred",
+                    ),
+                    Abstract(
+                        "quxar.fred",
+                    ),
+                ],
+                "grault": [
+                    Concrete(
+                        "fb.grault",
+                    ),
+                    Abstract(
+                        "quuz.grault",
+                    ),
+                ],
+                "bar": [
+                    Concrete(
+                        "fb.bar",
+                    ),
+                    Abstract(
+                        "foo.bar",
+                    ),
+                ],
+                "qux": [
+                    Concrete(
+                        "fb.qux",
+                    ),
+                    Abstract(
+                        "baz.qux",
+                    ),
+                ],
+            },
+        },
+    )
+    "#);
+}
+
+#[test]
+fn function_block_methods_have_overrides_from_extended_interface_annotated() {
+    let id_provider = IdProvider::default();
+    let (unit, index, _) = index_and_lower(
+        r#"
+        INTERFACE foo
+            METHOD bar
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE baz EXTENDS foo
+            METHOD qux
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quux
+            METHOD corge
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quuz EXTENDS quux
+            METHOD grault
+            END_METHOD
+
+            METHOD garply
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quxat
+            METHOD waldo
+            END_METHOD
+        END_INTERFACE
+
+        INTERFACE quxar EXTENDS quuz, baz, quxat
+            METHOD fred
+            END_METHOD
+        END_INTERFACE
+
+        FUNCTION_BLOCK fb IMPLEMENTS quxar
+            METHOD bar
+            END_METHOD
+            METHOD qux
+            END_METHOD
+            METHOD corge
+            END_METHOD
+            METHOD grault
+            END_METHOD
+            METHOD garply
+            END_METHOD
+            METHOD waldo
+            END_METHOD
+            METHOD fred
+            END_METHOD
+        END_FUNCTION_BLOCK
+    "#,
+        id_provider.clone(),
+    );
+
+    let (annotations, _, units) = annotate_and_lower_with_ids(unit, index, id_provider);
+    let units = &units[0].0.units;
+    let method = &units[1];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "foo.bar",
+                ),
+            ],
+        },
+    )
+    "#);
+    let method = &units[2];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "baz.qux",
+                ),
+            ],
+        },
+    )
+    "#);
+    let method = &units[3];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quux.corge",
+                ),
+            ],
+        },
+    )
+    "#);
+    let method = &units[4];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quuz.grault",
+                ),
+            ],
+        },
+    )
+    "#);
+    let method = &units[5];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quuz.garply",
+                ),
+            ],
+        },
+    )
+    "#);
+    let method = &units[6];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quxat.waldo",
+                ),
+            ],
+        },
+    )
+    "#);
+    let method = &units[7];
+    assert_debug_snapshot!(annotations.get_with_id(method.id), @r#"
+    Some(
+        Override {
+            definitions: [
+                Abstract(
+                    "quxar.fred",
+                ),
+            ],
+        },
+    )
+    "#);
+}

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -18,7 +18,7 @@ use crate::{
 
 use self::{
     global::GlobalValidator,
-    pou::{visit_implementation, visit_pou},
+    pou::{visit_implementation, visit_interface, visit_pou},
     recursive::RecursiveValidator,
     types::visit_user_type_declaration,
     variable::visit_variable_block,
@@ -196,6 +196,10 @@ impl<'a> Validator<'a> {
         // Validate implementations
         for implementation in &unit.implementations {
             visit_implementation(self, implementation, &context);
+        }
+
+        for interface in &unit.interfaces {
+            visit_interface(self, interface, &context);
         }
     }
 

--- a/src/validation/global.rs
+++ b/src/validation/global.rs
@@ -226,7 +226,7 @@ impl GlobalValidator {
         let interfaces = index
             .get_interfaces()
             .values()
-            .map(|interface| (interface.name.as_str(), &interface.location_name));
+            .map(|interface| (interface.get_name(), interface.get_name_location()));
 
         self.check_uniqueness_of_cluster(interfaces, Some("Ambiguous interface"));
     }

--- a/src/validation/recursive.rs
+++ b/src/validation/recursive.rs
@@ -1,9 +1,13 @@
+use std::hash::Hash;
+use std::marker::PhantomData;
+
 use itertools::Itertools;
 
 use plc_ast::ast::PouType;
 use plc_diagnostics::diagnostics::Diagnostic;
+use plc_source::source_location::SourceLocation;
 
-use crate::index::FxIndexSet;
+use crate::index::{FxIndexSet, InterfaceIndexEntry};
 use crate::{
     index::{Index, VariableIndexEntry},
     typesystem::{DataType, DataTypeInformation, DataTypeInformationProvider, StructSource},
@@ -39,97 +43,22 @@ impl RecursiveValidator {
 
     /// Entry point of finding and reporting all recursive data structures.
     pub fn validate(&mut self, index: &Index) {
-        let mut nodes_all: FxIndexSet<&DataType> = FxIndexSet::default();
-        let mut nodes_visited = FxIndexSet::default();
+        let mut detective = CycleInvestigator::<DataType>::new();
+        self.diagnostics.extend(detective.investigate(index));
 
-        // Structs (includes arrays defined in structs)
-        nodes_all.extend(index.get_types().values().filter(|x| x.get_type_information().is_struct()));
-
-        // Function Blocks
-        nodes_all.extend(index.get_pou_types().values().filter(|x| {
-            matches!(
-                x.get_type_information(),
-                DataTypeInformation::Struct { source: StructSource::Pou(PouType::FunctionBlock), .. }
-            )
-        }));
-
-        self.find_cycle(index, nodes_all, &mut nodes_visited);
+        let mut detective = CycleInvestigator::<InterfaceIndexEntry>::new();
+        self.diagnostics.extend(detective.investigate(index));
     }
+}
 
-    /// Finds cycles for the given nodes.
-    fn find_cycle<'idx>(
-        &mut self,
-        index: &'idx Index,
-        nodes_all: FxIndexSet<&'idx DataType>,
-        nodes_visited: &mut FxIndexSet<&'idx DataType>,
-    ) {
-        let mut path = FxIndexSet::default();
+struct CycleInvestigator<T> {
+    diagnostics: Vec<Diagnostic>,
+    _marker: PhantomData<T>,
+}
 
-        for node in &nodes_all {
-            if !nodes_visited.contains(node) {
-                self.dfs(index, &mut path, node, nodes_visited);
-            }
-        }
-    }
-
-    /// In DFS manner recursively visits a node and all its child nodes while simultaneously creating a path
-    /// of it. Ends either by detecting a cycle, i.e. re-visting a node that is already present in our path,
-    /// or by reaching a node with no further child nodes. In both cases the function goes back one recursion
-    /// depth repeating itself for the remaining child nodes until all nodes have been visited. All detected
-    /// cycles are added to the diagnostician.
-    fn dfs<'idx>(
-        &mut self,
-        index: &'idx Index,
-        path: &mut FxIndexSet<&'idx DataType>,
-        node_curr: &'idx DataType,
-        nodes_visited: &mut FxIndexSet<&'idx DataType>,
-    ) {
-        nodes_visited.insert(node_curr);
-        path.insert(node_curr);
-
-        for node in
-            node_curr.get_struct_members().iter().map(|x| self.get_type(index, x)).collect::<FxIndexSet<_>>()
-        {
-            if path.contains(node) {
-                self.report(node, path);
-            } else if !nodes_visited.contains(node) {
-                self.dfs(index, path, node, nodes_visited);
-            }
-        }
-        path.pop();
-    }
-
-    /// Generates and reports the minimal path of a cycle. Specifically `path` contains all nodes visited up
-    /// until a cycle, e.g. `A -> B -> C -> B`. We are only interested in `B -> C -> B` as such this method
-    /// finds the first occurence of `B` to create a vector slice of `B -> C -> B` for the diagnostician.
-    fn report<'idx>(&mut self, node: &'idx DataType, path: &mut FxIndexSet<&'idx DataType>) {
-        match path.get_index_of(node) {
-            Some(idx) => {
-                let mut slice = path.iter().skip(idx).copied().collect::<Vec<_>>();
-                let ranges = slice.iter().map(|node| node.location.to_owned()).collect::<Vec<_>>();
-
-                slice.push(node); // Append to get `B -> C -> B` instead of `B -> C` in the report
-                let error = slice.iter().map(|it| it.get_name()).join(" -> ");
-                let diagnostic =
-                    Diagnostic::new(format!("Recursive data structure `{}` has infinite size", error))
-                        .with_error_code("E029");
-
-                let diagnostic = if let Some(first) = ranges.first() {
-                    diagnostic.with_location(first)
-                } else {
-                    diagnostic
-                };
-
-                let diagnostic = if ranges.len() > 1 {
-                    ranges.iter().fold(diagnostic, |prev, it| prev.with_secondary_location(it))
-                } else {
-                    diagnostic
-                };
-                self.diagnostics.push(diagnostic);
-            }
-
-            None => unreachable!("Node has to be in the FxIndexSet"),
-        }
+impl<T> CycleInvestigator<T> {
+    fn new() -> Self {
+        Self { diagnostics: vec![], _marker: PhantomData }
     }
 
     /// Returns the data type of `entry` distinguishing between two cases:
@@ -157,5 +86,193 @@ impl RecursiveValidator {
         } else {
             dt
         }
+    }
+}
+
+trait CycleDetector {
+    type Item;
+
+    /// Entry point for the cycle detection. Returns a diagnostic for each cycle detected during investigation.
+    fn investigate(&mut self, index: &Index) -> Vec<Diagnostic>;
+
+    /// Finds cycles for the given nodes.
+    fn find_cycle<'idx>(
+        &mut self,
+        index: &'idx Index,
+        nodes_all: &FxIndexSet<&'idx Self::Item>,
+        nodes_visited: &mut FxIndexSet<&'idx Self::Item>,
+    ) where
+        Self::Item: Hash + Eq,
+    {
+        let mut path = FxIndexSet::default();
+
+        for node in nodes_all {
+            if !nodes_visited.contains(node) {
+                self.dfs(index, &mut path, node, nodes_visited);
+            }
+        }
+    }
+    /// In DFS manner recursively visits a node and all its child nodes while simultaneously creating a path
+    /// of it. Ends either by detecting a cycle, i.e. re-visting a node that is already present in our path,
+    /// or by reaching a node with no further child nodes. In both cases the function goes back one recursion
+    /// depth repeating itself for the remaining child nodes until all nodes have been visited. All detected
+    /// cycles are added to the diagnostician.
+    fn dfs<'idx>(
+        &mut self,
+        index: &'idx Index,
+        path: &mut FxIndexSet<&'idx Self::Item>,
+        node_curr: &'idx Self::Item,
+        nodes_visited: &mut FxIndexSet<&'idx Self::Item>,
+    );
+
+    /// Generates and reports the minimal path of a cycle. Specifically `path` contains all nodes visited up
+    /// until a cycle, e.g. `A -> B -> C -> B`. We are only interested in `B -> C -> B` as such this method
+    /// finds the first occurence of `B` to create a vector slice of `B -> C -> B` for the diagnostician.
+    fn report<'idx>(&mut self, node: &'idx Self::Item, path: &mut FxIndexSet<&'idx Self::Item>) -> Diagnostic
+    where
+        Self::Item: DataProvider,
+        Self::Item: Hash + Eq,
+    {
+        let idx = path.get_index_of(node).expect("Node has to be in the IndexSet");
+
+        let mut slice = path.iter().skip(idx).copied().collect::<Vec<_>>();
+        let ranges = slice.iter().map(|node| node.get_location()).collect::<Vec<_>>();
+
+        slice.push(node); // Append to get `B -> C -> B` instead of `B -> C` in the report
+        let error = slice.iter().map(|it| it.get_name()).join(" -> ");
+        let diagnostic =
+            Diagnostic::new(format!("Recursive {} `{}` has infinite size", node.get_category_name(), error))
+                .with_error_code("E029");
+
+        let diagnostic =
+            if let Some(first) = ranges.first() { diagnostic.with_location(first) } else { diagnostic };
+
+        let diagnostic = if ranges.len() > 1 {
+            ranges.iter().fold(diagnostic, |prev, it| prev.with_secondary_location(it))
+        } else {
+            diagnostic
+        };
+
+        diagnostic
+    }
+}
+
+impl CycleDetector for CycleInvestigator<DataType> {
+    type Item = DataType;
+
+    fn investigate(&mut self, index: &Index) -> Vec<Diagnostic> {
+        let mut nodes_all = FxIndexSet::default();
+        let mut nodes_visited = FxIndexSet::default();
+
+        // Structs (includes arrays defined in structs)
+        nodes_all.extend(index.get_types().values().filter(|x| x.get_type_information().is_struct()));
+
+        // Function Blocks
+        nodes_all.extend(index.get_pou_types().values().filter(|x| {
+            matches!(
+                x.get_type_information(),
+                DataTypeInformation::Struct { source: StructSource::Pou(PouType::FunctionBlock), .. }
+            )
+        }));
+
+        self.find_cycle(index, &nodes_all, &mut nodes_visited);
+        std::mem::take(&mut self.diagnostics)
+    }
+
+    fn dfs<'idx>(
+        &mut self,
+        index: &'idx Index,
+        path: &mut FxIndexSet<&'idx Self::Item>,
+        node_curr: &'idx Self::Item,
+        nodes_visited: &mut FxIndexSet<&'idx Self::Item>,
+    ) {
+        nodes_visited.insert(node_curr);
+        path.insert(node_curr);
+
+        for node in
+            node_curr.get_struct_members().iter().map(|x| self.get_type(index, x)).collect::<FxIndexSet<_>>()
+        {
+            if path.contains(node) {
+                let diagnostic = self.report(node, path);
+                self.diagnostics.push(diagnostic);
+            } else if !nodes_visited.contains(node) {
+                self.dfs(index, path, node, nodes_visited);
+            }
+        }
+        path.pop();
+    }
+}
+
+impl CycleDetector for CycleInvestigator<InterfaceIndexEntry> {
+    type Item = InterfaceIndexEntry;
+
+    fn investigate(&mut self, index: &Index) -> Vec<Diagnostic> {
+        let mut nodes_all = FxIndexSet::default();
+        let mut nodes_visited = FxIndexSet::default();
+
+        nodes_all.extend(index.get_interfaces().values());
+
+        self.find_cycle(index, &nodes_all, &mut nodes_visited);
+        std::mem::take(&mut self.diagnostics)
+    }
+
+    fn dfs<'idx>(
+        &mut self,
+        index: &'idx Index,
+        path: &mut FxIndexSet<&'idx Self::Item>,
+        node_curr: &'idx Self::Item,
+        nodes_visited: &mut FxIndexSet<&'idx Self::Item>,
+    ) {
+        nodes_visited.insert(node_curr);
+        path.insert(node_curr);
+
+        for node in node_curr
+            .get_extensions()
+            .iter()
+            .filter_map(|id| index.find_interface(&id.name))
+            .collect::<FxIndexSet<_>>()
+        {
+            if path.contains(node) {
+                let diagnostic = self.report(node, path);
+                self.diagnostics.push(diagnostic);
+            } else if !nodes_visited.contains(node) {
+                self.dfs(index, path, node, nodes_visited);
+            }
+        }
+        path.pop();
+    }
+}
+
+trait DataProvider {
+    fn get_location(&self) -> SourceLocation;
+    fn get_name(&self) -> &str;
+    fn get_category_name(&self) -> &str;
+}
+
+impl DataProvider for DataType {
+    fn get_location(&self) -> SourceLocation {
+        self.location.to_owned()
+    }
+
+    fn get_name(&self) -> &str {
+        self.get_name()
+    }
+
+    fn get_category_name(&self) -> &str {
+        "data structure"
+    }
+}
+
+impl DataProvider for InterfaceIndexEntry {
+    fn get_location(&self) -> SourceLocation {
+        self.get_name_location().to_owned()
+    }
+
+    fn get_name(&self) -> &str {
+        self.get_name()
+    }
+
+    fn get_category_name(&self) -> &str {
+        "inheritance"
     }
 }


### PR DESCRIPTION
Interfaces can now be extended by other interfaces. 
This involves changes in the parsing, indexing, resolving and most importantly the validation stage.
Extends the already existing validations for extended `FUNCTION_BLOCKS` to also take interfaces into account, wherever applicable.