### PR TITLE
fix: recursive type check no longer fails on duplicate fields

### DIFF
--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -2256,3 +2256,36 @@ fn inheritance_chain_correctly_finds_parents() {
     let inheritance_chain = index.get_inheritance_chain("grandparent", "child");
     assert_eq!(inheritance_chain, Vec::<&PouIndexEntry>::new());
 }
+
+#[test]
+fn pou_with_two_types_not_consireded_recursive() {
+    let (_, index) = index(
+        "
+        FUNCTION_BLOCK fb
+        VAR x,y : DINT; END_VAR
+        END_FUNCTION_BLOCK
+        PROGRAM p
+        VAR
+            x : fb;
+            y : fb;
+        END_VAR
+        END_PROGRAM",
+    );
+
+    let pou_type = index.find_pou_type("p").unwrap();
+    assert_eq!(pou_type.get_type_information().get_size(&index).unwrap().bits(), 128);
+}
+
+#[test]
+fn pou_with_recursive_type_fails() {
+    let (_, index) = index(
+        "
+        FUNCTION_BLOCK fb
+        VAR x : fb; END_VAR
+        END_FUNCTION_BLOCK
+        ",
+    );
+
+    let pou_type = index.find_pou_type("fb").unwrap();
+    assert!(pou_type.get_type_information().get_size(&index).is_err());
+}

--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -631,7 +631,7 @@ impl DataTypeInformation {
         if self.is_struct() && !seen.insert(self.get_name()) {
             return Err(anyhow!("Recursive type detected: {}", self.get_name()));
         }
-        match self {
+        let res = match self {
             DataTypeInformation::Integer { size, .. } => Ok(Bytes::from_bits(*size)),
             DataTypeInformation::Float { size, .. } => Ok(Bytes::from_bits(*size)),
             DataTypeInformation::String { size, encoding } => Ok(size
@@ -668,7 +668,9 @@ impl DataTypeInformation {
                 .map(|it| it.get_size(index))
                 .unwrap_or_else(|| Ok(Bytes::from_bits(DINT_SIZE))),
             DataTypeInformation::Generic { .. } | DataTypeInformation::Void => Ok(Bytes::from_bits(0)),
-        }
+        };
+        seen.remove(self.get_name());
+        res
     }
 
     /// Returns the String encoding's alignment (character)


### PR DESCRIPTION
Recursive checks were failing in debug if the pou had the same type defined twice