### PR TITLE
feat: add proper debug info for constants using DW_TAG_const_type

### DIFF
--- a/compiler/plc_driver/src/tests/multi_files.rs
+++ b/compiler/plc_driver/src/tests/multi_files.rs
@@ -117,3 +117,274 @@ fn multiple_files_in_different_locations_with_debug_info() {
     //The functions are defined correctly
     filtered_assert_snapshot!(results.join("\n"));
 }
+
+#[test]
+fn forward_declared_constant_is_also_marked_constant() {
+    // GIVEN 2 sources, one with a forward declaration of a constant
+    // and the other with the definition of that constant.
+    let src1 = SourceCode::new(
+        "
+    FUNCTION main : INT
+    VAR
+        f: foo;
+    END_VAR
+        mainProg(f.something_to_initialize);
+    END_FUNCTION
+
+    ",
+        "external_file1.st",
+    );
+    let src2 = SourceCode::new(
+        "
+    VAR_GLOBAL CONSTANT
+        a: INT := 10;
+    END_VAR
+
+    PROGRAM mainProg
+    VAR_INPUT
+        a: INT;
+    END_VAR
+    END_PROGRAM
+
+    FUNCTION_BLOCK foo
+    VAR
+        something_to_initialize: INT := 10 + a;
+    END_VAR
+    END_FUNCTION_BLOCK
+    ",
+        "external_file2.st",
+    );
+
+    // WHEN they are generated
+    let results = compile_with_root(vec![src1, src2], vec![], "root", DebugLevel::Full(5)).unwrap();
+
+    // THEN the constant is marked as constant in the generated code
+    filtered_assert_snapshot!(results.join("\n"), @r###"
+    ; ModuleID = 'external_file1.st'
+    source_filename = "external_file1.st"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %foo = type { i16 }
+    %mainProg = type { i16 }
+
+    @__foo__init = external unnamed_addr constant %foo, !dbg !0
+    @mainProg_instance = external global %mainProg, !dbg !8
+
+    define i16 @main() !dbg !18 {
+    entry:
+      %main = alloca i16, align 2
+      %f = alloca %foo, align 8
+      call void @llvm.dbg.declare(metadata %foo* %f, metadata !23, metadata !DIExpression()), !dbg !24
+      %0 = bitcast %foo* %f to i8*
+      call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %0, i8* align 1 bitcast (%foo* @__foo__init to i8*), i64 ptrtoint (%foo* getelementptr (%foo, %foo* null, i32 1) to i64), i1 false)
+      call void @llvm.dbg.declare(metadata i16* %main, metadata !25, metadata !DIExpression()), !dbg !26
+      store i16 0, i16* %main, align 2
+      call void @__init_foo(%foo* %f), !dbg !27
+      call void @__user_init_foo(%foo* %f), !dbg !27
+      %something_to_initialize = getelementptr inbounds %foo, %foo* %f, i32 0, i32 0, !dbg !27
+      %load_something_to_initialize = load i16, i16* %something_to_initialize, align 2, !dbg !27
+      store i16 %load_something_to_initialize, i16* getelementptr inbounds (%mainProg, %mainProg* @mainProg_instance, i32 0, i32 0), align 2, !dbg !27
+      call void @mainProg(%mainProg* @mainProg_instance), !dbg !28
+      %main_ret = load i16, i16* %main, align 2, !dbg !29
+      ret i16 %main_ret, !dbg !29
+    }
+
+    declare !dbg !30 void @foo(%foo*)
+
+    declare void @__init_foo(%foo*)
+
+    declare !dbg !33 void @__user_init_foo(%foo*)
+
+    declare !dbg !38 void @mainProg(%mainProg*)
+
+    ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+    declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+    ; Function Attrs: argmemonly nofree nounwind willreturn
+    declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #1
+
+    attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
+    attributes #1 = { argmemonly nofree nounwind willreturn }
+
+    !llvm.module.flags = !{!13, !14}
+    !llvm.dbg.cu = !{!15}
+
+    !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+    !1 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 12, type: !3, isLocal: false, isDefinition: true)
+    !2 = !DIFile(filename: "external_file2.st", directory: "")
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 12, size: 16, align: 64, flags: DIFlagPublic, elements: !5, identifier: "foo")
+    !5 = !{!6}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "something_to_initialize", scope: !2, file: !2, line: 14, baseType: !7, size: 16, align: 16, flags: DIFlagPublic)
+    !7 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !8 = !DIGlobalVariableExpression(var: !9, expr: !DIExpression())
+    !9 = distinct !DIGlobalVariable(name: "mainProg", scope: !2, file: !2, line: 6, type: !10, isLocal: false, isDefinition: true)
+    !10 = !DICompositeType(tag: DW_TAG_structure_type, name: "mainProg", scope: !2, file: !2, line: 6, size: 16, align: 64, flags: DIFlagPublic, elements: !11, identifier: "mainProg")
+    !11 = !{!12}
+    !12 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 8, baseType: !7, size: 16, align: 16, flags: DIFlagPublic)
+    !13 = !{i32 2, !"Dwarf Version", i32 5}
+    !14 = !{i32 2, !"Debug Info Version", i32 3}
+    !15 = distinct !DICompileUnit(language: DW_LANG_C, file: !16, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !17, splitDebugInlining: false)
+    !16 = !DIFile(filename: "external_file1.st", directory: "root")
+    !17 = !{!0, !8}
+    !18 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !19, file: !19, line: 2, type: !20, scopeLine: 2, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !15, retainedNodes: !22)
+    !19 = !DIFile(filename: "external_file1.st", directory: "")
+    !20 = !DISubroutineType(flags: DIFlagPublic, types: !21)
+    !21 = !{null}
+    !22 = !{}
+    !23 = !DILocalVariable(name: "f", scope: !18, file: !19, line: 4, type: !4, align: 64)
+    !24 = !DILocation(line: 4, column: 8, scope: !18)
+    !25 = !DILocalVariable(name: "main", scope: !18, file: !19, line: 2, type: !7, align: 16)
+    !26 = !DILocation(line: 2, column: 13, scope: !18)
+    !27 = !DILocation(line: 0, scope: !18)
+    !28 = !DILocation(line: 6, column: 8, scope: !18)
+    !29 = !DILocation(line: 7, column: 4, scope: !18)
+    !30 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 12, type: !31, scopeLine: 16, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !15, retainedNodes: !22)
+    !31 = !DISubroutineType(flags: DIFlagPublic, types: !32)
+    !32 = !{null, !4}
+    !33 = distinct !DISubprogram(name: "__user_init_foo", linkageName: "__user_init_foo", scope: !34, file: !34, type: !35, scopeLine: 1, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !15, retainedNodes: !22)
+    !34 = !DIFile(filename: "__initializers", directory: "")
+    !35 = !DISubroutineType(flags: DIFlagPublic, types: !36)
+    !36 = !{null, !37}
+    !37 = !DIDerivedType(tag: DW_TAG_pointer_type, name: "__auto_pointer_to_foo", baseType: !4, size: 64, align: 64, dwarfAddressSpace: 1)
+    !38 = distinct !DISubprogram(name: "mainProg", linkageName: "mainProg", scope: !2, file: !2, line: 6, type: !39, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !15, retainedNodes: !22)
+    !39 = !DISubroutineType(flags: DIFlagPublic, types: !40)
+    !40 = !{null, !10, !7}
+
+    ; ModuleID = 'external_file2.st'
+    source_filename = "external_file2.st"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %mainProg = type { i16 }
+    %foo = type { i16 }
+
+    @a = unnamed_addr constant i16 10, !dbg !0
+    @mainProg_instance = global %mainProg zeroinitializer, !dbg !5
+    @__foo__init = unnamed_addr constant %foo { i16 20 }, !dbg !10
+
+    define void @mainProg(%mainProg* %0) !dbg !21 {
+    entry:
+      call void @llvm.dbg.declare(metadata %mainProg* %0, metadata !25, metadata !DIExpression()), !dbg !26
+      %a = getelementptr inbounds %mainProg, %mainProg* %0, i32 0, i32 0
+      ret void, !dbg !26
+    }
+
+    define void @foo(%foo* %0) !dbg !27 {
+    entry:
+      call void @llvm.dbg.declare(metadata %foo* %0, metadata !30, metadata !DIExpression()), !dbg !31
+      %this = alloca %foo*, align 8
+      store %foo* %0, %foo** %this, align 8
+      %something_to_initialize = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
+      ret void, !dbg !31
+    }
+
+    ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+    declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+    attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
+
+    !llvm.module.flags = !{!16, !17}
+    !llvm.dbg.cu = !{!18}
+
+    !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+    !1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !2, line: 3, type: !3, isLocal: false, isDefinition: true)
+    !2 = !DIFile(filename: "external_file2.st", directory: "")
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
+    !6 = distinct !DIGlobalVariable(name: "mainProg", scope: !2, file: !2, line: 6, type: !7, isLocal: false, isDefinition: true)
+    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "mainProg", scope: !2, file: !2, line: 6, size: 16, align: 64, flags: DIFlagPublic, elements: !8, identifier: "mainProg")
+    !8 = !{!9}
+    !9 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 8, baseType: !4, size: 16, align: 16, flags: DIFlagPublic)
+    !10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression())
+    !11 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 12, type: !12, isLocal: false, isDefinition: true)
+    !12 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !13)
+    !13 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 12, size: 16, align: 64, flags: DIFlagPublic, elements: !14, identifier: "foo")
+    !14 = !{!15}
+    !15 = !DIDerivedType(tag: DW_TAG_member, name: "something_to_initialize", scope: !2, file: !2, line: 14, baseType: !4, size: 16, align: 16, flags: DIFlagPublic)
+    !16 = !{i32 2, !"Dwarf Version", i32 5}
+    !17 = !{i32 2, !"Debug Info Version", i32 3}
+    !18 = distinct !DICompileUnit(language: DW_LANG_C, file: !19, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !20, splitDebugInlining: false)
+    !19 = !DIFile(filename: "external_file2.st", directory: "root")
+    !20 = !{!0, !5, !10}
+    !21 = distinct !DISubprogram(name: "mainProg", linkageName: "mainProg", scope: !2, file: !2, line: 6, type: !22, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !18, retainedNodes: !24)
+    !22 = !DISubroutineType(flags: DIFlagPublic, types: !23)
+    !23 = !{null, !7, !4}
+    !24 = !{}
+    !25 = !DILocalVariable(name: "mainProg", scope: !21, file: !2, line: 10, type: !7)
+    !26 = !DILocation(line: 10, column: 4, scope: !21)
+    !27 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 12, type: !28, scopeLine: 16, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !18, retainedNodes: !24)
+    !28 = !DISubroutineType(flags: DIFlagPublic, types: !29)
+    !29 = !{null, !13}
+    !30 = !DILocalVariable(name: "foo", scope: !27, file: !2, line: 16, type: !13)
+    !31 = !DILocation(line: 16, column: 4, scope: !27)
+
+    ; ModuleID = '__initializers'
+    source_filename = "__initializers"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %mainProg = type { i16 }
+    %foo = type { i16 }
+
+    @mainProg_instance = external global %mainProg
+    @__foo__init = external unnamed_addr constant %foo
+
+    define void @__init_mainprog(%mainProg* %0) {
+    entry:
+      %self = alloca %mainProg*, align 8
+      store %mainProg* %0, %mainProg** %self, align 8
+      ret void
+    }
+
+    declare void @mainProg(%mainProg*)
+
+    define void @__init_foo(%foo* %0) {
+    entry:
+      %self = alloca %foo*, align 8
+      store %foo* %0, %foo** %self, align 8
+      ret void
+    }
+
+    declare void @foo(%foo*)
+
+    define void @__user_init_mainProg(%mainProg* %0) {
+    entry:
+      %self = alloca %mainProg*, align 8
+      store %mainProg* %0, %mainProg** %self, align 8
+      ret void
+    }
+
+    define void @__user_init_foo(%foo* %0) {
+    entry:
+      %self = alloca %foo*, align 8
+      store %foo* %0, %foo** %self, align 8
+      ret void
+    }
+
+    ; ModuleID = '__init___TestProject'
+    source_filename = "__init___TestProject"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %mainProg = type { i16 }
+
+    @mainProg_instance = external global %mainProg
+    @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___TestProject, i8* null }]
+
+    define void @__init___TestProject() {
+    entry:
+      call void @__init_mainprog(%mainProg* @mainProg_instance)
+      call void @__user_init_mainProg(%mainProg* @mainProg_instance)
+      ret void
+    }
+
+    declare void @__init_mainprog(%mainProg*)
+
+    declare void @mainProg(%mainProg*)
+
+    declare void @__user_init_mainProg(%mainProg*)
+    "###);
+}

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -134,9 +134,6 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         let mut global_ir_variable = self.llvm.create_global_variable(self.module, name, variable_type);
         if linkage == LinkageType::External {
             global_ir_variable = global_ir_variable.make_external();
-            if global_variable.is_constant() {
-                global_ir_variable = global_ir_variable.make_constant();
-            };
         } else {
             let initial_value = if let Some(ConstExpression::Unresolvable {
                 reason: UnresolvableKind::Address { .. },
@@ -178,16 +175,17 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
                 // 3rd try: get the compiler's default for the given type (zero-initializer)
                 .or_else(|| self.types_index.find_associated_type(type_name).map(get_default_for));
             global_ir_variable.set_initial_value(initial_value, variable_type);
-            if global_variable.is_constant() {
-                global_ir_variable = global_ir_variable.make_constant();
-                if initial_value.is_none() {
-                    return Err(Diagnostic::codegen_error(
-                        "Cannot generate uninitialized constant",
-                        &global_variable.source_location,
-                    ));
-                }
+            if global_variable.is_constant() && initial_value.is_none() {
+                return Err(Diagnostic::codegen_error(
+                    "Cannot generate uninitialized constant",
+                    &global_variable.source_location,
+                ));
             }
         }
+
+        if global_variable.is_constant() {
+            global_ir_variable = global_ir_variable.make_constant();
+        };
 
         let global_name = if global_variable.get_name().ends_with("instance") {
             global_variable.get_name()

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -134,6 +134,9 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
         let mut global_ir_variable = self.llvm.create_global_variable(self.module, name, variable_type);
         if linkage == LinkageType::External {
             global_ir_variable = global_ir_variable.make_external();
+            if global_variable.is_constant() {
+                global_ir_variable = global_ir_variable.make_constant();
+            };
         } else {
             let initial_value = if let Some(ConstExpression::Unresolvable {
                 reason: UnresolvableKind::Address { .. },

--- a/src/codegen/tests/debug_tests.rs
+++ b/src/codegen/tests/debug_tests.rs
@@ -351,7 +351,7 @@ fn dbg_declare_has_valid_metadata_references_for_methods() {
         ",
     );
 
-    filtered_assert_snapshot!(codegen, @r#"
+    filtered_assert_snapshot!(codegen, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -359,23 +359,23 @@ fn dbg_declare_has_valid_metadata_references_for_methods() {
 
     %fb = type {}
 
-    @__fb__init = constant %fb zeroinitializer, !dbg !0
+    @__fb__init = unnamed_addr constant %fb zeroinitializer, !dbg !0
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @fb(%fb* %0) !dbg !9 {
+    define void @fb(%fb* %0) !dbg !10 {
     entry:
-      call void @llvm.dbg.declare(metadata %fb* %0, metadata !12, metadata !DIExpression()), !dbg !13
+      call void @llvm.dbg.declare(metadata %fb* %0, metadata !13, metadata !DIExpression()), !dbg !14
       %this = alloca %fb*, align 8
       store %fb* %0, %fb** %this, align 8
-      ret void, !dbg !13
+      ret void, !dbg !14
     }
 
-    define void @fb__foo(%fb* %0) !dbg !14 {
+    define void @fb__foo(%fb* %0) !dbg !15 {
     entry:
-      call void @llvm.dbg.declare(metadata %fb* %0, metadata !15, metadata !DIExpression()), !dbg !16
+      call void @llvm.dbg.declare(metadata %fb* %0, metadata !16, metadata !DIExpression()), !dbg !17
       %this = alloca %fb*, align 8
       store %fb* %0, %fb** %this, align 8
-      ret void, !dbg !16
+      ret void, !dbg !17
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -402,27 +402,28 @@ fn dbg_declare_has_valid_metadata_references_for_methods() {
 
     attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-    !llvm.module.flags = !{!5, !6}
-    !llvm.dbg.cu = !{!7}
+    !llvm.module.flags = !{!6, !7}
+    !llvm.dbg.cu = !{!8}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__fb__init", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb", scope: !2, file: !2, line: 2, align: 64, flags: DIFlagPublic, elements: !4, identifier: "fb")
-    !4 = !{}
-    !5 = !{i32 2, !"Dwarf Version", i32 5}
-    !6 = !{i32 2, !"Debug Info Version", i32 3}
-    !7 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !8, splitDebugInlining: false)
-    !8 = !{!0}
-    !9 = distinct !DISubprogram(name: "fb", linkageName: "fb", scope: !2, file: !2, line: 2, type: !10, scopeLine: 5, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !7, retainedNodes: !4)
-    !10 = !DISubroutineType(flags: DIFlagPublic, types: !11)
-    !11 = !{null, !3}
-    !12 = !DILocalVariable(name: "fb", scope: !9, file: !2, line: 5, type: !3)
-    !13 = !DILocation(line: 5, column: 8, scope: !9)
-    !14 = distinct !DISubprogram(name: "fb.foo", linkageName: "fb.foo", scope: !9, file: !2, line: 3, type: !10, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !7, retainedNodes: !4)
-    !15 = !DILocalVariable(name: "fb", scope: !14, file: !2, line: 4, type: !3)
-    !16 = !DILocation(line: 4, column: 8, scope: !14)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb", scope: !2, file: !2, line: 2, align: 64, flags: DIFlagPublic, elements: !5, identifier: "fb")
+    !5 = !{}
+    !6 = !{i32 2, !"Dwarf Version", i32 5}
+    !7 = !{i32 2, !"Debug Info Version", i32 3}
+    !8 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !9, splitDebugInlining: false)
+    !9 = !{!0}
+    !10 = distinct !DISubprogram(name: "fb", linkageName: "fb", scope: !2, file: !2, line: 2, type: !11, scopeLine: 5, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !8, retainedNodes: !5)
+    !11 = !DISubroutineType(flags: DIFlagPublic, types: !12)
+    !12 = !{null, !4}
+    !13 = !DILocalVariable(name: "fb", scope: !10, file: !2, line: 5, type: !4)
+    !14 = !DILocation(line: 5, column: 8, scope: !10)
+    !15 = distinct !DISubprogram(name: "fb.foo", linkageName: "fb.foo", scope: !10, file: !2, line: 3, type: !11, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !8, retainedNodes: !5)
+    !16 = !DILocalVariable(name: "fb", scope: !15, file: !2, line: 4, type: !4)
+    !17 = !DILocation(line: 4, column: 8, scope: !15)
+    "###);
 }
 
 #[test]
@@ -609,7 +610,7 @@ END_FUNCTION
     ",
     );
 
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -618,85 +619,85 @@ END_FUNCTION
     %struct_ = type { %inner, [3 x %inner], [81 x i8], i8, float, [3 x [81 x i8]], i16 }
     %inner = type { [81 x i8], i8, float, [3 x [81 x i8]], i16 }
 
-    @__struct___init = constant %struct_ { %inner { [81 x i8] c"Hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", i8 1, float 0x400921CAC0000000, [3 x [81 x i8]] [[81 x i8] c"aaaa\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"bbbb\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"cccc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"], i16 42 }, [3 x %inner] zeroinitializer, [81 x i8] c"Hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", i8 1, float 0x400921CAC0000000, [3 x [81 x i8]] [[81 x i8] c"aa\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"bb\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"cc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"], i16 42 }, !dbg !0
-    @__inner__init = constant %inner { [81 x i8] c"Hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", i8 1, float 0x400921CAC0000000, [3 x [81 x i8]] [[81 x i8] c"aaaa\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"bbbb\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"cccc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"], i16 42 }, !dbg !30
+    @__struct___init = unnamed_addr constant %struct_ { %inner { [81 x i8] c"Hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", i8 1, float 0x400921CAC0000000, [3 x [81 x i8]] [[81 x i8] c"aaaa\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"bbbb\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"cccc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"], i16 42 }, [3 x %inner] zeroinitializer, [81 x i8] c"Hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", i8 1, float 0x400921CAC0000000, [3 x [81 x i8]] [[81 x i8] c"aa\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"bb\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"cc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"], i16 42 }, !dbg !0
+    @__inner__init = unnamed_addr constant %inner { [81 x i8] c"Hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", i8 1, float 0x400921CAC0000000, [3 x [81 x i8]] [[81 x i8] c"aaaa\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"bbbb\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"cccc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"], i16 42 }, !dbg !31
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @main() !dbg !36 {
+    define void @main() !dbg !38 {
     entry:
       %st = alloca %struct_, align 8
       %s = alloca [81 x i8], align 1
       %b = alloca i8, align 1
       %arr = alloca [3 x [81 x i8]], align 1
       %i = alloca i16, align 2
-      call void @llvm.dbg.declare(metadata %struct_* %st, metadata !40, metadata !DIExpression()), !dbg !41
+      call void @llvm.dbg.declare(metadata %struct_* %st, metadata !42, metadata !DIExpression()), !dbg !43
       %0 = bitcast %struct_* %st to i8*
       call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %0, i8* align 1 getelementptr inbounds (%struct_, %struct_* @__struct___init, i32 0, i32 0, i32 0, i32 0), i64 ptrtoint (%struct_* getelementptr (%struct_, %struct_* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata [81 x i8]* %s, metadata !42, metadata !DIExpression()), !dbg !43
+      call void @llvm.dbg.declare(metadata [81 x i8]* %s, metadata !44, metadata !DIExpression()), !dbg !45
       %1 = bitcast [81 x i8]* %s to i8*
       call void @llvm.memset.p0i8.i64(i8* align 1 %1, i8 0, i64 ptrtoint ([81 x i8]* getelementptr ([81 x i8], [81 x i8]* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata i8* %b, metadata !44, metadata !DIExpression()), !dbg !45
+      call void @llvm.dbg.declare(metadata i8* %b, metadata !46, metadata !DIExpression()), !dbg !47
       store i8 0, i8* %b, align 1
-      call void @llvm.dbg.declare(metadata [3 x [81 x i8]]* %arr, metadata !46, metadata !DIExpression()), !dbg !47
+      call void @llvm.dbg.declare(metadata [3 x [81 x i8]]* %arr, metadata !48, metadata !DIExpression()), !dbg !49
       %2 = bitcast [3 x [81 x i8]]* %arr to i8*
       call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 ptrtoint ([3 x [81 x i8]]* getelementptr ([3 x [81 x i8]], [3 x [81 x i8]]* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata i16* %i, metadata !48, metadata !DIExpression()), !dbg !49
+      call void @llvm.dbg.declare(metadata i16* %i, metadata !50, metadata !DIExpression()), !dbg !51
       store i16 0, i16* %i, align 2
-      call void @__init_struct_(%struct_* %st), !dbg !50
-      call void @__user_init_struct_(%struct_* %st), !dbg !50
-      %s1 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 2, !dbg !51
-      %3 = bitcast [81 x i8]* %s to i8*, !dbg !51
-      %4 = bitcast [81 x i8]* %s1 to i8*, !dbg !51
-      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 %4, i32 80, i1 false), !dbg !51
-      %inner = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !52
-      %s2 = getelementptr inbounds %inner, %inner* %inner, i32 0, i32 0, !dbg !52
-      %5 = bitcast [81 x i8]* %s to i8*, !dbg !52
-      %6 = bitcast [81 x i8]* %s2 to i8*, !dbg !52
-      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %5, i8* align 1 %6, i32 80, i1 false), !dbg !52
-      %b3 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 3, !dbg !53
-      %load_b = load i8, i8* %b3, align 1, !dbg !53
-      store i8 %load_b, i8* %b, align 1, !dbg !53
-      %inner4 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !54
-      %b5 = getelementptr inbounds %inner, %inner* %inner4, i32 0, i32 1, !dbg !54
-      %load_b6 = load i8, i8* %b5, align 1, !dbg !54
-      store i8 %load_b6, i8* %b, align 1, !dbg !54
-      %arr7 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 5, !dbg !55
-      %7 = bitcast [3 x [81 x i8]]* %arr to i8*, !dbg !55
-      %8 = bitcast [3 x [81 x i8]]* %arr7 to i8*, !dbg !55
-      call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 ptrtoint ([3 x [81 x i8]]* getelementptr ([3 x [81 x i8]], [3 x [81 x i8]]* null, i32 1) to i64), i1 false), !dbg !55
-      %inner8 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !56
-      %arr9 = getelementptr inbounds %inner, %inner* %inner8, i32 0, i32 3, !dbg !56
-      %9 = bitcast [3 x [81 x i8]]* %arr to i8*, !dbg !56
-      %10 = bitcast [3 x [81 x i8]]* %arr9 to i8*, !dbg !56
-      call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %9, i8* align 1 %10, i64 ptrtoint ([3 x [81 x i8]]* getelementptr ([3 x [81 x i8]], [3 x [81 x i8]]* null, i32 1) to i64), i1 false), !dbg !56
-      %i10 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 6, !dbg !57
-      %load_i = load i16, i16* %i10, align 2, !dbg !57
-      store i16 %load_i, i16* %i, align 2, !dbg !57
-      %inner11 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !58
-      %i12 = getelementptr inbounds %inner, %inner* %inner11, i32 0, i32 4, !dbg !58
-      %load_i13 = load i16, i16* %i12, align 2, !dbg !58
-      store i16 %load_i13, i16* %i, align 2, !dbg !58
-      %tmpVar = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr, i32 0, i32 0, !dbg !59
-      %arr14 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 5, !dbg !59
-      %tmpVar15 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr14, i32 0, i32 0, !dbg !59
-      %11 = bitcast [81 x i8]* %tmpVar to i8*, !dbg !59
-      %12 = bitcast [81 x i8]* %tmpVar15 to i8*, !dbg !59
-      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %11, i8* align 1 %12, i32 80, i1 false), !dbg !59
-      %tmpVar16 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr, i32 0, i32 1, !dbg !60
-      %inner17 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !60
-      %arr18 = getelementptr inbounds %inner, %inner* %inner17, i32 0, i32 3, !dbg !60
-      %tmpVar19 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr18, i32 0, i32 1, !dbg !60
-      %13 = bitcast [81 x i8]* %tmpVar16 to i8*, !dbg !60
-      %14 = bitcast [81 x i8]* %tmpVar19 to i8*, !dbg !60
-      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %13, i8* align 1 %14, i32 80, i1 false), !dbg !60
-      %tmpVar20 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr, i32 0, i32 2, !dbg !61
-      %inner21 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !61
-      %arr22 = getelementptr inbounds %inner, %inner* %inner21, i32 0, i32 3, !dbg !61
-      %tmpVar23 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr22, i32 0, i32 2, !dbg !61
-      %15 = bitcast [81 x i8]* %tmpVar20 to i8*, !dbg !61
-      %16 = bitcast [81 x i8]* %tmpVar23 to i8*, !dbg !61
-      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %15, i8* align 1 %16, i32 80, i1 false), !dbg !61
-      ret void, !dbg !62
+      call void @__init_struct_(%struct_* %st), !dbg !52
+      call void @__user_init_struct_(%struct_* %st), !dbg !52
+      %s1 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 2, !dbg !53
+      %3 = bitcast [81 x i8]* %s to i8*, !dbg !53
+      %4 = bitcast [81 x i8]* %s1 to i8*, !dbg !53
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %3, i8* align 1 %4, i32 80, i1 false), !dbg !53
+      %inner = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !54
+      %s2 = getelementptr inbounds %inner, %inner* %inner, i32 0, i32 0, !dbg !54
+      %5 = bitcast [81 x i8]* %s to i8*, !dbg !54
+      %6 = bitcast [81 x i8]* %s2 to i8*, !dbg !54
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %5, i8* align 1 %6, i32 80, i1 false), !dbg !54
+      %b3 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 3, !dbg !55
+      %load_b = load i8, i8* %b3, align 1, !dbg !55
+      store i8 %load_b, i8* %b, align 1, !dbg !55
+      %inner4 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !56
+      %b5 = getelementptr inbounds %inner, %inner* %inner4, i32 0, i32 1, !dbg !56
+      %load_b6 = load i8, i8* %b5, align 1, !dbg !56
+      store i8 %load_b6, i8* %b, align 1, !dbg !56
+      %arr7 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 5, !dbg !57
+      %7 = bitcast [3 x [81 x i8]]* %arr to i8*, !dbg !57
+      %8 = bitcast [3 x [81 x i8]]* %arr7 to i8*, !dbg !57
+      call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 ptrtoint ([3 x [81 x i8]]* getelementptr ([3 x [81 x i8]], [3 x [81 x i8]]* null, i32 1) to i64), i1 false), !dbg !57
+      %inner8 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !58
+      %arr9 = getelementptr inbounds %inner, %inner* %inner8, i32 0, i32 3, !dbg !58
+      %9 = bitcast [3 x [81 x i8]]* %arr to i8*, !dbg !58
+      %10 = bitcast [3 x [81 x i8]]* %arr9 to i8*, !dbg !58
+      call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %9, i8* align 1 %10, i64 ptrtoint ([3 x [81 x i8]]* getelementptr ([3 x [81 x i8]], [3 x [81 x i8]]* null, i32 1) to i64), i1 false), !dbg !58
+      %i10 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 6, !dbg !59
+      %load_i = load i16, i16* %i10, align 2, !dbg !59
+      store i16 %load_i, i16* %i, align 2, !dbg !59
+      %inner11 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !60
+      %i12 = getelementptr inbounds %inner, %inner* %inner11, i32 0, i32 4, !dbg !60
+      %load_i13 = load i16, i16* %i12, align 2, !dbg !60
+      store i16 %load_i13, i16* %i, align 2, !dbg !60
+      %tmpVar = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr, i32 0, i32 0, !dbg !61
+      %arr14 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 5, !dbg !61
+      %tmpVar15 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr14, i32 0, i32 0, !dbg !61
+      %11 = bitcast [81 x i8]* %tmpVar to i8*, !dbg !61
+      %12 = bitcast [81 x i8]* %tmpVar15 to i8*, !dbg !61
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %11, i8* align 1 %12, i32 80, i1 false), !dbg !61
+      %tmpVar16 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr, i32 0, i32 1, !dbg !62
+      %inner17 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !62
+      %arr18 = getelementptr inbounds %inner, %inner* %inner17, i32 0, i32 3, !dbg !62
+      %tmpVar19 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr18, i32 0, i32 1, !dbg !62
+      %13 = bitcast [81 x i8]* %tmpVar16 to i8*, !dbg !62
+      %14 = bitcast [81 x i8]* %tmpVar19 to i8*, !dbg !62
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %13, i8* align 1 %14, i32 80, i1 false), !dbg !62
+      %tmpVar20 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr, i32 0, i32 2, !dbg !63
+      %inner21 = getelementptr inbounds %struct_, %struct_* %st, i32 0, i32 0, !dbg !63
+      %arr22 = getelementptr inbounds %inner, %inner* %inner21, i32 0, i32 3, !dbg !63
+      %tmpVar23 = getelementptr inbounds [3 x [81 x i8]], [3 x [81 x i8]]* %arr22, i32 0, i32 2, !dbg !63
+      %15 = bitcast [81 x i8]* %tmpVar20 to i8*, !dbg !63
+      %16 = bitcast [81 x i8]* %tmpVar23 to i8*, !dbg !63
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %15, i8* align 1 %16, i32 80, i1 false), !dbg !63
+      ret void, !dbg !64
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -754,71 +755,232 @@ END_FUNCTION
     attributes #1 = { argmemonly nofree nounwind willreturn }
     attributes #2 = { argmemonly nofree nounwind willreturn writeonly }
 
-    !llvm.module.flags = !{!32, !33}
-    !llvm.dbg.cu = !{!34}
+    !llvm.module.flags = !{!34, !35}
+    !llvm.dbg.cu = !{!36}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__struct___init", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "struct_", scope: !2, file: !2, line: 2, size: 13440, align: 64, flags: DIFlagPublic, elements: !4, identifier: "struct_")
-    !4 = !{!5, !23, !25, !26, !27, !28, !29}
-    !5 = !DIDerivedType(tag: DW_TAG_member, name: "inner", scope: !2, file: !2, line: 3, baseType: !6, size: 2688, align: 64, flags: DIFlagPublic)
-    !6 = !DICompositeType(tag: DW_TAG_structure_type, name: "inner", scope: !2, file: !2, line: 13, size: 2688, align: 64, flags: DIFlagPublic, elements: !7, identifier: "inner")
-    !7 = !{!8, !13, !15, !17, !21}
-    !8 = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: !2, file: !2, line: 14, baseType: !9, size: 648, align: 8, flags: DIFlagPublic)
-    !9 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 648, align: 8, elements: !11)
-    !10 = !DIBasicType(name: "CHAR", size: 8, encoding: DW_ATE_UTF, flags: DIFlagPublic)
-    !11 = !{!12}
-    !12 = !DISubrange(count: 81, lowerBound: 0)
-    !13 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 15, baseType: !14, size: 8, align: 8, offset: 648, flags: DIFlagPublic)
-    !14 = !DIBasicType(name: "BOOL", size: 8, encoding: DW_ATE_boolean, flags: DIFlagPublic)
-    !15 = !DIDerivedType(tag: DW_TAG_member, name: "r", scope: !2, file: !2, line: 16, baseType: !16, size: 32, align: 32, offset: 672, flags: DIFlagPublic)
-    !16 = !DIBasicType(name: "REAL", size: 32, encoding: DW_ATE_float, flags: DIFlagPublic)
-    !17 = !DIDerivedType(tag: DW_TAG_member, name: "arr", scope: !2, file: !2, line: 17, baseType: !18, size: 1944, align: 8, offset: 704, flags: DIFlagPublic)
-    !18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !9, size: 1944, align: 8, elements: !19)
-    !19 = !{!20}
-    !20 = !DISubrange(count: 3, lowerBound: 0)
-    !21 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !2, file: !2, line: 18, baseType: !22, size: 16, align: 16, offset: 2656, flags: DIFlagPublic)
-    !22 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
-    !23 = !DIDerivedType(tag: DW_TAG_member, name: "inner_arr", scope: !2, file: !2, line: 4, baseType: !24, size: 8064, align: 64, offset: 2688, flags: DIFlagPublic)
-    !24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !6, size: 8064, align: 64, elements: !19)
-    !25 = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: !2, file: !2, line: 5, baseType: !9, size: 648, align: 8, offset: 10752, flags: DIFlagPublic)
-    !26 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 6, baseType: !14, size: 8, align: 8, offset: 11400, flags: DIFlagPublic)
-    !27 = !DIDerivedType(tag: DW_TAG_member, name: "r", scope: !2, file: !2, line: 7, baseType: !16, size: 32, align: 32, offset: 11424, flags: DIFlagPublic)
-    !28 = !DIDerivedType(tag: DW_TAG_member, name: "arr", scope: !2, file: !2, line: 8, baseType: !18, size: 1944, align: 8, offset: 11456, flags: DIFlagPublic)
-    !29 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !2, file: !2, line: 9, baseType: !22, size: 16, align: 16, offset: 13408, flags: DIFlagPublic)
-    !30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
-    !31 = distinct !DIGlobalVariable(name: "__inner__init", scope: !2, file: !2, line: 13, type: !6, isLocal: false, isDefinition: true)
-    !32 = !{i32 2, !"Dwarf Version", i32 5}
-    !33 = !{i32 2, !"Debug Info Version", i32 3}
-    !34 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !35, splitDebugInlining: false)
-    !35 = !{!0, !30}
-    !36 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 22, type: !37, scopeLine: 22, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !34, retainedNodes: !39)
-    !37 = !DISubroutineType(flags: DIFlagPublic, types: !38)
-    !38 = !{null}
-    !39 = !{}
-    !40 = !DILocalVariable(name: "st", scope: !36, file: !2, line: 24, type: !3, align: 64)
-    !41 = !DILocation(line: 24, column: 4, scope: !36)
-    !42 = !DILocalVariable(name: "s", scope: !36, file: !2, line: 25, type: !9, align: 8)
-    !43 = !DILocation(line: 25, column: 4, scope: !36)
-    !44 = !DILocalVariable(name: "b", scope: !36, file: !2, line: 26, type: !14, align: 8)
-    !45 = !DILocation(line: 26, column: 4, scope: !36)
-    !46 = !DILocalVariable(name: "arr", scope: !36, file: !2, line: 27, type: !18, align: 8)
-    !47 = !DILocation(line: 27, column: 4, scope: !36)
-    !48 = !DILocalVariable(name: "i", scope: !36, file: !2, line: 28, type: !22, align: 16)
-    !49 = !DILocation(line: 28, column: 4, scope: !36)
-    !50 = !DILocation(line: 0, scope: !36)
-    !51 = !DILocation(line: 32, column: 4, scope: !36)
-    !52 = !DILocation(line: 33, column: 4, scope: !36)
-    !53 = !DILocation(line: 34, column: 4, scope: !36)
-    !54 = !DILocation(line: 35, column: 4, scope: !36)
-    !55 = !DILocation(line: 36, column: 4, scope: !36)
-    !56 = !DILocation(line: 37, column: 4, scope: !36)
-    !57 = !DILocation(line: 38, column: 4, scope: !36)
-    !58 = !DILocation(line: 39, column: 4, scope: !36)
-    !59 = !DILocation(line: 41, column: 4, scope: !36)
-    !60 = !DILocation(line: 42, column: 4, scope: !36)
-    !61 = !DILocation(line: 43, column: 4, scope: !36)
-    !62 = !DILocation(line: 45, scope: !36)
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "struct_", scope: !2, file: !2, line: 2, size: 13440, align: 64, flags: DIFlagPublic, elements: !5, identifier: "struct_")
+    !5 = !{!6, !24, !26, !27, !28, !29, !30}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "inner", scope: !2, file: !2, line: 3, baseType: !7, size: 2688, align: 64, flags: DIFlagPublic)
+    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "inner", scope: !2, file: !2, line: 13, size: 2688, align: 64, flags: DIFlagPublic, elements: !8, identifier: "inner")
+    !8 = !{!9, !14, !16, !18, !22}
+    !9 = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: !2, file: !2, line: 14, baseType: !10, size: 648, align: 8, flags: DIFlagPublic)
+    !10 = !DICompositeType(tag: DW_TAG_array_type, baseType: !11, size: 648, align: 8, elements: !12)
+    !11 = !DIBasicType(name: "CHAR", size: 8, encoding: DW_ATE_UTF, flags: DIFlagPublic)
+    !12 = !{!13}
+    !13 = !DISubrange(count: 81, lowerBound: 0)
+    !14 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 15, baseType: !15, size: 8, align: 8, offset: 648, flags: DIFlagPublic)
+    !15 = !DIBasicType(name: "BOOL", size: 8, encoding: DW_ATE_boolean, flags: DIFlagPublic)
+    !16 = !DIDerivedType(tag: DW_TAG_member, name: "r", scope: !2, file: !2, line: 16, baseType: !17, size: 32, align: 32, offset: 672, flags: DIFlagPublic)
+    !17 = !DIBasicType(name: "REAL", size: 32, encoding: DW_ATE_float, flags: DIFlagPublic)
+    !18 = !DIDerivedType(tag: DW_TAG_member, name: "arr", scope: !2, file: !2, line: 17, baseType: !19, size: 1944, align: 8, offset: 704, flags: DIFlagPublic)
+    !19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 1944, align: 8, elements: !20)
+    !20 = !{!21}
+    !21 = !DISubrange(count: 3, lowerBound: 0)
+    !22 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !2, file: !2, line: 18, baseType: !23, size: 16, align: 16, offset: 2656, flags: DIFlagPublic)
+    !23 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !24 = !DIDerivedType(tag: DW_TAG_member, name: "inner_arr", scope: !2, file: !2, line: 4, baseType: !25, size: 8064, align: 64, offset: 2688, flags: DIFlagPublic)
+    !25 = !DICompositeType(tag: DW_TAG_array_type, baseType: !7, size: 8064, align: 64, elements: !20)
+    !26 = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: !2, file: !2, line: 5, baseType: !10, size: 648, align: 8, offset: 10752, flags: DIFlagPublic)
+    !27 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 6, baseType: !15, size: 8, align: 8, offset: 11400, flags: DIFlagPublic)
+    !28 = !DIDerivedType(tag: DW_TAG_member, name: "r", scope: !2, file: !2, line: 7, baseType: !17, size: 32, align: 32, offset: 11424, flags: DIFlagPublic)
+    !29 = !DIDerivedType(tag: DW_TAG_member, name: "arr", scope: !2, file: !2, line: 8, baseType: !19, size: 1944, align: 8, offset: 11456, flags: DIFlagPublic)
+    !30 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !2, file: !2, line: 9, baseType: !23, size: 16, align: 16, offset: 13408, flags: DIFlagPublic)
+    !31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
+    !32 = distinct !DIGlobalVariable(name: "__inner__init", scope: !2, file: !2, line: 13, type: !33, isLocal: false, isDefinition: true)
+    !33 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+    !34 = !{i32 2, !"Dwarf Version", i32 5}
+    !35 = !{i32 2, !"Debug Info Version", i32 3}
+    !36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !37, splitDebugInlining: false)
+    !37 = !{!0, !31}
+    !38 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 22, type: !39, scopeLine: 22, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !41)
+    !39 = !DISubroutineType(flags: DIFlagPublic, types: !40)
+    !40 = !{null}
+    !41 = !{}
+    !42 = !DILocalVariable(name: "st", scope: !38, file: !2, line: 24, type: !4, align: 64)
+    !43 = !DILocation(line: 24, column: 4, scope: !38)
+    !44 = !DILocalVariable(name: "s", scope: !38, file: !2, line: 25, type: !10, align: 8)
+    !45 = !DILocation(line: 25, column: 4, scope: !38)
+    !46 = !DILocalVariable(name: "b", scope: !38, file: !2, line: 26, type: !15, align: 8)
+    !47 = !DILocation(line: 26, column: 4, scope: !38)
+    !48 = !DILocalVariable(name: "arr", scope: !38, file: !2, line: 27, type: !19, align: 8)
+    !49 = !DILocation(line: 27, column: 4, scope: !38)
+    !50 = !DILocalVariable(name: "i", scope: !38, file: !2, line: 28, type: !23, align: 16)
+    !51 = !DILocation(line: 28, column: 4, scope: !38)
+    !52 = !DILocation(line: 0, scope: !38)
+    !53 = !DILocation(line: 32, column: 4, scope: !38)
+    !54 = !DILocation(line: 33, column: 4, scope: !38)
+    !55 = !DILocation(line: 34, column: 4, scope: !38)
+    !56 = !DILocation(line: 35, column: 4, scope: !38)
+    !57 = !DILocation(line: 36, column: 4, scope: !38)
+    !58 = !DILocation(line: 37, column: 4, scope: !38)
+    !59 = !DILocation(line: 38, column: 4, scope: !38)
+    !60 = !DILocation(line: 39, column: 4, scope: !38)
+    !61 = !DILocation(line: 41, column: 4, scope: !38)
+    !62 = !DILocation(line: 42, column: 4, scope: !38)
+    !63 = !DILocation(line: 43, column: 4, scope: !38)
+    !64 = !DILocation(line: 45, scope: !38)
+    "###);
+}
+
+#[test]
+fn constants_are_tagged_as_such() {
+    let result = codegen(
+        "
+        VAR_GLOBAL CONSTANT
+            x: DINT;
+            s: STRING;
+            f: foo;
+        END_VAR
+
+        PROGRAM prog
+        VAR CONSTANT
+            a, b, c: DINT;
+        END_VAR
+        END_PROGRAM
+
+        TYPE foo : STRUCT
+            z: DINT;
+        END_STRUCT
+        END_TYPE
+
+        FUNCTION bar : DINT
+        VAR CONSTANT
+            d: DINT := 42;
+        END_VAR
+        END_FUNCTION
+    ",
+    );
+
+    filtered_assert_snapshot!(result, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %prog = type { i32, i32, i32 }
+    %foo = type { i32 }
+
+    @x = unnamed_addr constant i32 0, !dbg !0
+    @s = unnamed_addr constant [81 x i8] zeroinitializer, !dbg !5
+    @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
+    @prog_instance = global %prog zeroinitializer, !dbg !12
+    @__foo__init = unnamed_addr constant %foo zeroinitializer, !dbg !19
+    @f = unnamed_addr constant %foo zeroinitializer, !dbg !25
+
+    define void @prog(%prog* %0) !dbg !31 {
+    entry:
+      call void @llvm.dbg.declare(metadata %prog* %0, metadata !35, metadata !DIExpression()), !dbg !36
+      %a = getelementptr inbounds %prog, %prog* %0, i32 0, i32 0
+      %b = getelementptr inbounds %prog, %prog* %0, i32 0, i32 1
+      %c = getelementptr inbounds %prog, %prog* %0, i32 0, i32 2
+      ret void, !dbg !36
+    }
+
+    define i32 @bar() !dbg !37 {
+    entry:
+      %bar = alloca i32, align 4
+      %d = alloca i32, align 4
+      call void @llvm.dbg.declare(metadata i32* %d, metadata !40, metadata !DIExpression()), !dbg !41
+      store i32 42, i32* %d, align 4
+      call void @llvm.dbg.declare(metadata i32* %bar, metadata !42, metadata !DIExpression()), !dbg !43
+      store i32 0, i32* %bar, align 4
+      %bar_ret = load i32, i32* %bar, align 4, !dbg !44
+      ret i32 %bar_ret, !dbg !44
+    }
+
+    ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+    declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+    define void @__init_foo(%foo* %0) {
+    entry:
+      %self = alloca %foo*, align 8
+      store %foo* %0, %foo** %self, align 8
+      ret void
+    }
+
+    define void @__init_prog(%prog* %0) {
+    entry:
+      %self = alloca %prog*, align 8
+      store %prog* %0, %prog** %self, align 8
+      ret void
+    }
+
+    define void @__user_init_foo(%foo* %0) {
+    entry:
+      %self = alloca %foo*, align 8
+      store %foo* %0, %foo** %self, align 8
+      ret void
+    }
+
+    define void @__user_init_prog(%prog* %0) {
+    entry:
+      %self = alloca %prog*, align 8
+      store %prog* %0, %prog** %self, align 8
+      ret void
+    }
+
+    define void @__init___Test() {
+    entry:
+      call void @__init_prog(%prog* @prog_instance)
+      call void @__init_foo(%foo* @f)
+      call void @__user_init_prog(%prog* @prog_instance)
+      call void @__user_init_foo(%foo* @f)
+      ret void
+    }
+
+    attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
+
+    !llvm.module.flags = !{!27, !28}
+    !llvm.dbg.cu = !{!29}
+
+    !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+    !1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !2, line: 3, type: !3, isLocal: false, isDefinition: true)
+    !2 = !DIFile(filename: "<internal>", directory: "")
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
+    !6 = distinct !DIGlobalVariable(name: "s", scope: !2, file: !2, line: 4, type: !7, isLocal: false, isDefinition: true)
+    !7 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !8)
+    !8 = !DICompositeType(tag: DW_TAG_array_type, baseType: !9, size: 648, align: 8, elements: !10)
+    !9 = !DIBasicType(name: "CHAR", size: 8, encoding: DW_ATE_UTF, flags: DIFlagPublic)
+    !10 = !{!11}
+    !11 = !DISubrange(count: 81, lowerBound: 0)
+    !12 = !DIGlobalVariableExpression(var: !13, expr: !DIExpression())
+    !13 = distinct !DIGlobalVariable(name: "prog", scope: !2, file: !2, line: 8, type: !14, isLocal: false, isDefinition: true)
+    !14 = !DICompositeType(tag: DW_TAG_structure_type, name: "prog", scope: !2, file: !2, line: 8, size: 96, align: 64, flags: DIFlagPublic, elements: !15, identifier: "prog")
+    !15 = !{!16, !17, !18}
+    !16 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 10, baseType: !3, size: 32, align: 32, flags: DIFlagPublic)
+    !17 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 10, baseType: !3, size: 32, align: 32, offset: 32, flags: DIFlagPublic)
+    !18 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !2, file: !2, line: 10, baseType: !3, size: 32, align: 32, offset: 64, flags: DIFlagPublic)
+    !19 = !DIGlobalVariableExpression(var: !20, expr: !DIExpression())
+    !20 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 14, type: !21, isLocal: false, isDefinition: true)
+    !21 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !22)
+    !22 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 14, size: 32, align: 64, flags: DIFlagPublic, elements: !23, identifier: "foo")
+    !23 = !{!24}
+    !24 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !2, file: !2, line: 15, baseType: !4, size: 32, align: 32, flags: DIFlagPublic)
+    !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+    !26 = distinct !DIGlobalVariable(name: "f", scope: !2, file: !2, line: 5, type: !21, isLocal: false, isDefinition: true)
+    !27 = !{i32 2, !"Dwarf Version", i32 5}
+    !28 = !{i32 2, !"Debug Info Version", i32 3}
+    !29 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !30, splitDebugInlining: false)
+    !30 = !{!0, !5, !25, !19, !12}
+    !31 = distinct !DISubprogram(name: "prog", linkageName: "prog", scope: !2, file: !2, line: 8, type: !32, scopeLine: 12, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
+    !32 = !DISubroutineType(flags: DIFlagPublic, types: !33)
+    !33 = !{null, !14}
+    !34 = !{}
+    !35 = !DILocalVariable(name: "prog", scope: !31, file: !2, line: 12, type: !14)
+    !36 = !DILocation(line: 12, column: 8, scope: !31)
+    !37 = distinct !DISubprogram(name: "bar", linkageName: "bar", scope: !2, file: !2, line: 19, type: !38, scopeLine: 23, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
+    !38 = !DISubroutineType(flags: DIFlagPublic, types: !39)
+    !39 = !{null}
+    !40 = !DILocalVariable(name: "d", scope: !37, file: !2, line: 21, type: !3, align: 32)
+    !41 = !DILocation(line: 21, column: 12, scope: !37)
+    !42 = !DILocalVariable(name: "bar", scope: !37, file: !2, line: 19, type: !4, align: 32)
+    !43 = !DILocation(line: 19, column: 17, scope: !37)
+    !44 = !DILocation(line: 23, column: 8, scope: !37)
     "#);
 }

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/debug_tests/expression_debugging.rs
 expression: result
-snapshot_kind: text
 ---
 ; ModuleID = '<internal>'
 source_filename = "<internal>"
@@ -12,7 +11,7 @@ target triple = "[filtered]"
 %myFb = type {}
 
 @myPrg_instance = external global %myPrg, !dbg !0
-@__myFb__init = external global %myFb, !dbg !5
+@__myFb__init = external unnamed_addr constant %myFb, !dbg !5
 
 declare i32 @myFunc()
 
@@ -20,8 +19,8 @@ declare void @myPrg(%myPrg*)
 
 declare void @myFb(%myFb*)
 
-!llvm.module.flags = !{!8, !9}
-!llvm.dbg.cu = !{!10}
+!llvm.module.flags = !{!9, !10}
+!llvm.dbg.cu = !{!11}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "myPrg", scope: !2, file: !2, line: 4, type: !3, isLocal: false, isDefinition: true)
@@ -30,9 +29,10 @@ declare void @myFb(%myFb*)
 !4 = !{}
 !5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
 !6 = distinct !DIGlobalVariable(name: "__myFb__init", scope: !2, file: !2, line: 6, type: !7, isLocal: false, isDefinition: true)
