### PR TITLE
feat: use the target triple without unknown in tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "Build command : ./scripts/build.sh --build --release"
           ./scripts/build.sh --build --release --package \
-          --target x86_64-linux-gnu,aarch64-linux-gnu \
+          --target x86_64-linux-gnu,aarch64-linux-gnu, \
           x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
 
       - uses: actions/upload-artifact@master

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           echo "Build command : ./scripts/build.sh --build --release"
           ./scripts/build.sh --build --release --package \
-          --target x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
+          --target x86_64-linux-gnu,aarch64-linux-gnu \
+          x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
 
       - uses: actions/upload-artifact@master
         with:

--- a/tests/integration/build_description_tests.rs
+++ b/tests/integration/build_description_tests.rs
@@ -45,13 +45,13 @@ fn exports_env_variable() {
         "build",
         &get_test_file("json/build_to_temp.json"),
         "--target",
-        "aarch64-unknown-linux-gnu",
+        "aarch64-linux-gnu",
         "--build-location",
         dir.path().to_str().unwrap(),
     ];
     compile(parameters).unwrap();
 
-    assert_eq!(std::env::var("ARCH").unwrap(), "aarch64-unknown-linux-gnu");
+    assert_eq!(std::env::var("ARCH").unwrap(), "aarch64-linux-gnu");
 }
 
 #[test]
@@ -86,13 +86,13 @@ fn build_with_target_but_without_sysroot() {
         "build",
         &get_test_file("json/build_without_sysroot.json"),
         "--target",
-        "x86_64-unknown-linux-gnu",
+        "x86_64-linux-gnu",
         "--build-location",
         dir.path().to_str().unwrap(),
     ];
     compile(parameters).unwrap();
 
-    assert!(dir.path().join("x86_64-unknown-linux-gnu").join("proj.so").is_file());
+    assert!(dir.path().join("x86_64-linux-gnu").join("proj.so").is_file());
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn build_with_cc_linker() {
     let dir = tempfile::tempdir().unwrap();
     let arch = match () {
         #[cfg(target_arch = "x86_64")]
-        _ => "x86_64-unknown-linux-gnu",
+        _ => "x86_64-linux-gnu",
 
         #[cfg(target_arch = "aarch64")]
         _ => match () {
@@ -110,7 +110,7 @@ fn build_with_cc_linker() {
             _ => "aarch64-apple-darwin",
 
             #[cfg(not(target_os = "macos"))]
-            _ => "aarch64-unknown-linux-gnu",
+            _ => "aarch64-linux-gnu",
         },
     };
 

--- a/tests/integration/external_files.rs
+++ b/tests/integration/external_files.rs
@@ -13,7 +13,7 @@ fn compile_all(name: &str, encoding: Option<&'static Encoding>) {
     let out_name = format!("{}.out", &name);
     out.push(out_name);
     let out = out.into_os_string().into_string().unwrap();
-    let mut main_args = vec!["plc", &path, "-o", &out, "-Odefault", "--target", "x86_64-unknown-linux-pc"];
+    let mut main_args = vec!["plc", &path, "-o", &out, "-Odefault", "--target", "x86_64-linux-pc"];
     if let Some(encoding) = encoding {
         main_args.push("--encoding");
         main_args.push(encoding.name());


### PR DESCRIPTION
There is no need to add the vendor id in our target triples.
This commit removes it from the test but keeps it in the github action for compatiblity.