### PR TITLE
fix: action containers should not include methods

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -111,7 +111,20 @@ pub fn parse(mut lexer: ParseSession, lnk: LinkageType, file_name: &str) -> Pars
                 }
             }
             KeywordActions => {
-                let last_pou = unit.units.last().map(|it| it.name.as_str()).unwrap_or("__unknown__");
+                let last_pou = unit
+                    .units
+                    .iter()
+                    .filter(|it| {
+                        // Only consider the last POU that is a program, function, function block
+                        // or class
+                        matches!(
+                            it.kind,
+                            PouType::Program | PouType::Function | PouType::FunctionBlock | PouType::Class
+                        )
+                    })
+                    .last()
+                    .map(|it| it.name.as_str())
+                    .unwrap_or("__unknown__");
                 let mut actions = parse_actions(&mut lexer, linkage, last_pou);
                 unit.implementations.append(&mut actions);
             }

--- a/src/parser/tests/container_parser_tests.rs
+++ b/src/parser/tests/container_parser_tests.rs
@@ -74,6 +74,30 @@ fn actions_with_no_container_inherits_previous_pou() {
 }
 
 #[test]
+fn actions_with_no_container_inherits_previous_pou_excluding_methods_and_actions() {
+    let src = "PROGRAM buz END_PROGRAM PROGRAM foo METHOD x END_METHOD END_PROGRAM ACTIONS ACTION bar END_ACTION END_ACTIONS ACTIONS ACTION baz END_ACTION END_ACTIONS";
+    let (result, diagnostic) = parse(src);
+    let prg = &result.implementations[0];
+    assert_eq!(prg.name, "buz");
+    assert_eq!(prg.type_name, "buz");
+
+    let prg = &result.implementations[2];
+    assert_eq!(prg.name, "foo");
+    assert_eq!(prg.type_name, "foo");
+
+    let prg = &result.implementations[3];
+    assert_eq!(prg.name, "foo.bar");
+    assert_eq!(prg.type_name, "foo");
+
+    let prg = &result.implementations[4];
+    assert_eq!(prg.name, "foo.baz");
+    assert_eq!(prg.type_name, "foo");
+
+    //Expect no diagnostic, actions container name is optional
+    assert_eq!(diagnostic, []);
+}
+
+#[test]
 fn actions_with_invalid_token() {
     let src = "ACTIONS LIMA BRAVO END_ACTIONS";
     let errors = parse(src).1;


### PR DESCRIPTION
When looking for action containers, ignore POUs that are not Programs, Functions, Function_Blocks or Classes