-!7 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 6, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myFb")
-!8 = !{i32 2, !"Dwarf Version", i32 5}
-!9 = !{i32 2, !"Debug Info Version", i32 3}
-!10 = distinct !DICompileUnit(language: DW_LANG_C, file: !11, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !12, splitDebugInlining: false)
-!11 = !DIFile(filename: "<internal>", directory: "src")
-!12 = !{!0, !5}
+!7 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !8)
+!8 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 6, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myFb")
+!9 = !{i32 2, !"Dwarf Version", i32 5}
+!10 = !{i32 2, !"Debug Info Version", i32 3}
+!11 = distinct !DICompileUnit(language: DW_LANG_C, file: !12, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !13, splitDebugInlining: false)
+!12 = !DIFile(filename: "<internal>", directory: "src")
+!13 = !{!0, !5}

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__implementation_added_as_subroutine.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__implementation_added_as_subroutine.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/debug_tests/expression_debugging.rs
 expression: result
-snapshot_kind: text
 ---
 ; ModuleID = '<internal>'
 source_filename = "<internal>"
@@ -14,27 +13,27 @@ target triple = "[filtered]"
 @myPrg_instance = global %myPrg zeroinitializer, !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, !dbg !5
 
-define i32 @myFunc() !dbg !13 {
+define i32 @myFunc() !dbg !14 {
 entry:
   %myFunc = alloca i32, align 4
-  call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !16, metadata !DIExpression()), !dbg !18
+  call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !17, metadata !DIExpression()), !dbg !19
   store i32 0, i32* %myFunc, align 4
-  %myFunc_ret = load i32, i32* %myFunc, align 4, !dbg !19
-  ret i32 %myFunc_ret, !dbg !19
+  %myFunc_ret = load i32, i32* %myFunc, align 4, !dbg !20
+  ret i32 %myFunc_ret, !dbg !20
 }
 
-define void @myPrg(%myPrg* %0) !dbg !20 {
+define void @myPrg(%myPrg* %0) !dbg !21 {
 entry:
-  call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !23, metadata !DIExpression()), !dbg !24
-  ret void, !dbg !24
+  call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !24, metadata !DIExpression()), !dbg !25
+  ret void, !dbg !25
 }
 
