### PR TITLE
fix(parser): Array access on fn-call result

### DIFF
--- a/src/codegen/tests/function_tests.rs
+++ b/src/codegen/tests/function_tests.rs
@@ -403,3 +403,24 @@ fn argument_fed_by_ref_then_by_val() {
 
     insta::assert_snapshot!(result)
 }
+
+#[test]
+fn function_call_with_array_access() {
+    let result = codegen(
+        "
+        FUNCTION foo : ARRAY[1..5] OF DINT
+            foo := [5, 4, 3, 2, 1];
+        END_FUNCTION
+
+        FUNCTION main
+            VAR
+                value : DINT;
+            END_VAR
+
+            value := foo()[3];
+        END_FUNCTION
+    ",
+    );
+
+    insta::assert_snapshot!(result)
+}

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_call_with_array_access.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__function_call_with_array_access.snap
@@ -1,0 +1,44 @@
+---
+source: src/codegen/tests/function_tests.rs
+expression: result
+---
+; ModuleID = '<internal>'
+source_filename = "<internal>"
+
+define void @foo(i32* %0) {
+entry:
+  %foo = alloca i32*, align 8
+  store i32* %0, i32** %foo, align 8
+  %deref = load i32*, i32** %foo, align 8
+  store [5 x i32] [i32 5, i32 4, i32 3, i32 2, i32 1], i32* %deref, align 4
+  ret void
+}
+
+define void @main() {
+entry:
+  %value = alloca i32, align 4
+  store i32 0, i32* %value, align 4
+  %__foo0 = alloca [5 x i32], align 4
+  %0 = bitcast [5 x i32]* %__foo0 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %0, i8 0, i64 ptrtoint ([5 x i32]* getelementptr ([5 x i32], [5 x i32]* null, i32 1) to i64), i1 false)
+  %1 = bitcast [5 x i32]* %__foo0 to i32*
+  call void @foo(i32* %1)
+  %tmpVar = getelementptr inbounds [5 x i32], [5 x i32]* %__foo0, i32 0, i32 2
+  %load_tmpVar = load i32, i32* %tmpVar, align 4
+  store i32 %load_tmpVar, i32* %value, align 4
+  ret void
+}
+
+; Function Attrs: argmemonly nofree nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
+
+attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
+; ModuleID = '__init___testproject'
+source_filename = "__init___testproject"
+
+@llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___testproject, i8* null }]
+
+define void @__init___testproject() {
+entry:
+  ret void
+}

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -376,7 +376,20 @@ pub fn parse_call_statement(lexer: &mut ParseSession) -> Option<AstNode> {
                 )
             })
         };
-        Some(call_statement)
+
+        if lexer.try_consume(KeywordSquareParensOpen) {
+            let index = parse_any_in_region(lexer, vec![KeywordSquareParensClose], parse_expression);
+            let node = AstFactory::create_index_reference(
+                index,
+                Some(call_statement),
+                lexer.next_id(),
+                SourceLocation::undefined(),
+            );
+
+            Some(node)
+        } else {
+            Some(call_statement)
+        }
     } else {
         Some(reference)
     }

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1740,3 +1740,19 @@ fn parenthesized_expression_span() {
     let range = array.elements().unwrap().get_location().get_span().to_range().unwrap();
     assert_eq!(&src[range.start..range.end], "(1 + 2)");
 }
+
+#[test]
+fn function_call_array_index() {
+    let src = "
+    PROGRAM prg
+        foo()[1];
+        foo()[1 + 2]
+        foo()[one];
+        foo()[one + two];
+        foo()[bar()];
+    END_PROGRAM
+    ";
+
+    let parse_result = parse(src).0;
+    assert_debug_snapshot!(parse_result.implementations[0].statements);
+}

--- a/src/parser/tests/snapshots/rusty__parser__tests__expressions_parser_tests__function_call_array_index.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__expressions_parser_tests__function_call_array_index.snap
@@ -1,0 +1,116 @@
+---
+source: src/parser/tests/expressions_parser_tests.rs
+expression: "parse_result.implementations[0].statements"
+---
+[
+    ReferenceExpr {
+        kind: Index(
+            LiteralInteger {
+                value: 1,
+            },
+        ),
+        base: Some(
+            CallStatement {
+                operator: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "foo",
+                        },
+                    ),
+                    base: None,
+                },
+                parameters: None,
+            },
+        ),
+    },
+    ReferenceExpr {
+        kind: Index(
+            BinaryExpression {
+                operator: Plus,
+                left: LiteralInteger {
+                    value: 1,
+                },
+                right: LiteralInteger {
+                    value: 2,
+                },
+            },
+        ),
+        base: Some(
+            CallStatement {
+                operator: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "foo",
+                        },
+                    ),
+                    base: None,
+                },
+                parameters: None,
+            },
+        ),
+    },
+    ReferenceExpr {
+        kind: Index(
+            BinaryExpression {
+                operator: Plus,
+                left: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "one",
+                        },
+                    ),
+                    base: None,
+                },
+                right: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "two",
+                        },
+                    ),
+                    base: None,
+                },
+            },
+        ),
+        base: Some(
+            CallStatement {
+                operator: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "foo",
+                        },
+                    ),
+                    base: None,
+                },
+                parameters: None,
+            },
+        ),
+    },
+    ReferenceExpr {
+        kind: Index(
+            CallStatement {
+                operator: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "bar",
+                        },
+                    ),
+                    base: None,
+                },
+                parameters: None,
+            },
+        ),
+        base: Some(
+            CallStatement {
+                operator: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "foo",
+                        },
+                    ),
+                    base: None,
+                },
+                parameters: None,
+            },
+        ),
+    },
+]

--- a/tests/lit/single/functions/call_with_array_access_on_result.st
+++ b/tests/lit/single/functions/call_with_array_access_on_result.st
@@ -1,0 +1,37 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+FUNCTION foo: ARRAY[1..5] OF DINT
+    foo := [5, 4, 3, 2, 1];
+END_FUNCTION
+
+FUNCTION alwaysOne: DINT
+    alwaysOne := 1;
+END_FUNCTION
+
+FUNCTION main
+    VAR
+        value: DINT;
+        one: DINT := 1;
+        two: DINT := 2;
+    END_VAR
+
+    // CHECK: 5
+    value := foo()[1];
+    printf('%d$N', value);
+
+    // CHECK: 3
+    value := foo()[1 + 2];
+    printf('%d$N', value);
+
+    // CHECK: 5
+    value := foo()[one];
+    printf('%d$N', value);
+
+    // CHECK: 3
+    value := foo()[one + two];
+    printf('%d$N', value);
+
+    // CHECK: 5
+    value := foo()[alwaysOne()];
+    printf('%d$N', value);
+END_FUNCTION


### PR DESCRIPTION
This commit allows for code such as `foo()[3];` where `foo` is some POU returning an array