### PR TITLE
fix: Handle generics with no return type

### DIFF
--- a/src/resolver/generics.rs
+++ b/src/resolver/generics.rs
@@ -143,8 +143,7 @@ impl TypeAnnotator<'_> {
                 generic_implementation.get_location().to_owned(),
             );
 
-            let return_type =
-                self.index.find_type(return_type_name).expect("Return type must be in the index");
+            let return_type = self.index.find_type(return_type_name).unwrap_or(self.index.get_void_type());
             //register a copy of the pou under the new name
             self.annotation_map.new_index.register_pou(PouIndexEntry::create_generated_function_entry(
                 new_name,


### PR DESCRIPTION
The following code example will panic on master because we except a return type to be present. However, with https://github.com/PLC-lang/rusty/pull/1103 this is no longer the case. This commit fixes the issue by assigning a `VOID` datatype if the index was not able to find a return type for generics.

```
FUNCTION genericVoidFunction<U: ANY>
  VAR_INPUT
    in : U;
  END_VAR
END_FUNCTION

FUNCTION main
  VAR
    localVar : DINT;
  END_VAR

  genericVoidFunction(localVar);
END_FUNCTION
```