-define void @myFb(%myFb* %0) !dbg !25 {
+define void @myFb(%myFb* %0) !dbg !26 {
 entry:
-  call void @llvm.dbg.declare(metadata %myFb* %0, metadata !28, metadata !DIExpression()), !dbg !29
+  call void @llvm.dbg.declare(metadata %myFb* %0, metadata !29, metadata !DIExpression()), !dbg !30
   %this = alloca %myFb*, align 8
   store %myFb* %0, %myFb** %this, align 8
-  ret void, !dbg !29
+  ret void, !dbg !30
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -42,8 +41,8 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 
 attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-!llvm.module.flags = !{!8, !9}
-!llvm.dbg.cu = !{!10}
+!llvm.module.flags = !{!9, !10}
+!llvm.dbg.cu = !{!11}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "myPrg", scope: !2, file: !2, line: 4, type: !3, isLocal: false, isDefinition: true)
@@ -52,26 +51,27 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !4 = !{}
 !5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
 !6 = distinct !DIGlobalVariable(name: "__myFb__init", scope: !2, file: !2, line: 6, type: !7, isLocal: false, isDefinition: true)
-!7 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 6, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myFb")
-!8 = !{i32 2, !"Dwarf Version", i32 5}
-!9 = !{i32 2, !"Debug Info Version", i32 3}
-!10 = distinct !DICompileUnit(language: DW_LANG_C, file: !11, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !12, splitDebugInlining: false)
-!11 = !DIFile(filename: "<internal>", directory: "src")
-!12 = !{!0, !5}
-!13 = distinct !DISubprogram(name: "myFunc", linkageName: "myFunc", scope: !2, file: !2, line: 2, type: !14, scopeLine: 3, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
-!14 = !DISubroutineType(flags: DIFlagPublic, types: !15)
-!15 = !{null}
-!16 = !DILocalVariable(name: "myFunc", scope: !13, file: !2, line: 2, type: !17, align: 32)
-!17 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-!18 = !DILocation(line: 2, column: 17, scope: !13)
-!19 = !DILocation(line: 3, column: 8, scope: !13)
-!20 = distinct !DISubprogram(name: "myPrg", linkageName: "myPrg", scope: !2, file: !2, line: 4, type: !21, scopeLine: 5, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
-!21 = !DISubroutineType(flags: DIFlagPublic, types: !22)
-!22 = !{null, !3}
-!23 = !DILocalVariable(name: "myPrg", scope: !20, file: !2, line: 5, type: !3)
-!24 = !DILocation(line: 5, column: 8, scope: !20)
-!25 = distinct !DISubprogram(name: "myFb", linkageName: "myFb", scope: !2, file: !2, line: 6, type: !26, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
-!26 = !DISubroutineType(flags: DIFlagPublic, types: !27)
-!27 = !{null, !7}
-!28 = !DILocalVariable(name: "myFb", scope: !25, file: !2, line: 7, type: !7)
-!29 = !DILocation(line: 7, column: 8, scope: !25)
+!7 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !8)
+!8 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 6, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myFb")
+!9 = !{i32 2, !"Dwarf Version", i32 5}
+!10 = !{i32 2, !"Debug Info Version", i32 3}
+!11 = distinct !DICompileUnit(language: DW_LANG_C, file: !12, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !13, splitDebugInlining: false)
+!12 = !DIFile(filename: "<internal>", directory: "src")
+!13 = !{!0, !5}
+!14 = distinct !DISubprogram(name: "myFunc", linkageName: "myFunc", scope: !2, file: !2, line: 2, type: !15, scopeLine: 3, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !11, retainedNodes: !4)
+!15 = !DISubroutineType(flags: DIFlagPublic, types: !16)
+!16 = !{null}
+!17 = !DILocalVariable(name: "myFunc", scope: !14, file: !2, line: 2, type: !18, align: 32)
+!18 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+!19 = !DILocation(line: 2, column: 17, scope: !14)
+!20 = !DILocation(line: 3, column: 8, scope: !14)
+!21 = distinct !DISubprogram(name: "myPrg", linkageName: "myPrg", scope: !2, file: !2, line: 4, type: !22, scopeLine: 5, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !11, retainedNodes: !4)
+!22 = !DISubroutineType(flags: DIFlagPublic, types: !23)
+!23 = !{null, !3}
+!24 = !DILocalVariable(name: "myPrg", scope: !21, file: !2, line: 5, type: !3)
+!25 = !DILocation(line: 5, column: 8, scope: !21)
+!26 = distinct !DISubprogram(name: "myFb", linkageName: "myFb", scope: !2, file: !2, line: 6, type: !27, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !11, retainedNodes: !4)
+!27 = !DISubroutineType(flags: DIFlagPublic, types: !28)
+!28 = !{null, !8}
+!29 = !DILocalVariable(name: "myFb", scope: !26, file: !2, line: 7, type: !8)
+!30 = !DILocation(line: 7, column: 8, scope: !26)

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_function_pous_have_struct_as_param.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_function_pous_have_struct_as_param.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/debug_tests/expression_debugging.rs
 expression: result
-snapshot_kind: text
 ---
 ; ModuleID = '<internal>'
 source_filename = "<internal>"
@@ -14,26 +13,26 @@ target triple = "[filtered]"
 @myProg_instance = global %myProg zeroinitializer, !dbg !0
 @__fb__init = unnamed_addr constant %fb zeroinitializer, !dbg !7
 
-define void @myProg(%myProg* %0) !dbg !17 {
+define void @myProg(%myProg* %0) !dbg !18 {
 entry:
-  call void @llvm.dbg.declare(metadata %myProg* %0, metadata !21, metadata !DIExpression()), !dbg !22
+  call void @llvm.dbg.declare(metadata %myProg* %0, metadata !22, metadata !DIExpression()), !dbg !23
   %x = getelementptr inbounds %myProg, %myProg* %0, i32 0, i32 0
-  %load_x = load i32, i32* %x, align 4, !dbg !22
-  %tmpVar = add i32 %load_x, 2, !dbg !22
-  store i32 %tmpVar, i32* %x, align 4, !dbg !22
-  ret void, !dbg !23
+  %load_x = load i32, i32* %x, align 4, !dbg !23
+  %tmpVar = add i32 %load_x, 2, !dbg !23
+  store i32 %tmpVar, i32* %x, align 4, !dbg !23
+  ret void, !dbg !24
 }
 
-define void @fb(%fb* %0) !dbg !24 {
+define void @fb(%fb* %0) !dbg !25 {
 entry:
-  call void @llvm.dbg.declare(metadata %fb* %0, metadata !27, metadata !DIExpression()), !dbg !28
+  call void @llvm.dbg.declare(metadata %fb* %0, metadata !28, metadata !DIExpression()), !dbg !29
   %this = alloca %fb*, align 8
   store %fb* %0, %fb** %this, align 8
   %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
-  %load_x = load i32, i32* %x, align 4, !dbg !28
-  %tmpVar = add i32 %load_x, 2, !dbg !28
-  store i32 %tmpVar, i32* %x, align 4, !dbg !28
-  ret void, !dbg !29
+  %load_x = load i32, i32* %x, align 4, !dbg !29
+  %tmpVar = add i32 %load_x, 2, !dbg !29
+  store i32 %tmpVar, i32* %x, align 4, !dbg !29
+  ret void, !dbg !30
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -41,8 +40,8 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 
 attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-!llvm.module.flags = !{!12, !13}
-!llvm.dbg.cu = !{!14}
+!llvm.module.flags = !{!13, !14}
+!llvm.dbg.cu = !{!15}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "myProg", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
@@ -53,24 +52,25 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !6 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "__fb__init", scope: !2, file: !2, line: 9, type: !9, isLocal: false, isDefinition: true)
-!9 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb", scope: !2, file: !2, line: 9, size: 32, align: 64, flags: DIFlagPublic, elements: !10, identifier: "fb")
-!10 = !{!11}
-!11 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 11, baseType: !6, size: 32, align: 32, flags: DIFlagPublic)
-!12 = !{i32 2, !"Dwarf Version", i32 5}
-!13 = !{i32 2, !"Debug Info Version", i32 3}
-!14 = distinct !DICompileUnit(language: DW_LANG_C, file: !15, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !16, splitDebugInlining: false)
-!15 = !DIFile(filename: "<internal>", directory: "src")
-!16 = !{!0, !7}
-!17 = distinct !DISubprogram(name: "myProg", linkageName: "myProg", scope: !2, file: !2, line: 2, type: !18, scopeLine: 6, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !20)
-!18 = !DISubroutineType(flags: DIFlagPublic, types: !19)
-!19 = !{null, !3, !6}
-!20 = !{}
-!21 = !DILocalVariable(name: "myProg", scope: !17, file: !2, line: 6, type: !3)
-!22 = !DILocation(line: 6, column: 12, scope: !17)
-!23 = !DILocation(line: 7, column: 8, scope: !17)
-!24 = distinct !DISubprogram(name: "fb", linkageName: "fb", scope: !2, file: !2, line: 9, type: !25, scopeLine: 13, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !20)
-!25 = !DISubroutineType(flags: DIFlagPublic, types: !26)
-!26 = !{null, !9, !6}
-!27 = !DILocalVariable(name: "fb", scope: !24, file: !2, line: 13, type: !9)
-!28 = !DILocation(line: 13, column: 12, scope: !24)
-!29 = !DILocation(line: 14, column: 8, scope: !24)
+!9 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !10)
+!10 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb", scope: !2, file: !2, line: 9, size: 32, align: 64, flags: DIFlagPublic, elements: !11, identifier: "fb")
+!11 = !{!12}
+!12 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 11, baseType: !6, size: 32, align: 32, flags: DIFlagPublic)
+!13 = !{i32 2, !"Dwarf Version", i32 5}
+!14 = !{i32 2, !"Debug Info Version", i32 3}
+!15 = distinct !DICompileUnit(language: DW_LANG_C, file: !16, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !17, splitDebugInlining: false)
+!16 = !DIFile(filename: "<internal>", directory: "src")
+!17 = !{!0, !7}
+!18 = distinct !DISubprogram(name: "myProg", linkageName: "myProg", scope: !2, file: !2, line: 2, type: !19, scopeLine: 6, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !15, retainedNodes: !21)
+!19 = !DISubroutineType(flags: DIFlagPublic, types: !20)
+!20 = !{null, !3, !6}
+!21 = !{}
+!22 = !DILocalVariable(name: "myProg", scope: !18, file: !2, line: 6, type: !3)
+!23 = !DILocation(line: 6, column: 12, scope: !18)
+!24 = !DILocation(line: 7, column: 8, scope: !18)
+!25 = distinct !DISubprogram(name: "fb", linkageName: "fb", scope: !2, file: !2, line: 9, type: !26, scopeLine: 13, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !15, retainedNodes: !21)
+!26 = !DISubroutineType(flags: DIFlagPublic, types: !27)
+!27 = !{null, !10, !6}
+!28 = !DILocalVariable(name: "fb", scope: !25, file: !2, line: 13, type: !10)
+!29 = !DILocation(line: 13, column: 12, scope: !25)
+!30 = !DILocation(line: 14, column: 8, scope: !25)

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__var_and_vartemp_variables_in_pous_added_as_local.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/debug_tests/expression_debugging.rs
 expression: result
-snapshot_kind: text
 ---
 ; ModuleID = '<internal>'
 source_filename = "<internal>"
@@ -14,54 +13,54 @@ target triple = "[filtered]"
 @myPrg_instance = global %myPrg zeroinitializer, !dbg !0
 @__myFb__init = unnamed_addr constant %myFb zeroinitializer, !dbg !5
 
-define i32 @myFunc() !dbg !13 {
+define i32 @myFunc() !dbg !14 {
 entry:
   %myFunc = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   %c = alloca i32, align 4
-  call void @llvm.dbg.declare(metadata i32* %a, metadata !16, metadata !DIExpression()), !dbg !18
+  call void @llvm.dbg.declare(metadata i32* %a, metadata !17, metadata !DIExpression()), !dbg !19
   store i32 0, i32* %a, align 4
-  call void @llvm.dbg.declare(metadata i32* %b, metadata !19, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.declare(metadata i32* %b, metadata !20, metadata !DIExpression()), !dbg !21
   store i32 0, i32* %b, align 4
-  call void @llvm.dbg.declare(metadata i32* %c, metadata !21, metadata !DIExpression()), !dbg !22
+  call void @llvm.dbg.declare(metadata i32* %c, metadata !22, metadata !DIExpression()), !dbg !23
   store i32 0, i32* %c, align 4
-  call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !23, metadata !DIExpression()), !dbg !24
+  call void @llvm.dbg.declare(metadata i32* %myFunc, metadata !24, metadata !DIExpression()), !dbg !25
   store i32 0, i32* %myFunc, align 4
-  %myFunc_ret = load i32, i32* %myFunc, align 4, !dbg !25
-  ret i32 %myFunc_ret, !dbg !25
+  %myFunc_ret = load i32, i32* %myFunc, align 4, !dbg !26
+  ret i32 %myFunc_ret, !dbg !26
 }
 
-define void @myPrg(%myPrg* %0) !dbg !26 {
+define void @myPrg(%myPrg* %0) !dbg !27 {
 entry:
-  call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !29, metadata !DIExpression()), !dbg !30
+  call void @llvm.dbg.declare(metadata %myPrg* %0, metadata !30, metadata !DIExpression()), !dbg !31
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   %c = alloca i32, align 4
-  call void @llvm.dbg.declare(metadata i32* %a, metadata !31, metadata !DIExpression()), !dbg !32
+  call void @llvm.dbg.declare(metadata i32* %a, metadata !32, metadata !DIExpression()), !dbg !33
   store i32 0, i32* %a, align 4
-  call void @llvm.dbg.declare(metadata i32* %b, metadata !33, metadata !DIExpression()), !dbg !34
+  call void @llvm.dbg.declare(metadata i32* %b, metadata !34, metadata !DIExpression()), !dbg !35
   store i32 0, i32* %b, align 4
-  call void @llvm.dbg.declare(metadata i32* %c, metadata !35, metadata !DIExpression()), !dbg !36
+  call void @llvm.dbg.declare(metadata i32* %c, metadata !36, metadata !DIExpression()), !dbg !37
   store i32 0, i32* %c, align 4
-  ret void, !dbg !30
+  ret void, !dbg !31
 }
 
-define void @myFb(%myFb* %0) !dbg !37 {
+define void @myFb(%myFb* %0) !dbg !38 {
 entry:
-  call void @llvm.dbg.declare(metadata %myFb* %0, metadata !40, metadata !DIExpression()), !dbg !41
+  call void @llvm.dbg.declare(metadata %myFb* %0, metadata !41, metadata !DIExpression()), !dbg !42
   %this = alloca %myFb*, align 8
   store %myFb* %0, %myFb** %this, align 8
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   %c = alloca i32, align 4
-  call void @llvm.dbg.declare(metadata i32* %a, metadata !42, metadata !DIExpression()), !dbg !43
+  call void @llvm.dbg.declare(metadata i32* %a, metadata !43, metadata !DIExpression()), !dbg !44
   store i32 0, i32* %a, align 4
-  call void @llvm.dbg.declare(metadata i32* %b, metadata !44, metadata !DIExpression()), !dbg !45
+  call void @llvm.dbg.declare(metadata i32* %b, metadata !45, metadata !DIExpression()), !dbg !46
   store i32 0, i32* %b, align 4
-  call void @llvm.dbg.declare(metadata i32* %c, metadata !46, metadata !DIExpression()), !dbg !47
+  call void @llvm.dbg.declare(metadata i32* %c, metadata !47, metadata !DIExpression()), !dbg !48
   store i32 0, i32* %c, align 4
-  ret void, !dbg !41
+  ret void, !dbg !42
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -69,8 +68,8 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 
 attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-!llvm.module.flags = !{!8, !9}
-!llvm.dbg.cu = !{!10}
+!llvm.module.flags = !{!9, !10}
+!llvm.dbg.cu = !{!11}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "myPrg", scope: !2, file: !2, line: 5, type: !3, isLocal: false, isDefinition: true)
@@ -79,44 +78,45 @@ attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 !4 = !{}
 !5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
 !6 = distinct !DIGlobalVariable(name: "__myFb__init", scope: !2, file: !2, line: 8, type: !7, isLocal: false, isDefinition: true)
-!7 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 8, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myFb")
-!8 = !{i32 2, !"Dwarf Version", i32 5}
-!9 = !{i32 2, !"Debug Info Version", i32 3}
-!10 = distinct !DICompileUnit(language: DW_LANG_C, file: !11, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !12, splitDebugInlining: false)
-!11 = !DIFile(filename: "<internal>", directory: "src")
-!12 = !{!0, !5}
-!13 = distinct !DISubprogram(name: "myFunc", linkageName: "myFunc", scope: !2, file: !2, line: 2, type: !14, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
-!14 = !DISubroutineType(flags: DIFlagPublic, types: !15)
-!15 = !{null}
-!16 = !DILocalVariable(name: "a", scope: !13, file: !2, line: 3, type: !17, align: 32)
-!17 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-!18 = !DILocation(line: 3, column: 12, scope: !13)
-!19 = !DILocalVariable(name: "b", scope: !13, file: !2, line: 3, type: !17, align: 32)
-!20 = !DILocation(line: 3, column: 14, scope: !13)
-!21 = !DILocalVariable(name: "c", scope: !13, file: !2, line: 3, type: !17, align: 32)
-!22 = !DILocation(line: 3, column: 16, scope: !13)
-!23 = !DILocalVariable(name: "myFunc", scope: !13, file: !2, line: 2, type: !17, align: 32)
-!24 = !DILocation(line: 2, column: 17, scope: !13)
-!25 = !DILocation(line: 4, column: 8, scope: !13)
-!26 = distinct !DISubprogram(name: "myPrg", linkageName: "myPrg", scope: !2, file: !2, line: 5, type: !27, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
-!27 = !DISubroutineType(flags: DIFlagPublic, types: !28)
-!28 = !{null, !3}
-!29 = !DILocalVariable(name: "myPrg", scope: !26, file: !2, line: 7, type: !3)
-!30 = !DILocation(line: 7, column: 8, scope: !26)
-!31 = !DILocalVariable(name: "a", scope: !26, file: !2, line: 6, type: !17, align: 32)
-!32 = !DILocation(line: 6, column: 17, scope: !26)
-!33 = !DILocalVariable(name: "b", scope: !26, file: !2, line: 6, type: !17, align: 32)
-!34 = !DILocation(line: 6, column: 19, scope: !26)
-!35 = !DILocalVariable(name: "c", scope: !26, file: !2, line: 6, type: !17, align: 32)
-!36 = !DILocation(line: 6, column: 21, scope: !26)
-!37 = distinct !DISubprogram(name: "myFb", linkageName: "myFb", scope: !2, file: !2, line: 8, type: !38, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !10, retainedNodes: !4)
-!38 = !DISubroutineType(flags: DIFlagPublic, types: !39)
-!39 = !{null, !7}
-!40 = !DILocalVariable(name: "myFb", scope: !37, file: !2, line: 10, type: !7)
-!41 = !DILocation(line: 10, column: 8, scope: !37)
-!42 = !DILocalVariable(name: "a", scope: !37, file: !2, line: 9, type: !17, align: 32)
-!43 = !DILocation(line: 9, column: 17, scope: !37)
-!44 = !DILocalVariable(name: "b", scope: !37, file: !2, line: 9, type: !17, align: 32)
-!45 = !DILocation(line: 9, column: 19, scope: !37)
-!46 = !DILocalVariable(name: "c", scope: !37, file: !2, line: 9, type: !17, align: 32)
-!47 = !DILocation(line: 9, column: 21, scope: !37)
+!7 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !8)
+!8 = !DICompositeType(tag: DW_TAG_structure_type, name: "myFb", scope: !2, file: !2, line: 8, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myFb")
+!9 = !{i32 2, !"Dwarf Version", i32 5}
+!10 = !{i32 2, !"Debug Info Version", i32 3}
+!11 = distinct !DICompileUnit(language: DW_LANG_C, file: !12, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !13, splitDebugInlining: false)
+!12 = !DIFile(filename: "<internal>", directory: "src")
+!13 = !{!0, !5}
+!14 = distinct !DISubprogram(name: "myFunc", linkageName: "myFunc", scope: !2, file: !2, line: 2, type: !15, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !11, retainedNodes: !4)
+!15 = !DISubroutineType(flags: DIFlagPublic, types: !16)
+!16 = !{null}
+!17 = !DILocalVariable(name: "a", scope: !14, file: !2, line: 3, type: !18, align: 32)
+!18 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+!19 = !DILocation(line: 3, column: 12, scope: !14)
+!20 = !DILocalVariable(name: "b", scope: !14, file: !2, line: 3, type: !18, align: 32)
+!21 = !DILocation(line: 3, column: 14, scope: !14)
+!22 = !DILocalVariable(name: "c", scope: !14, file: !2, line: 3, type: !18, align: 32)
+!23 = !DILocation(line: 3, column: 16, scope: !14)
+!24 = !DILocalVariable(name: "myFunc", scope: !14, file: !2, line: 2, type: !18, align: 32)
+!25 = !DILocation(line: 2, column: 17, scope: !14)
+!26 = !DILocation(line: 4, column: 8, scope: !14)
+!27 = distinct !DISubprogram(name: "myPrg", linkageName: "myPrg", scope: !2, file: !2, line: 5, type: !28, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !11, retainedNodes: !4)
+!28 = !DISubroutineType(flags: DIFlagPublic, types: !29)
+!29 = !{null, !3}
+!30 = !DILocalVariable(name: "myPrg", scope: !27, file: !2, line: 7, type: !3)
+!31 = !DILocation(line: 7, column: 8, scope: !27)
+!32 = !DILocalVariable(name: "a", scope: !27, file: !2, line: 6, type: !18, align: 32)
+!33 = !DILocation(line: 6, column: 17, scope: !27)
+!34 = !DILocalVariable(name: "b", scope: !27, file: !2, line: 6, type: !18, align: 32)
+!35 = !DILocation(line: 6, column: 19, scope: !27)
+!36 = !DILocalVariable(name: "c", scope: !27, file: !2, line: 6, type: !18, align: 32)
+!37 = !DILocation(line: 6, column: 21, scope: !27)
+!38 = distinct !DISubprogram(name: "myFb", linkageName: "myFb", scope: !2, file: !2, line: 8, type: !39, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !11, retainedNodes: !4)
+!39 = !DISubroutineType(flags: DIFlagPublic, types: !40)
+!40 = !{null, !8}
+!41 = !DILocalVariable(name: "myFb", scope: !38, file: !2, line: 10, type: !8)
+!42 = !DILocation(line: 10, column: 8, scope: !38)
+!43 = !DILocalVariable(name: "a", scope: !38, file: !2, line: 9, type: !18, align: 32)
+!44 = !DILocation(line: 9, column: 17, scope: !38)
+!45 = !DILocalVariable(name: "b", scope: !38, file: !2, line: 9, type: !18, align: 32)
+!46 = !DILocation(line: 9, column: 19, scope: !38)
+!47 = !DILocalVariable(name: "c", scope: !38, file: !2, line: 9, type: !18, align: 32)
+!48 = !DILocation(line: 9, column: 21, scope: !38)

--- a/src/codegen/tests/initialization_test/complex_initializers.rs
+++ b/src/codegen/tests/initialization_test/complex_initializers.rs
@@ -269,7 +269,7 @@ fn init_functions_generated_for_function_blocks() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -277,7 +277,7 @@ fn init_functions_generated_for_function_blocks() {
 
     %foo = type { [81 x i8]* }
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @s = global [81 x i8] zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
@@ -310,7 +310,7 @@ fn init_functions_generated_for_function_blocks() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -378,7 +378,7 @@ fn nested_initializer_pous() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -393,9 +393,9 @@ fn nested_initializer_pous() {
     @str = global [81 x i8] c"hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @mainProg_instance = global %mainProg zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
-    @__bar__init = constant %bar zeroinitializer
-    @__baz__init = constant %baz zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
+    @__bar__init = unnamed_addr constant %bar zeroinitializer
+    @__baz__init = unnamed_addr constant %baz zeroinitializer
     @sideProg_instance = global %sideProg zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -581,7 +581,7 @@ fn nested_initializer_pous() {
       call void @__user_init_sideProg(%sideProg* @sideProg_instance)
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -609,7 +609,7 @@ fn local_address() {
 
     %foo = type { i16, i16* }
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -682,7 +682,7 @@ fn user_init_called_for_variables_on_stack() {
 
     %foo = type { i16, i16* }
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -846,7 +846,7 @@ fn struct_types() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -859,7 +859,7 @@ fn struct_types() {
     @s2 = global [2 x [81 x i8]] [[81 x i8] c"hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"world\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"]
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
-    @__myStruct__init = constant %myStruct zeroinitializer
+    @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
 
     define void @prog(%prog* %0) {
     entry:
@@ -913,7 +913,7 @@ fn struct_types() {
       call void @__user_init_prog(%prog* @prog_instance)
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -950,7 +950,7 @@ fn stateful_pous_methods_and_structs_get_init_functions() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -961,9 +961,9 @@ fn stateful_pous_methods_and_structs_get_init_functions() {
     %cl = type {}
     %prog = type {}
 
-    @__myStruct__init = constant %myStruct zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
-    @__cl__init = constant %cl zeroinitializer
+    @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
+    @__cl__init = unnamed_addr constant %cl zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
 
@@ -1058,7 +1058,7 @@ fn stateful_pous_methods_and_structs_get_init_functions() {
       call void @__user_init_prog(%prog* @prog_instance)
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1086,7 +1086,7 @@ fn global_instance() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1098,7 +1098,7 @@ fn global_instance() {
     @ps = global [81 x i8] zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @fb = global %foo zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -1154,7 +1154,7 @@ fn global_instance() {
       call void @__user_init_foo(%foo* @fb)
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1187,7 +1187,7 @@ fn aliased_types() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1199,7 +1199,7 @@ fn aliased_types() {
     @ps = global [81 x i8] zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @global_alias = global %foo zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -1262,7 +1262,7 @@ fn aliased_types() {
       call void @__user_init_foo(%foo* @global_alias)
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1360,7 +1360,7 @@ fn var_config_aliased_variables_initialized() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1371,7 +1371,7 @@ fn var_config_aliased_variables_initialized() {
 
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
-    @__FB__init = constant %FB zeroinitializer
+    @__FB__init = unnamed_addr constant %FB zeroinitializer
     @__PI_1_2_1 = global i32 0
     @__PI_1_2_2 = global i32 0
 
@@ -1444,7 +1444,7 @@ fn var_config_aliased_variables_initialized() {
       store i32* @__PI_1_2_2, i32** getelementptr inbounds (%prog, %prog* @prog_instance, i32 0, i32 1, i32 0), align 8
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1473,7 +1473,7 @@ fn var_external_blocks_are_ignored_in_init_functions() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1481,7 +1481,7 @@ fn var_external_blocks_are_ignored_in_init_functions() {
 
     %foo = type {}
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @s = global [81 x i8] zeroinitializer
     @refString = global [81 x i8]* null
@@ -1517,7 +1517,7 @@ fn var_external_blocks_are_ignored_in_init_functions() {
       store [81 x i8]* @s, [81 x i8]** @refString, align 8
       ret void
     }
-    "#)
+    "###)
 }
 
 #[test]
@@ -1538,7 +1538,7 @@ fn ref_to_local_member() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1546,7 +1546,7 @@ fn ref_to_local_member() {
 
     %foo = type { [81 x i8], [81 x i8]*, [81 x i8]*, [81 x i8]* }
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -1593,7 +1593,7 @@ fn ref_to_local_member() {
     entry:
       ret void
     }
-    "#)
+    "###)
 }
 
 #[test]
@@ -1618,7 +1618,7 @@ fn ref_to_local_member_shadows_global() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1627,7 +1627,7 @@ fn ref_to_local_member_shadows_global() {
     %foo = type { [81 x i8], [81 x i8]*, [81 x i8]*, [81 x i8]* }
 
     @s = global [81 x i8] zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -1674,7 +1674,7 @@ fn ref_to_local_member_shadows_global() {
     entry:
       ret void
     }
-    "#)
+    "###)
 }
 
 #[test]
@@ -1697,7 +1697,7 @@ fn temporary_variable_ref_to_local_member() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1705,7 +1705,7 @@ fn temporary_variable_ref_to_local_member() {
 
     %foo = type { [81 x i8] }
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -1743,7 +1743,7 @@ fn temporary_variable_ref_to_local_member() {
     entry:
       ret void
     }
-    "#)
+    "###)
 }
 
 #[test]
@@ -1822,7 +1822,7 @@ fn initializing_method_variables_with_refs() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1830,7 +1830,7 @@ fn initializing_method_variables_with_refs() {
 
     %foo = type {}
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -1870,7 +1870,7 @@ fn initializing_method_variables_with_refs() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1894,7 +1894,7 @@ fn initializing_method_variables_with_refs_referencing_parent_pou_variable() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1902,7 +1902,7 @@ fn initializing_method_variables_with_refs_referencing_parent_pou_variable() {
 
     %foo = type { i32 }
 
-    @__foo__init = constant %foo { i32 5 }
+    @__foo__init = unnamed_addr constant %foo { i32 5 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -1942,7 +1942,7 @@ fn initializing_method_variables_with_refs_referencing_parent_pou_variable() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1966,7 +1966,7 @@ fn initializing_method_variables_with_refs_referencing_global_variable() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1975,7 +1975,7 @@ fn initializing_method_variables_with_refs_referencing_global_variable() {
     %foo = type {}
 
     @x = global i32 0
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -2013,7 +2013,7 @@ fn initializing_method_variables_with_refs_referencing_global_variable() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -2038,7 +2038,7 @@ fn initializing_method_variables_with_refs_shadowing() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2047,7 +2047,7 @@ fn initializing_method_variables_with_refs_shadowing() {
     %foo = type {}
 
     @x = global i32 0
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -2087,7 +2087,7 @@ fn initializing_method_variables_with_refs_shadowing() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -2108,7 +2108,7 @@ fn initializing_method_variables_with_alias() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2116,7 +2116,7 @@ fn initializing_method_variables_with_alias() {
 
     %foo = type {}
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -2156,7 +2156,7 @@ fn initializing_method_variables_with_alias() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -2177,7 +2177,7 @@ fn initializing_method_variables_with_reference_to() {
         )],
     )
     .unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2185,7 +2185,7 @@ fn initializing_method_variables_with_reference_to() {
 
     %foo = type {}
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -2225,7 +2225,7 @@ fn initializing_method_variables_with_reference_to() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -2253,7 +2253,7 @@ fn methods_call_init_functions_for_their_members() {
     )
     .unwrap();
     // when compiling to ir, we expect `bar.baz` to call `__init_foo` with the local instance.
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2262,8 +2262,8 @@ fn methods_call_init_functions_for_their_members() {
     %foo = type { i32, i32* }
     %bar = type {}
 
-    @__foo__init = constant %foo zeroinitializer
-    @__bar__init = constant %bar zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
+    @__bar__init = unnamed_addr constant %bar zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -2336,7 +2336,7 @@ fn methods_call_init_functions_for_their_members() {
     }
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
-    "#);
+    "###);
 }
 
 #[test]
@@ -2367,7 +2367,7 @@ fn user_fb_init_is_added_and_called_if_it_exists() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2378,7 +2378,7 @@ fn user_fb_init_is_added_and_called_if_it_exists() {
 
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
 
     define void @foo(%foo* %0) {
     entry:
@@ -2449,7 +2449,7 @@ fn user_fb_init_is_added_and_called_if_it_exists() {
       call void @__user_init_prog(%prog* @prog_instance)
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -2490,7 +2490,7 @@ fn user_fb_init_in_global_struct() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2502,8 +2502,8 @@ fn user_fb_init_in_global_struct() {
 
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
-    @__bar__init = constant %bar zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__bar__init = unnamed_addr constant %bar zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @str = global %bar zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -2598,7 +2598,7 @@ fn user_fb_init_in_global_struct() {
       call void @__user_init_bar(%bar* @str)
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -2628,7 +2628,7 @@ fn user_init_called_when_declared_as_external() {
     )
     .unwrap();
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2639,7 +2639,7 @@ fn user_init_called_when_declared_as_external() {
 
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
-    @__foo__init = external global %foo
+    @__foo__init = external unnamed_addr constant %foo
 
     declare void @foo(%foo*)
 
@@ -2684,5 +2684,5 @@ fn user_init_called_when_declared_as_external() {
       call void @__user_init_prog(%prog* @prog_instance)
       ret void
     }
-    "#);
+    "###);
 }

--- a/src/codegen/tests/initialization_test/global_initializers.rs
+++ b/src/codegen/tests/initialization_test/global_initializers.rs
@@ -164,7 +164,7 @@ fn external_pous_get_external_initializers() {
         ",
     );
 
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -173,13 +173,13 @@ fn external_pous_get_external_initializers() {
     %ext_fb = type {}
     %ext_prog = type {}
 
-    @__ext_fb__init = external global %ext_fb
+    @__ext_fb__init = external unnamed_addr constant %ext_fb
     @ext_prog_instance = external global %ext_prog
 
     declare void @ext_fb(%ext_fb*)
 
     declare void @ext_prog(%ext_prog*)
-    "#);
+    "###);
 }
 
 #[test]

--- a/src/codegen/tests/oop_tests.rs
+++ b/src/codegen/tests/oop_tests.rs
@@ -19,7 +19,7 @@ fn members_from_base_class_are_available_in_subclasses() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -28,8 +28,8 @@ fn members_from_base_class_are_available_in_subclasses() {
     %foo = type { i16, [81 x i8], [11 x [81 x i8]] }
     %bar = type { %foo }
 
-    @__foo__init = constant %foo zeroinitializer
-    @__bar__init = constant %bar zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
+    @__bar__init = unnamed_addr constant %bar zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -88,7 +88,7 @@ fn members_from_base_class_are_available_in_subclasses() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn write_to_parent_variable_qualified_access() {
        ",
     );
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -124,9 +124,9 @@ fn write_to_parent_variable_qualified_access() {
     %fb = type { i16, i16 }
     %foo = type { %fb2 }
 
-    @__fb2__init = constant %fb2 zeroinitializer
-    @__fb__init = constant %fb zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__fb2__init = unnamed_addr constant %fb2 zeroinitializer
+    @__fb__init = unnamed_addr constant %fb zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @fb(%fb* %0) {
@@ -215,7 +215,7 @@ fn write_to_parent_variable_qualified_access() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn write_to_parent_variable_in_instance() {
         END_FUNCTION
     "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -256,8 +256,8 @@ fn write_to_parent_variable_in_instance() {
 
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
-    @__bar__init = constant %bar zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__bar__init = unnamed_addr constant %bar zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -355,7 +355,7 @@ fn write_to_parent_variable_in_instance() {
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
     attributes #1 = { argmemonly nofree nounwind willreturn writeonly }
-    "#);
+    "###);
 }
 
 #[test]
@@ -394,7 +394,7 @@ fn array_in_parent_generated() {
         END_FUNCTION
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -404,9 +404,9 @@ fn array_in_parent_generated() {
     %parent = type { %grandparent, [11 x i16], i16 }
     %grandparent = type { [6 x i16], i16 }
 
-    @__child__init = constant %child zeroinitializer
-    @__parent__init = constant %parent zeroinitializer
-    @__grandparent__init = constant %grandparent zeroinitializer
+    @__child__init = unnamed_addr constant %child zeroinitializer
+    @__parent__init = unnamed_addr constant %parent zeroinitializer
+    @__grandparent__init = unnamed_addr constant %grandparent zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @grandparent(%grandparent* %0) {
@@ -532,7 +532,7 @@ fn array_in_parent_generated() {
     }
 
     attributes #0 = { argmemonly nofree nounwind willreturn writeonly }
-    "#);
+    "###);
 }
 
 #[test]
@@ -562,7 +562,7 @@ fn complex_array_access_generated() {
         "#,
     );
 
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -572,9 +572,9 @@ fn complex_array_access_generated() {
     %grandparent = type { [6 x i16], i16 }
     %child = type { %parent, [11 x i16] }
 
-    @__parent__init = constant %parent zeroinitializer
-    @__grandparent__init = constant %grandparent zeroinitializer
-    @__child__init = constant %child zeroinitializer
+    @__parent__init = unnamed_addr constant %parent zeroinitializer
+    @__grandparent__init = unnamed_addr constant %grandparent zeroinitializer
+    @__child__init = unnamed_addr constant %child zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @grandparent(%grandparent* %0) {
@@ -687,7 +687,7 @@ fn complex_array_access_generated() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -755,7 +755,7 @@ fn this_in_method_call_chain() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -763,7 +763,7 @@ fn this_in_method_call_chain() {
 
     %FB_Test = type {}
 
-    @__FB_Test__init = constant %FB_Test zeroinitializer
+    @__FB_Test__init = unnamed_addr constant %FB_Test zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB_Test(%FB_Test* %0) {
@@ -807,7 +807,7 @@ fn this_in_method_call_chain() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -827,7 +827,7 @@ fn this_in_method_and_body_in_function_block() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -835,7 +835,7 @@ fn this_in_method_and_body_in_function_block() {
 
     %FB_Test = type { i16 }
 
-    @__FB_Test__init = constant %FB_Test { i16 5 }
+    @__FB_Test__init = unnamed_addr constant %FB_Test { i16 5 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB_Test(%FB_Test* %0) {
@@ -887,7 +887,7 @@ fn this_in_method_and_body_in_function_block() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -918,7 +918,7 @@ fn pass_this_to_method() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -927,8 +927,8 @@ fn pass_this_to_method() {
     %FB_Test = type { i16 }
     %FB_Test2 = type {}
 
-    @__FB_Test__init = constant %FB_Test { i16 5 }
-    @__FB_Test2__init = constant %FB_Test2 zeroinitializer
+    @__FB_Test__init = unnamed_addr constant %FB_Test { i16 5 }
+    @__FB_Test2__init = unnamed_addr constant %FB_Test2 zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB_Test(%FB_Test* %0) {
@@ -1016,7 +1016,7 @@ fn pass_this_to_method() {
     }
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1039,7 +1039,7 @@ fn this_with_shadowed_variable() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1047,7 +1047,7 @@ fn this_with_shadowed_variable() {
 
     %FB_Test = type { i16 }
 
-    @__FB_Test__init = constant %FB_Test { i16 5 }
+    @__FB_Test__init = unnamed_addr constant %FB_Test { i16 5 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB_Test(%FB_Test* %0) {
@@ -1096,7 +1096,7 @@ fn this_with_shadowed_variable() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1117,7 +1117,7 @@ fn this_calling_function_and_passing_this() {
         END_FUNCTION
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1125,7 +1125,7 @@ fn this_calling_function_and_passing_this() {
 
     %FB_Test = type { i16 }
 
-    @__FB_Test__init = constant %FB_Test zeroinitializer
+    @__FB_Test__init = unnamed_addr constant %FB_Test zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB_Test(%FB_Test* %0) {
@@ -1170,7 +1170,7 @@ fn this_calling_function_and_passing_this() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1197,7 +1197,7 @@ fn this_in_property_and_calling_method() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1205,7 +1205,7 @@ fn this_in_property_and_calling_method() {
 
     %FB_Test = type { i16 }
 
-    @__FB_Test__init = constant %FB_Test zeroinitializer
+    @__FB_Test__init = unnamed_addr constant %FB_Test zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB_Test(%FB_Test* %0) {
@@ -1284,7 +1284,7 @@ fn this_in_property_and_calling_method() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1304,7 +1304,7 @@ fn this_with_self_pointer() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1312,7 +1312,7 @@ fn this_with_self_pointer() {
 
     %FB_Test = type { %FB_Test* }
 
-    @__FB_Test__init = constant %FB_Test zeroinitializer
+    @__FB_Test__init = unnamed_addr constant %FB_Test zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB_Test(%FB_Test* %0) {
@@ -1355,7 +1355,7 @@ fn this_with_self_pointer() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1373,7 +1373,7 @@ fn this_in_variable_initialization() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1381,7 +1381,7 @@ fn this_in_variable_initialization() {
 
     %FB = type { i16, %FB*, i16 }
 
-    @__FB__init = constant %FB { i16 5, %FB* null, i16 5 }
+    @__FB__init = unnamed_addr constant %FB { i16 5, %FB* null, i16 5 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @FB(%FB* %0) {
@@ -1412,7 +1412,7 @@ fn this_in_variable_initialization() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1427,7 +1427,7 @@ fn this_in_action_in_functionblock() {
         END_ACTION
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1435,7 +1435,7 @@ fn this_in_action_in_functionblock() {
 
     %fb = type {}
 
-    @__fb__init = constant %fb zeroinitializer
+    @__fb__init = unnamed_addr constant %fb zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @fb(%fb* %0) {
@@ -1472,7 +1472,7 @@ fn this_in_action_in_functionblock() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1486,7 +1486,7 @@ fn this_calling_functionblock_body_from_method() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(code, @r#"
+    filtered_assert_snapshot!(code, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1494,7 +1494,7 @@ fn this_calling_functionblock_body_from_method() {
 
     %fb = type {}
 
-    @__fb__init = constant %fb zeroinitializer
+    @__fb__init = unnamed_addr constant %fb zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @fb(%fb* %0) {
@@ -1534,5 +1534,5 @@ fn this_calling_functionblock_body_from_method() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }

--- a/src/codegen/tests/oop_tests/debug_tests.rs
+++ b/src/codegen/tests/oop_tests/debug_tests.rs
@@ -17,7 +17,7 @@ fn members_from_base_class_are_available_in_subclasses() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -26,28 +26,28 @@ fn members_from_base_class_are_available_in_subclasses() {
     %foo = type { i16, [81 x i8], [11 x [81 x i8]] }
     %bar = type { %foo }
 
-    @__foo__init = constant %foo zeroinitializer, !dbg !0
-    @__bar__init = constant %bar zeroinitializer, !dbg !16
+    @__foo__init = unnamed_addr constant %foo zeroinitializer, !dbg !0
+    @__bar__init = unnamed_addr constant %bar zeroinitializer, !dbg !17
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @foo(%foo* %0) !dbg !25 {
+    define void @foo(%foo* %0) !dbg !27 {
     entry:
-      call void @llvm.dbg.declare(metadata %foo* %0, metadata !29, metadata !DIExpression()), !dbg !30
+      call void @llvm.dbg.declare(metadata %foo* %0, metadata !31, metadata !DIExpression()), !dbg !32
       %this = alloca %foo*, align 8
       store %foo* %0, %foo** %this, align 8
       %a = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
       %b = getelementptr inbounds %foo, %foo* %0, i32 0, i32 1
       %c = getelementptr inbounds %foo, %foo* %0, i32 0, i32 2
-      ret void, !dbg !30
+      ret void, !dbg !32
     }
 
-    define void @bar(%bar* %0) !dbg !31 {
+    define void @bar(%bar* %0) !dbg !33 {
     entry:
-      call void @llvm.dbg.declare(metadata %bar* %0, metadata !34, metadata !DIExpression()), !dbg !35
+      call void @llvm.dbg.declare(metadata %bar* %0, metadata !36, metadata !DIExpression()), !dbg !37
       %this = alloca %bar*, align 8
       store %bar* %0, %bar** %this, align 8
       %__foo = getelementptr inbounds %bar, %bar* %0, i32 0, i32 0
-      ret void, !dbg !35
+      ret void, !dbg !37
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -94,46 +94,48 @@ fn members_from_base_class_are_available_in_subclasses() {
 
     attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-    !llvm.module.flags = !{!21, !22}
-    !llvm.dbg.cu = !{!23}
+    !llvm.module.flags = !{!23, !24}
+    !llvm.dbg.cu = !{!25}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 2, size: 7792, align: 64, flags: DIFlagPublic, elements: !4, identifier: "foo")
-    !4 = !{!5, !7, !12}
-    !5 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 4, baseType: !6, size: 16, align: 16, flags: DIFlagPublic)
-    !6 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
-    !7 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 5, baseType: !8, size: 648, align: 8, offset: 16, flags: DIFlagPublic)
-    !8 = !DICompositeType(tag: DW_TAG_array_type, baseType: !9, size: 648, align: 8, elements: !10)
-    !9 = !DIBasicType(name: "CHAR", size: 8, encoding: DW_ATE_UTF, flags: DIFlagPublic)
-    !10 = !{!11}
-    !11 = !DISubrange(count: 81, lowerBound: 0)
-    !12 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !2, file: !2, line: 6, baseType: !13, size: 7128, align: 8, offset: 664, flags: DIFlagPublic)
-    !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 7128, align: 8, elements: !14)
-    !14 = !{!15}
-    !15 = !DISubrange(count: 11, lowerBound: 0)
-    !16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
-    !17 = distinct !DIGlobalVariable(name: "__bar__init", scope: !2, file: !2, line: 10, type: !18, isLocal: false, isDefinition: true)
-    !18 = !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !2, file: !2, line: 10, size: 7792, align: 64, flags: DIFlagPublic, elements: !19, identifier: "bar")
-    !19 = !{!20}
-    !20 = !DIDerivedType(tag: DW_TAG_member, name: "__foo", scope: !2, file: !2, baseType: !3, size: 7792, align: 64, flags: DIFlagPublic)
-    !21 = !{i32 2, !"Dwarf Version", i32 5}
-    !22 = !{i32 2, !"Debug Info Version", i32 3}
-    !23 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !24, splitDebugInlining: false)
-    !24 = !{!0, !16}
-    !25 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 2, type: !26, scopeLine: 8, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !23, retainedNodes: !28)
-    !26 = !DISubroutineType(flags: DIFlagPublic, types: !27)
-    !27 = !{null, !3}
-    !28 = !{}
-    !29 = !DILocalVariable(name: "foo", scope: !25, file: !2, line: 8, type: !3)
-    !30 = !DILocation(line: 8, column: 8, scope: !25)
-    !31 = distinct !DISubprogram(name: "bar", linkageName: "bar", scope: !2, file: !2, line: 10, type: !32, scopeLine: 11, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !23, retainedNodes: !28)
-    !32 = !DISubroutineType(flags: DIFlagPublic, types: !33)
-    !33 = !{null, !18}
-    !34 = !DILocalVariable(name: "bar", scope: !31, file: !2, line: 11, type: !18)
-    !35 = !DILocation(line: 11, column: 8, scope: !31)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 2, size: 7792, align: 64, flags: DIFlagPublic, elements: !5, identifier: "foo")
+    !5 = !{!6, !8, !13}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 4, baseType: !7, size: 16, align: 16, flags: DIFlagPublic)
+    !7 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !8 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 5, baseType: !9, size: 648, align: 8, offset: 16, flags: DIFlagPublic)
+    !9 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 648, align: 8, elements: !11)
+    !10 = !DIBasicType(name: "CHAR", size: 8, encoding: DW_ATE_UTF, flags: DIFlagPublic)
+    !11 = !{!12}
+    !12 = !DISubrange(count: 81, lowerBound: 0)
+    !13 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !2, file: !2, line: 6, baseType: !14, size: 7128, align: 8, offset: 664, flags: DIFlagPublic)
+    !14 = !DICompositeType(tag: DW_TAG_array_type, baseType: !9, size: 7128, align: 8, elements: !15)
+    !15 = !{!16}
+    !16 = !DISubrange(count: 11, lowerBound: 0)
+    !17 = !DIGlobalVariableExpression(var: !18, expr: !DIExpression())
+    !18 = distinct !DIGlobalVariable(name: "__bar__init", scope: !2, file: !2, line: 10, type: !19, isLocal: false, isDefinition: true)
+    !19 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !20)
+    !20 = !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !2, file: !2, line: 10, size: 7792, align: 64, flags: DIFlagPublic, elements: !21, identifier: "bar")
+    !21 = !{!22}
+    !22 = !DIDerivedType(tag: DW_TAG_member, name: "__foo", scope: !2, file: !2, baseType: !4, size: 7792, align: 64, flags: DIFlagPublic)
+    !23 = !{i32 2, !"Dwarf Version", i32 5}
+    !24 = !{i32 2, !"Debug Info Version", i32 3}
+    !25 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !26, splitDebugInlining: false)
+    !26 = !{!0, !17}
+    !27 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 2, type: !28, scopeLine: 8, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !25, retainedNodes: !30)
+    !28 = !DISubroutineType(flags: DIFlagPublic, types: !29)
+    !29 = !{null, !4}
+    !30 = !{}
+    !31 = !DILocalVariable(name: "foo", scope: !27, file: !2, line: 8, type: !4)
+    !32 = !DILocation(line: 8, column: 8, scope: !27)
+    !33 = distinct !DISubprogram(name: "bar", linkageName: "bar", scope: !2, file: !2, line: 10, type: !34, scopeLine: 11, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !25, retainedNodes: !30)
+    !34 = !DISubroutineType(flags: DIFlagPublic, types: !35)
+    !35 = !{null, !20}
+    !36 = !DILocalVariable(name: "bar", scope: !33, file: !2, line: 11, type: !20)
+    !37 = !DILocation(line: 11, column: 8, scope: !33)
+    "###);
 }
 
 #[test]
@@ -159,7 +161,7 @@ fn write_to_parent_variable_qualified_access() {
        ",
     );
 
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -169,40 +171,40 @@ fn write_to_parent_variable_qualified_access() {
     %fb = type { i16, i16 }
     %foo = type { %fb2 }
 
-    @__fb2__init = constant %fb2 zeroinitializer, !dbg !0
-    @__fb__init = constant %fb zeroinitializer, !dbg !11
-    @__foo__init = constant %foo zeroinitializer, !dbg !13
+    @__fb2__init = unnamed_addr constant %fb2 zeroinitializer, !dbg !0
+    @__fb__init = unnamed_addr constant %fb zeroinitializer, !dbg !12
+    @__foo__init = unnamed_addr constant %foo zeroinitializer, !dbg !15
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @fb(%fb* %0) !dbg !22 {
+    define void @fb(%fb* %0) !dbg !25 {
     entry:
-      call void @llvm.dbg.declare(metadata %fb* %0, metadata !26, metadata !DIExpression()), !dbg !27
+      call void @llvm.dbg.declare(metadata %fb* %0, metadata !29, metadata !DIExpression()), !dbg !30
       %this = alloca %fb*, align 8
       store %fb* %0, %fb** %this, align 8
       %x = getelementptr inbounds %fb, %fb* %0, i32 0, i32 0
       %y = getelementptr inbounds %fb, %fb* %0, i32 0, i32 1
-      ret void, !dbg !27
+      ret void, !dbg !30
     }
 
-    define void @fb2(%fb2* %0) !dbg !28 {
+    define void @fb2(%fb2* %0) !dbg !31 {
     entry:
-      call void @llvm.dbg.declare(metadata %fb2* %0, metadata !31, metadata !DIExpression()), !dbg !32
+      call void @llvm.dbg.declare(metadata %fb2* %0, metadata !34, metadata !DIExpression()), !dbg !35
       %this = alloca %fb2*, align 8
       store %fb2* %0, %fb2** %this, align 8
       %__fb = getelementptr inbounds %fb2, %fb2* %0, i32 0, i32 0
-      ret void, !dbg !32
+      ret void, !dbg !35
     }
 
-    define void @foo(%foo* %0) !dbg !33 {
+    define void @foo(%foo* %0) !dbg !36 {
     entry:
-      call void @llvm.dbg.declare(metadata %foo* %0, metadata !36, metadata !DIExpression()), !dbg !37
+      call void @llvm.dbg.declare(metadata %foo* %0, metadata !39, metadata !DIExpression()), !dbg !40
       %this = alloca %foo*, align 8
       store %foo* %0, %foo** %this, align 8
       %myFb = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
-      %__fb = getelementptr inbounds %fb2, %fb2* %myFb, i32 0, i32 0, !dbg !37
-      %x = getelementptr inbounds %fb, %fb* %__fb, i32 0, i32 0, !dbg !37
-      store i16 1, i16* %x, align 2, !dbg !37
-      ret void, !dbg !38
+      %__fb = getelementptr inbounds %fb2, %fb2* %myFb, i32 0, i32 0, !dbg !40
+      %x = getelementptr inbounds %fb, %fb* %__fb, i32 0, i32 0, !dbg !40
+      store i16 1, i16* %x, align 2, !dbg !40
+      ret void, !dbg !41
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -269,49 +271,52 @@ fn write_to_parent_variable_qualified_access() {
 
     attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-    !llvm.module.flags = !{!18, !19}
-    !llvm.dbg.cu = !{!20}
+    !llvm.module.flags = !{!21, !22}
+    !llvm.dbg.cu = !{!23}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__fb2__init", scope: !2, file: !2, line: 9, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb2", scope: !2, file: !2, line: 9, size: 32, align: 64, flags: DIFlagPublic, elements: !4, identifier: "fb2")
-    !4 = !{!5}
-    !5 = !DIDerivedType(tag: DW_TAG_member, name: "__fb", scope: !2, file: !2, baseType: !6, size: 32, align: 64, flags: DIFlagPublic)
-    !6 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb", scope: !2, file: !2, line: 2, size: 32, align: 64, flags: DIFlagPublic, elements: !7, identifier: "fb")
-    !7 = !{!8, !10}
-    !8 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 4, baseType: !9, size: 16, align: 16, flags: DIFlagPublic)
-    !9 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
-    !10 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !2, file: !2, line: 5, baseType: !9, size: 16, align: 16, offset: 16, flags: DIFlagPublic)
-    !11 = !DIGlobalVariableExpression(var: !12, expr: !DIExpression())
-    !12 = distinct !DIGlobalVariable(name: "__fb__init", scope: !2, file: !2, line: 2, type: !6, isLocal: false, isDefinition: true)
-    !13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
-    !14 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 12, type: !15, isLocal: false, isDefinition: true)
-    !15 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 12, size: 32, align: 64, flags: DIFlagPublic, elements: !16, identifier: "foo")
-    !16 = !{!17}
-    !17 = !DIDerivedType(tag: DW_TAG_member, name: "myFb", scope: !2, file: !2, line: 14, baseType: !3, size: 32, align: 64, flags: DIFlagPublic)
-    !18 = !{i32 2, !"Dwarf Version", i32 5}
-    !19 = !{i32 2, !"Debug Info Version", i32 3}
-    !20 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !21, splitDebugInlining: false)
-    !21 = !{!11, !0, !13}
-    !22 = distinct !DISubprogram(name: "fb", linkageName: "fb", scope: !2, file: !2, line: 2, type: !23, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !20, retainedNodes: !25)
-    !23 = !DISubroutineType(flags: DIFlagPublic, types: !24)
-    !24 = !{null, !6}
-    !25 = !{}
-    !26 = !DILocalVariable(name: "fb", scope: !22, file: !2, line: 7, type: !6)
-    !27 = !DILocation(line: 7, column: 8, scope: !22)
-    !28 = distinct !DISubprogram(name: "fb2", linkageName: "fb2", scope: !2, file: !2, line: 9, type: !29, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !20, retainedNodes: !25)
-    !29 = !DISubroutineType(flags: DIFlagPublic, types: !30)
-    !30 = !{null, !3}
-    !31 = !DILocalVariable(name: "fb2", scope: !28, file: !2, line: 10, type: !3)
-    !32 = !DILocation(line: 10, column: 8, scope: !28)
-    !33 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 12, type: !34, scopeLine: 16, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !20, retainedNodes: !25)
-    !34 = !DISubroutineType(flags: DIFlagPublic, types: !35)
-    !35 = !{null, !15}
-    !36 = !DILocalVariable(name: "foo", scope: !33, file: !2, line: 16, type: !15)
-    !37 = !DILocation(line: 16, column: 12, scope: !33)
-    !38 = !DILocation(line: 17, column: 8, scope: !33)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb2", scope: !2, file: !2, line: 9, size: 32, align: 64, flags: DIFlagPublic, elements: !5, identifier: "fb2")
+    !5 = !{!6}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "__fb", scope: !2, file: !2, baseType: !7, size: 32, align: 64, flags: DIFlagPublic)
+    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "fb", scope: !2, file: !2, line: 2, size: 32, align: 64, flags: DIFlagPublic, elements: !8, identifier: "fb")
+    !8 = !{!9, !11}
+    !9 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 4, baseType: !10, size: 16, align: 16, flags: DIFlagPublic)
+    !10 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !11 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !2, file: !2, line: 5, baseType: !10, size: 16, align: 16, offset: 16, flags: DIFlagPublic)
+    !12 = !DIGlobalVariableExpression(var: !13, expr: !DIExpression())
+    !13 = distinct !DIGlobalVariable(name: "__fb__init", scope: !2, file: !2, line: 2, type: !14, isLocal: false, isDefinition: true)
+    !14 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+    !15 = !DIGlobalVariableExpression(var: !16, expr: !DIExpression())
+    !16 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 12, type: !17, isLocal: false, isDefinition: true)
+    !17 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !18)
+    !18 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 12, size: 32, align: 64, flags: DIFlagPublic, elements: !19, identifier: "foo")
+    !19 = !{!20}
+    !20 = !DIDerivedType(tag: DW_TAG_member, name: "myFb", scope: !2, file: !2, line: 14, baseType: !4, size: 32, align: 64, flags: DIFlagPublic)
+    !21 = !{i32 2, !"Dwarf Version", i32 5}
+    !22 = !{i32 2, !"Debug Info Version", i32 3}
+    !23 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !24, splitDebugInlining: false)
+    !24 = !{!12, !0, !15}
+    !25 = distinct !DISubprogram(name: "fb", linkageName: "fb", scope: !2, file: !2, line: 2, type: !26, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !23, retainedNodes: !28)
+    !26 = !DISubroutineType(flags: DIFlagPublic, types: !27)
+    !27 = !{null, !7}
+    !28 = !{}
+    !29 = !DILocalVariable(name: "fb", scope: !25, file: !2, line: 7, type: !7)
+    !30 = !DILocation(line: 7, column: 8, scope: !25)
+    !31 = distinct !DISubprogram(name: "fb2", linkageName: "fb2", scope: !2, file: !2, line: 9, type: !32, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !23, retainedNodes: !28)
+    !32 = !DISubroutineType(flags: DIFlagPublic, types: !33)
+    !33 = !{null, !4}
+    !34 = !DILocalVariable(name: "fb2", scope: !31, file: !2, line: 10, type: !4)
+    !35 = !DILocation(line: 10, column: 8, scope: !31)
+    !36 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 12, type: !37, scopeLine: 16, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !23, retainedNodes: !28)
+    !37 = !DISubroutineType(flags: DIFlagPublic, types: !38)
+    !38 = !{null, !18}
+    !39 = !DILocalVariable(name: "foo", scope: !36, file: !2, line: 16, type: !18)
+    !40 = !DILocation(line: 16, column: 12, scope: !36)
+    !41 = !DILocation(line: 17, column: 8, scope: !36)
+    "###);
 }
 
 #[test]
@@ -341,7 +346,7 @@ fn write_to_parent_variable_in_instance() {
         END_FUNCTION
     "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -352,58 +357,58 @@ fn write_to_parent_variable_in_instance() {
 
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
-    @__bar__init = constant %bar zeroinitializer, !dbg !0
-    @__foo__init = constant %foo zeroinitializer, !dbg !13
+    @__bar__init = unnamed_addr constant %bar zeroinitializer, !dbg !0
+    @__foo__init = unnamed_addr constant %foo zeroinitializer, !dbg !14
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @foo(%foo* %0) !dbg !19 {
+    define void @foo(%foo* %0) !dbg !21 {
     entry:
-      call void @llvm.dbg.declare(metadata %foo* %0, metadata !23, metadata !DIExpression()), !dbg !24
+      call void @llvm.dbg.declare(metadata %foo* %0, metadata !25, metadata !DIExpression()), !dbg !26
       %this = alloca %foo*, align 8
       store %foo* %0, %foo** %this, align 8
       %s = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
-      ret void, !dbg !24
+      ret void, !dbg !26
     }
 
-    define void @foo__baz(%foo* %0) !dbg !25 {
+    define void @foo__baz(%foo* %0) !dbg !27 {
     entry:
-      call void @llvm.dbg.declare(metadata %foo* %0, metadata !26, metadata !DIExpression()), !dbg !27
+      call void @llvm.dbg.declare(metadata %foo* %0, metadata !28, metadata !DIExpression()), !dbg !29
       %this = alloca %foo*, align 8
       store %foo* %0, %foo** %this, align 8
       %s = getelementptr inbounds %foo, %foo* %0, i32 0, i32 0
-      %1 = bitcast [81 x i8]* %s to i8*, !dbg !27
-      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_0, i32 0, i32 0), i32 6, i1 false), !dbg !27
-      ret void, !dbg !28
+      %1 = bitcast [81 x i8]* %s to i8*, !dbg !29
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_0, i32 0, i32 0), i32 6, i1 false), !dbg !29
+      ret void, !dbg !30
     }
 
-    define void @bar(%bar* %0) !dbg !29 {
+    define void @bar(%bar* %0) !dbg !31 {
     entry:
-      call void @llvm.dbg.declare(metadata %bar* %0, metadata !32, metadata !DIExpression()), !dbg !33
+      call void @llvm.dbg.declare(metadata %bar* %0, metadata !34, metadata !DIExpression()), !dbg !35
       %this = alloca %bar*, align 8
       store %bar* %0, %bar** %this, align 8
       %__foo = getelementptr inbounds %bar, %bar* %0, i32 0, i32 0
-      %s = getelementptr inbounds %foo, %foo* %__foo, i32 0, i32 0, !dbg !33
-      %1 = bitcast [81 x i8]* %s to i8*, !dbg !33
-      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_1, i32 0, i32 0), i32 6, i1 false), !dbg !33
-      ret void, !dbg !34
+      %s = getelementptr inbounds %foo, %foo* %__foo, i32 0, i32 0, !dbg !35
+      %1 = bitcast [81 x i8]* %s to i8*, !dbg !35
+      call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 1 %1, i8* align 1 getelementptr inbounds ([6 x i8], [6 x i8]* @utf08_literal_1, i32 0, i32 0), i32 6, i1 false), !dbg !35
+      ret void, !dbg !36
     }
 
-    define void @main() !dbg !35 {
+    define void @main() !dbg !37 {
     entry:
       %s = alloca [81 x i8], align 1
       %fb = alloca %bar, align 8
-      call void @llvm.dbg.declare(metadata [81 x i8]* %s, metadata !38, metadata !DIExpression()), !dbg !39
+      call void @llvm.dbg.declare(metadata [81 x i8]* %s, metadata !40, metadata !DIExpression()), !dbg !41
       %0 = bitcast [81 x i8]* %s to i8*
       call void @llvm.memset.p0i8.i64(i8* align 1 %0, i8 0, i64 ptrtoint ([81 x i8]* getelementptr ([81 x i8], [81 x i8]* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata %bar* %fb, metadata !40, metadata !DIExpression()), !dbg !41
+      call void @llvm.dbg.declare(metadata %bar* %fb, metadata !42, metadata !DIExpression()), !dbg !43
       %1 = bitcast %bar* %fb to i8*
       call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %1, i8* align 1 getelementptr inbounds (%bar, %bar* @__bar__init, i32 0, i32 0, i32 0, i32 0), i64 ptrtoint (%bar* getelementptr (%bar, %bar* null, i32 1) to i64), i1 false)
-      call void @__init_bar(%bar* %fb), !dbg !42
-      call void @__user_init_bar(%bar* %fb), !dbg !42
-      %__foo = getelementptr inbounds %bar, %bar* %fb, i32 0, i32 0, !dbg !42
-      call void @foo__baz(%foo* %__foo), !dbg !43
-      call void @bar(%bar* %fb), !dbg !44
-      ret void, !dbg !45
+      call void @__init_bar(%bar* %fb), !dbg !44
+      call void @__user_init_bar(%bar* %fb), !dbg !44
+      %__foo = getelementptr inbounds %bar, %bar* %fb, i32 0, i32 0, !dbg !44
+      call void @foo__baz(%foo* %__foo), !dbg !45
+      call void @bar(%bar* %fb), !dbg !46
+      ret void, !dbg !47
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -461,56 +466,58 @@ fn write_to_parent_variable_in_instance() {
     attributes #1 = { argmemonly nofree nounwind willreturn }
     attributes #2 = { argmemonly nofree nounwind willreturn writeonly }
 
-    !llvm.module.flags = !{!15, !16}
-    !llvm.dbg.cu = !{!17}
+    !llvm.module.flags = !{!17, !18}
+    !llvm.dbg.cu = !{!19}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__bar__init", scope: !2, file: !2, line: 11, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !2, file: !2, line: 11, size: 648, align: 64, flags: DIFlagPublic, elements: !4, identifier: "bar")
-    !4 = !{!5}
-    !5 = !DIDerivedType(tag: DW_TAG_member, name: "__foo", scope: !2, file: !2, baseType: !6, size: 648, align: 64, flags: DIFlagPublic)
-    !6 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 2, size: 648, align: 64, flags: DIFlagPublic, elements: !7, identifier: "foo")
-    !7 = !{!8}
-    !8 = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: !2, file: !2, line: 4, baseType: !9, size: 648, align: 8, flags: DIFlagPublic)
-    !9 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 648, align: 8, elements: !11)
-    !10 = !DIBasicType(name: "CHAR", size: 8, encoding: DW_ATE_UTF, flags: DIFlagPublic)
-    !11 = !{!12}
-    !12 = !DISubrange(count: 81, lowerBound: 0)
-    !13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
-    !14 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 2, type: !6, isLocal: false, isDefinition: true)
-    !15 = !{i32 2, !"Dwarf Version", i32 5}
-    !16 = !{i32 2, !"Debug Info Version", i32 3}
-    !17 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !18, splitDebugInlining: false)
-    !18 = !{!13, !0}
-    !19 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 2, type: !20, scopeLine: 9, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !17, retainedNodes: !22)
-    !20 = !DISubroutineType(flags: DIFlagPublic, types: !21)
-    !21 = !{null, !6}
-    !22 = !{}
-    !23 = !DILocalVariable(name: "foo", scope: !19, file: !2, line: 9, type: !6)
-    !24 = !DILocation(line: 9, column: 8, scope: !19)
-    !25 = distinct !DISubprogram(name: "foo.baz", linkageName: "foo.baz", scope: !19, file: !2, line: 6, type: !20, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !17, retainedNodes: !22)
-    !26 = !DILocalVariable(name: "foo", scope: !25, file: !2, line: 7, type: !6)
-    !27 = !DILocation(line: 7, column: 12, scope: !25)
-    !28 = !DILocation(line: 8, column: 8, scope: !25)
-    !29 = distinct !DISubprogram(name: "bar", linkageName: "bar", scope: !2, file: !2, line: 11, type: !30, scopeLine: 12, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !17, retainedNodes: !22)
-    !30 = !DISubroutineType(flags: DIFlagPublic, types: !31)
-    !31 = !{null, !3}
-    !32 = !DILocalVariable(name: "bar", scope: !29, file: !2, line: 12, type: !3)
-    !33 = !DILocation(line: 12, column: 12, scope: !29)
-    !34 = !DILocation(line: 13, column: 8, scope: !29)
-    !35 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 15, type: !36, scopeLine: 15, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !17, retainedNodes: !22)
-    !36 = !DISubroutineType(flags: DIFlagPublic, types: !37)
-    !37 = !{null}
-    !38 = !DILocalVariable(name: "s", scope: !35, file: !2, line: 17, type: !9, align: 8)
-    !39 = !DILocation(line: 17, column: 12, scope: !35)
-    !40 = !DILocalVariable(name: "fb", scope: !35, file: !2, line: 18, type: !3, align: 64)
-    !41 = !DILocation(line: 18, column: 12, scope: !35)
-    !42 = !DILocation(line: 0, scope: !35)
-    !43 = !DILocation(line: 20, column: 12, scope: !35)
-    !44 = !DILocation(line: 21, column: 12, scope: !35)
-    !45 = !DILocation(line: 22, column: 8, scope: !35)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !2, file: !2, line: 11, size: 648, align: 64, flags: DIFlagPublic, elements: !5, identifier: "bar")
+    !5 = !{!6}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "__foo", scope: !2, file: !2, baseType: !7, size: 648, align: 64, flags: DIFlagPublic)
+    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 2, size: 648, align: 64, flags: DIFlagPublic, elements: !8, identifier: "foo")
+    !8 = !{!9}
+    !9 = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: !2, file: !2, line: 4, baseType: !10, size: 648, align: 8, flags: DIFlagPublic)
+    !10 = !DICompositeType(tag: DW_TAG_array_type, baseType: !11, size: 648, align: 8, elements: !12)
+    !11 = !DIBasicType(name: "CHAR", size: 8, encoding: DW_ATE_UTF, flags: DIFlagPublic)
+    !12 = !{!13}
+    !13 = !DISubrange(count: 81, lowerBound: 0)
+    !14 = !DIGlobalVariableExpression(var: !15, expr: !DIExpression())
+    !15 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 2, type: !16, isLocal: false, isDefinition: true)
+    !16 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+    !17 = !{i32 2, !"Dwarf Version", i32 5}
+    !18 = !{i32 2, !"Debug Info Version", i32 3}
+    !19 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !20, splitDebugInlining: false)
+    !20 = !{!14, !0}
+    !21 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 2, type: !22, scopeLine: 9, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !19, retainedNodes: !24)
+    !22 = !DISubroutineType(flags: DIFlagPublic, types: !23)
+    !23 = !{null, !7}
+    !24 = !{}
+    !25 = !DILocalVariable(name: "foo", scope: !21, file: !2, line: 9, type: !7)
+    !26 = !DILocation(line: 9, column: 8, scope: !21)
+    !27 = distinct !DISubprogram(name: "foo.baz", linkageName: "foo.baz", scope: !21, file: !2, line: 6, type: !22, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !19, retainedNodes: !24)
+    !28 = !DILocalVariable(name: "foo", scope: !27, file: !2, line: 7, type: !7)
+    !29 = !DILocation(line: 7, column: 12, scope: !27)
+    !30 = !DILocation(line: 8, column: 8, scope: !27)
+    !31 = distinct !DISubprogram(name: "bar", linkageName: "bar", scope: !2, file: !2, line: 11, type: !32, scopeLine: 12, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !19, retainedNodes: !24)
+    !32 = !DISubroutineType(flags: DIFlagPublic, types: !33)
+    !33 = !{null, !4}
+    !34 = !DILocalVariable(name: "bar", scope: !31, file: !2, line: 12, type: !4)
+    !35 = !DILocation(line: 12, column: 12, scope: !31)
+    !36 = !DILocation(line: 13, column: 8, scope: !31)
+    !37 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 15, type: !38, scopeLine: 15, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !19, retainedNodes: !24)
+    !38 = !DISubroutineType(flags: DIFlagPublic, types: !39)
+    !39 = !{null}
+    !40 = !DILocalVariable(name: "s", scope: !37, file: !2, line: 17, type: !10, align: 8)
+    !41 = !DILocation(line: 17, column: 12, scope: !37)
+    !42 = !DILocalVariable(name: "fb", scope: !37, file: !2, line: 18, type: !4, align: 64)
+    !43 = !DILocation(line: 18, column: 12, scope: !37)
+    !44 = !DILocation(line: 0, scope: !37)
+    !45 = !DILocation(line: 20, column: 12, scope: !37)
+    !46 = !DILocation(line: 21, column: 12, scope: !37)
+    !47 = !DILocation(line: 22, column: 8, scope: !37)
+    "###);
 }
 
 #[test]
@@ -549,7 +556,7 @@ fn array_in_parent_generated() {
         END_FUNCTION
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -559,73 +566,73 @@ fn array_in_parent_generated() {
     %parent = type { %grandparent, [11 x i16], i16 }
     %grandparent = type { [6 x i16], i16 }
 
-    @__child__init = constant %child zeroinitializer, !dbg !0
-    @__parent__init = constant %parent zeroinitializer, !dbg !23
-    @__grandparent__init = constant %grandparent zeroinitializer, !dbg !25
+    @__child__init = unnamed_addr constant %child zeroinitializer, !dbg !0
+    @__parent__init = unnamed_addr constant %parent zeroinitializer, !dbg !24
+    @__grandparent__init = unnamed_addr constant %grandparent zeroinitializer, !dbg !27
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @grandparent(%grandparent* %0) !dbg !31 {
+    define void @grandparent(%grandparent* %0) !dbg !34 {
     entry:
-      call void @llvm.dbg.declare(metadata %grandparent* %0, metadata !35, metadata !DIExpression()), !dbg !36
+      call void @llvm.dbg.declare(metadata %grandparent* %0, metadata !38, metadata !DIExpression()), !dbg !39
       %this = alloca %grandparent*, align 8
       store %grandparent* %0, %grandparent** %this, align 8
       %y = getelementptr inbounds %grandparent, %grandparent* %0, i32 0, i32 0
       %a = getelementptr inbounds %grandparent, %grandparent* %0, i32 0, i32 1
-      ret void, !dbg !36
+      ret void, !dbg !39
     }
 
-    define void @parent(%parent* %0) !dbg !37 {
+    define void @parent(%parent* %0) !dbg !40 {
     entry:
-      call void @llvm.dbg.declare(metadata %parent* %0, metadata !40, metadata !DIExpression()), !dbg !41
+      call void @llvm.dbg.declare(metadata %parent* %0, metadata !43, metadata !DIExpression()), !dbg !44
       %this = alloca %parent*, align 8
       store %parent* %0, %parent** %this, align 8
       %__grandparent = getelementptr inbounds %parent, %parent* %0, i32 0, i32 0
       %x = getelementptr inbounds %parent, %parent* %0, i32 0, i32 1
       %b = getelementptr inbounds %parent, %parent* %0, i32 0, i32 2
-      ret void, !dbg !41
+      ret void, !dbg !44
     }
 
-    define void @child(%child* %0) !dbg !42 {
+    define void @child(%child* %0) !dbg !45 {
     entry:
-      call void @llvm.dbg.declare(metadata %child* %0, metadata !45, metadata !DIExpression()), !dbg !46
+      call void @llvm.dbg.declare(metadata %child* %0, metadata !48, metadata !DIExpression()), !dbg !49
       %this = alloca %child*, align 8
       store %child* %0, %child** %this, align 8
       %__parent = getelementptr inbounds %child, %child* %0, i32 0, i32 0
       %z = getelementptr inbounds %child, %child* %0, i32 0, i32 1
-      ret void, !dbg !46
+      ret void, !dbg !49
     }
 
-    define void @main() !dbg !47 {
+    define void @main() !dbg !50 {
     entry:
       %arr = alloca [11 x %child], align 8
-      call void @llvm.dbg.declare(metadata [11 x %child]* %arr, metadata !50, metadata !DIExpression()), !dbg !52
+      call void @llvm.dbg.declare(metadata [11 x %child]* %arr, metadata !53, metadata !DIExpression()), !dbg !55
       %0 = bitcast [11 x %child]* %arr to i8*
       call void @llvm.memset.p0i8.i64(i8* align 1 %0, i8 0, i64 ptrtoint ([11 x %child]* getelementptr ([11 x %child], [11 x %child]* null, i32 1) to i64), i1 false)
-      %tmpVar = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 0, !dbg !53
-      %__parent = getelementptr inbounds %child, %child* %tmpVar, i32 0, i32 0, !dbg !53
-      %__grandparent = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !53
-      %a = getelementptr inbounds %grandparent, %grandparent* %__grandparent, i32 0, i32 1, !dbg !53
-      store i16 10, i16* %a, align 2, !dbg !53
-      %tmpVar1 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 0, !dbg !54
-      %__parent2 = getelementptr inbounds %child, %child* %tmpVar1, i32 0, i32 0, !dbg !54
-      %__grandparent3 = getelementptr inbounds %parent, %parent* %__parent2, i32 0, i32 0, !dbg !54
-      %y = getelementptr inbounds %grandparent, %grandparent* %__grandparent3, i32 0, i32 0, !dbg !54
-      %tmpVar4 = getelementptr inbounds [6 x i16], [6 x i16]* %y, i32 0, i32 0, !dbg !54
-      store i16 20, i16* %tmpVar4, align 2, !dbg !54
-      %tmpVar5 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 1, !dbg !55
-      %__parent6 = getelementptr inbounds %child, %child* %tmpVar5, i32 0, i32 0, !dbg !55
-      %b = getelementptr inbounds %parent, %parent* %__parent6, i32 0, i32 2, !dbg !55
-      store i16 30, i16* %b, align 2, !dbg !55
-      %tmpVar7 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 1, !dbg !56
-      %__parent8 = getelementptr inbounds %child, %child* %tmpVar7, i32 0, i32 0, !dbg !56
-      %x = getelementptr inbounds %parent, %parent* %__parent8, i32 0, i32 1, !dbg !56
-      %tmpVar9 = getelementptr inbounds [11 x i16], [11 x i16]* %x, i32 0, i32 1, !dbg !56
-      store i16 40, i16* %tmpVar9, align 2, !dbg !56
-      %tmpVar10 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 2, !dbg !57
-      %z = getelementptr inbounds %child, %child* %tmpVar10, i32 0, i32 1, !dbg !57
-      %tmpVar11 = getelementptr inbounds [11 x i16], [11 x i16]* %z, i32 0, i32 2, !dbg !57
-      store i16 50, i16* %tmpVar11, align 2, !dbg !57
-      ret void, !dbg !58
+      %tmpVar = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 0, !dbg !56
+      %__parent = getelementptr inbounds %child, %child* %tmpVar, i32 0, i32 0, !dbg !56
+      %__grandparent = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !56
+      %a = getelementptr inbounds %grandparent, %grandparent* %__grandparent, i32 0, i32 1, !dbg !56
+      store i16 10, i16* %a, align 2, !dbg !56
+      %tmpVar1 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 0, !dbg !57
+      %__parent2 = getelementptr inbounds %child, %child* %tmpVar1, i32 0, i32 0, !dbg !57
+      %__grandparent3 = getelementptr inbounds %parent, %parent* %__parent2, i32 0, i32 0, !dbg !57
+      %y = getelementptr inbounds %grandparent, %grandparent* %__grandparent3, i32 0, i32 0, !dbg !57
+      %tmpVar4 = getelementptr inbounds [6 x i16], [6 x i16]* %y, i32 0, i32 0, !dbg !57
+      store i16 20, i16* %tmpVar4, align 2, !dbg !57
+      %tmpVar5 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 1, !dbg !58
+      %__parent6 = getelementptr inbounds %child, %child* %tmpVar5, i32 0, i32 0, !dbg !58
+      %b = getelementptr inbounds %parent, %parent* %__parent6, i32 0, i32 2, !dbg !58
+      store i16 30, i16* %b, align 2, !dbg !58
+      %tmpVar7 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 1, !dbg !59
+      %__parent8 = getelementptr inbounds %child, %child* %tmpVar7, i32 0, i32 0, !dbg !59
+      %x = getelementptr inbounds %parent, %parent* %__parent8, i32 0, i32 1, !dbg !59
+      %tmpVar9 = getelementptr inbounds [11 x i16], [11 x i16]* %x, i32 0, i32 1, !dbg !59
+      store i16 40, i16* %tmpVar9, align 2, !dbg !59
+      %tmpVar10 = getelementptr inbounds [11 x %child], [11 x %child]* %arr, i32 0, i32 2, !dbg !60
+      %z = getelementptr inbounds %child, %child* %tmpVar10, i32 0, i32 1, !dbg !60
+      %tmpVar11 = getelementptr inbounds [11 x i16], [11 x i16]* %z, i32 0, i32 2, !dbg !60
+      store i16 50, i16* %tmpVar11, align 2, !dbg !60
+      ret void, !dbg !61
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -696,69 +703,72 @@ fn array_in_parent_generated() {
     attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
     attributes #1 = { argmemonly nofree nounwind willreturn writeonly }
 
-    !llvm.module.flags = !{!27, !28}
-    !llvm.dbg.cu = !{!29}
+    !llvm.module.flags = !{!30, !31}
+    !llvm.dbg.cu = !{!32}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__child__init", scope: !2, file: !2, line: 16, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "child", scope: !2, file: !2, line: 16, size: 480, align: 64, flags: DIFlagPublic, elements: !4, identifier: "child")
-    !4 = !{!5, !22}
-    !5 = !DIDerivedType(tag: DW_TAG_member, name: "__parent", scope: !2, file: !2, baseType: !6, size: 304, align: 64, flags: DIFlagPublic)
-    !6 = !DICompositeType(tag: DW_TAG_structure_type, name: "parent", scope: !2, file: !2, line: 9, size: 304, align: 64, flags: DIFlagPublic, elements: !7, identifier: "parent")
-    !7 = !{!8, !17, !21}
-    !8 = !DIDerivedType(tag: DW_TAG_member, name: "__grandparent", scope: !2, file: !2, baseType: !9, size: 112, align: 64, flags: DIFlagPublic)
-    !9 = !DICompositeType(tag: DW_TAG_structure_type, name: "grandparent", scope: !2, file: !2, line: 2, size: 112, align: 64, flags: DIFlagPublic, elements: !10, identifier: "grandparent")
-    !10 = !{!11, !16}
-    !11 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !2, file: !2, line: 4, baseType: !12, size: 96, align: 16, flags: DIFlagPublic)
-    !12 = !DICompositeType(tag: DW_TAG_array_type, baseType: !13, size: 96, align: 16, elements: !14)
-    !13 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
-    !14 = !{!15}
-    !15 = !DISubrange(count: 6, lowerBound: 0)
-    !16 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 5, baseType: !13, size: 16, align: 16, offset: 96, flags: DIFlagPublic)
-    !17 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 11, baseType: !18, size: 176, align: 16, offset: 112, flags: DIFlagPublic)
-    !18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !13, size: 176, align: 16, elements: !19)
-    !19 = !{!20}
-    !20 = !DISubrange(count: 11, lowerBound: 0)
-    !21 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 12, baseType: !13, size: 16, align: 16, offset: 288, flags: DIFlagPublic)
-    !22 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !2, file: !2, line: 18, baseType: !18, size: 176, align: 16, offset: 304, flags: DIFlagPublic)
-    !23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
-    !24 = distinct !DIGlobalVariable(name: "__parent__init", scope: !2, file: !2, line: 9, type: !6, isLocal: false, isDefinition: true)
-    !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
-    !26 = distinct !DIGlobalVariable(name: "__grandparent__init", scope: !2, file: !2, line: 2, type: !9, isLocal: false, isDefinition: true)
-    !27 = !{i32 2, !"Dwarf Version", i32 5}
-    !28 = !{i32 2, !"Debug Info Version", i32 3}
-    !29 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !30, splitDebugInlining: false)
-    !30 = !{!25, !23, !0}
-    !31 = distinct !DISubprogram(name: "grandparent", linkageName: "grandparent", scope: !2, file: !2, line: 2, type: !32, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
-    !32 = !DISubroutineType(flags: DIFlagPublic, types: !33)
-    !33 = !{null, !9}
-    !34 = !{}
-    !35 = !DILocalVariable(name: "grandparent", scope: !31, file: !2, line: 7, type: !9)
-    !36 = !DILocation(line: 7, column: 8, scope: !31)
-    !37 = distinct !DISubprogram(name: "parent", linkageName: "parent", scope: !2, file: !2, line: 9, type: !38, scopeLine: 14, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
-    !38 = !DISubroutineType(flags: DIFlagPublic, types: !39)
-    !39 = !{null, !6}
-    !40 = !DILocalVariable(name: "parent", scope: !37, file: !2, line: 14, type: !6)
-    !41 = !DILocation(line: 14, column: 8, scope: !37)
-    !42 = distinct !DISubprogram(name: "child", linkageName: "child", scope: !2, file: !2, line: 16, type: !43, scopeLine: 20, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
-    !43 = !DISubroutineType(flags: DIFlagPublic, types: !44)
-    !44 = !{null, !3}
-    !45 = !DILocalVariable(name: "child", scope: !42, file: !2, line: 20, type: !3)
-    !46 = !DILocation(line: 20, column: 8, scope: !42)
-    !47 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 22, type: !48, scopeLine: 26, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
-    !48 = !DISubroutineType(flags: DIFlagPublic, types: !49)
-    !49 = !{null}
-    !50 = !DILocalVariable(name: "arr", scope: !47, file: !2, line: 24, type: !51, align: 64)
-    !51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !3, size: 5280, align: 64, elements: !19)
-    !52 = !DILocation(line: 24, column: 12, scope: !47)
-    !53 = !DILocation(line: 26, column: 12, scope: !47)
-    !54 = !DILocation(line: 27, column: 12, scope: !47)
-    !55 = !DILocation(line: 28, column: 12, scope: !47)
-    !56 = !DILocation(line: 29, column: 12, scope: !47)
-    !57 = !DILocation(line: 30, column: 12, scope: !47)
-    !58 = !DILocation(line: 31, column: 8, scope: !47)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "child", scope: !2, file: !2, line: 16, size: 480, align: 64, flags: DIFlagPublic, elements: !5, identifier: "child")
+    !5 = !{!6, !23}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "__parent", scope: !2, file: !2, baseType: !7, size: 304, align: 64, flags: DIFlagPublic)
+    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "parent", scope: !2, file: !2, line: 9, size: 304, align: 64, flags: DIFlagPublic, elements: !8, identifier: "parent")
+    !8 = !{!9, !18, !22}
+    !9 = !DIDerivedType(tag: DW_TAG_member, name: "__grandparent", scope: !2, file: !2, baseType: !10, size: 112, align: 64, flags: DIFlagPublic)
+    !10 = !DICompositeType(tag: DW_TAG_structure_type, name: "grandparent", scope: !2, file: !2, line: 2, size: 112, align: 64, flags: DIFlagPublic, elements: !11, identifier: "grandparent")
+    !11 = !{!12, !17}
+    !12 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !2, file: !2, line: 4, baseType: !13, size: 96, align: 16, flags: DIFlagPublic)
+    !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 96, align: 16, elements: !15)
+    !14 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !15 = !{!16}
+    !16 = !DISubrange(count: 6, lowerBound: 0)
+    !17 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 5, baseType: !14, size: 16, align: 16, offset: 96, flags: DIFlagPublic)
+    !18 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 11, baseType: !19, size: 176, align: 16, offset: 112, flags: DIFlagPublic)
+    !19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 176, align: 16, elements: !20)
+    !20 = !{!21}
+    !21 = !DISubrange(count: 11, lowerBound: 0)
+    !22 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 12, baseType: !14, size: 16, align: 16, offset: 288, flags: DIFlagPublic)
+    !23 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !2, file: !2, line: 18, baseType: !19, size: 176, align: 16, offset: 304, flags: DIFlagPublic)
+    !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+    !25 = distinct !DIGlobalVariable(name: "__parent__init", scope: !2, file: !2, line: 9, type: !26, isLocal: false, isDefinition: true)
+    !26 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+    !27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+    !28 = distinct !DIGlobalVariable(name: "__grandparent__init", scope: !2, file: !2, line: 2, type: !29, isLocal: false, isDefinition: true)
+    !29 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !10)
+    !30 = !{i32 2, !"Dwarf Version", i32 5}
+    !31 = !{i32 2, !"Debug Info Version", i32 3}
+    !32 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !33, splitDebugInlining: false)
+    !33 = !{!27, !24, !0}
+    !34 = distinct !DISubprogram(name: "grandparent", linkageName: "grandparent", scope: !2, file: !2, line: 2, type: !35, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !32, retainedNodes: !37)
+    !35 = !DISubroutineType(flags: DIFlagPublic, types: !36)
+    !36 = !{null, !10}
+    !37 = !{}
+    !38 = !DILocalVariable(name: "grandparent", scope: !34, file: !2, line: 7, type: !10)
+    !39 = !DILocation(line: 7, column: 8, scope: !34)
+    !40 = distinct !DISubprogram(name: "parent", linkageName: "parent", scope: !2, file: !2, line: 9, type: !41, scopeLine: 14, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !32, retainedNodes: !37)
+    !41 = !DISubroutineType(flags: DIFlagPublic, types: !42)
+    !42 = !{null, !7}
+    !43 = !DILocalVariable(name: "parent", scope: !40, file: !2, line: 14, type: !7)
+    !44 = !DILocation(line: 14, column: 8, scope: !40)
+    !45 = distinct !DISubprogram(name: "child", linkageName: "child", scope: !2, file: !2, line: 16, type: !46, scopeLine: 20, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !32, retainedNodes: !37)
+    !46 = !DISubroutineType(flags: DIFlagPublic, types: !47)
+    !47 = !{null, !4}
+    !48 = !DILocalVariable(name: "child", scope: !45, file: !2, line: 20, type: !4)
+    !49 = !DILocation(line: 20, column: 8, scope: !45)
+    !50 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 22, type: !51, scopeLine: 26, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !32, retainedNodes: !37)
+    !51 = !DISubroutineType(flags: DIFlagPublic, types: !52)
+    !52 = !{null}
+    !53 = !DILocalVariable(name: "arr", scope: !50, file: !2, line: 24, type: !54, align: 64)
+    !54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 5280, align: 64, elements: !20)
+    !55 = !DILocation(line: 24, column: 12, scope: !50)
+    !56 = !DILocation(line: 26, column: 12, scope: !50)
+    !57 = !DILocation(line: 27, column: 12, scope: !50)
+    !58 = !DILocation(line: 28, column: 12, scope: !50)
+    !59 = !DILocation(line: 29, column: 12, scope: !50)
+    !60 = !DILocation(line: 30, column: 12, scope: !50)
+    !61 = !DILocation(line: 31, column: 8, scope: !50)
+    "###);
 }
 
 #[test]
@@ -788,7 +798,7 @@ fn complex_array_access_generated() {
         "#,
     );
 
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -798,64 +808,64 @@ fn complex_array_access_generated() {
     %grandparent = type { [6 x i16], i16 }
     %child = type { %parent, [11 x i16] }
 
-    @__parent__init = constant %parent zeroinitializer, !dbg !0
-    @__grandparent__init = constant %grandparent zeroinitializer, !dbg !19
-    @__child__init = constant %child zeroinitializer, !dbg !21
+    @__parent__init = unnamed_addr constant %parent zeroinitializer, !dbg !0
+    @__grandparent__init = unnamed_addr constant %grandparent zeroinitializer, !dbg !20
+    @__child__init = unnamed_addr constant %child zeroinitializer, !dbg !23
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @grandparent(%grandparent* %0) !dbg !31 {
+    define void @grandparent(%grandparent* %0) !dbg !34 {
     entry:
-      call void @llvm.dbg.declare(metadata %grandparent* %0, metadata !35, metadata !DIExpression()), !dbg !36
+      call void @llvm.dbg.declare(metadata %grandparent* %0, metadata !38, metadata !DIExpression()), !dbg !39
       %this = alloca %grandparent*, align 8
       store %grandparent* %0, %grandparent** %this, align 8
       %y = getelementptr inbounds %grandparent, %grandparent* %0, i32 0, i32 0
       %a = getelementptr inbounds %grandparent, %grandparent* %0, i32 0, i32 1
-      ret void, !dbg !36
+      ret void, !dbg !39
     }
 
-    define void @parent(%parent* %0) !dbg !37 {
+    define void @parent(%parent* %0) !dbg !40 {
     entry:
-      call void @llvm.dbg.declare(metadata %parent* %0, metadata !40, metadata !DIExpression()), !dbg !41
+      call void @llvm.dbg.declare(metadata %parent* %0, metadata !43, metadata !DIExpression()), !dbg !44
       %this = alloca %parent*, align 8
       store %parent* %0, %parent** %this, align 8
       %__grandparent = getelementptr inbounds %parent, %parent* %0, i32 0, i32 0
       %x = getelementptr inbounds %parent, %parent* %0, i32 0, i32 1
       %b = getelementptr inbounds %parent, %parent* %0, i32 0, i32 2
-      ret void, !dbg !41
+      ret void, !dbg !44
     }
 
-    define void @child(%child* %0) !dbg !42 {
+    define void @child(%child* %0) !dbg !45 {
     entry:
-      call void @llvm.dbg.declare(metadata %child* %0, metadata !45, metadata !DIExpression()), !dbg !46
+      call void @llvm.dbg.declare(metadata %child* %0, metadata !48, metadata !DIExpression()), !dbg !49
       %this = alloca %child*, align 8
       store %child* %0, %child** %this, align 8
       %__parent = getelementptr inbounds %child, %child* %0, i32 0, i32 0
       %z = getelementptr inbounds %child, %child* %0, i32 0, i32 1
-      %__grandparent = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !46
-      %y = getelementptr inbounds %grandparent, %grandparent* %__grandparent, i32 0, i32 0, !dbg !46
-      %b = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 2, !dbg !46
-      %load_b = load i16, i16* %b, align 2, !dbg !46
-      %1 = sext i16 %load_b to i32, !dbg !46
-      %b1 = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 2, !dbg !46
-      %load_b2 = load i16, i16* %b1, align 2, !dbg !46
-      %2 = sext i16 %load_b2 to i32, !dbg !46
-      %tmpVar = mul i32 %2, 2, !dbg !46
-      %tmpVar3 = mul i32 1, %tmpVar, !dbg !46
-      %tmpVar4 = add i32 %tmpVar3, 0, !dbg !46
-      %tmpVar5 = getelementptr inbounds [11 x i16], [11 x i16]* %z, i32 0, i32 %tmpVar4, !dbg !46
-      %load_tmpVar = load i16, i16* %tmpVar5, align 2, !dbg !46
-      %3 = sext i16 %load_tmpVar to i32, !dbg !46
-      %tmpVar6 = add i32 %1, %3, !dbg !46
-      %__grandparent7 = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !46
-      %a = getelementptr inbounds %grandparent, %grandparent* %__grandparent7, i32 0, i32 1, !dbg !46
-      %load_a = load i16, i16* %a, align 2, !dbg !46
-      %4 = sext i16 %load_a to i32, !dbg !46
-      %tmpVar8 = sub i32 %tmpVar6, %4, !dbg !46
-      %tmpVar9 = mul i32 1, %tmpVar8, !dbg !46
-      %tmpVar10 = add i32 %tmpVar9, 0, !dbg !46
-      %tmpVar11 = getelementptr inbounds [6 x i16], [6 x i16]* %y, i32 0, i32 %tmpVar10, !dbg !46
-      store i16 20, i16* %tmpVar11, align 2, !dbg !46
-      ret void, !dbg !47
+      %__grandparent = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !49
+      %y = getelementptr inbounds %grandparent, %grandparent* %__grandparent, i32 0, i32 0, !dbg !49
+      %b = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 2, !dbg !49
+      %load_b = load i16, i16* %b, align 2, !dbg !49
+      %1 = sext i16 %load_b to i32, !dbg !49
+      %b1 = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 2, !dbg !49
+      %load_b2 = load i16, i16* %b1, align 2, !dbg !49
+      %2 = sext i16 %load_b2 to i32, !dbg !49
+      %tmpVar = mul i32 %2, 2, !dbg !49
+      %tmpVar3 = mul i32 1, %tmpVar, !dbg !49
+      %tmpVar4 = add i32 %tmpVar3, 0, !dbg !49
+      %tmpVar5 = getelementptr inbounds [11 x i16], [11 x i16]* %z, i32 0, i32 %tmpVar4, !dbg !49
+      %load_tmpVar = load i16, i16* %tmpVar5, align 2, !dbg !49
+      %3 = sext i16 %load_tmpVar to i32, !dbg !49
+      %tmpVar6 = add i32 %1, %3, !dbg !49
+      %__grandparent7 = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !49
+      %a = getelementptr inbounds %grandparent, %grandparent* %__grandparent7, i32 0, i32 1, !dbg !49
+      %load_a = load i16, i16* %a, align 2, !dbg !49
+      %4 = sext i16 %load_a to i32, !dbg !49
+      %tmpVar8 = sub i32 %tmpVar6, %4, !dbg !49
+      %tmpVar9 = mul i32 1, %tmpVar8, !dbg !49
+      %tmpVar10 = add i32 %tmpVar9, 0, !dbg !49
+      %tmpVar11 = getelementptr inbounds [6 x i16], [6 x i16]* %y, i32 0, i32 %tmpVar10, !dbg !49
+      store i16 20, i16* %tmpVar11, align 2, !dbg !49
+      ret void, !dbg !50
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -922,58 +932,61 @@ fn complex_array_access_generated() {
 
     attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-    !llvm.module.flags = !{!27, !28}
-    !llvm.dbg.cu = !{!29}
+    !llvm.module.flags = !{!30, !31}
+    !llvm.dbg.cu = !{!32}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__parent__init", scope: !2, file: !2, line: 9, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "parent", scope: !2, file: !2, line: 9, size: 304, align: 64, flags: DIFlagPublic, elements: !4, identifier: "parent")
-    !4 = !{!5, !14, !18}
-    !5 = !DIDerivedType(tag: DW_TAG_member, name: "__grandparent", scope: !2, file: !2, baseType: !6, size: 112, align: 64, flags: DIFlagPublic)
-    !6 = !DICompositeType(tag: DW_TAG_structure_type, name: "grandparent", scope: !2, file: !2, line: 2, size: 112, align: 64, flags: DIFlagPublic, elements: !7, identifier: "grandparent")
-    !7 = !{!8, !13}
-    !8 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !2, file: !2, line: 4, baseType: !9, size: 96, align: 16, flags: DIFlagPublic)
-    !9 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 96, align: 16, elements: !11)
-    !10 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
-    !11 = !{!12}
-    !12 = !DISubrange(count: 6, lowerBound: 0)
-    !13 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 5, baseType: !10, size: 16, align: 16, offset: 96, flags: DIFlagPublic)
-    !14 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 11, baseType: !15, size: 176, align: 16, offset: 112, flags: DIFlagPublic)
-    !15 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 176, align: 16, elements: !16)
-    !16 = !{!17}
-    !17 = !DISubrange(count: 11, lowerBound: 0)
-    !18 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 12, baseType: !10, size: 16, align: 16, offset: 288, flags: DIFlagPublic)
-    !19 = !DIGlobalVariableExpression(var: !20, expr: !DIExpression())
-    !20 = distinct !DIGlobalVariable(name: "__grandparent__init", scope: !2, file: !2, line: 2, type: !6, isLocal: false, isDefinition: true)
-    !21 = !DIGlobalVariableExpression(var: !22, expr: !DIExpression())
-    !22 = distinct !DIGlobalVariable(name: "__child__init", scope: !2, file: !2, line: 16, type: !23, isLocal: false, isDefinition: true)
-    !23 = !DICompositeType(tag: DW_TAG_structure_type, name: "child", scope: !2, file: !2, line: 16, size: 480, align: 64, flags: DIFlagPublic, elements: !24, identifier: "child")
-    !24 = !{!25, !26}
-    !25 = !DIDerivedType(tag: DW_TAG_member, name: "__parent", scope: !2, file: !2, baseType: !3, size: 304, align: 64, flags: DIFlagPublic)
-    !26 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !2, file: !2, line: 18, baseType: !15, size: 176, align: 16, offset: 304, flags: DIFlagPublic)
-    !27 = !{i32 2, !"Dwarf Version", i32 5}
-    !28 = !{i32 2, !"Debug Info Version", i32 3}
-    !29 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !30, splitDebugInlining: false)
-    !30 = !{!19, !0, !21}
-    !31 = distinct !DISubprogram(name: "grandparent", linkageName: "grandparent", scope: !2, file: !2, line: 2, type: !32, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
-    !32 = !DISubroutineType(flags: DIFlagPublic, types: !33)
-    !33 = !{null, !6}
-    !34 = !{}
-    !35 = !DILocalVariable(name: "grandparent", scope: !31, file: !2, line: 7, type: !6)
-    !36 = !DILocation(line: 7, column: 8, scope: !31)
-    !37 = distinct !DISubprogram(name: "parent", linkageName: "parent", scope: !2, file: !2, line: 9, type: !38, scopeLine: 14, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
-    !38 = !DISubroutineType(flags: DIFlagPublic, types: !39)
-    !39 = !{null, !3}
-    !40 = !DILocalVariable(name: "parent", scope: !37, file: !2, line: 14, type: !3)
-    !41 = !DILocation(line: 14, column: 8, scope: !37)
-    !42 = distinct !DISubprogram(name: "child", linkageName: "child", scope: !2, file: !2, line: 16, type: !43, scopeLine: 20, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !29, retainedNodes: !34)
-    !43 = !DISubroutineType(flags: DIFlagPublic, types: !44)
-    !44 = !{null, !23}
-    !45 = !DILocalVariable(name: "child", scope: !42, file: !2, line: 20, type: !23)
-    !46 = !DILocation(line: 20, column: 12, scope: !42)
-    !47 = !DILocation(line: 21, column: 8, scope: !42)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "parent", scope: !2, file: !2, line: 9, size: 304, align: 64, flags: DIFlagPublic, elements: !5, identifier: "parent")
+    !5 = !{!6, !15, !19}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "__grandparent", scope: !2, file: !2, baseType: !7, size: 112, align: 64, flags: DIFlagPublic)
+    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "grandparent", scope: !2, file: !2, line: 2, size: 112, align: 64, flags: DIFlagPublic, elements: !8, identifier: "grandparent")
+    !8 = !{!9, !14}
+    !9 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !2, file: !2, line: 4, baseType: !10, size: 96, align: 16, flags: DIFlagPublic)
+    !10 = !DICompositeType(tag: DW_TAG_array_type, baseType: !11, size: 96, align: 16, elements: !12)
+    !11 = !DIBasicType(name: "INT", size: 16, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !12 = !{!13}
+    !13 = !DISubrange(count: 6, lowerBound: 0)
+    !14 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 5, baseType: !11, size: 16, align: 16, offset: 96, flags: DIFlagPublic)
+    !15 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !2, file: !2, line: 11, baseType: !16, size: 176, align: 16, offset: 112, flags: DIFlagPublic)
+    !16 = !DICompositeType(tag: DW_TAG_array_type, baseType: !11, size: 176, align: 16, elements: !17)
+    !17 = !{!18}
+    !18 = !DISubrange(count: 11, lowerBound: 0)
+    !19 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 12, baseType: !11, size: 16, align: 16, offset: 288, flags: DIFlagPublic)
+    !20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+    !21 = distinct !DIGlobalVariable(name: "__grandparent__init", scope: !2, file: !2, line: 2, type: !22, isLocal: false, isDefinition: true)
+    !22 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+    !23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+    !24 = distinct !DIGlobalVariable(name: "__child__init", scope: !2, file: !2, line: 16, type: !25, isLocal: false, isDefinition: true)
+    !25 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !26)
+    !26 = !DICompositeType(tag: DW_TAG_structure_type, name: "child", scope: !2, file: !2, line: 16, size: 480, align: 64, flags: DIFlagPublic, elements: !27, identifier: "child")
+    !27 = !{!28, !29}
+    !28 = !DIDerivedType(tag: DW_TAG_member, name: "__parent", scope: !2, file: !2, baseType: !4, size: 304, align: 64, flags: DIFlagPublic)
+    !29 = !DIDerivedType(tag: DW_TAG_member, name: "z", scope: !2, file: !2, line: 18, baseType: !16, size: 176, align: 16, offset: 304, flags: DIFlagPublic)
+    !30 = !{i32 2, !"Dwarf Version", i32 5}
+    !31 = !{i32 2, !"Debug Info Version", i32 3}
+    !32 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !33, splitDebugInlining: false)
+    !33 = !{!20, !0, !23}
+    !34 = distinct !DISubprogram(name: "grandparent", linkageName: "grandparent", scope: !2, file: !2, line: 2, type: !35, scopeLine: 7, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !32, retainedNodes: !37)
+    !35 = !DISubroutineType(flags: DIFlagPublic, types: !36)
+    !36 = !{null, !7}
+    !37 = !{}
+    !38 = !DILocalVariable(name: "grandparent", scope: !34, file: !2, line: 7, type: !7)
+    !39 = !DILocation(line: 7, column: 8, scope: !34)
+    !40 = distinct !DISubprogram(name: "parent", linkageName: "parent", scope: !2, file: !2, line: 9, type: !41, scopeLine: 14, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !32, retainedNodes: !37)
+    !41 = !DISubroutineType(flags: DIFlagPublic, types: !42)
+    !42 = !{null, !4}
+    !43 = !DILocalVariable(name: "parent", scope: !40, file: !2, line: 14, type: !4)
+    !44 = !DILocation(line: 14, column: 8, scope: !40)
+    !45 = distinct !DISubprogram(name: "child", linkageName: "child", scope: !2, file: !2, line: 16, type: !46, scopeLine: 20, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !32, retainedNodes: !37)
+    !46 = !DISubroutineType(flags: DIFlagPublic, types: !47)
+    !47 = !{null, !26}
+    !48 = !DILocalVariable(name: "child", scope: !45, file: !2, line: 20, type: !26)
+    !49 = !DILocation(line: 20, column: 12, scope: !45)
+    !50 = !DILocation(line: 21, column: 8, scope: !45)
+    "###);
 }
 
 #[test]
@@ -989,7 +1002,7 @@ fn function_block_method_debug_info() {
         END_FUNCTION_BLOCK
     "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -998,33 +1011,33 @@ fn function_block_method_debug_info() {
     %foo = type {}
     %bar = type { %foo }
 
-    @__foo__init = constant %foo zeroinitializer, !dbg !0
-    @__bar__init = constant %bar zeroinitializer, !dbg !5
+    @__foo__init = unnamed_addr constant %foo zeroinitializer, !dbg !0
+    @__bar__init = unnamed_addr constant %bar zeroinitializer, !dbg !6
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @foo(%foo* %0) !dbg !14 {
+    define void @foo(%foo* %0) !dbg !16 {
     entry:
-      call void @llvm.dbg.declare(metadata %foo* %0, metadata !17, metadata !DIExpression()), !dbg !18
+      call void @llvm.dbg.declare(metadata %foo* %0, metadata !19, metadata !DIExpression()), !dbg !20
       %this = alloca %foo*, align 8
       store %foo* %0, %foo** %this, align 8
-      ret void, !dbg !18
+      ret void, !dbg !20
     }
 
-    define void @foo__baz(%foo* %0) !dbg !19 {
+    define void @foo__baz(%foo* %0) !dbg !21 {
     entry:
-      call void @llvm.dbg.declare(metadata %foo* %0, metadata !20, metadata !DIExpression()), !dbg !21
+      call void @llvm.dbg.declare(metadata %foo* %0, metadata !22, metadata !DIExpression()), !dbg !23
       %this = alloca %foo*, align 8
       store %foo* %0, %foo** %this, align 8
-      ret void, !dbg !21
+      ret void, !dbg !23
     }
 
-    define void @bar(%bar* %0) !dbg !22 {
+    define void @bar(%bar* %0) !dbg !24 {
     entry:
-      call void @llvm.dbg.declare(metadata %bar* %0, metadata !25, metadata !DIExpression()), !dbg !26
+      call void @llvm.dbg.declare(metadata %bar* %0, metadata !27, metadata !DIExpression()), !dbg !28
       %this = alloca %bar*, align 8
       store %bar* %0, %bar** %this, align 8
       %__foo = getelementptr inbounds %bar, %bar* %0, i32 0, i32 0
-      ret void, !dbg !26
+      ret void, !dbg !28
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -1071,37 +1084,39 @@ fn function_block_method_debug_info() {
 
     attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }
 
-    !llvm.module.flags = !{!10, !11}
-    !llvm.dbg.cu = !{!12}
+    !llvm.module.flags = !{!12, !13}
+    !llvm.dbg.cu = !{!14}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__foo__init", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 2, align: 64, flags: DIFlagPublic, elements: !4, identifier: "foo")
-    !4 = !{}
-    !5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
-    !6 = distinct !DIGlobalVariable(name: "__bar__init", scope: !2, file: !2, line: 7, type: !7, isLocal: false, isDefinition: true)
-    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !2, file: !2, line: 7, align: 64, flags: DIFlagPublic, elements: !8, identifier: "bar")
-    !8 = !{!9}
-    !9 = !DIDerivedType(tag: DW_TAG_member, name: "__foo", scope: !2, file: !2, baseType: !3, align: 64, flags: DIFlagPublic)
-    !10 = !{i32 2, !"Dwarf Version", i32 5}
-    !11 = !{i32 2, !"Debug Info Version", i32 3}
-    !12 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !13, splitDebugInlining: false)
-    !13 = !{!0, !5}
-    !14 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 2, type: !15, scopeLine: 5, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !12, retainedNodes: !4)
-    !15 = !DISubroutineType(flags: DIFlagPublic, types: !16)
-    !16 = !{null, !3}
-    !17 = !DILocalVariable(name: "foo", scope: !14, file: !2, line: 5, type: !3)
-    !18 = !DILocation(line: 5, column: 8, scope: !14)
-    !19 = distinct !DISubprogram(name: "foo.baz", linkageName: "foo.baz", scope: !14, file: !2, line: 3, type: !15, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !12, retainedNodes: !4)
-    !20 = !DILocalVariable(name: "foo", scope: !19, file: !2, line: 4, type: !3)
-    !21 = !DILocation(line: 4, column: 8, scope: !19)
-    !22 = distinct !DISubprogram(name: "bar", linkageName: "bar", scope: !2, file: !2, line: 7, type: !23, scopeLine: 8, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !12, retainedNodes: !4)
-    !23 = !DISubroutineType(flags: DIFlagPublic, types: !24)
-    !24 = !{null, !7}
-    !25 = !DILocalVariable(name: "bar", scope: !22, file: !2, line: 8, type: !7)
-    !26 = !DILocation(line: 8, column: 8, scope: !22)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "foo", scope: !2, file: !2, line: 2, align: 64, flags: DIFlagPublic, elements: !5, identifier: "foo")
+    !5 = !{}
+    !6 = !DIGlobalVariableExpression(var: !7, expr: !DIExpression())
+    !7 = distinct !DIGlobalVariable(name: "__bar__init", scope: !2, file: !2, line: 7, type: !8, isLocal: false, isDefinition: true)
+    !8 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !9)
+    !9 = !DICompositeType(tag: DW_TAG_structure_type, name: "bar", scope: !2, file: !2, line: 7, align: 64, flags: DIFlagPublic, elements: !10, identifier: "bar")
+    !10 = !{!11}
+    !11 = !DIDerivedType(tag: DW_TAG_member, name: "__foo", scope: !2, file: !2, baseType: !4, align: 64, flags: DIFlagPublic)
+    !12 = !{i32 2, !"Dwarf Version", i32 5}
+    !13 = !{i32 2, !"Debug Info Version", i32 3}
+    !14 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !15, splitDebugInlining: false)
+    !15 = !{!0, !6}
+    !16 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: !2, file: !2, line: 2, type: !17, scopeLine: 5, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !5)
+    !17 = !DISubroutineType(flags: DIFlagPublic, types: !18)
+    !18 = !{null, !4}
+    !19 = !DILocalVariable(name: "foo", scope: !16, file: !2, line: 5, type: !4)
+    !20 = !DILocation(line: 5, column: 8, scope: !16)
+    !21 = distinct !DISubprogram(name: "foo.baz", linkageName: "foo.baz", scope: !16, file: !2, line: 3, type: !17, scopeLine: 4, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !5)
+    !22 = !DILocalVariable(name: "foo", scope: !21, file: !2, line: 4, type: !4)
+    !23 = !DILocation(line: 4, column: 8, scope: !21)
+    !24 = distinct !DISubprogram(name: "bar", linkageName: "bar", scope: !2, file: !2, line: 7, type: !25, scopeLine: 8, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !14, retainedNodes: !5)
+    !25 = !DISubroutineType(flags: DIFlagPublic, types: !26)
+    !26 = !{null, !9}
+    !27 = !DILocalVariable(name: "bar", scope: !24, file: !2, line: 8, type: !9)
+    !28 = !DILocation(line: 8, column: 8, scope: !24)
+    "###);
 }
 
 #[test]
@@ -1166,7 +1181,7 @@ END_FUNCTION
 ",
     );
 
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1176,41 +1191,41 @@ END_FUNCTION
     %child = type { %parent, i32 }
     %parent = type { i32 }
 
-    @__grandchild__init = constant %grandchild zeroinitializer, !dbg !0
-    @__child__init = constant %child zeroinitializer, !dbg !15
-    @__parent__init = constant %parent zeroinitializer, !dbg !17
+    @__grandchild__init = unnamed_addr constant %grandchild zeroinitializer, !dbg !0
+    @__child__init = unnamed_addr constant %child zeroinitializer, !dbg !16
+    @__parent__init = unnamed_addr constant %parent zeroinitializer, !dbg !19
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
-    define void @parent(%parent* %0) !dbg !23 {
+    define void @parent(%parent* %0) !dbg !26 {
     entry:
-      call void @llvm.dbg.declare(metadata %parent* %0, metadata !27, metadata !DIExpression()), !dbg !28
+      call void @llvm.dbg.declare(metadata %parent* %0, metadata !30, metadata !DIExpression()), !dbg !31
       %this = alloca %parent*, align 8
       store %parent* %0, %parent** %this, align 8
       %a = getelementptr inbounds %parent, %parent* %0, i32 0, i32 0
-      ret void, !dbg !28
+      ret void, !dbg !31
     }
 
-    define void @child(%child* %0) !dbg !29 {
+    define void @child(%child* %0) !dbg !32 {
     entry:
-      call void @llvm.dbg.declare(metadata %child* %0, metadata !32, metadata !DIExpression()), !dbg !33
+      call void @llvm.dbg.declare(metadata %child* %0, metadata !35, metadata !DIExpression()), !dbg !36
       %this = alloca %child*, align 8
       store %child* %0, %child** %this, align 8
       %__parent = getelementptr inbounds %child, %child* %0, i32 0, i32 0
       %b = getelementptr inbounds %child, %child* %0, i32 0, i32 1
-      ret void, !dbg !33
+      ret void, !dbg !36
     }
 
-    define void @grandchild(%grandchild* %0) !dbg !34 {
+    define void @grandchild(%grandchild* %0) !dbg !37 {
     entry:
-      call void @llvm.dbg.declare(metadata %grandchild* %0, metadata !37, metadata !DIExpression()), !dbg !38
+      call void @llvm.dbg.declare(metadata %grandchild* %0, metadata !40, metadata !DIExpression()), !dbg !41
       %this = alloca %grandchild*, align 8
       store %grandchild* %0, %grandchild** %this, align 8
       %__child = getelementptr inbounds %grandchild, %grandchild* %0, i32 0, i32 0
       %c = getelementptr inbounds %grandchild, %grandchild* %0, i32 0, i32 1
-      ret void, !dbg !38
+      ret void, !dbg !41
     }
 
-    define i32 @main() !dbg !39 {
+    define i32 @main() !dbg !42 {
     entry:
       %main = alloca i32, align 4
       %array_of_parent = alloca [3 x %parent], align 8
@@ -1219,116 +1234,116 @@ END_FUNCTION
       %parent1 = alloca %parent, align 8
       %child1 = alloca %child, align 8
       %grandchild1 = alloca %grandchild, align 8
-      call void @llvm.dbg.declare(metadata [3 x %parent]* %array_of_parent, metadata !42, metadata !DIExpression()), !dbg !46
+      call void @llvm.dbg.declare(metadata [3 x %parent]* %array_of_parent, metadata !45, metadata !DIExpression()), !dbg !49
       %0 = bitcast [3 x %parent]* %array_of_parent to i8*
       call void @llvm.memset.p0i8.i64(i8* align 1 %0, i8 0, i64 ptrtoint ([3 x %parent]* getelementptr ([3 x %parent], [3 x %parent]* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata [3 x %child]* %array_of_child, metadata !47, metadata !DIExpression()), !dbg !49
+      call void @llvm.dbg.declare(metadata [3 x %child]* %array_of_child, metadata !50, metadata !DIExpression()), !dbg !52
       %1 = bitcast [3 x %child]* %array_of_child to i8*
       call void @llvm.memset.p0i8.i64(i8* align 1 %1, i8 0, i64 ptrtoint ([3 x %child]* getelementptr ([3 x %child], [3 x %child]* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata [3 x %grandchild]* %array_of_grandchild, metadata !50, metadata !DIExpression()), !dbg !52
+      call void @llvm.dbg.declare(metadata [3 x %grandchild]* %array_of_grandchild, metadata !53, metadata !DIExpression()), !dbg !55
       %2 = bitcast [3 x %grandchild]* %array_of_grandchild to i8*
       call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 ptrtoint ([3 x %grandchild]* getelementptr ([3 x %grandchild], [3 x %grandchild]* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata %parent* %parent1, metadata !53, metadata !DIExpression()), !dbg !54
+      call void @llvm.dbg.declare(metadata %parent* %parent1, metadata !56, metadata !DIExpression()), !dbg !57
       %3 = bitcast %parent* %parent1 to i8*
       call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %3, i8* align 1 bitcast (%parent* @__parent__init to i8*), i64 ptrtoint (%parent* getelementptr (%parent, %parent* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata %child* %child1, metadata !55, metadata !DIExpression()), !dbg !56
+      call void @llvm.dbg.declare(metadata %child* %child1, metadata !58, metadata !DIExpression()), !dbg !59
       %4 = bitcast %child* %child1 to i8*
       call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %4, i8* align 1 bitcast (%child* @__child__init to i8*), i64 ptrtoint (%child* getelementptr (%child, %child* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata %grandchild* %grandchild1, metadata !57, metadata !DIExpression()), !dbg !58
+      call void @llvm.dbg.declare(metadata %grandchild* %grandchild1, metadata !60, metadata !DIExpression()), !dbg !61
       %5 = bitcast %grandchild* %grandchild1 to i8*
       call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %5, i8* align 1 bitcast (%grandchild* @__grandchild__init to i8*), i64 ptrtoint (%grandchild* getelementptr (%grandchild, %grandchild* null, i32 1) to i64), i1 false)
-      call void @llvm.dbg.declare(metadata i32* %main, metadata !59, metadata !DIExpression()), !dbg !60
+      call void @llvm.dbg.declare(metadata i32* %main, metadata !62, metadata !DIExpression()), !dbg !63
       store i32 0, i32* %main, align 4
-      call void @__init_parent(%parent* %parent1), !dbg !61
-      call void @__init_child(%child* %child1), !dbg !61
-      call void @__init_grandchild(%grandchild* %grandchild1), !dbg !61
-      call void @__user_init_parent(%parent* %parent1), !dbg !61
-      call void @__user_init_child(%child* %child1), !dbg !61
-      call void @__user_init_grandchild(%grandchild* %grandchild1), !dbg !61
-      %a = getelementptr inbounds %parent, %parent* %parent1, i32 0, i32 0, !dbg !62
-      store i32 1, i32* %a, align 4, !dbg !62
-      %__parent = getelementptr inbounds %child, %child* %child1, i32 0, i32 0, !dbg !63
-      %a1 = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !63
-      store i32 2, i32* %a1, align 4, !dbg !63
-      %b = getelementptr inbounds %child, %child* %child1, i32 0, i32 1, !dbg !64
-      store i32 3, i32* %b, align 4, !dbg !64
-      %__child = getelementptr inbounds %grandchild, %grandchild* %grandchild1, i32 0, i32 0, !dbg !65
-      %__parent2 = getelementptr inbounds %child, %child* %__child, i32 0, i32 0, !dbg !65
-      %a3 = getelementptr inbounds %parent, %parent* %__parent2, i32 0, i32 0, !dbg !65
-      store i32 4, i32* %a3, align 4, !dbg !65
-      %__child4 = getelementptr inbounds %grandchild, %grandchild* %grandchild1, i32 0, i32 0, !dbg !66
-      %b5 = getelementptr inbounds %child, %child* %__child4, i32 0, i32 1, !dbg !66
-      store i32 5, i32* %b5, align 4, !dbg !66
-      %c = getelementptr inbounds %grandchild, %grandchild* %grandchild1, i32 0, i32 1, !dbg !67
-      store i32 6, i32* %c, align 4, !dbg !67
-      %tmpVar = getelementptr inbounds [3 x %parent], [3 x %parent]* %array_of_parent, i32 0, i32 0, !dbg !68
-      %a6 = getelementptr inbounds %parent, %parent* %tmpVar, i32 0, i32 0, !dbg !68
-      store i32 7, i32* %a6, align 4, !dbg !68
-      %tmpVar7 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 0, !dbg !69
-      %__parent8 = getelementptr inbounds %child, %child* %tmpVar7, i32 0, i32 0, !dbg !69
-      %a9 = getelementptr inbounds %parent, %parent* %__parent8, i32 0, i32 0, !dbg !69
-      store i32 8, i32* %a9, align 4, !dbg !69
-      %tmpVar10 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 0, !dbg !70
-      %b11 = getelementptr inbounds %child, %child* %tmpVar10, i32 0, i32 1, !dbg !70
-      store i32 9, i32* %b11, align 4, !dbg !70
-      %tmpVar12 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 0, !dbg !71
-      %__child13 = getelementptr inbounds %grandchild, %grandchild* %tmpVar12, i32 0, i32 0, !dbg !71
-      %__parent14 = getelementptr inbounds %child, %child* %__child13, i32 0, i32 0, !dbg !71
-      %a15 = getelementptr inbounds %parent, %parent* %__parent14, i32 0, i32 0, !dbg !71
-      store i32 10, i32* %a15, align 4, !dbg !71
-      %tmpVar16 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 0, !dbg !72
-      %__child17 = getelementptr inbounds %grandchild, %grandchild* %tmpVar16, i32 0, i32 0, !dbg !72
-      %b18 = getelementptr inbounds %child, %child* %__child17, i32 0, i32 1, !dbg !72
-      store i32 11, i32* %b18, align 4, !dbg !72
-      %tmpVar19 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 0, !dbg !73
-      %c20 = getelementptr inbounds %grandchild, %grandchild* %tmpVar19, i32 0, i32 1, !dbg !73
-      store i32 12, i32* %c20, align 4, !dbg !73
-      %tmpVar21 = getelementptr inbounds [3 x %parent], [3 x %parent]* %array_of_parent, i32 0, i32 1, !dbg !74
-      %a22 = getelementptr inbounds %parent, %parent* %tmpVar21, i32 0, i32 0, !dbg !74
-      store i32 13, i32* %a22, align 4, !dbg !74
-      %tmpVar23 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 1, !dbg !75
-      %__parent24 = getelementptr inbounds %child, %child* %tmpVar23, i32 0, i32 0, !dbg !75
-      %a25 = getelementptr inbounds %parent, %parent* %__parent24, i32 0, i32 0, !dbg !75
-      store i32 14, i32* %a25, align 4, !dbg !75
-      %tmpVar26 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 1, !dbg !76
-      %b27 = getelementptr inbounds %child, %child* %tmpVar26, i32 0, i32 1, !dbg !76
-      store i32 15, i32* %b27, align 4, !dbg !76
-      %tmpVar28 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 1, !dbg !77
-      %__child29 = getelementptr inbounds %grandchild, %grandchild* %tmpVar28, i32 0, i32 0, !dbg !77
-      %__parent30 = getelementptr inbounds %child, %child* %__child29, i32 0, i32 0, !dbg !77
-      %a31 = getelementptr inbounds %parent, %parent* %__parent30, i32 0, i32 0, !dbg !77
-      store i32 16, i32* %a31, align 4, !dbg !77
-      %tmpVar32 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 1, !dbg !78
-      %__child33 = getelementptr inbounds %grandchild, %grandchild* %tmpVar32, i32 0, i32 0, !dbg !78
-      %b34 = getelementptr inbounds %child, %child* %__child33, i32 0, i32 1, !dbg !78
-      store i32 17, i32* %b34, align 4, !dbg !78
-      %tmpVar35 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 1, !dbg !79
-      %c36 = getelementptr inbounds %grandchild, %grandchild* %tmpVar35, i32 0, i32 1, !dbg !79
-      store i32 18, i32* %c36, align 4, !dbg !79
-      %tmpVar37 = getelementptr inbounds [3 x %parent], [3 x %parent]* %array_of_parent, i32 0, i32 2, !dbg !80
-      %a38 = getelementptr inbounds %parent, %parent* %tmpVar37, i32 0, i32 0, !dbg !80
-      store i32 19, i32* %a38, align 4, !dbg !80
-      %tmpVar39 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 2, !dbg !81
-      %__parent40 = getelementptr inbounds %child, %child* %tmpVar39, i32 0, i32 0, !dbg !81
-      %a41 = getelementptr inbounds %parent, %parent* %__parent40, i32 0, i32 0, !dbg !81
-      store i32 20, i32* %a41, align 4, !dbg !81
-      %tmpVar42 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 2, !dbg !82
-      %b43 = getelementptr inbounds %child, %child* %tmpVar42, i32 0, i32 1, !dbg !82
-      store i32 21, i32* %b43, align 4, !dbg !82
-      %tmpVar44 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 2, !dbg !83
-      %__child45 = getelementptr inbounds %grandchild, %grandchild* %tmpVar44, i32 0, i32 0, !dbg !83
-      %__parent46 = getelementptr inbounds %child, %child* %__child45, i32 0, i32 0, !dbg !83
-      %a47 = getelementptr inbounds %parent, %parent* %__parent46, i32 0, i32 0, !dbg !83
-      store i32 22, i32* %a47, align 4, !dbg !83
-      %tmpVar48 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 2, !dbg !84
-      %__child49 = getelementptr inbounds %grandchild, %grandchild* %tmpVar48, i32 0, i32 0, !dbg !84
-      %b50 = getelementptr inbounds %child, %child* %__child49, i32 0, i32 1, !dbg !84
-      store i32 23, i32* %b50, align 4, !dbg !84
-      %tmpVar51 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 2, !dbg !85
-      %c52 = getelementptr inbounds %grandchild, %grandchild* %tmpVar51, i32 0, i32 1, !dbg !85
-      store i32 24, i32* %c52, align 4, !dbg !85
-      %main_ret = load i32, i32* %main, align 4, !dbg !86
-      ret i32 %main_ret, !dbg !86
+      call void @__init_parent(%parent* %parent1), !dbg !64
+      call void @__init_child(%child* %child1), !dbg !64
+      call void @__init_grandchild(%grandchild* %grandchild1), !dbg !64
+      call void @__user_init_parent(%parent* %parent1), !dbg !64
+      call void @__user_init_child(%child* %child1), !dbg !64
+      call void @__user_init_grandchild(%grandchild* %grandchild1), !dbg !64
+      %a = getelementptr inbounds %parent, %parent* %parent1, i32 0, i32 0, !dbg !65
+      store i32 1, i32* %a, align 4, !dbg !65
+      %__parent = getelementptr inbounds %child, %child* %child1, i32 0, i32 0, !dbg !66
+      %a1 = getelementptr inbounds %parent, %parent* %__parent, i32 0, i32 0, !dbg !66
+      store i32 2, i32* %a1, align 4, !dbg !66
+      %b = getelementptr inbounds %child, %child* %child1, i32 0, i32 1, !dbg !67
+      store i32 3, i32* %b, align 4, !dbg !67
+      %__child = getelementptr inbounds %grandchild, %grandchild* %grandchild1, i32 0, i32 0, !dbg !68
+      %__parent2 = getelementptr inbounds %child, %child* %__child, i32 0, i32 0, !dbg !68
+      %a3 = getelementptr inbounds %parent, %parent* %__parent2, i32 0, i32 0, !dbg !68
+      store i32 4, i32* %a3, align 4, !dbg !68
+      %__child4 = getelementptr inbounds %grandchild, %grandchild* %grandchild1, i32 0, i32 0, !dbg !69
+      %b5 = getelementptr inbounds %child, %child* %__child4, i32 0, i32 1, !dbg !69
+      store i32 5, i32* %b5, align 4, !dbg !69
+      %c = getelementptr inbounds %grandchild, %grandchild* %grandchild1, i32 0, i32 1, !dbg !70
+      store i32 6, i32* %c, align 4, !dbg !70
+      %tmpVar = getelementptr inbounds [3 x %parent], [3 x %parent]* %array_of_parent, i32 0, i32 0, !dbg !71
+      %a6 = getelementptr inbounds %parent, %parent* %tmpVar, i32 0, i32 0, !dbg !71
+      store i32 7, i32* %a6, align 4, !dbg !71
+      %tmpVar7 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 0, !dbg !72
+      %__parent8 = getelementptr inbounds %child, %child* %tmpVar7, i32 0, i32 0, !dbg !72
+      %a9 = getelementptr inbounds %parent, %parent* %__parent8, i32 0, i32 0, !dbg !72
+      store i32 8, i32* %a9, align 4, !dbg !72
+      %tmpVar10 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 0, !dbg !73
+      %b11 = getelementptr inbounds %child, %child* %tmpVar10, i32 0, i32 1, !dbg !73
+      store i32 9, i32* %b11, align 4, !dbg !73
+      %tmpVar12 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 0, !dbg !74
+      %__child13 = getelementptr inbounds %grandchild, %grandchild* %tmpVar12, i32 0, i32 0, !dbg !74
+      %__parent14 = getelementptr inbounds %child, %child* %__child13, i32 0, i32 0, !dbg !74
+      %a15 = getelementptr inbounds %parent, %parent* %__parent14, i32 0, i32 0, !dbg !74
+      store i32 10, i32* %a15, align 4, !dbg !74
+      %tmpVar16 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 0, !dbg !75
+      %__child17 = getelementptr inbounds %grandchild, %grandchild* %tmpVar16, i32 0, i32 0, !dbg !75
+      %b18 = getelementptr inbounds %child, %child* %__child17, i32 0, i32 1, !dbg !75
+      store i32 11, i32* %b18, align 4, !dbg !75
+      %tmpVar19 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 0, !dbg !76
+      %c20 = getelementptr inbounds %grandchild, %grandchild* %tmpVar19, i32 0, i32 1, !dbg !76
+      store i32 12, i32* %c20, align 4, !dbg !76
+      %tmpVar21 = getelementptr inbounds [3 x %parent], [3 x %parent]* %array_of_parent, i32 0, i32 1, !dbg !77
+      %a22 = getelementptr inbounds %parent, %parent* %tmpVar21, i32 0, i32 0, !dbg !77
+      store i32 13, i32* %a22, align 4, !dbg !77
+      %tmpVar23 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 1, !dbg !78
+      %__parent24 = getelementptr inbounds %child, %child* %tmpVar23, i32 0, i32 0, !dbg !78
+      %a25 = getelementptr inbounds %parent, %parent* %__parent24, i32 0, i32 0, !dbg !78
+      store i32 14, i32* %a25, align 4, !dbg !78
+      %tmpVar26 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 1, !dbg !79
+      %b27 = getelementptr inbounds %child, %child* %tmpVar26, i32 0, i32 1, !dbg !79
+      store i32 15, i32* %b27, align 4, !dbg !79
+      %tmpVar28 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 1, !dbg !80
+      %__child29 = getelementptr inbounds %grandchild, %grandchild* %tmpVar28, i32 0, i32 0, !dbg !80
+      %__parent30 = getelementptr inbounds %child, %child* %__child29, i32 0, i32 0, !dbg !80
+      %a31 = getelementptr inbounds %parent, %parent* %__parent30, i32 0, i32 0, !dbg !80
+      store i32 16, i32* %a31, align 4, !dbg !80
+      %tmpVar32 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 1, !dbg !81
+      %__child33 = getelementptr inbounds %grandchild, %grandchild* %tmpVar32, i32 0, i32 0, !dbg !81
+      %b34 = getelementptr inbounds %child, %child* %__child33, i32 0, i32 1, !dbg !81
+      store i32 17, i32* %b34, align 4, !dbg !81
+      %tmpVar35 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 1, !dbg !82
+      %c36 = getelementptr inbounds %grandchild, %grandchild* %tmpVar35, i32 0, i32 1, !dbg !82
+      store i32 18, i32* %c36, align 4, !dbg !82
+      %tmpVar37 = getelementptr inbounds [3 x %parent], [3 x %parent]* %array_of_parent, i32 0, i32 2, !dbg !83
+      %a38 = getelementptr inbounds %parent, %parent* %tmpVar37, i32 0, i32 0, !dbg !83
+      store i32 19, i32* %a38, align 4, !dbg !83
+      %tmpVar39 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 2, !dbg !84
+      %__parent40 = getelementptr inbounds %child, %child* %tmpVar39, i32 0, i32 0, !dbg !84
+      %a41 = getelementptr inbounds %parent, %parent* %__parent40, i32 0, i32 0, !dbg !84
+      store i32 20, i32* %a41, align 4, !dbg !84
+      %tmpVar42 = getelementptr inbounds [3 x %child], [3 x %child]* %array_of_child, i32 0, i32 2, !dbg !85
+      %b43 = getelementptr inbounds %child, %child* %tmpVar42, i32 0, i32 1, !dbg !85
+      store i32 21, i32* %b43, align 4, !dbg !85
+      %tmpVar44 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 2, !dbg !86
+      %__child45 = getelementptr inbounds %grandchild, %grandchild* %tmpVar44, i32 0, i32 0, !dbg !86
+      %__parent46 = getelementptr inbounds %child, %child* %__child45, i32 0, i32 0, !dbg !86
+      %a47 = getelementptr inbounds %parent, %parent* %__parent46, i32 0, i32 0, !dbg !86
+      store i32 22, i32* %a47, align 4, !dbg !86
+      %tmpVar48 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 2, !dbg !87
+      %__child49 = getelementptr inbounds %grandchild, %grandchild* %tmpVar48, i32 0, i32 0, !dbg !87
+      %b50 = getelementptr inbounds %child, %child* %__child49, i32 0, i32 1, !dbg !87
+      store i32 23, i32* %b50, align 4, !dbg !87
+      %tmpVar51 = getelementptr inbounds [3 x %grandchild], [3 x %grandchild]* %array_of_grandchild, i32 0, i32 2, !dbg !88
+      %c52 = getelementptr inbounds %grandchild, %grandchild* %tmpVar51, i32 0, i32 1, !dbg !88
+      store i32 24, i32* %c52, align 4, !dbg !88
+      %main_ret = load i32, i32* %main, align 4, !dbg !89
+      ret i32 %main_ret, !dbg !89
     }
 
     ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
@@ -1403,95 +1418,98 @@ END_FUNCTION
     attributes #1 = { argmemonly nofree nounwind willreturn writeonly }
     attributes #2 = { argmemonly nofree nounwind willreturn }
 
-    !llvm.module.flags = !{!19, !20}
-    !llvm.dbg.cu = !{!21}
+    !llvm.module.flags = !{!22, !23}
+    !llvm.dbg.cu = !{!24}
 
     !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
     !1 = distinct !DIGlobalVariable(name: "__grandchild__init", scope: !2, file: !2, line: 14, type: !3, isLocal: false, isDefinition: true)
     !2 = !DIFile(filename: "<internal>", directory: "")
-    !3 = !DICompositeType(tag: DW_TAG_structure_type, name: "grandchild", scope: !2, file: !2, line: 14, size: 96, align: 64, flags: DIFlagPublic, elements: !4, identifier: "grandchild")
-    !4 = !{!5, !14}
-    !5 = !DIDerivedType(tag: DW_TAG_member, name: "__child", scope: !2, file: !2, baseType: !6, size: 64, align: 64, flags: DIFlagPublic)
-    !6 = !DICompositeType(tag: DW_TAG_structure_type, name: "child", scope: !2, file: !2, line: 8, size: 64, align: 64, flags: DIFlagPublic, elements: !7, identifier: "child")
-    !7 = !{!8, !13}
-    !8 = !DIDerivedType(tag: DW_TAG_member, name: "__parent", scope: !2, file: !2, baseType: !9, size: 32, align: 64, flags: DIFlagPublic)
-    !9 = !DICompositeType(tag: DW_TAG_structure_type, name: "parent", scope: !2, file: !2, line: 2, size: 32, align: 64, flags: DIFlagPublic, elements: !10, identifier: "parent")
-    !10 = !{!11}
-    !11 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 4, baseType: !12, size: 32, align: 32, flags: DIFlagPublic)
-    !12 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-    !13 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 10, baseType: !12, size: 32, align: 32, offset: 32, flags: DIFlagPublic)
-    !14 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !2, file: !2, line: 16, baseType: !12, size: 32, align: 32, offset: 64, flags: DIFlagPublic)
-    !15 = !DIGlobalVariableExpression(var: !16, expr: !DIExpression())
-    !16 = distinct !DIGlobalVariable(name: "__child__init", scope: !2, file: !2, line: 8, type: !6, isLocal: false, isDefinition: true)
-    !17 = !DIGlobalVariableExpression(var: !18, expr: !DIExpression())
-    !18 = distinct !DIGlobalVariable(name: "__parent__init", scope: !2, file: !2, line: 2, type: !9, isLocal: false, isDefinition: true)
-    !19 = !{i32 2, !"Dwarf Version", i32 5}
-    !20 = !{i32 2, !"Debug Info Version", i32 3}
-    !21 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !22, splitDebugInlining: false)
-    !22 = !{!17, !15, !0}
-    !23 = distinct !DISubprogram(name: "parent", linkageName: "parent", scope: !2, file: !2, line: 2, type: !24, scopeLine: 6, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !21, retainedNodes: !26)
-    !24 = !DISubroutineType(flags: DIFlagPublic, types: !25)
-    !25 = !{null, !9}
-    !26 = !{}
-    !27 = !DILocalVariable(name: "parent", scope: !23, file: !2, line: 6, type: !9)
-    !28 = !DILocation(line: 6, scope: !23)
-    !29 = distinct !DISubprogram(name: "child", linkageName: "child", scope: !2, file: !2, line: 8, type: !30, scopeLine: 12, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !21, retainedNodes: !26)
-    !30 = !DISubroutineType(flags: DIFlagPublic, types: !31)
-    !31 = !{null, !6}
-    !32 = !DILocalVariable(name: "child", scope: !29, file: !2, line: 12, type: !6)
-    !33 = !DILocation(line: 12, scope: !29)
-    !34 = distinct !DISubprogram(name: "grandchild", linkageName: "grandchild", scope: !2, file: !2, line: 14, type: !35, scopeLine: 18, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !21, retainedNodes: !26)
-    !35 = !DISubroutineType(flags: DIFlagPublic, types: !36)
-    !36 = !{null, !3}
-    !37 = !DILocalVariable(name: "grandchild", scope: !34, file: !2, line: 18, type: !3)
-    !38 = !DILocation(line: 18, scope: !34)
-    !39 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 20, type: !40, scopeLine: 20, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !21, retainedNodes: !26)
-    !40 = !DISubroutineType(flags: DIFlagPublic, types: !41)
-    !41 = !{null}
-    !42 = !DILocalVariable(name: "array_of_parent", scope: !39, file: !2, line: 22, type: !43, align: 64)
-    !43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !9, size: 96, align: 64, elements: !44)
-    !44 = !{!45}
-    !45 = !DISubrange(count: 3, lowerBound: 0)
-    !46 = !DILocation(line: 22, column: 4, scope: !39)
-    !47 = !DILocalVariable(name: "array_of_child", scope: !39, file: !2, line: 23, type: !48, align: 64)
-    !48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !6, size: 192, align: 64, elements: !44)
-    !49 = !DILocation(line: 23, column: 4, scope: !39)
-    !50 = !DILocalVariable(name: "array_of_grandchild", scope: !39, file: !2, line: 24, type: !51, align: 64)
-    !51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !3, size: 288, align: 64, elements: !44)
-    !52 = !DILocation(line: 24, column: 4, scope: !39)
-    !53 = !DILocalVariable(name: "parent1", scope: !39, file: !2, line: 25, type: !9, align: 64)
-    !54 = !DILocation(line: 25, column: 4, scope: !39)
-    !55 = !DILocalVariable(name: "child1", scope: !39, file: !2, line: 26, type: !6, align: 64)
-    !56 = !DILocation(line: 26, column: 4, scope: !39)
-    !57 = !DILocalVariable(name: "grandchild1", scope: !39, file: !2, line: 27, type: !3, align: 64)
-    !58 = !DILocation(line: 27, column: 4, scope: !39)
-    !59 = !DILocalVariable(name: "main", scope: !39, file: !2, line: 20, type: !12, align: 32)
-    !60 = !DILocation(line: 20, column: 9, scope: !39)
-    !61 = !DILocation(line: 0, scope: !39)
-    !62 = !DILocation(line: 30, column: 4, scope: !39)
-    !63 = !DILocation(line: 31, column: 4, scope: !39)
-    !64 = !DILocation(line: 32, column: 4, scope: !39)
-    !65 = !DILocation(line: 33, column: 4, scope: !39)
-    !66 = !DILocation(line: 34, column: 4, scope: !39)
-    !67 = !DILocation(line: 35, column: 4, scope: !39)
-    !68 = !DILocation(line: 37, column: 4, scope: !39)
-    !69 = !DILocation(line: 38, column: 4, scope: !39)
-    !70 = !DILocation(line: 39, column: 4, scope: !39)
-    !71 = !DILocation(line: 40, column: 4, scope: !39)
-    !72 = !DILocation(line: 41, column: 4, scope: !39)
-    !73 = !DILocation(line: 42, column: 4, scope: !39)
-    !74 = !DILocation(line: 43, column: 4, scope: !39)
-    !75 = !DILocation(line: 44, column: 4, scope: !39)
-    !76 = !DILocation(line: 45, column: 4, scope: !39)
-    !77 = !DILocation(line: 46, column: 4, scope: !39)
-    !78 = !DILocation(line: 47, column: 4, scope: !39)
-    !79 = !DILocation(line: 48, column: 4, scope: !39)
-    !80 = !DILocation(line: 49, column: 4, scope: !39)
-    !81 = !DILocation(line: 50, column: 4, scope: !39)
-    !82 = !DILocation(line: 51, column: 4, scope: !39)
-    !83 = !DILocation(line: 52, column: 4, scope: !39)
-    !84 = !DILocation(line: 53, column: 4, scope: !39)
-    !85 = !DILocation(line: 54, column: 4, scope: !39)
-    !86 = !DILocation(line: 56, scope: !39)
-    "#);
+    !3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+    !4 = !DICompositeType(tag: DW_TAG_structure_type, name: "grandchild", scope: !2, file: !2, line: 14, size: 96, align: 64, flags: DIFlagPublic, elements: !5, identifier: "grandchild")
+    !5 = !{!6, !15}
+    !6 = !DIDerivedType(tag: DW_TAG_member, name: "__child", scope: !2, file: !2, baseType: !7, size: 64, align: 64, flags: DIFlagPublic)
+    !7 = !DICompositeType(tag: DW_TAG_structure_type, name: "child", scope: !2, file: !2, line: 8, size: 64, align: 64, flags: DIFlagPublic, elements: !8, identifier: "child")
+    !8 = !{!9, !14}
+    !9 = !DIDerivedType(tag: DW_TAG_member, name: "__parent", scope: !2, file: !2, baseType: !10, size: 32, align: 64, flags: DIFlagPublic)
+    !10 = !DICompositeType(tag: DW_TAG_structure_type, name: "parent", scope: !2, file: !2, line: 2, size: 32, align: 64, flags: DIFlagPublic, elements: !11, identifier: "parent")
+    !11 = !{!12}
+    !12 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 4, baseType: !13, size: 32, align: 32, flags: DIFlagPublic)
+    !13 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+    !14 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 10, baseType: !13, size: 32, align: 32, offset: 32, flags: DIFlagPublic)
+    !15 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !2, file: !2, line: 16, baseType: !13, size: 32, align: 32, offset: 64, flags: DIFlagPublic)
+    !16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+    !17 = distinct !DIGlobalVariable(name: "__child__init", scope: !2, file: !2, line: 8, type: !18, isLocal: false, isDefinition: true)
+    !18 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+    !19 = !DIGlobalVariableExpression(var: !20, expr: !DIExpression())
+    !20 = distinct !DIGlobalVariable(name: "__parent__init", scope: !2, file: !2, line: 2, type: !21, isLocal: false, isDefinition: true)
+    !21 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !10)
+    !22 = !{i32 2, !"Dwarf Version", i32 5}
+    !23 = !{i32 2, !"Debug Info Version", i32 3}
+    !24 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !25, splitDebugInlining: false)
+    !25 = !{!19, !16, !0}
+    !26 = distinct !DISubprogram(name: "parent", linkageName: "parent", scope: !2, file: !2, line: 2, type: !27, scopeLine: 6, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !24, retainedNodes: !29)
+    !27 = !DISubroutineType(flags: DIFlagPublic, types: !28)
+    !28 = !{null, !10}
+    !29 = !{}
+    !30 = !DILocalVariable(name: "parent", scope: !26, file: !2, line: 6, type: !10)
+    !31 = !DILocation(line: 6, scope: !26)
+    !32 = distinct !DISubprogram(name: "child", linkageName: "child", scope: !2, file: !2, line: 8, type: !33, scopeLine: 12, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !24, retainedNodes: !29)
+    !33 = !DISubroutineType(flags: DIFlagPublic, types: !34)
+    !34 = !{null, !7}
+    !35 = !DILocalVariable(name: "child", scope: !32, file: !2, line: 12, type: !7)
+    !36 = !DILocation(line: 12, scope: !32)
+    !37 = distinct !DISubprogram(name: "grandchild", linkageName: "grandchild", scope: !2, file: !2, line: 14, type: !38, scopeLine: 18, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !24, retainedNodes: !29)
+    !38 = !DISubroutineType(flags: DIFlagPublic, types: !39)
+    !39 = !{null, !4}
+    !40 = !DILocalVariable(name: "grandchild", scope: !37, file: !2, line: 18, type: !4)
+    !41 = !DILocation(line: 18, scope: !37)
+    !42 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !2, file: !2, line: 20, type: !43, scopeLine: 20, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !24, retainedNodes: !29)
+    !43 = !DISubroutineType(flags: DIFlagPublic, types: !44)
+    !44 = !{null}
+    !45 = !DILocalVariable(name: "array_of_parent", scope: !42, file: !2, line: 22, type: !46, align: 64)
+    !46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !10, size: 96, align: 64, elements: !47)
+    !47 = !{!48}
+    !48 = !DISubrange(count: 3, lowerBound: 0)
+    !49 = !DILocation(line: 22, column: 4, scope: !42)
+    !50 = !DILocalVariable(name: "array_of_child", scope: !42, file: !2, line: 23, type: !51, align: 64)
+    !51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !7, size: 192, align: 64, elements: !47)
+    !52 = !DILocation(line: 23, column: 4, scope: !42)
+    !53 = !DILocalVariable(name: "array_of_grandchild", scope: !42, file: !2, line: 24, type: !54, align: 64)
+    !54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 288, align: 64, elements: !47)
+    !55 = !DILocation(line: 24, column: 4, scope: !42)
+    !56 = !DILocalVariable(name: "parent1", scope: !42, file: !2, line: 25, type: !10, align: 64)
+    !57 = !DILocation(line: 25, column: 4, scope: !42)
+    !58 = !DILocalVariable(name: "child1", scope: !42, file: !2, line: 26, type: !7, align: 64)
+    !59 = !DILocation(line: 26, column: 4, scope: !42)
+    !60 = !DILocalVariable(name: "grandchild1", scope: !42, file: !2, line: 27, type: !4, align: 64)
+    !61 = !DILocation(line: 27, column: 4, scope: !42)
+    !62 = !DILocalVariable(name: "main", scope: !42, file: !2, line: 20, type: !13, align: 32)
+    !63 = !DILocation(line: 20, column: 9, scope: !42)
+    !64 = !DILocation(line: 0, scope: !42)
+    !65 = !DILocation(line: 30, column: 4, scope: !42)
+    !66 = !DILocation(line: 31, column: 4, scope: !42)
+    !67 = !DILocation(line: 32, column: 4, scope: !42)
+    !68 = !DILocation(line: 33, column: 4, scope: !42)
+    !69 = !DILocation(line: 34, column: 4, scope: !42)
+    !70 = !DILocation(line: 35, column: 4, scope: !42)
+    !71 = !DILocation(line: 37, column: 4, scope: !42)
+    !72 = !DILocation(line: 38, column: 4, scope: !42)
+    !73 = !DILocation(line: 39, column: 4, scope: !42)
+    !74 = !DILocation(line: 40, column: 4, scope: !42)
+    !75 = !DILocation(line: 41, column: 4, scope: !42)
+    !76 = !DILocation(line: 42, column: 4, scope: !42)
+    !77 = !DILocation(line: 43, column: 4, scope: !42)
+    !78 = !DILocation(line: 44, column: 4, scope: !42)
+    !79 = !DILocation(line: 45, column: 4, scope: !42)
+    !80 = !DILocation(line: 46, column: 4, scope: !42)
+    !81 = !DILocation(line: 47, column: 4, scope: !42)
+    !82 = !DILocation(line: 48, column: 4, scope: !42)
+    !83 = !DILocation(line: 49, column: 4, scope: !42)
+    !84 = !DILocation(line: 50, column: 4, scope: !42)
+    !85 = !DILocation(line: 51, column: 4, scope: !42)
+    !86 = !DILocation(line: 52, column: 4, scope: !42)
+    !87 = !DILocation(line: 53, column: 4, scope: !42)
+    !88 = !DILocation(line: 54, column: 4, scope: !42)
+    !89 = !DILocation(line: 56, scope: !42)
+    "###);
 }

