### PR TITLE
refactor: Introduce `StatementAnnotation::Argument`

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -1269,13 +1269,13 @@ impl AstNode {
     pub fn has_super_metadata(&self) -> bool {
         self.get_metadata()
             .or_else(|| self.get_identifier().and_then(|it| it.get_metadata()))
-            .map_or(false, |it| it.is_super())
+            .is_some_and(|it| it.is_super())
     }
 
     pub fn has_super_metadata_deref(&self) -> bool {
         self.get_metadata()
             .or_else(|| self.get_identifier().and_then(|it| it.get_metadata()))
-            .map_or(false, |it| it.is_super_deref())
+            .is_some_and(|it| it.is_super_deref())
     }
 
     pub fn can_be_assigned_to(&self) -> bool {

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -593,8 +593,8 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
                     index: self
                         .annotations
                         .get_hint(assignment_statement)
-                        .expect("arguments must have a type hint")
-                        .get_location_in_parent(),
+                        .and_then(StatementAnnotation::get_location_in_parent)
+                        .expect("arguments must have a type hint"),
                     parameter_struct,
                 })?
             }
@@ -1173,8 +1173,8 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
                 index: self
                     .annotations
                     .get_hint(argument)
-                    .expect("arguments must have a type-hint")
-                    .get_location_in_parent(),
+                    .and_then(StatementAnnotation::get_location_in_parent)
+                    .expect("arguments must have a type hint"),
                 parameter_struct,
             })?;
             if let Some(parameter) = parameter {

--- a/src/codegen/tests/directaccess_test.rs
+++ b/src/codegen/tests/directaccess_test.rs
@@ -141,7 +141,7 @@ fn direct_acess_in_output_assignment_implicit_explicit_and_mixed() {
         ",
     );
 
-    assert_snapshot!(ir, @r#"
+    assert_snapshot!(ir, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
 
@@ -218,7 +218,7 @@ fn direct_acess_in_output_assignment_implicit_explicit_and_mixed() {
     declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
-    "#);
+    "###);
 }
 
 #[test]
@@ -305,7 +305,7 @@ fn direct_acess_in_output_assignment_with_simple_expression_implicit() {
         ",
     );
 
-    assert_snapshot!(ir, @r#"
+    assert_snapshot!(ir, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
 
@@ -344,7 +344,7 @@ fn direct_acess_in_output_assignment_with_simple_expression_implicit() {
     declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
-    "#);
+    "###);
 }
 
 #[test]

--- a/src/codegen/tests/parameters_tests.rs
+++ b/src/codegen/tests/parameters_tests.rs
@@ -1025,7 +1025,7 @@ fn by_value_fb_arg_aggregates_are_memcopied() {
         "#,
     );
 
-    assert_snapshot!(result, @r#"
+    assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
 
@@ -1077,7 +1077,7 @@ fn by_value_fb_arg_aggregates_are_memcopied() {
 
     attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
     attributes #1 = { argmemonly nofree nounwind willreturn }
-    "#);
+    "###);
 }
 
 #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -700,24 +700,19 @@ pub enum PouIndexEntry {
 }
 
 impl PouIndexEntry {
-    pub fn get_method_name(&self) -> String {
+    pub fn get_method_name(&self) -> Option<String> {
         match self {
             PouIndexEntry::Method { property: Some((name, kind)), .. } => {
                 let kind = kind.to_string().to_uppercase();
-                format!("Property `{name}` ({kind})")
+                Some(format!("Property `{name}` ({kind})"))
             }
 
             PouIndexEntry::Method { name, .. } => {
                 let name = name.rsplit_once('.').map(|(_, rhs)| rhs).unwrap_or_default();
-                format!("Method `{name}`")
+                Some(format!("Method `{name}`"))
             }
 
-            _ => unreachable!(
-                "
-                *>yfw reading the name of this method*
-                https://i.pinimg.com/originals/47/8c/fe/478cfec0807b19eb0d96073c0301c82d.gif
-                "
-            ),
+            _ => None,
         }
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -442,9 +442,12 @@ pub enum StatementAnnotation {
     Value {
         resulting_type: String,
     },
-    /// XXX
+    /// An argument of a call statement
     Argument {
+        /// The resulting type of this argument
         resulting_type: String,
+
+        /// The position of the parameter this argument is assigned to
         position: usize,
     },
     /// a reference that resolves to a declared variable (e.g. `a` --> `PLC_PROGRAM.a`)
@@ -728,10 +731,24 @@ impl StatementAnnotation {
         }
     }
 
+    /// Returns the location of a parameter in some POU the argument is assigned to, for example
+    /// `foo(a, b, c)` will return `0` for `a`, `1` for `b` and `3` for c if `foo` has the following variable
+    /// blocks
+    /// ```norun
+    /// VAR_INPUT
+    ///     a, b : DINT;
+    /// END_VAR
+    /// VAR
+    ///     placeholder: DINT;
+    /// END_VAR
+    /// VAR_INPUT
+    ///     c : DINT;
+    /// END_VAR`
+    /// ```
     pub(crate) fn get_location_in_parent(&self) -> u32 {
         match self {
             StatementAnnotation::Argument { position, .. } => *position as u32,
-            _ => panic!(),
+            _ => panic!("incorrect use, must only be used when we dealing with arguments"),
         }
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -304,7 +304,6 @@ impl TypeAnnotator<'_> {
         } else {
             vec![]
         };
-        let operator_qualifier = &self.get_call_name(operator);
 
         let mut generics_candidates: FxHashMap<String, Vec<String>> = FxHashMap::default();
         let mut params = vec![];
@@ -312,6 +311,7 @@ impl TypeAnnotator<'_> {
 
         // If we are dealing with an action call statement, we need to get the declared parameters from the parent POU in order
         // to annotate them with the correct type hint.
+        let operator_qualifier = &self.get_call_name(operator);
         let implementation = self.index.find_implementation_by_name(operator_qualifier);
         let operator_qualifier = implementation.map(|it| it.get_type_name()).unwrap_or(operator_qualifier);
         for m in self.index.get_declared_parameters(operator_qualifier).into_iter() {
@@ -322,7 +322,7 @@ impl TypeAnnotator<'_> {
                 {
                     generics_candidates.entry(key.to_string()).or_default().push(candidate.to_string())
                 } else {
-                    params.push((p, type_name.to_string()))
+                    params.push((p, type_name.to_string(), m.get_location_in_parent()))
                 }
             }
         }
@@ -331,9 +331,8 @@ impl TypeAnnotator<'_> {
         match self.index.find_pou(operator_qualifier) {
             Some(pou) if pou.is_variadic() => {
                 //get variadic argument type, if it is generic, update the generic candidates
-                if let Some(type_name) =
-                    self.index.get_variadic_member(pou.get_name()).map(VariableIndexEntry::get_type_name)
-                {
+                if let Some(variadic) = self.index.get_variadic_member(pou.get_name()) {
+                    let type_name = variadic.get_type_name();
                     for parameter in parameters {
                         if let Some((key, candidate)) = TypeAnnotator::get_generic_candidate(
                             self.index,
@@ -383,17 +382,23 @@ impl TypeAnnotator<'_> {
                                 type_name
                             };
 
-                            params.push((parameter, type_name.to_string()));
+                            params.push((
+                                parameter,
+                                type_name.to_string(),
+                                variadic.get_location_in_parent(),
+                            ));
                         }
                     }
                 }
             }
             _ => {}
         }
-        for (p, name) in params {
-            self.annotate_parameters(p, &name);
+
+        for (p, name, position) in params {
+            self.annotate_parameters(p, &name, position as usize);
         }
-        //Attempt to resolve the generic signature here
+
+        // Attempt to resolve the generic signature here
         self.update_generic_call_statement(
             generics_candidates,
             operator_qualifier,
@@ -436,6 +441,11 @@ pub enum StatementAnnotation {
     /// an expression that resolves to a certain type (e.g. `a + b` --> `INT`)
     Value {
         resulting_type: String,
+    },
+    /// XXX
+    Argument {
+        resulting_type: String,
+        position: usize,
     },
     /// a reference that resolves to a declared variable (e.g. `a` --> `PLC_PROGRAM.a`)
     Variable {
@@ -717,6 +727,13 @@ impl StatementAnnotation {
             _ => None,
         }
     }
+
+    pub(crate) fn get_location_in_parent(&self) -> u32 {
+        match self {
+            StatementAnnotation::Argument { position, .. } => *position as u32,
+            _ => panic!(),
+        }
+    }
 }
 
 impl From<&PouIndexEntry> for StatementAnnotation {
@@ -807,6 +824,7 @@ pub trait AnnotationMap {
     fn get_type_name_for_annotation<'a>(&'a self, annotation: &'a StatementAnnotation) -> Option<&'a str> {
         match annotation {
             StatementAnnotation::Value { resulting_type } => Some(resulting_type.as_str()),
+            StatementAnnotation::Argument { resulting_type, .. } => Some(resulting_type.as_str()),
             StatementAnnotation::Variable { resulting_type, .. } => Some(resulting_type.as_str()),
             StatementAnnotation::ReplacementAst { statement } => self
                 .get_hint(statement)
@@ -2133,10 +2151,9 @@ impl<'i> TypeAnnotator<'i> {
                 }
                 StatementAnnotation::Program { qualified_name } => Some(qualified_name.clone()),
                 StatementAnnotation::Variable { resulting_type, .. } => {
-                    //lets see if this is a FB
                     self.index
                         .find_pou(resulting_type.as_str())
-                        .filter(|it| matches!(it, PouIndexEntry::FunctionBlock { .. }))
+                        .filter(|it| matches!(it, PouIndexEntry::FunctionBlock { .. } | PouIndexEntry::Program { .. }))
                         .map(|it| it.get_name().to_string())
                 }
                 // call statements on array access "arr[1]()" will return a StatementAnnotation::Value
@@ -2158,18 +2175,17 @@ impl<'i> TypeAnnotator<'i> {
         operator_qualifier
     }
 
-    pub(crate) fn annotate_parameters(&mut self, p: &AstNode, type_name: &str) {
-        if !matches!(
-            p.get_stmt(),
-            AstStatement::Assignment(..)
-                | AstStatement::OutputAssignment(..)
-                | AstStatement::RefAssignment(..)
-        ) {
-            if let Some(effective_member_type) = self.index.find_effective_type_by_name(type_name) {
-                //update the type hint
-                self.annotation_map
-                    .annotate_type_hint(p, StatementAnnotation::value(effective_member_type.get_name()))
-            }
+    pub(crate) fn annotate_parameters(&mut self, p: &AstNode, type_name: &str, position: usize) {
+        if let Some(effective_member_type) = self.index.find_effective_type_by_name(type_name) {
+            //update the type hint
+            // self.annotation_map.annotate_type_hint(p, StatementAnnotation::value(effective_member_type.get_name()))
+            self.annotation_map.annotate_type_hint(
+                p,
+                StatementAnnotation::Argument {
+                    resulting_type: effective_member_type.get_name().to_string(),
+                    position,
+                },
+            );
         }
     }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -745,10 +745,10 @@ impl StatementAnnotation {
     ///     c : DINT;
     /// END_VAR`
     /// ```
-    pub(crate) fn get_location_in_parent(&self) -> u32 {
+    pub(crate) fn get_location_in_parent(&self) -> Option<u32> {
         match self {
-            StatementAnnotation::Argument { position, .. } => *position as u32,
-            _ => panic!("incorrect use, must only be used when we dealing with arguments"),
+            StatementAnnotation::Argument { position, .. } => Some(*position as u32),
+            _ => None,
         }
     }
 }

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -5957,3 +5957,196 @@ fn global_namespace_operator_is_not_resolved() {
 
     assert_eq!(annotations.get(node), None);
 }
+
+#[test]
+fn implicit_output_assignment_arguments_are_annotated() {
+    let id_provider = IdProvider::default();
+    let (unit, mut index) = index_with_ids(
+        "
+        FUNCTION_BLOCK fb
+            VAR
+                placeholder_one : DINT;
+            END_VAR
+            VAR_OUTPUT
+                x : DINT;
+                y : BOOL;
+            END_VAR
+        END_FUNCTION_BLOCK
+
+        FUNCTION main
+            VAR
+                fb : fb;
+                x_local : DINT := 1;
+                y_local : BOOL := TRUE;
+            END_VAR
+
+            fb(x_local, y_local);
+        END_FUNCTION
+        ",
+        id_provider.clone(),
+    );
+
+    let annotations = annotate_with_ids(&unit, &mut index, id_provider);
+    let stmt = &unit.implementations[1].statements[0];
+    let AstStatement::CallStatement(CallStatement { parameters, .. }) = stmt.get_stmt() else {
+        unreachable!()
+    };
+
+    let AstStatement::ExpressionList(expressions) = &parameters.as_ref().unwrap().as_ref().stmt else {
+        unreachable!()
+    };
+
+    insta::assert_debug_snapshot!(annotations.get_hint(&expressions[0]).unwrap(), @r###"
+    Argument {
+        resulting_type: "DINT",
+        position: 1,
+    }
+    "###);
+
+    insta::assert_debug_snapshot!(annotations.get_hint(&expressions[1]).unwrap(), @r###"
+    Argument {
+        resulting_type: "BOOL",
+        position: 2,
+    }
+    "###);
+}
+
+#[test]
+fn explicit_output_assignment_arguments_are_annotated() {
+    let id_provider = IdProvider::default();
+    let (unit, mut index) = index_with_ids(
+        "
+        TYPE foo_struct : STRUCT
+            bar : bar_struct;
+        END_STRUCT END_TYPE
+
+        TYPE bar_struct : STRUCT
+            baz : DINT; 
+        END_STRUCT END_TYPE
+
+        FUNCTION_BLOCK QUUX
+            VAR
+                placeholder_one : DINT;
+            END_VAR
+            VAR_INPUT
+                x : DINT;
+            END_VAR
+            VAR
+                placeholder_two : DINT;
+            END_VAR
+            VAR_OUTPUT
+                Q : BOOL;
+            END_VAR
+        END_FUNCTION_BLOCK
+
+        FUNCTION main : DINT
+            VAR
+                foo : foo_struct;
+                f : QUUX;
+            END_VAR
+
+            f(x := 0, Q => foo.bar.baz.%W1.%B1.%X3);
+        END_FUNCTION
+        ",
+        id_provider.clone(),
+    );
+
+    let annotations = annotate_with_ids(&unit, &mut index, id_provider);
+    let stmt = &unit.implementations[1].statements[0];
+    let AstStatement::CallStatement(CallStatement { parameters, .. }) = stmt.get_stmt() else {
+        unreachable!()
+    };
+
+    let AstStatement::ExpressionList(expressions) = &parameters.as_ref().unwrap().as_ref().stmt else {
+        unreachable!()
+    };
+
+    insta::assert_debug_snapshot!(annotations.get_hint(&expressions[0]), @r###"
+    Some(
+        Argument {
+            resulting_type: "DINT",
+            position: 1,
+        },
+    )
+    "###);
+
+    insta::assert_debug_snapshot!(annotations.get_hint(&expressions[1]), @r###"
+    Some(
+        Argument {
+            resulting_type: "BOOL",
+            position: 3,
+        },
+    )
+    "###);
+}
+
+#[test]
+fn program_call_declared_as_variable_is_annotated() {
+    let id_provider = IdProvider::default();
+    let (unit, mut index) = index_with_ids(
+        "
+        PROGRAM ridiculous_chaining
+            VAR
+                z : DINT;
+            END_VAR
+
+            VAR_INPUT
+                x, y : DINT;
+            END_VAR
+        END_PROGRAM
+
+        FUNCTION main
+            VAR
+                x : DINT := 2;
+                y : DINT := 2;
+                chainer : ridiculous_chaining;
+            END_VAR
+
+            chainer(x, y);
+        END_FUNCTION
+        ",
+        id_provider.clone(),
+    );
+
+    let annotations = annotate_with_ids(&unit, &mut index, id_provider);
+    let stmt = &unit.implementations[1].statements[0];
+    let AstStatement::CallStatement(CallStatement { operator, parameters, .. }) = stmt.get_stmt() else {
+        unreachable!()
+    };
+
+    let AstStatement::ExpressionList(expressions) = &parameters.as_ref().unwrap().as_ref().stmt else {
+        unreachable!()
+    };
+
+    insta::assert_debug_snapshot!(annotations.get(&operator), @r###"
+    Some(
+        Variable {
+            resulting_type: "ridiculous_chaining",
+            qualified_name: "main.chainer",
+            constant: false,
+            argument_type: ByVal(
+                Local,
+            ),
+            auto_deref: None,
+        },
+    )
+    "###);
+
+    insta::assert_debug_snapshot!(annotations.get_hint(&expressions[0]), @r###"
+    Some(
+        Argument {
+            resulting_type: "DINT",
+            position: 1,
+        },
+    )
+    "###);
+
+    insta::assert_debug_snapshot!(annotations.get_hint(&expressions[1]), @r###"
+    Some(
+        Argument {
+            resulting_type: "DINT",
+            position: 2,
+        },
+    )
+    "###);
+}

--- a/src/tests/adr/annotated_ast_adr.rs
+++ b/src/tests/adr/annotated_ast_adr.rs
@@ -261,7 +261,10 @@ fn type_annotations_indicates_necessary_casts() {
     // foo(3)
     let (_, parameters) = deconstruct_call_statement!(&statements[2]);
     // 3 is a DINT but hinted as an INT because foo expects an INT as first parameter
-    assert_eq!(annotations.get_hint(parameters[0]), Some(&StatementAnnotation::value("INT")));
+    assert_eq!(
+        annotations.get_hint(parameters[0]).unwrap(),
+        &StatementAnnotation::Argument { resulting_type: "INT".to_string(), position: 0 }
+    );
 }
 
 /// The resolver also hints necessary upscaling of operands in binary-expressions (e.g. `myInt + mySInt;`

--- a/src/validation/pou.rs
+++ b/src/validation/pou.rs
@@ -56,7 +56,7 @@ fn validate_methods_overrides<T: AnnotationMap>(
                 validator.push_diagnostic(
                     Diagnostic::new(format!(
                         "{} in `{}` is declared with conflicting signatures in `{}` and `{}`",
-                        method1.get_method_name(),
+                        method1.get_method_name().expect("must be a method"),
                         container_name,
                         method1.get_parent_pou_name().unwrap(),
                         method2.get_parent_pou_name().unwrap()
@@ -101,7 +101,7 @@ fn validate_methods_overrides<T: AnnotationMap>(
                     validator.push_diagnostic(
                         Diagnostic::new(format!(
                             "{} defined in interface `{}` is missing in POU `{}`",
-                            intf.get_method_name(),
+                            intf.get_method_name().expect("must be a method"),
                             name,
                             container_name
                         ))

--- a/tests/integration/build_description_tests.rs
+++ b/tests/integration/build_description_tests.rs
@@ -189,5 +189,5 @@ fn build_empty_project_debug() {
         dir.path().to_str().unwrap(),
     ];
     compile(parameters).unwrap();
-    assert!(dbg!(dir.path().join("x86_64-linux-gnu").join("prog.so")).is_file());
+    assert!(dir.path().join("x86_64-linux-gnu").join("prog.so").is_file());
 }

--- a/tests/lit/single/functions/segmented_variable_blocks_with_implicit_arguments_call.st
+++ b/tests/lit/single/functions/segmented_variable_blocks_with_implicit_arguments_call.st
@@ -1,0 +1,31 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+FUNCTION_BLOCK foo
+    VAR
+        placeholder_one: DINT;
+    END_VAR
+
+    VAR_INPUT
+        a, b: DINT;
+    END_VAR
+
+    VAR
+        placeholder_two: DINT;
+    END_VAR
+
+    VAR_OUTPUT
+        c: DINT;
+    END_VAR
+
+    c := a + b;
+END_FUNCTION_BLOCK
+
+FUNCTION main
+    VAR
+        foo: foo;
+        local_a, local_b, local_c: DINT := 2;
+    END_VAR
+
+    foo(local_a, local_b, local_c);
+    printf('%d$N', local_c); // CHECK: 4
+END_FUNCTION


### PR DESCRIPTION
Identical to `StatementAnnotation::Value` with an additional `position` field indicating the position of a parameter in an POU. Helpful for codegen later on when generating the arguments of a function call for implicit calls.