### PR TITLE
cli: Distinguish between pre- and post-lowered AST

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -269,7 +269,9 @@ impl Debug for Pou {
             .field("variable_blocks", &self.variable_blocks)
             .field("pou_type", &self.kind)
             .field("return_type", &self.return_type)
-            .field("interfaces", &self.interfaces);
+            .field("interfaces", &self.interfaces)
+            .field("properties", &self.properties);
+
         if !self.generics.is_empty() {
             str.field("generics", &self.generics);
         }

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -27,7 +27,15 @@ pub struct CompileParameters {
         global = true,
         help = "Emit AST (Abstract Syntax Tree) as output"
     )]
-    pub output_ast: bool,
+    pub print_ast: bool,
+
+    #[clap(
+        long = "ast-lowered",
+        group = "format",
+        global = true,
+        help = "Emit lowered AST (Abstract Syntax Tree) as output"
+    )]
+    pub print_ast_lowered: bool,
 
     #[clap(long = "version", group = "format", global = true)]
     pub build_info: bool,
@@ -673,7 +681,8 @@ mod cli_tests {
     fn valid_output_formats() {
         let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--ir")).unwrap();
         assert!(parameters.output_ir);
-        assert!(!parameters.output_ast);
+        assert!(!parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
         assert!(!parameters.output_bit_code);
         assert!(!parameters.output_obj_code);
         assert!(!parameters.output_pic_obj);
@@ -682,7 +691,18 @@ mod cli_tests {
 
         let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--ast")).unwrap();
         assert!(!parameters.output_ir);
-        assert!(parameters.output_ast);
+        assert!(parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
+        assert!(!parameters.output_bit_code);
+        assert!(!parameters.output_obj_code);
+        assert!(!parameters.output_pic_obj);
+        assert!(!parameters.output_shared_obj);
+        assert!(!parameters.output_reloc_code);
+
+        let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--ast-lowered")).unwrap();
+        assert!(!parameters.output_ir);
+        assert!(!parameters.print_ast);
+        assert!(parameters.print_ast_lowered);
         assert!(!parameters.output_bit_code);
         assert!(!parameters.output_obj_code);
         assert!(!parameters.output_pic_obj);
@@ -691,7 +711,8 @@ mod cli_tests {
 
         let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--bc")).unwrap();
         assert!(!parameters.output_ir);
-        assert!(!parameters.output_ast);
+        assert!(!parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
         assert!(parameters.output_bit_code);
         assert!(!parameters.output_obj_code);
         assert!(!parameters.output_pic_obj);
@@ -700,7 +721,8 @@ mod cli_tests {
 
         let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--static")).unwrap();
         assert!(!parameters.output_ir);
-        assert!(!parameters.output_ast);
+        assert!(!parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
         assert!(!parameters.output_bit_code);
         assert!(parameters.output_obj_code);
         assert!(!parameters.output_pic_obj);
@@ -709,7 +731,8 @@ mod cli_tests {
 
         let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--pic")).unwrap();
         assert!(!parameters.output_ir);
-        assert!(!parameters.output_ast);
+        assert!(!parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
         assert!(!parameters.output_bit_code);
         assert!(!parameters.output_obj_code);
         assert!(parameters.output_pic_obj);
@@ -718,7 +741,8 @@ mod cli_tests {
 
         let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--shared")).unwrap();
         assert!(!parameters.output_ir);
-        assert!(!parameters.output_ast);
+        assert!(!parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
         assert!(!parameters.output_bit_code);
         assert!(!parameters.output_obj_code);
         assert!(!parameters.output_pic_obj);
@@ -727,7 +751,8 @@ mod cli_tests {
 
         let parameters = CompileParameters::parse(vec_of_strings!("input.st", "--relocatable")).unwrap();
         assert!(!parameters.output_ir);
-        assert!(!parameters.output_ast);
+        assert!(!parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
         assert!(!parameters.output_bit_code);
         assert!(!parameters.output_obj_code);
         assert!(!parameters.output_pic_obj);
@@ -736,7 +761,8 @@ mod cli_tests {
 
         let parameters = CompileParameters::parse(vec_of_strings!("input.st")).unwrap();
         assert!(!parameters.output_ir);
-        assert!(!parameters.output_ast);
+        assert!(!parameters.print_ast);
+        assert!(!parameters.print_ast_lowered);
         assert!(!parameters.output_bit_code);
         assert!(!parameters.output_obj_code);
         assert!(!parameters.output_pic_obj);

--- a/compiler/plc_lowering/src/inheritance.rs
+++ b/compiler/plc_lowering/src/inheritance.rs
@@ -295,6 +295,7 @@ mod units_tests {
             pou_type: FunctionBlock,
             return_type: None,
             interfaces: [],
+            properties: [],
         }
         "###);
     }
@@ -2065,6 +2066,7 @@ mod units_tests {
             pou_type: FunctionBlock,
             return_type: None,
             interfaces: [],
+            properties: [],
         }
         "###);
     }
@@ -2095,7 +2097,7 @@ mod units_tests {
 
         let (_, project) = parse_and_annotate("test", vec![src]).unwrap();
         let unit = &project.units[0].get_unit().pous[3];
-        assert_debug_snapshot!(unit, @r#"
+        assert_debug_snapshot!(unit, @r###"
         POU {
             name: "child.foo",
             variable_blocks: [
@@ -2146,8 +2148,9 @@ mod units_tests {
             },
             return_type: None,
             interfaces: [],
+            properties: [],
         }
-        "#);
+        "###);
     }
 
     #[test]

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__jump_and_label_converted_to_ast.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__jump_and_label_converted_to_ast.snap
@@ -29,6 +29,7 @@ CompilationUnit {
             pou_type: Program,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__negated_jump_ast.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__negated_jump_ast.snap
@@ -29,6 +29,7 @@ CompilationUnit {
             pou_type: Program,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__unconnected_jump_generated_as_empty_statement.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__unconnected_jump_generated_as_empty_statement.snap
@@ -29,6 +29,7 @@ CompilationUnit {
             pou_type: Program,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__unnamed_controls.snap
+++ b/compiler/plc_xml/src/xml_parser/snapshots/plc_xml__xml_parser__control__tests__unnamed_controls.snap
@@ -12,6 +12,7 @@ CompilationUnit {
             pou_type: Program,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/src/lowering/property.rs
+++ b/src/lowering/property.rs
@@ -457,6 +457,7 @@ mod tests {
                     },
                 ),
                 interfaces: [],
+                properties: [],
             }
             "###);
 
@@ -525,6 +526,7 @@ mod tests {
                 },
                 return_type: None,
                 interfaces: [],
+                properties: [],
             }
             "###);
         }
@@ -803,6 +805,7 @@ mod tests {
                         },
                     ),
                     interfaces: [],
+                    properties: [],
                 },
                 POU {
                     name: "foo.__set_bar",
@@ -833,6 +836,7 @@ mod tests {
                     },
                     return_type: None,
                     interfaces: [],
+                    properties: [],
                 },
             ]
             "###);

--- a/src/lowering/snapshots/rusty__lowering__calls__tests__function_wirh_array_of_string_return-3.snap
+++ b/src/lowering/snapshots/rusty__lowering__calls__tests__function_wirh_array_of_string_return-3.snap
@@ -33,6 +33,7 @@ CompilationUnit {
                 },
             ),
             interfaces: [],
+            properties: [],
         },
         POU {
             name: "main",
@@ -40,6 +41,7 @@ CompilationUnit {
             pou_type: Function,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/src/lowering/snapshots/rusty__lowering__calls__tests__function_with_string_return_is_changed.snap
+++ b/src/lowering/snapshots/rusty__lowering__calls__tests__function_with_string_return_is_changed.snap
@@ -1,6 +1,6 @@
 ---
 source: src/lowering/calls.rs
-expression: "unit.units[0]"
+expression: "unit.pous[0]"
 ---
 POU {
     name: "complexType",
@@ -37,4 +37,5 @@ POU {
         },
     ),
     interfaces: [],
+    properties: [],
 }

--- a/src/lowering/snapshots/rusty__lowering__calls__tests__method_with_string_return_is_changed.snap
+++ b/src/lowering/snapshots/rusty__lowering__calls__tests__method_with_string_return_is_changed.snap
@@ -1,6 +1,6 @@
 ---
 source: src/lowering/calls.rs
-expression: "unit.units[1]"
+expression: "unit.pous[1]"
 ---
 POU {
     name: "fb.complexMethod",
@@ -28,4 +28,5 @@ POU {
         },
     ),
     interfaces: [],
+    properties: [],
 }

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1571,7 +1571,7 @@ fn sized_string_as_function_return() {
     END_FUNCTION
     ",
     );
-    assert_debug_snapshot!(ast.pous[0], @r#"
+    assert_debug_snapshot!(ast.pous[0], @r###"
     POU {
         name: "foo",
         variable_blocks: [],
@@ -1590,8 +1590,9 @@ fn sized_string_as_function_return() {
             },
         ),
         interfaces: [],
+        properties: [],
     }
-    "#);
+    "###);
     assert_eq!(diagnostics.is_empty(), true);
 }
 
@@ -1604,7 +1605,7 @@ fn array_type_as_function_return() {
     ",
     );
 
-    assert_debug_snapshot!(ast.pous[0], @r#"
+    assert_debug_snapshot!(ast.pous[0], @r###"
     POU {
         name: "foo",
         variable_blocks: [],
@@ -1629,8 +1630,9 @@ fn array_type_as_function_return() {
             },
         ),
         interfaces: [],
+        properties: [],
     }
-    "#);
+    "###);
     assert_eq!(diagnostics.is_empty(), true);
 }
 

--- a/src/parser/tests/function_parser_tests.rs
+++ b/src/parser/tests/function_parser_tests.rs
@@ -183,7 +183,7 @@ fn varargs_parameters_can_be_parsed() {
     let (parse_result, diagnostics) = parse(src);
 
     assert_eq!(format!("{diagnostics:#?}"), format!("{:#?}", Vec::<Diagnostic>::new()).as_str());
-    assert_debug_snapshot!(parse_result.pous[0], @r#"
+    assert_debug_snapshot!(parse_result.pous[0], @r###"
     POU {
         name: "foo",
         variable_blocks: [
@@ -224,8 +224,9 @@ fn varargs_parameters_can_be_parsed() {
             },
         ),
         interfaces: [],
+        properties: [],
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -241,7 +242,7 @@ fn sized_varargs_parameters_can_be_parsed() {
     let (parse_result, diagnostics) = parse(src);
 
     assert_eq!(format!("{diagnostics:#?}"), format!("{:#?}", Vec::<Diagnostic>::new()).as_str());
-    assert_debug_snapshot!(parse_result.pous[0], @r#"
+    assert_debug_snapshot!(parse_result.pous[0], @r###"
     POU {
         name: "foo",
         variable_blocks: [
@@ -282,8 +283,9 @@ fn sized_varargs_parameters_can_be_parsed() {
             },
         ),
         interfaces: [],
+        properties: [],
     }
-    "#);
+    "###);
 }
 
 // Tests for function return types

--- a/src/parser/tests/interface_parser_tests.rs
+++ b/src/parser/tests/interface_parser_tests.rs
@@ -67,7 +67,7 @@ fn interface_with_single_method() {
     let (unit, diagnostics) = parse(source);
 
     assert_eq!(diagnostics.len(), 0, "Expected no diagnostics but got {:#?}", diagnostics);
-    insta::assert_debug_snapshot!(unit.interfaces, @r#"
+    insta::assert_debug_snapshot!(unit.interfaces, @r###"
     [
         Interface {
             id: 2,
@@ -135,13 +135,14 @@ fn interface_with_single_method() {
                         },
                     ),
                     interfaces: [],
+                    properties: [],
                 },
             ],
             extensions: [],
             properties: [],
         },
     ]
-    "#);
+    "###);
 }
 
 #[test]
@@ -170,7 +171,7 @@ fn interface_with_multiple_methods() {
     let (unit, diagnostics) = parse(source);
 
     assert_eq!(diagnostics.len(), 0, "Expected no diagnostics but got {:#?}", diagnostics);
-    insta::assert_debug_snapshot!(unit.interfaces, @r#"
+    insta::assert_debug_snapshot!(unit.interfaces, @r###"
     [
         Interface {
             id: 3,
@@ -238,6 +239,7 @@ fn interface_with_multiple_methods() {
                         },
                     ),
                     interfaces: [],
+                    properties: [],
                 },
                 POU {
                     name: "myInterface.bar",
@@ -278,13 +280,14 @@ fn interface_with_multiple_methods() {
                         },
                     ),
                     interfaces: [],
+                    properties: [],
                 },
             ],
             extensions: [],
             properties: [],
         },
     ]
-    "#);
+    "###);
 }
 
 #[test]
@@ -320,6 +323,7 @@ fn pou_implementing_single_interface() {
                 },
             },
         ],
+        properties: [],
     }
     "###);
 }
@@ -389,6 +393,7 @@ fn pou_implementing_multiple_interfaces() {
                 },
             },
         ],
+        properties: [],
     }
     "###);
 }
@@ -410,7 +415,7 @@ fn interface_deriving_from_other_interface() {
     let (unit, diagnostics) = parse(source);
 
     assert_eq!(diagnostics.len(), 0, "Expected no diagnostics but got {:#?}", diagnostics);
-    insta::assert_debug_snapshot!(unit.interfaces[1], @r#"
+    insta::assert_debug_snapshot!(unit.interfaces[1], @r###"
     Interface {
         id: 4,
         ident: Identifier {
@@ -453,6 +458,7 @@ fn interface_deriving_from_other_interface() {
                 },
                 return_type: None,
                 interfaces: [],
+                properties: [],
             },
         ],
         extensions: [
@@ -475,7 +481,7 @@ fn interface_deriving_from_other_interface() {
         ],
         properties: [],
     }
-    "#);
+    "###);
 }
 
 #[test]

--- a/src/parser/tests/snapshots/rusty__parser__tests__expressions_parser_tests__direct_access_as_expression_parsed.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__expressions_parser_tests__direct_access_as_expression_parsed.snap
@@ -12,6 +12,7 @@ CompilationUnit {
             pou_type: Program,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/src/parser/tests/snapshots/rusty__parser__tests__expressions_parser_tests__exp_mul_priority_test.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__expressions_parser_tests__exp_mul_priority_test.snap
@@ -16,6 +16,7 @@ CompilationUnit {
                 },
             ),
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/src/parser/tests/snapshots/rusty__parser__tests__misc_parser_tests__exponent_literals_parsed_as_variables.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__misc_parser_tests__exponent_literals_parsed_as_variables.snap
@@ -26,4 +26,5 @@ POU {
         },
     ),
     interfaces: [],
+    properties: [],
 }

--- a/src/parser/tests/snapshots/rusty__parser__tests__statement_parser_tests__empty_parameter_assignments_in_call_statement.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__statement_parser_tests__empty_parameter_assignments_in_call_statement.snap
@@ -52,6 +52,7 @@ CompilationUnit {
                 },
             ),
             interfaces: [],
+            properties: [],
         },
         POU {
             name: "main",
@@ -83,6 +84,7 @@ CompilationUnit {
             pou_type: Program,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/src/parser/tests/snapshots/rusty__parser__tests__type_parser_tests__typed_inline_enum_with_initial_values_can_be_parsed.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__type_parser_tests__typed_inline_enum_with_initial_values_can_be_parsed.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser/tests/type_parser_tests.rs
-expression: "result.units[0]"
+expression: "result.pous[0]"
 ---
 POU {
     name: "prg",
@@ -66,4 +66,5 @@ POU {
     pou_type: Program,
     return_type: None,
     interfaces: [],
+    properties: [],
 }

--- a/src/parser/tests/snapshots/rusty__parser__tests__variable_parser_tests__pou_var_with_address.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__variable_parser_tests__pou_var_with_address.snap
@@ -321,6 +321,7 @@ CompilationUnit {
             pou_type: Program,
             return_type: None,
             interfaces: [],
+            properties: [],
         },
     ],
     implementations: [

--- a/src/parser/tests/variable_parser_tests.rs
+++ b/src/parser/tests/variable_parser_tests.rs
@@ -504,6 +504,7 @@ fn var_external() {
                 pou_type: Function,
                 return_type: None,
                 interfaces: [],
+                properties: [],
             },
         ],
         implementations: [
@@ -645,6 +646,7 @@ fn var_external_constant() {
                 pou_type: Function,
                 return_type: None,
                 interfaces: [],
+                properties: [],
             },
         ],
         implementations: [

--- a/src/tests/adr/initializer_functions_adr.rs
+++ b/src/tests/adr/initializer_functions_adr.rs
@@ -74,6 +74,7 @@ fn ref_call_in_initializer_is_lowered_to_init_function() {
         pou_type: Init,
         return_type: None,
         interfaces: [],
+        properties: [],
     }
     "###);
 }
@@ -344,6 +345,7 @@ fn global_initializers_are_wrapped_in_single_init_function() {
         pou_type: ProjectInit,
         return_type: None,
         interfaces: [],
+        properties: [],
     }
     "###);
 


### PR DESCRIPTION
Changes the behavior of the `--ast` flag to always emit the pre-lowered AST while introducing a `--ast-lowered` that matches the current `--ast` output.

Still not perfect in that one can not adjust at what stage to emit the AST (i.e. similar to the participant trait) but good enough for now to peek at the AST before ANY lowering step was executed.