--- a/src/codegen/tests/oop_tests/super_tests.rs
+++ b/src/codegen/tests/oop_tests/super_tests.rs
@@ -17,7 +17,7 @@ fn super_keyword_basic_access() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -26,8 +26,8 @@ fn super_keyword_basic_access() {
     %parent = type { i16 }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 10 }
-    @__child__init = constant %child { %parent { i16 10 } }
+    @__parent__init = unnamed_addr constant %parent { i16 10 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 10 } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -86,7 +86,7 @@ fn super_keyword_basic_access() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -108,7 +108,7 @@ fn super_without_deref() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -117,8 +117,8 @@ fn super_without_deref() {
     %parent = type { i16 }
     %child = type { %parent, %parent* }
 
-    @__parent__init = constant %parent { i16 10 }
-    @__child__init = constant %child { %parent { i16 10 }, %parent* null }
+    @__parent__init = unnamed_addr constant %parent { i16 10 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 10 }, %parent* null }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -177,7 +177,7 @@ fn super_without_deref() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -206,7 +206,7 @@ fn super_in_method_calls() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -215,8 +215,8 @@ fn super_in_method_calls() {
     %parent = type { i16 }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 10 }
-    @__child__init = constant %child { %parent { i16 10 } }
+    @__parent__init = unnamed_addr constant %parent { i16 10 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 10 } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -319,7 +319,7 @@ fn super_in_method_calls() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -342,7 +342,7 @@ fn super_in_complex_expressions() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -351,8 +351,8 @@ fn super_in_complex_expressions() {
     %parent = type { i16, i16 }
     %child = type { %parent, i16 }
 
-    @__parent__init = constant %parent { i16 10, i16 20 }
-    @__child__init = constant %child { %parent { i16 10, i16 20 }, i16 30 }
+    @__parent__init = unnamed_addr constant %parent { i16 10, i16 20 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 10, i16 20 }, i16 30 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -421,7 +421,7 @@ fn super_in_complex_expressions() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -443,7 +443,7 @@ fn super_with_array_access() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -453,8 +453,8 @@ fn super_with_array_access() {
     %child = type { %parent, i16 }
 
     @__parent.arr__init = unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
-    @__parent__init = constant %parent { [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] }
-    @__child__init = constant %child { %parent { [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] }, i16 3 }
+    @__parent__init = unnamed_addr constant %parent { [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] }
+    @__child__init = unnamed_addr constant %child { %parent { [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] }, i16 3 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -519,7 +519,7 @@ fn super_with_array_access() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -558,7 +558,7 @@ fn super_in_multi_level_inheritance() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -568,9 +568,9 @@ fn super_in_multi_level_inheritance() {
     %grandparent = type { i16 }
     %child = type { %parent, i16 }
 
-    @__parent__init = constant %parent { %grandparent { i16 10 }, i16 20 }
-    @__grandparent__init = constant %grandparent { i16 10 }
-    @__child__init = constant %child { %parent { %grandparent { i16 10 }, i16 20 }, i16 30 }
+    @__parent__init = unnamed_addr constant %parent { %grandparent { i16 10 }, i16 20 }
+    @__grandparent__init = unnamed_addr constant %grandparent { i16 10 }
+    @__child__init = unnamed_addr constant %child { %parent { %grandparent { i16 10 }, i16 20 }, i16 30 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @grandparent(%grandparent* %0) {
@@ -703,7 +703,7 @@ fn super_in_multi_level_inheritance() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -725,7 +725,7 @@ fn super_with_pointer_operations() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -734,8 +734,8 @@ fn super_with_pointer_operations() {
     %parent = type { i16, i16* }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 10, i16* null }
-    @__child__init = constant %child { %parent { i16 10, i16* null } }
+    @__parent__init = unnamed_addr constant %parent { i16 10, i16* null }
+    @__child__init = unnamed_addr constant %child { %parent { i16 10, i16* null } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -804,7 +804,7 @@ fn super_with_pointer_operations() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -836,7 +836,7 @@ fn super_in_conditionals() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -845,8 +845,8 @@ fn super_in_conditionals() {
     %parent = type { i16, i16 }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 50, i16 10 }
-    @__child__init = constant %child { %parent { i16 50, i16 10 } }
+    @__parent__init = unnamed_addr constant %parent { i16 50, i16 10 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 50, i16 10 } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -955,7 +955,7 @@ fn super_in_conditionals() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -977,7 +977,7 @@ fn super_with_const_variables() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -986,8 +986,8 @@ fn super_with_const_variables() {
     %parent = type { i16, i16 }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 100, i16 50 }
-    @__child__init = constant %child { %parent { i16 100, i16 50 } }
+    @__parent__init = unnamed_addr constant %parent { i16 100, i16 50 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 100, i16 50 } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -1047,7 +1047,7 @@ fn super_with_const_variables() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1083,7 +1083,7 @@ fn super_as_function_parameter() {
         END_FUNCTION
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1092,8 +1092,8 @@ fn super_as_function_parameter() {
     %parent = type { i16 }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 10 }
-    @__child__init = constant %child { %parent { i16 10 } }
+    @__parent__init = unnamed_addr constant %parent { i16 10 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 10 } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -1192,7 +1192,7 @@ fn super_as_function_parameter() {
     }
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1219,7 +1219,7 @@ fn super_with_deeply_nested_expressions() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1228,8 +1228,8 @@ fn super_with_deeply_nested_expressions() {
     %parent = type { i16, i16, i16 }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 1, i16 2, i16 3 }
-    @__child__init = constant %child { %parent { i16 1, i16 2, i16 3 } }
+    @__parent__init = unnamed_addr constant %parent { i16 1, i16 2, i16 3 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 1, i16 2, i16 3 } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -1343,7 +1343,7 @@ fn super_with_deeply_nested_expressions() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1388,7 +1388,7 @@ fn super_in_loop_constructs() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1398,8 +1398,8 @@ fn super_in_loop_constructs() {
     %child = type { %parent }
 
     @__parent.arr__init = unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
-    @__parent__init = constant %parent { i16 0, [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] }
-    @__child__init = constant %child { %parent { i16 0, [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] } }
+    @__parent__init = unnamed_addr constant %parent { i16 0, [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] }
+    @__child__init = unnamed_addr constant %child { %parent { i16 0, [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6] } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -1581,7 +1581,7 @@ fn super_in_loop_constructs() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1609,7 +1609,7 @@ fn super_with_method_overrides_in_three_levels() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1619,9 +1619,9 @@ fn super_with_method_overrides_in_three_levels() {
     %grandparent = type {}
     %child = type { %parent }
 
-    @__parent__init = constant %parent zeroinitializer
-    @__grandparent__init = constant %grandparent zeroinitializer
-    @__child__init = constant %child zeroinitializer
+    @__parent__init = unnamed_addr constant %parent zeroinitializer
+    @__grandparent__init = unnamed_addr constant %grandparent zeroinitializer
+    @__child__init = unnamed_addr constant %child zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @grandparent(%grandparent* %0) {
@@ -1748,7 +1748,7 @@ fn super_with_method_overrides_in_three_levels() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1830,7 +1830,7 @@ fn super_with_structured_types() {
         END_FUNCTION_BLOCK
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -1842,9 +1842,9 @@ fn super_with_structured_types() {
 
     @__parent.data__init = unnamed_addr constant %Complex_Type { i16 10, i16 20, float 3.050000e+01 }
     @__parent.arr_data__init = unnamed_addr constant [2 x %Complex_Type] [%Complex_Type { i16 1, i16 2, float 3.500000e+00 }, %Complex_Type { i16 4, i16 5, float 6.500000e+00 }]
-    @__Complex_Type__init = constant %Complex_Type zeroinitializer
-    @__parent__init = constant %parent { %Complex_Type { i16 10, i16 20, float 3.050000e+01 }, [2 x %Complex_Type] [%Complex_Type { i16 1, i16 2, float 3.500000e+00 }, %Complex_Type { i16 4, i16 5, float 6.500000e+00 }] }
-    @__child__init = constant %child { %parent { %Complex_Type { i16 10, i16 20, float 3.050000e+01 }, [2 x %Complex_Type] [%Complex_Type { i16 1, i16 2, float 3.500000e+00 }, %Complex_Type { i16 4, i16 5, float 6.500000e+00 }] } }
+    @__Complex_Type__init = unnamed_addr constant %Complex_Type zeroinitializer
+    @__parent__init = unnamed_addr constant %parent { %Complex_Type { i16 10, i16 20, float 3.050000e+01 }, [2 x %Complex_Type] [%Complex_Type { i16 1, i16 2, float 3.500000e+00 }, %Complex_Type { i16 4, i16 5, float 6.500000e+00 }] }
+    @__child__init = unnamed_addr constant %child { %parent { %Complex_Type { i16 10, i16 20, float 3.050000e+01 }, [2 x %Complex_Type] [%Complex_Type { i16 1, i16 2, float 3.500000e+00 }, %Complex_Type { i16 4, i16 5, float 6.500000e+00 }] } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -1970,7 +1970,7 @@ fn super_with_structured_types() {
     }
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
-    "#);
+    "###);
 }
 
 #[test]
@@ -1997,7 +1997,7 @@ fn super_in_action_blocks() {
         END_ACTION
         "#,
     );
-    filtered_assert_snapshot!(result, @r#"
+    filtered_assert_snapshot!(result, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -2006,8 +2006,8 @@ fn super_in_action_blocks() {
     %parent = type { i16 }
     %child = type { %parent }
 
-    @__parent__init = constant %parent { i16 10 }
-    @__child__init = constant %child { %parent { i16 10 } }
+    @__parent__init = unnamed_addr constant %parent { i16 10 }
+    @__child__init = unnamed_addr constant %child { %parent { i16 10 } }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @parent(%parent* %0) {
@@ -2093,5 +2093,5 @@ fn super_in_action_blocks() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_enum_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_enum_added_to_debug_info.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/debug_tests.rs
 expression: codegen
-snapshot_kind: text
 ---
 ; ModuleID = '<internal>'
 source_filename = "<internal>"
@@ -10,17 +9,17 @@ target triple = "[filtered]"
 
 @en3 = global i64 0, !dbg !0
 @en1.a = unnamed_addr constant i32 0, !dbg !5
-@en1.b = unnamed_addr constant i32 1, !dbg !9
-@en1.c = unnamed_addr constant i32 2, !dbg !11
-@en2.d = unnamed_addr constant i8 0, !dbg !13
-@en2.e = unnamed_addr constant i8 1, !dbg !17
-@en2.f = unnamed_addr constant i8 2, !dbg !19
-@__global_en3.a = unnamed_addr constant i64 0, !dbg !21
-@__global_en3.b = unnamed_addr constant i64 1, !dbg !23
-@__global_en3.c = unnamed_addr constant i64 2, !dbg !25
+@en1.b = unnamed_addr constant i32 1, !dbg !10
+@en1.c = unnamed_addr constant i32 2, !dbg !12
+@en2.d = unnamed_addr constant i8 0, !dbg !14
+@en2.e = unnamed_addr constant i8 1, !dbg !19
+@en2.f = unnamed_addr constant i8 2, !dbg !21
+@__global_en3.a = unnamed_addr constant i64 0, !dbg !23
+@__global_en3.b = unnamed_addr constant i64 1, !dbg !26
+@__global_en3.c = unnamed_addr constant i64 2, !dbg !28
 
-!llvm.module.flags = !{!27, !28}
-!llvm.dbg.cu = !{!29}
+!llvm.module.flags = !{!30, !31}
+!llvm.dbg.cu = !{!32}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "en3", scope: !2, file: !2, line: 5, type: !3, isLocal: false, isDefinition: true)
@@ -29,27 +28,30 @@ target triple = "[filtered]"
 !4 = !DIBasicType(name: "LINT", size: 64, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression())
 !6 = distinct !DIGlobalVariable(name: "en1.a", scope: !2, file: !2, line: 2, type: !7, isLocal: false, isDefinition: true)
-!7 = !DIDerivedType(tag: DW_TAG_typedef, name: "en1", scope: !2, file: !2, line: 2, baseType: !8, align: 32)
-!8 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-!9 = !DIGlobalVariableExpression(var: !10, expr: !DIExpression())
-!10 = distinct !DIGlobalVariable(name: "en1.b", scope: !2, file: !2, line: 2, type: !7, isLocal: false, isDefinition: true)
-!11 = !DIGlobalVariableExpression(var: !12, expr: !DIExpression())
-!12 = distinct !DIGlobalVariable(name: "en1.c", scope: !2, file: !2, line: 2, type: !7, isLocal: false, isDefinition: true)
-!13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
-!14 = distinct !DIGlobalVariable(name: "en2.d", scope: !2, file: !2, line: 3, type: !15, isLocal: false, isDefinition: true)
-!15 = !DIDerivedType(tag: DW_TAG_typedef, name: "en2", scope: !2, file: !2, line: 3, baseType: !16, align: 8)
-!16 = !DIBasicType(name: "BYTE", size: 8, encoding: DW_ATE_unsigned, flags: DIFlagPublic)
-!17 = !DIGlobalVariableExpression(var: !18, expr: !DIExpression())
-!18 = distinct !DIGlobalVariable(name: "en2.e", scope: !2, file: !2, line: 3, type: !15, isLocal: false, isDefinition: true)
+!7 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !8)
+!8 = !DIDerivedType(tag: DW_TAG_typedef, name: "en1", scope: !2, file: !2, line: 2, baseType: !9, align: 32)
+!9 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+!10 = !DIGlobalVariableExpression(var: !11, expr: !DIExpression())
+!11 = distinct !DIGlobalVariable(name: "en1.b", scope: !2, file: !2, line: 2, type: !7, isLocal: false, isDefinition: true)
+!12 = !DIGlobalVariableExpression(var: !13, expr: !DIExpression())
+!13 = distinct !DIGlobalVariable(name: "en1.c", scope: !2, file: !2, line: 2, type: !7, isLocal: false, isDefinition: true)
+!14 = !DIGlobalVariableExpression(var: !15, expr: !DIExpression())
+!15 = distinct !DIGlobalVariable(name: "en2.d", scope: !2, file: !2, line: 3, type: !16, isLocal: false, isDefinition: true)
+!16 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !17)
+!17 = !DIDerivedType(tag: DW_TAG_typedef, name: "en2", scope: !2, file: !2, line: 3, baseType: !18, align: 8)
+!18 = !DIBasicType(name: "BYTE", size: 8, encoding: DW_ATE_unsigned, flags: DIFlagPublic)
 !19 = !DIGlobalVariableExpression(var: !20, expr: !DIExpression())
-!20 = distinct !DIGlobalVariable(name: "en2.f", scope: !2, file: !2, line: 3, type: !15, isLocal: false, isDefinition: true)
+!20 = distinct !DIGlobalVariable(name: "en2.e", scope: !2, file: !2, line: 3, type: !16, isLocal: false, isDefinition: true)
 !21 = !DIGlobalVariableExpression(var: !22, expr: !DIExpression())
-!22 = distinct !DIGlobalVariable(name: "__global_en3.a", scope: !2, file: !2, line: 5, type: !3, isLocal: false, isDefinition: true)
+!22 = distinct !DIGlobalVariable(name: "en2.f", scope: !2, file: !2, line: 3, type: !16, isLocal: false, isDefinition: true)
 !23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
-!24 = distinct !DIGlobalVariable(name: "__global_en3.b", scope: !2, file: !2, line: 5, type: !3, isLocal: false, isDefinition: true)
-!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
-!26 = distinct !DIGlobalVariable(name: "__global_en3.c", scope: !2, file: !2, line: 5, type: !3, isLocal: false, isDefinition: true)
-!27 = !{i32 2, !"Dwarf Version", i32 5}
-!28 = !{i32 2, !"Debug Info Version", i32 3}
-!29 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !30, splitDebugInlining: false)
-!30 = !{!0, !5, !9, !11, !13, !17, !19, !21, !23, !25}
+!24 = distinct !DIGlobalVariable(name: "__global_en3.a", scope: !2, file: !2, line: 5, type: !25, isLocal: false, isDefinition: true)
+!25 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !3)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "__global_en3.b", scope: !2, file: !2, line: 5, type: !25, isLocal: false, isDefinition: true)
+!28 = !DIGlobalVariableExpression(var: !29, expr: !DIExpression())
+!29 = distinct !DIGlobalVariable(name: "__global_en3.c", scope: !2, file: !2, line: 5, type: !25, isLocal: false, isDefinition: true)
+!30 = !{i32 2, !"Dwarf Version", i32 5}
+!31 = !{i32 2, !"Debug Info Version", i32 3}
+!32 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !33, splitDebugInlining: false)
+!33 = !{!0, !5, !10, !12, !14, !19, !21, !23, !26, !28}

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_nested_struct_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_nested_struct_added_to_debug_info.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/debug_tests.rs
 expression: codegen
-snapshot_kind: text
 ---
 ; ModuleID = '<internal>'
 source_filename = "<internal>"
@@ -12,9 +11,9 @@ target triple = "[filtered]"
 %myStruct2 = type { i32, double }
 
 @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
-@__myStruct__init = constant %myStruct zeroinitializer, !dbg !0
-@__myStruct2__init = constant %myStruct2 zeroinitializer, !dbg !13
-@gStruct = global %myStruct zeroinitializer, !dbg !15
+@__myStruct__init = unnamed_addr constant %myStruct zeroinitializer, !dbg !0
+@__myStruct2__init = unnamed_addr constant %myStruct2 zeroinitializer, !dbg !14
+@gStruct = global %myStruct zeroinitializer, !dbg !17
 
 define void @__init_mystruct(%myStruct* %0) {
 entry:
@@ -57,27 +56,29 @@ entry:
   ret void
 }
 
-!llvm.module.flags = !{!17, !18}
-!llvm.dbg.cu = !{!19}
+!llvm.module.flags = !{!19, !20}
+!llvm.dbg.cu = !{!21}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "__myStruct__init", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
 !2 = !DIFile(filename: "<internal>", directory: "")
-!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "myStruct", scope: !2, file: !2, line: 2, size: 192, align: 64, flags: DIFlagPublic, elements: !4, identifier: "myStruct")
-!4 = !{!5, !7}
-!5 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 3, baseType: !6, size: 32, align: 32, flags: DIFlagPublic)
-!6 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-!7 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 4, baseType: !8, size: 128, align: 64, offset: 64, flags: DIFlagPublic)
-!8 = !DICompositeType(tag: DW_TAG_structure_type, name: "myStruct2", scope: !2, file: !2, line: 8, size: 128, align: 64, flags: DIFlagPublic, elements: !9, identifier: "myStruct2")
-!9 = !{!10, !11}
-!10 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 9, baseType: !6, size: 32, align: 32, flags: DIFlagPublic)
-!11 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 10, baseType: !12, size: 64, align: 64, offset: 64, flags: DIFlagPublic)
-!12 = !DIBasicType(name: "LREAL", size: 64, encoding: DW_ATE_float, flags: DIFlagPublic)
-!13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
-!14 = distinct !DIGlobalVariable(name: "__myStruct2__init", scope: !2, file: !2, line: 8, type: !8, isLocal: false, isDefinition: true)
-!15 = !DIGlobalVariableExpression(var: !16, expr: !DIExpression())
-!16 = distinct !DIGlobalVariable(name: "gStruct", scope: !2, file: !2, line: 15, type: !3, isLocal: false, isDefinition: true)
-!17 = !{i32 2, !"Dwarf Version", i32 5}
-!18 = !{i32 2, !"Debug Info Version", i32 3}
-!19 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !20, splitDebugInlining: false)
-!20 = !{!15, !0, !13}
+!3 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+!4 = !DICompositeType(tag: DW_TAG_structure_type, name: "myStruct", scope: !2, file: !2, line: 2, size: 192, align: 64, flags: DIFlagPublic, elements: !5, identifier: "myStruct")
+!5 = !{!6, !8}
+!6 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 3, baseType: !7, size: 32, align: 32, flags: DIFlagPublic)
+!7 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+!8 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 4, baseType: !9, size: 128, align: 64, offset: 64, flags: DIFlagPublic)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, name: "myStruct2", scope: !2, file: !2, line: 8, size: 128, align: 64, flags: DIFlagPublic, elements: !10, identifier: "myStruct2")
+!10 = !{!11, !12}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !2, file: !2, line: 9, baseType: !7, size: 32, align: 32, flags: DIFlagPublic)
+!12 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !2, file: !2, line: 10, baseType: !13, size: 64, align: 64, offset: 64, flags: DIFlagPublic)
+!13 = !DIBasicType(name: "LREAL", size: 64, encoding: DW_ATE_float, flags: DIFlagPublic)
+!14 = !DIGlobalVariableExpression(var: !15, expr: !DIExpression())
+!15 = distinct !DIGlobalVariable(name: "__myStruct2__init", scope: !2, file: !2, line: 8, type: !16, isLocal: false, isDefinition: true)
+!16 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !9)
+!17 = !DIGlobalVariableExpression(var: !18, expr: !DIExpression())
+!18 = distinct !DIGlobalVariable(name: "gStruct", scope: !2, file: !2, line: 15, type: !4, isLocal: false, isDefinition: true)
+!19 = !{i32 2, !"Dwarf Version", i32 5}
+!20 = !{i32 2, !"Debug Info Version", i32 3}
+!21 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !22, splitDebugInlining: false)
+!22 = !{!17, !0, !14}

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/debug_tests.rs
 expression: codegen
