### PR TITLE
chore: Show output when debugging in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.runnables.extraTestBinaryArgs": [
+        "--nocapture"
+    ]
+}


### PR DESCRIPTION
This change allows for any std{out,err} output to be displayed in the VSCode terminal when debugging, which by default is disabled. Can be quite useful since the Rust debugger is notoriously bad at displaying the content of complex-ish datastructures.