### PR TITLE
fix: correctly handle temp varibles in actions and programs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -99,6 +99,15 @@
                 "RUST_LOG": "rusty"
             },
             "terminal": "integrated"
+        },
+        {
+            "type": "codelldb",
+            "request": "launch",
+            "name": "Debug st application demo",
+            "cwd": "${workspaceFolder}",
+            "program": "target/demo",
+            "terminal": "integrated"
+
         }
     ]
 }

--- a/src/codegen/debug.rs
+++ b/src/codegen/debug.rs
@@ -275,6 +275,7 @@ impl<'ink> DebugBuilder<'ink> {
         //Create each type
         let index_types = members
             .iter()
+            .filter(|it| !(it.is_temp() || it.is_variadic() || it.is_var_external()))
             .map(|it| (it.get_name(), it.get_type_name(), &it.source_location))
             .map(|(name, type_name, location)| {
                 index.get_type(type_name.as_ref()).map(|dt| (name, dt, location))
@@ -522,7 +523,7 @@ impl<'ink> DebugBuilder<'ink> {
     ///Creates the debug information for function variables
     ///For a `Function` these will be all VAR_INPUT, VAR_OUTPUT and VAR_IN_OUT in addition to
     ///entries for VAR and VAR_TEMP
-    ///For other POUs we create enties in VAR_TEMP and an additional single parameter at position 0
+    ///For other POUs we create entries in VAR_TEMP and an additional single parameter at position 0
     ///(the struct)
     fn create_function_variables(
         &mut self,
@@ -533,7 +534,7 @@ impl<'ink> DebugBuilder<'ink> {
         let mut param_offset = 0;
         //Register the return and local variables for debugging
         for variable in index
-            .get_pou_members(pou.get_name())
+            .get_variables_for_pou(pou)
             .iter()
             .filter(|it| it.is_local() || it.is_temp() || it.is_return())
         {

--- a/src/codegen/generators/pou_generator.rs
+++ b/src/codegen/generators/pou_generator.rs
@@ -696,7 +696,6 @@ impl<'ink, 'cg> PouGenerator<'ink, 'cg> {
             .ok_or_else(|| Diagnostic::missing_function(location))?;
         //Generate POU struct declaration for debug
         if let Some(block) = self.llvm.builder.get_insert_block() {
-            // debug.register_struct_parameter(type_name, function_context);
             debug.add_variable_declaration(
                 type_name,
                 param_pointer,

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
@@ -9,54 +9,54 @@ source_filename = "<internal>"
 %myFb = type {}
 
 @myPrg_instance = global %myPrg zeroinitializer, !dbg !0
-@__myFb__init = unnamed_addr constant %myFb zeroinitializer, !dbg !9
+@__myFb__init = unnamed_addr constant %myFb zeroinitializer, !dbg !5
 
-define i32 @myFunc() !dbg !21 {
+define i32 @myFunc() !dbg !13 {
 entry:
-  %myFunc = alloca i32, align 4, !dbg !25
-  %a = alloca i32, align 4, !dbg !25
-  %b = alloca i32, align 4, !dbg !25
-  %c = alloca i32, align 4, !dbg !25
-  call void @llvm.dbg.declare(metadata i32* %a, metadata !26, metadata !DIExpression()), !dbg !27
-  store i32 0, i32* %a, align 4, !dbg !25
-  call void @llvm.dbg.declare(metadata i32* %b, metadata !28, metadata !DIExpression()), !dbg !29
-  store i32 0, i32* %b, align 4, !dbg !25
-  call void @llvm.dbg.declare(metadata i32* %c, metadata !30, metadata !DIExpression()), !dbg !31
-  store i32 0, i32* %c, align 4, !dbg !25
-  call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !32, metadata !DIExpression()), !dbg !33
-  store i32 0, i32* %myFunc, align 4, !dbg !25
-  %myFunc_ret = load i32, i32* %myFunc, align 4, !dbg !25
-  ret i32 %myFunc_ret, !dbg !25
+  %myFunc = alloca i32, align 4, !dbg !16
+  %a = alloca i32, align 4, !dbg !16
+  %b = alloca i32, align 4, !dbg !16
+  %c = alloca i32, align 4, !dbg !16
+  call void @llvm.dbg.declare(metadata i32* %a, metadata !17, metadata !DIExpression()), !dbg !19
+  store i32 0, i32* %a, align 4, !dbg !16
+  call void @llvm.dbg.declare(metadata i32* %b, metadata !20, metadata !DIExpression()), !dbg !21
+  store i32 0, i32* %b, align 4, !dbg !16
+  call void @llvm.dbg.declare(metadata i32* %c, metadata !22, metadata !DIExpression()), !dbg !23
+  store i32 0, i32* %c, align 4, !dbg !16
+  call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !24, metadata !DIExpression()), !dbg !25
+  store i32 0, i32* %myFunc, align 4, !dbg !16
+  %myFunc_ret = load i32, i32* %myFunc, align 4, !dbg !16
+  ret i32 %myFunc_ret, !dbg !16
 }
 
-define void @myPrg(%myPrg* %0) !dbg !34 {
+define void @myPrg(%myPrg* %0) !dbg !26 {
 entry:
-  call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !37, metadata !DIExpression()), !dbg !38
-  %a = alloca i32, align 4, !dbg !38
-  %b = alloca i32, align 4, !dbg !38
-  %c = alloca i32, align 4, !dbg !38
-  call void @llvm.dbg.declare(metadata i32* %a, metadata !39, metadata !DIExpression()), !dbg !40
-  store i32 0, i32* %a, align 4, !dbg !38
-  call void @llvm.dbg.declare(metadata i32* %b, metadata !41, metadata !DIExpression()), !dbg !42
-  store i32 0, i32* %b, align 4, !dbg !38
-  call void @llvm.dbg.declare(metadata i32* %c, metadata !43, metadata !DIExpression()), !dbg !44
-  store i32 0, i32* %c, align 4, !dbg !38
-  ret void, !dbg !38
+  call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !29, metadata !DIExpression()), !dbg !30
+  %a = alloca i32, align 4, !dbg !30
+  %b = alloca i32, align 4, !dbg !30
+  %c = alloca i32, align 4, !dbg !30
+  call void @llvm.dbg.declare(metadata i32* %a, metadata !31, metadata !DIExpression()), !dbg !32
+  store i32 0, i32* %a, align 4, !dbg !30
+  call void @llvm.dbg.declare(metadata i32* %b, metadata !33, metadata !DIExpression()), !dbg !34
+  store i32 0, i32* %b, align 4, !dbg !30
+  call void @llvm.dbg.declare(metadata i32* %c, metadata !35, metadata !DIExpression()), !dbg !36
+  store i32 0, i32* %c, align 4, !dbg !30
+  ret void, !dbg !30
 }
 
-define void @myFb(%myFb* %0) !dbg !45 {
+define void @myFb(%myFb* %0) !dbg !37 {
 entry:
-  call void @llvm.dbg.declare(metadata %myFb* %0, metadata !48, metadata !DIExpression()), !dbg !49
-  %a = alloca i32, align 4, !dbg !49
-  %b = alloca i32, align 4, !dbg !49
-  %c = alloca i32, align 4, !dbg !49
-  call void @llvm.dbg.declare(metadata i32* %a, metadata !50, metadata !DIExpression()), !dbg !51
-  store i32 0, i32* %a, align 4, !dbg !49
-  call void @llvm.dbg.declare(metadata i32* %b, metadata !52, metadata !DIExpression()), !dbg !53
-  store i32 0, i32* %b, align 4, !dbg !49
-  call void @llvm.dbg.declare(metadata i32* %c, metadata !54, metadata !DIExpression()), !dbg !55
-  store i32 0, i32* %c, align 4, !dbg !49
-  ret void, !dbg !49
+  call void @llvm.dbg.declare(metadata %myFb* %0, metadata !40, metadata !DIExpression()), !dbg !41
+  %a = alloca i32, align 4, !dbg !41
+  %b = alloca i32, align 4, !dbg !41
+  %c = alloca i32, align 4, !dbg !41
+  call void @llvm.dbg.declare(metadata i32* %a, metadata !42, metadata !DIExpression()), !dbg !43
+  store i32 0, i32* %a, align 4, !dbg !41
+  call void @llvm.dbg.declare(metadata i32* %b, metadata !44, metadata !DIExpression()), !dbg !45
+  store i32 0, i32* %b, align 4, !dbg !41
+  call void @llvm.dbg.declare(metadata i32* %c, metadata !46, metadata !DIExpression()), !dbg !47
+  store i32 0, i32* %c, align 4, !dbg !41
+  ret void, !dbg !41
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -64,65 +64,57 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 
 attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-!llvm.module.flags = !{!16, !17}
-!llvm.dbg.cu = !{!18}
+!llvm.module.flags = !{!8, !9}
+!llvm.dbg.cu = !{!10}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "myPrg", scope: !2, file: !2, line: 5, type: !3, isLocal: false, isDefinition: true)
 !2 = !DIFile(filename: "<internal>", directory: "")
-!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "myPrg", scope: !2, file: !2, line: 5, size: 96, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myPrg")
-!4 = !{!5, !7, !8}
-!5 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 6, baseType: !6, size: 32, align: 32, flags: DIFlagPublic)
-!6 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-!7 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 6, baseType: !6, size: 32, align: 32, offset: 32, flags: DIFlagPublic)
-!8 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !2, file: !2, line: 6, baseType: !6, size: 32, align: 32, offset: 64, flags: DIFlagPublic)
-!9 = !DIGlobalVariableExpression(var: !10, expr: !DIExpression())
-!10 = distinct !DIGlobalVariable(name: "__myFb__init", scope: !2, file: !2, line: 8, type: !11, isLocal: false, isDefinition: true)
-!11 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 8, size: 96, align: 64, flags: DIFlagPublic, elements: !12, identifier: "myFb")
-!12 = !{!13, !14, !15}
-!13 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 9, baseType: !6, size: 32, align: 32, flags: DIFlagPublic)
-!14 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 9, baseType: !6, size: 32, align: 32, offset: 32, flags: DIFlagPublic)
-!15 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !2, file: !2, line: 9, baseType: !6, size: 32, align: 32, offset: 64, flags: DIFlagPublic)
-!16 = !{i32 2, !"Dwarf Version", i32 5}
-!17 = !{i32 2, !"Debug Info Version", i32 3}
-!18 = distinct !DICompileUnit(language: DW_LANG_C, file: !19, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !20, splitDebugInlining: false)
-!19 = !DIFile(filename: "<internal>", directory: "src")
-!20 = !{!0, !9}
-!21 = distinct !DISubprogram(name: "myFunc", linkageName: "myFunc", scope: !2, file: !2, line: 2, type: !22, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !18, retainedNodes: !24)
-!22 = !DISubroutineType(flags: DIFlagPublic, types: !23)
-!23 = !{null}
-!24 = !{}
-!25 = !DILocation(line: 4, column: 8, scope: !21)
-!26 = !DILocalVariable(name: "a", scope: !21, file: !2, line: 3, type: !6, align: 32)
-!27 = !DILocation(line: 3, column: 12, scope: !21)
-!28 = !DILocalVariable(name: "b", scope: !21, file: !2, line: 3, type: !6, align: 32)
-!29 = !DILocation(line: 3, column: 14, scope: !21)
-!30 = !DILocalVariable(name: "c", scope: !21, file: !2, line: 3, type: !6, align: 32)
-!31 = !DILocation(line: 3, column: 16, scope: !21)
-!32 = !DILocalVariable(name: "myFunc", scope: !21, file: !2, line: 2, type: !6, align: 32)
-!33 = !DILocation(line: 2, column: 17, scope: !21)
-!34 = distinct !DISubprogram(name: "myPrg", linkageName: "myPrg", scope: !2, file: !2, line: 5, type: !35, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !18, retainedNodes: !24)
-!35 = !DISubroutineType(flags: DIFlagPublic, types: !36)
-!36 = !{null, !3}
-!37 = !DILocalVariable(name: "myPrg", scope: !34, file: !2, line: 7, type: !3)
-!38 = !DILocation(line: 7, column: 8, scope: !34)
-!39 = !DILocalVariable(name: "a", scope: !34, file: !2, line: 6, type: !6, align: 32)
-!40 = !DILocation(line: 6, column: 17, scope: !34)
-!41 = !DILocalVariable(name: "b", scope: !34, file: !2, line: 6, type: !6, align: 32)
-!42 = !DILocation(line: 6, column: 19, scope: !34)
-!43 = !DILocalVariable(name: "c", scope: !34, file: !2, line: 6, type: !6, align: 32)
-!44 = !DILocation(line: 6, column: 21, scope: !34)
-!45 = distinct !DISubprogram(name: "myFb", linkageName: "myFb", scope: !2, file: !2, line: 8, type: !46, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !18, retainedNodes: !24)
-!46 = !DISubroutineType(flags: DIFlagPublic, types: !47)
-!47 = !{null, !11}
-!48 = !DILocalVariable(name: "myFb", scope: !45, file: !2, line: 10, type: !11)
-!49 = !DILocation(line: 10, column: 8, scope: !45)
-!50 = !DILocalVariable(name: "a", scope: !45, file: !2, line: 9, type: !6, align: 32)
-!51 = !DILocation(line: 9, column: 17, scope: !45)
-!52 = !DILocalVariable(name: "b", scope: !45, file: !2, line: 9, type: !6, align: 32)
-!53 = !DILocation(line: 9, column: 19, scope: !45)
-!54 = !DILocalVariable(name: "c", scope: !45, file: !2, line: 9, type: !6, align: 32)
-!55 = !DILocation(line: 9, column: 21, scope: !45)
+!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "myPrg", scope: !2, file: !2, line: 5, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myPrg")
+!4 = !{}
+!5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
+!6 = distinct !DIGlobalVariable(name: "__myFb__init", scope: !2, file: !2, line: 8, type: !7, isLocal: false, isDefinition: true)
+!7 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 8, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myFb")
+!8 = !{i32 2, !"Dwarf Version", i32 5}
+!9 = !{i32 2, !"Debug Info Version", i32 3}
+!10 = distinct !DICompileUnit(language: DW_LANG_C, file: !11, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !12, splitDebugInlining: false)
+!11 = !DIFile(filename: "<internal>", directory: "src")
+!12 = !{!0, !5}
+!13 = distinct !DISubprogram(name: "myFunc", linkageName: "myFunc", scope: !2, file: !2, line: 2, type: !14, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
+!14 = !DISubroutineType(flags: DIFlagPublic, types: !15)
+!15 = !{null}
+!16 = !DILocation(line: 4, column: 8, scope: !13)
+!17 = !DILocalVariable(name: "a", scope: !13, file: !2, line: 3, type: !18, align: 32)
+!18 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+!19 = !DILocation(line: 3, column: 12, scope: !13)
+!20 = !DILocalVariable(name: "b", scope: !13, file: !2, line: 3, type: !18, align: 32)
+!21 = !DILocation(line: 3, column: 14, scope: !13)
+!22 = !DILocalVariable(name: "c", scope: !13, file: !2, line: 3, type: !18, align: 32)
+!23 = !DILocation(line: 3, column: 16, scope: !13)
+!24 = !DILocalVariable(name: "myFunc", scope: !13, file: !2, line: 2, type: !18, align: 32)
+!25 = !DILocation(line: 2, column: 17, scope: !13)
+!26 = distinct !DISubprogram(name: "myPrg", linkageName: "myPrg", scope: !2, file: !2, line: 5, type: !27, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
+!27 = !DISubroutineType(flags: DIFlagPublic, types: !28)
+!28 = !{null, !3}
+!29 = !DILocalVariable(name: "myPrg", scope: !26, file: !2, line: 7, type: !3)
+!30 = !DILocation(line: 7, column: 8, scope: !26)
+!31 = !DILocalVariable(name: "a", scope: !26, file: !2, line: 6, type: !18, align: 32)
+!32 = !DILocation(line: 6, column: 17, scope: !26)
+!33 = !DILocalVariable(name: "b", scope: !26, file: !2, line: 6, type: !18, align: 32)
+!34 = !DILocation(line: 6, column: 19, scope: !26)
+!35 = !DILocalVariable(name: "c", scope: !26, file: !2, line: 6, type: !18, align: 32)
+!36 = !DILocation(line: 6, column: 21, scope: !26)
+!37 = distinct !DISubprogram(name: "myFb", linkageName: "myFb", scope: !2, file: !2, line: 8, type: !38, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
+!38 = !DISubroutineType(flags: DIFlagPublic, types: !39)
+!39 = !{null, !7}
+!40 = !DILocalVariable(name: "myFb", scope: !37, file: !2, line: 10, type: !7)
+!41 = !DILocation(line: 10, column: 8, scope: !37)
+!42 = !DILocalVariable(name: "a", scope: !37, file: !2, line: 9, type: !18, align: 32)
+!43 = !DILocation(line: 9, column: 17, scope: !37)
+!44 = !DILocalVariable(name: "b", scope: !37, file: !2, line: 9, type: !18, align: 32)
+!45 = !DILocation(line: 9, column: 19, scope: !37)
+!46 = !DILocalVariable(name: "c", scope: !37, file: !2, line: 9, type: !18, align: 32)
+!47 = !DILocation(line: 9, column: 21, scope: !37)
 ; ModuleID = '__initializers'
 source_filename = "__initializers"
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1413,6 +1413,14 @@ impl Index {
             .unwrap_or_else(|| &[])
     }
 
+    pub fn get_variables_for_pou(&self, pou: &PouIndexEntry) -> &[VariableIndexEntry] {
+        if pou.is_action() {
+            self.get_pou_members(pou.get_container())
+        } else {
+            self.get_pou_members(pou.get_name())
+        }
+    }
+
     pub fn find_pou_type(&self, pou_name: &str) -> Option<&DataType> {
         self.get_pou_types().get(&pou_name.to_lowercase())
     }


### PR DESCRIPTION
Make sure temp variables are not part of the program in debug structures.
When adding action debug info, get the struct from the parent pou

fixes #1428 