-snapshot_kind: text
 ---
 ; ModuleID = '<internal>'
 source_filename = "<internal>"
@@ -12,8 +11,8 @@ target triple = "[filtered]"
 
 @b = global [11 x %myStruct] zeroinitializer, !dbg !0
 @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
-@__myStruct__init = constant %myStruct zeroinitializer, !dbg !14
-@gStruct = global %myStruct zeroinitializer, !dbg !16
+@__myStruct__init = unnamed_addr constant %myStruct zeroinitializer, !dbg !14
+@gStruct = global %myStruct zeroinitializer, !dbg !17
 
 define void @__init_mystruct(%myStruct* %0) {
 entry:
@@ -36,8 +35,8 @@ entry:
   ret void
 }
 
-!llvm.module.flags = !{!18, !19}
-!llvm.dbg.cu = !{!20}
+!llvm.module.flags = !{!19, !20}
+!llvm.dbg.cu = !{!21}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "b", scope: !2, file: !2, line: 12, type: !3, isLocal: false, isDefinition: true)
@@ -54,10 +53,11 @@ entry:
 !12 = !{!13}
 !13 = !DISubrange(count: 11, lowerBound: 0)
 !14 = !DIGlobalVariableExpression(var: !15, expr: !DIExpression())
-!15 = distinct !DIGlobalVariable(name: "__myStruct__init", scope: !2, file: !2, line: 2, type: !4, isLocal: false, isDefinition: true)
-!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
-!17 = distinct !DIGlobalVariable(name: "gStruct", scope: !2, file: !2, line: 11, type: !4, isLocal: false, isDefinition: true)
-!18 = !{i32 2, !"Dwarf Version", i32 5}
-!19 = !{i32 2, !"Debug Info Version", i32 3}
-!20 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !21, splitDebugInlining: false)
-!21 = !{!16, !14, !0}
+!15 = distinct !DIGlobalVariable(name: "__myStruct__init", scope: !2, file: !2, line: 2, type: !16, isLocal: false, isDefinition: true)
+!16 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !4)
+!17 = !DIGlobalVariableExpression(var: !18, expr: !DIExpression())
+!18 = distinct !DIGlobalVariable(name: "gStruct", scope: !2, file: !2, line: 11, type: !4, isLocal: false, isDefinition: true)
+!19 = !{i32 2, !"Dwarf Version", i32 5}
+!20 = !{i32 2, !"Debug Info Version", i32 3}
+!21 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !22, splitDebugInlining: false)
+!22 = !{!17, !14, !0}

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_in_module.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__datatype_defined_in_external_file_in_module.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/multifile_codegen_tests.rs
 expression: "codegen_multi(units, crate::DebugLevel::None).join(\"\\n\")"
-snapshot_kind: text
 ---
 ; ModuleID = 'myStruct.st'
 source_filename = "myStruct.st"
@@ -21,7 +20,7 @@ target triple = "[filtered]"
 %myStruct.1 = type { i32, i16* }
 
 @prog_instance = global %prog zeroinitializer
-@__myStruct__init = external global %myStruct.1
+@__myStruct__init = external unnamed_addr constant %myStruct.1
 
 define void @prog(%prog* %0) {
 entry:

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__enum_referenced_in_fb_nested.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__enum_referenced_in_fb_nested.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/multifile_codegen_tests.rs
 expression: "codegen_multi(units, crate::DebugLevel::None).join(\"\\n\")"
-snapshot_kind: text
 ---
 ; ModuleID = 'myEnum.st'
 source_filename = "myEnum.st"
@@ -38,7 +37,7 @@ target triple = "[filtered]"
 %fb.2 = type { i32 }
 
 @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
-@__fb__init = external global %fb.2
+@__fb__init = external unnamed_addr constant %fb.2
 
 declare void @fb(%fb.2*)
 
@@ -52,8 +51,8 @@ target triple = "[filtered]"
 %fb.5 = type { i32 }
 
 @__fb2__init = unnamed_addr constant %fb2 zeroinitializer
-@__myStruct__init = external global %myStruct.4
-@__fb__init = external global %fb.5
+@__myStruct__init = external unnamed_addr constant %myStruct.4
+@__fb__init = external unnamed_addr constant %fb.5
 
 define void @fb2(%fb2* %0) {
 entry:

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__function_defined_in_external_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__function_defined_in_external_file.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/multifile_codegen_tests.rs
 expression: "codegen_multi(units, crate::DebugLevel::None).join(\"\\n\")"
-snapshot_kind: text
 ---
 ; ModuleID = 'func.st'
 source_filename = "func.st"
@@ -73,7 +72,7 @@ target triple = "[filtered]"
 %prg2.6 = type { i32 }
 
 @prog_instance = global %prog zeroinitializer
-@__fb__init = external global %fb.4
+@__fb__init = external unnamed_addr constant %fb.4
 @prg_instance = external global %prg.5
 @prg2_instance = external global %prg2.6
 

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__global_value_from_different_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__global_value_from_different_file.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/multifile_codegen_tests.rs
 expression: "codegen_multi(units, crate::DebugLevel::None).join(\"\\n\")"
-snapshot_kind: text
 ---
 ; ModuleID = 'g1.st'
 source_filename = "g1.st"
@@ -9,9 +8,9 @@ target datalayout = "[filtered]"
 target triple = "[filtered]"
 
 @x = global i32 6
-@d = external global i32
+@d = external unnamed_addr constant i32
 @y = global i32 7
-@e = external global i32
+@e = external unnamed_addr constant i32
 
 ; ModuleID = 'g2.st'
 source_filename = "g2.st"
@@ -30,7 +29,7 @@ target triple = "[filtered]"
 %prog = type {}
 
 @prog_instance = global %prog zeroinitializer
-@c = external global i32
+@c = external unnamed_addr constant i32
 @x = external global i32
 
 define void @prog(%prog* %0) {

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__struct_with_custom_init_in_different_file.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__multifile_codegen_tests__struct_with_custom_init_in_different_file.snap
@@ -1,7 +1,6 @@
 ---
 source: src/codegen/tests/multifile_codegen_tests.rs
 expression: "codegen_multi(units, crate::DebugLevel::None).join(\"\\n\")"
-snapshot_kind: text
 ---
 ; ModuleID = 'myStruct.st'
 source_filename = "myStruct.st"
@@ -31,8 +30,8 @@ target triple = "[filtered]"
 %myStruct2.3 = type { i32, i16 }
 
 @prog_instance = global %prog { %myStruct.2 { i32 5, i16 2 }, %myStruct2.3 { i32 6, i16 2 } }
-@__myStruct__init = external global %myStruct.2
-@__myStruct2__init = external global %myStruct2.3
+@__myStruct__init = external unnamed_addr constant %myStruct.2
+@__myStruct2__init = external unnamed_addr constant %myStruct2.3
 @__prog.x__init = unnamed_addr constant %myStruct.2 { i32 5, i16 2 }
 
 define void @prog(%prog* %0) {

--- a/src/tests/adr/initializer_functions_adr.rs
+++ b/src/tests/adr/initializer_functions_adr.rs
@@ -482,7 +482,7 @@ fn generating_init_functions() {
         ";
 
     let res = generate_to_string("Test", vec![SourceCode::from(src)]).unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -491,8 +491,8 @@ fn generating_init_functions() {
     %myStruct = type { i8, i8 }
     %myRefStruct = type { %myStruct* }
 
-    @__myStruct__init = constant %myStruct zeroinitializer
-    @__myRefStruct__init = constant %myRefStruct zeroinitializer
+    @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
+    @__myRefStruct__init = unnamed_addr constant %myRefStruct zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @__init_mystruct(%myStruct* %0) {
@@ -527,7 +527,7 @@ fn generating_init_functions() {
     entry:
       ret void
     }
-    "#);
+    "###);
 
     // The second example shows how each initializer function delegates member-initialization to the respective member-init-function
     // The wrapping init function contains a single call-statement to `__init_baz`, since `baz` is the only global instance in need of
@@ -563,7 +563,7 @@ fn generating_init_functions() {
     ";
 
     let res = generate_to_string("Test", vec![SourceCode::from(src)]).unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -576,9 +576,9 @@ fn generating_init_functions() {
 
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @baz_instance = global %baz zeroinitializer
-    @__bar__init = constant %bar zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
-    @__myStruct__init = constant %myStruct zeroinitializer
+    @__bar__init = unnamed_addr constant %bar zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
+    @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
     @s = global %myStruct zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -682,7 +682,7 @@ fn generating_init_functions() {
       call void @__user_init_myStruct(%myStruct* @s)
       ret void
     }
-    "#);
+    "###);
 }
 
 /// When dealing with local stack-allocated variables (`VAR_TEMP`-blocks (in addition to `VAR` for functions)),
@@ -718,7 +718,7 @@ fn intializing_temporary_variables() {
         ";
 
     let res = generate_to_string("Test", vec![SourceCode::from(src)]).unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -727,7 +727,7 @@ fn intializing_temporary_variables() {
     %foo = type { [81 x i8]* }
 
     @ps2 = global [81 x i8] zeroinitializer
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @ps = global [81 x i8] zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
@@ -788,7 +788,7 @@ fn intializing_temporary_variables() {
     }
 
     attributes #0 = { argmemonly nofree nounwind willreturn }
-    "#)
+    "###)
 }
 
 /// Initializing method variables behaves very similar to stack local variables from the previous example.
@@ -811,7 +811,7 @@ fn initializing_method_variables() {
     ";
 
     let res = generate_to_string("Test", vec![SourceCode::from(src)]).unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -819,7 +819,7 @@ fn initializing_method_variables() {
 
     %foo = type {}
 
-    @__foo__init = constant %foo zeroinitializer
+    @__foo__init = unnamed_addr constant %foo zeroinitializer
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -859,7 +859,7 @@ fn initializing_method_variables() {
     entry:
       ret void
     }
-    "#);
+    "###);
 
     // When no local reference is found, the parent variable is used if present. Otherwise we look for a
     // global variable.
@@ -888,7 +888,7 @@ fn initializing_method_variables() {
     ";
 
     let res = generate_to_string("Test", vec![SourceCode::from(src)]).unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -897,7 +897,7 @@ fn initializing_method_variables() {
     %foo = type { i32 }
 
     @y = global i32 0
-    @__foo__init = constant %foo { i32 5 }
+    @__foo__init = unnamed_addr constant %foo { i32 5 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -948,7 +948,7 @@ fn initializing_method_variables() {
     entry:
       ret void
     }
-    "#);
+    "###);
 
     // When both a local and a parent variable are present, the local variable takes precedence.
     let src = r"
@@ -967,7 +967,7 @@ fn initializing_method_variables() {
     ";
 
     let res = generate_to_string("Test", vec![SourceCode::from(src)]).unwrap();
-    filtered_assert_snapshot!(res, @r#"
+    filtered_assert_snapshot!(res, @r###"
     ; ModuleID = '<internal>'
     source_filename = "<internal>"
     target datalayout = "[filtered]"
@@ -975,7 +975,7 @@ fn initializing_method_variables() {
 
     %foo = type { i32 }
 
-    @__foo__init = constant %foo { i32 5 }
+    @__foo__init = unnamed_addr constant %foo { i32 5 }
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
 
     define void @foo(%foo* %0) {
@@ -1017,5 +1017,5 @@ fn initializing_method_variables() {
     entry:
       ret void
     }
-    "#);
+    "###);
 }

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
-snapshot_kind: text
 ---
 target triple = "[filtered]"
 
 %conditional_return = type { i32 }
 
-@__conditional_return__init = constant %conditional_return zeroinitializer
+@__conditional_return__init = unnamed_addr constant %conditional_return zeroinitializer
 @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___plc, i8* null }]
 
 define void @conditional_return(%conditional_return* %0) {

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
-snapshot_kind: text
 ---
 target triple = "[filtered]"
 
 %conditional_return = type { i32 }
 
-@__conditional_return__init = constant %conditional_return zeroinitializer
+@__conditional_return__init = unnamed_addr constant %conditional_return zeroinitializer
 @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___plc, i8* null }]
 
 define i32 @main() {

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/cfc.rs
 expression: output_file_content_without_headers
-snapshot_kind: text
 ---
 target triple = "[filtered]"
 
 %conditional_return = type { i32 }
 
-@__conditional_return__init = constant %conditional_return zeroinitializer
+@__conditional_return__init = unnamed_addr constant %conditional_return zeroinitializer
 @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___plc, i8* null }]
 
 define i32 @main() {


### PR DESCRIPTION
This PR improves debug info generation for constants by using the `DW_TAG_const_type` debug tag to wrap the types of constants. This enhancement allows external tools to identify constant variables through debug information without breaking existing debugging functionality in addition to correctly conveying which values are constant to the debugger.

## Background

The DWARF standard describes two different mechanisms for identifying constants:

> "The `DW_TAG_constant` is used for languages that distinguish between variables that may have constant value and true named constants."

> `DW_TAG_const_type`: "C or C++ const qualified type."

I've chosen `DW_TAG_const_type` as it works well with Inkwell's API and properly represents the semantics of PLC constants (the address is not part of the variables identity/only the content matters, not its specific address in memory).

Additionally, external constants are now also marked as constant in IR. This is needed to correctly tag forward-declared constants (type initializers, ...). As an additional benefit, the resulting LLVM IR now correctly uses the `unnamed_addr constant` tag where appropriate, enabling memory optimizations by allowing LLVM to merge identical constants while preserving their constant semantics in debug info.