### PR TITLE
fix: make sure vla accessors are cast to 32bit

### DIFF
--- a/src/codegen/generators/llvm.rs
+++ b/src/codegen/generators/llvm.rs
@@ -162,6 +162,11 @@ impl<'a> Llvm<'a> {
         self.context.i32_type()
     }
 
+    /// returns the i64_type
+    pub fn i64_type(&self) -> inkwell::types::IntType<'a> {
+        self.context.i64_type()
+    }
+
     /// create a constant bool with the given value
     ///
     /// - `index` the index to obtain the datatypeinformation for BOOL

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access_with_expr.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access_with_expr.snap
@@ -1,0 +1,70 @@
+---
+source: src/codegen/tests/vla_tests.rs
+expression: res
+---
+; ModuleID = '<internal>'
+source_filename = "<internal>"
+target datalayout = "[filtered]"
+target triple = "[filtered]"
+
+%__foo_vla = type { i16*, [2 x i32] }
+
+@____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
+
+define i16 @foo(%__foo_vla* %0) {
+entry:
+  %foo = alloca i16, align 2
+  %vla = alloca %__foo_vla, align 8
+  %1 = bitcast %__foo_vla* %vla to i8*
+  %2 = bitcast %__foo_vla* %0 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %1, i8* align 1 %2, i64 ptrtoint (%__foo_vla* getelementptr (%__foo_vla, %__foo_vla* null, i32 1) to i64), i1 false)
+  %i = alloca i32, align 4
+  store i32 0, i32* %i, align 4
+  store i16 0, i16* %foo, align 2
+  %vla_arr_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla, i32 0, i32 0
+  %vla_arr_ptr = load i16*, i16** %vla_arr_gep, align 8
+  %dim_arr = getelementptr inbounds %__foo_vla, %__foo_vla* %vla, i32 0, i32 1
+  %start_idx_ptr0 = getelementptr inbounds [2 x i32], [2 x i32]* %dim_arr, i32 0, i32 0
+  %end_idx_ptr0 = getelementptr inbounds [2 x i32], [2 x i32]* %dim_arr, i32 0, i32 1
+  %start_idx_value0 = load i32, i32* %start_idx_ptr0, align 4
+  %end_idx_value0 = load i32, i32* %end_idx_ptr0, align 4
+  %load_i = load i32, i32* %i, align 4
+  %tmpVar = add i32 %load_i, 1
+  %tmpVar1 = sub i32 %tmpVar, %start_idx_value0
+  %arr_val = getelementptr inbounds i16, i16* %vla_arr_ptr, i32 %tmpVar1
+  %load_tmpVar = load i16, i16* %arr_val, align 2
+  store i16 %load_tmpVar, i16* %foo, align 2
+  %foo_ret = load i16, i16* %foo, align 2
+  ret i16 %foo_ret
+}
+
+define i32 @main() {
+entry:
+  %main = alloca i32, align 4
+  %arr = alloca [2 x i16], align 2
+  %0 = bitcast [2 x i16]* %arr to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %0, i8 0, i64 ptrtoint ([2 x i16]* getelementptr ([2 x i16], [2 x i16]* null, i32 1) to i64), i1 false)
+  store i32 0, i32* %main, align 4
+  %auto_deref = load [2 x i16], [2 x i16]* %arr, align 2
+  %outer_arr_gep = getelementptr inbounds [2 x i16], [2 x i16]* %arr, i32 0, i32 0
+  %vla_struct = alloca %__foo_vla, align 8
+  %vla_array_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla_struct, i32 0, i32 0
+  %vla_dimensions_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla_struct, i32 0, i32 1
+  store [2 x i32] [i32 0, i32 1], [2 x i32]* %vla_dimensions_gep, align 4
+  store i16* %outer_arr_gep, i16** %vla_array_gep, align 8
+  %1 = load %__foo_vla, %__foo_vla* %vla_struct, align 8
+  %vla_struct_ptr = alloca %__foo_vla, align 8
+  store %__foo_vla %1, %__foo_vla* %vla_struct_ptr, align 8
+  %call = call i16 @foo(%__foo_vla* %vla_struct_ptr)
+  %main_ret = load i32, i32* %main, align 4
+  ret i32 %main_ret
+}
+
+; Function Attrs: argmemonly nofree nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
+
+; Function Attrs: argmemonly nofree nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #1
+
+attributes #0 = { argmemonly nofree nounwind willreturn }
+attributes #1 = { argmemonly nofree nounwind willreturn writeonly }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access_with_lint.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access_with_lint.snap
@@ -1,0 +1,66 @@
+---
+source: src/codegen/tests/vla_tests.rs
+expression: res
+---
+; ModuleID = '<internal>'
+source_filename = "<internal>"
+target datalayout = "[filtered]"
+target triple = "[filtered]"
+
+%__foo_vla = type { i16*, [2 x i32] }
+
+@____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
+
+define i16 @foo(%__foo_vla* %0) {
+entry:
+  %foo = alloca i16, align 2
+  %vla = alloca %__foo_vla, align 8
+  %1 = bitcast %__foo_vla* %vla to i8*
+  %2 = bitcast %__foo_vla* %0 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %1, i8* align 1 %2, i64 ptrtoint (%__foo_vla* getelementptr (%__foo_vla, %__foo_vla* null, i32 1) to i64), i1 false)
+  store i16 0, i16* %foo, align 2
+  %vla_arr_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla, i32 0, i32 0
+  %vla_arr_ptr = load i16*, i16** %vla_arr_gep, align 8
+  %dim_arr = getelementptr inbounds %__foo_vla, %__foo_vla* %vla, i32 0, i32 1
+  %start_idx_ptr0 = getelementptr inbounds [2 x i32], [2 x i32]* %dim_arr, i32 0, i32 0
+  %end_idx_ptr0 = getelementptr inbounds [2 x i32], [2 x i32]* %dim_arr, i32 0, i32 1
+  %start_idx_value0 = load i32, i32* %start_idx_ptr0, align 4
+  %end_idx_value0 = load i32, i32* %end_idx_ptr0, align 4
+  %tmpVar = sub i32 0, %start_idx_value0
+  %arr_val = getelementptr inbounds i16, i16* %vla_arr_ptr, i32 %tmpVar
+  %load_tmpVar = load i16, i16* %arr_val, align 2
+  store i16 %load_tmpVar, i16* %foo, align 2
+  %foo_ret = load i16, i16* %foo, align 2
+  ret i16 %foo_ret
+}
+
+define i32 @main() {
+entry:
+  %main = alloca i32, align 4
+  %arr = alloca [2 x i16], align 2
+  %0 = bitcast [2 x i16]* %arr to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %0, i8 0, i64 ptrtoint ([2 x i16]* getelementptr ([2 x i16], [2 x i16]* null, i32 1) to i64), i1 false)
+  store i32 0, i32* %main, align 4
+  %auto_deref = load [2 x i16], [2 x i16]* %arr, align 2
+  %outer_arr_gep = getelementptr inbounds [2 x i16], [2 x i16]* %arr, i32 0, i32 0
+  %vla_struct = alloca %__foo_vla, align 8
+  %vla_array_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla_struct, i32 0, i32 0
+  %vla_dimensions_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla_struct, i32 0, i32 1
+  store [2 x i32] [i32 0, i32 1], [2 x i32]* %vla_dimensions_gep, align 4
+  store i16* %outer_arr_gep, i16** %vla_array_gep, align 8
+  %1 = load %__foo_vla, %__foo_vla* %vla_struct, align 8
+  %vla_struct_ptr = alloca %__foo_vla, align 8
+  store %__foo_vla %1, %__foo_vla* %vla_struct_ptr, align 8
+  %call = call i16 @foo(%__foo_vla* %vla_struct_ptr)
+  %main_ret = load i32, i32* %main, align 4
+  ret i32 %main_ret
+}
+
+; Function Attrs: argmemonly nofree nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
+
+; Function Attrs: argmemonly nofree nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #1
+
+attributes #0 = { argmemonly nofree nounwind willreturn }
+attributes #1 = { argmemonly nofree nounwind willreturn writeonly }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access_with_var.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__vla_tests__vla_read_access_with_var.snap
@@ -1,0 +1,69 @@
+---
+source: src/codegen/tests/vla_tests.rs
+expression: res
+---
+; ModuleID = '<internal>'
+source_filename = "<internal>"
+target datalayout = "[filtered]"
+target triple = "[filtered]"
+
+%__foo_vla = type { i16*, [2 x i32] }
+
+@____foo_vla__init = unnamed_addr constant %__foo_vla zeroinitializer
+
+define i16 @foo(%__foo_vla* %0) {
+entry:
+  %foo = alloca i16, align 2
+  %vla = alloca %__foo_vla, align 8
+  %1 = bitcast %__foo_vla* %vla to i8*
+  %2 = bitcast %__foo_vla* %0 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %1, i8* align 1 %2, i64 ptrtoint (%__foo_vla* getelementptr (%__foo_vla, %__foo_vla* null, i32 1) to i64), i1 false)
+  %i = alloca i32, align 4
+  store i32 0, i32* %i, align 4
+  store i16 0, i16* %foo, align 2
+  %vla_arr_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla, i32 0, i32 0
+  %vla_arr_ptr = load i16*, i16** %vla_arr_gep, align 8
+  %dim_arr = getelementptr inbounds %__foo_vla, %__foo_vla* %vla, i32 0, i32 1
+  %start_idx_ptr0 = getelementptr inbounds [2 x i32], [2 x i32]* %dim_arr, i32 0, i32 0
+  %end_idx_ptr0 = getelementptr inbounds [2 x i32], [2 x i32]* %dim_arr, i32 0, i32 1
+  %start_idx_value0 = load i32, i32* %start_idx_ptr0, align 4
+  %end_idx_value0 = load i32, i32* %end_idx_ptr0, align 4
+  %load_i = load i32, i32* %i, align 4
+  %tmpVar = sub i32 %load_i, %start_idx_value0
+  %arr_val = getelementptr inbounds i16, i16* %vla_arr_ptr, i32 %tmpVar
+  %load_tmpVar = load i16, i16* %arr_val, align 2
+  store i16 %load_tmpVar, i16* %foo, align 2
+  %foo_ret = load i16, i16* %foo, align 2
+  ret i16 %foo_ret
+}
+
+define i32 @main() {
+entry:
+  %main = alloca i32, align 4
+  %arr = alloca [2 x i16], align 2
+  %0 = bitcast [2 x i16]* %arr to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %0, i8 0, i64 ptrtoint ([2 x i16]* getelementptr ([2 x i16], [2 x i16]* null, i32 1) to i64), i1 false)
+  store i32 0, i32* %main, align 4
+  %auto_deref = load [2 x i16], [2 x i16]* %arr, align 2
+  %outer_arr_gep = getelementptr inbounds [2 x i16], [2 x i16]* %arr, i32 0, i32 0
+  %vla_struct = alloca %__foo_vla, align 8
+  %vla_array_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla_struct, i32 0, i32 0
+  %vla_dimensions_gep = getelementptr inbounds %__foo_vla, %__foo_vla* %vla_struct, i32 0, i32 1
+  store [2 x i32] [i32 0, i32 1], [2 x i32]* %vla_dimensions_gep, align 4
+  store i16* %outer_arr_gep, i16** %vla_array_gep, align 8
+  %1 = load %__foo_vla, %__foo_vla* %vla_struct, align 8
+  %vla_struct_ptr = alloca %__foo_vla, align 8
+  store %__foo_vla %1, %__foo_vla* %vla_struct_ptr, align 8
+  %call = call i16 @foo(%__foo_vla* %vla_struct_ptr)
+  %main_ret = load i32, i32* %main, align 4
+  ret i32 %main_ret
+}
+
+; Function Attrs: argmemonly nofree nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #0
+
+; Function Attrs: argmemonly nofree nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #1
+
+attributes #0 = { argmemonly nofree nounwind willreturn }
+attributes #1 = { argmemonly nofree nounwind willreturn writeonly }

--- a/src/codegen/tests/vla_tests.rs
+++ b/src/codegen/tests/vla_tests.rs
@@ -46,6 +46,81 @@ fn vla_read_access() {
 }
 
 #[test]
+fn vla_read_access_with_lint() {
+    let res = codegen(
+        r#"
+        FUNCTION foo : INT
+        VAR_INPUT
+            vla : ARRAY[*] OF INT;
+        END_VAR
+            FOO := vla[LINT#0];
+        END_FUNCTION
+
+        FUNCTION main : DINT
+        VAR
+            arr : ARRAY[0..1] OF INT;
+        END_VAR
+            foo(arr);
+        END_FUNCTION
+    "#,
+    );
+
+    filtered_assert_snapshot!(res);
+}
+
+#[test]
+fn vla_read_access_with_var() {
+    let res = codegen(
+        r#"
+        FUNCTION foo : INT
+        VAR_INPUT
+            vla : ARRAY[*] OF INT;
+        END_VAR
+        VAR
+            i : DINT := 0;
+        END_VAR
+            FOO := vla[i];
+        END_FUNCTION
+
+        FUNCTION main : DINT
+        VAR
+            arr : ARRAY[0..1] OF INT;
+        END_VAR
+            foo(arr);
+        END_FUNCTION
+    "#,
+    );
+
+    filtered_assert_snapshot!(res);
+}
+
+#[test]
+fn vla_read_access_with_expr() {
+    let res = codegen(
+        r#"
+        FUNCTION foo : INT
+        VAR_INPUT
+            vla : ARRAY[*] OF INT;
+        END_VAR
+        VAR
+            i : DINT := 0;
+        END_VAR
+            FOO := vla[i+1];
+        END_FUNCTION
+
+        FUNCTION main : DINT
+        VAR
+            arr : ARRAY[0..1] OF INT;
+        END_VAR
+            foo(arr);
+        END_FUNCTION
+    "#,
+    );
+
+    filtered_assert_snapshot!(res);
+}
+
+#[test]
 fn global_variable_passed_to_function_as_vla() {
     let res = codegen(
         r#"

--- a/tests/correctness/vla.rs
+++ b/tests/correctness/vla.rs
@@ -11,16 +11,18 @@ fn variable_length_array_single_dimension_access() {
         c: i64,
         d: i64,
         e: i64,
+        f: i64,
     }
 
     let mut main_type = MainType::default();
     let src = r#"
     PROGRAM main
         VAR
-            a, b, c, d, e : LINT;
+            a, b, c, d, e,f : LINT;
         END_VAR
         VAR_TEMP
             arr : ARRAY[-21..4] OF LINT;
+            access_index : DINT := -20;
         END_VAR
 
         foo(arr);
@@ -29,11 +31,13 @@ fn variable_length_array_single_dimension_access() {
         c := arr[2];
         d := arr[3];
         e := arr[4];
+        f := arr[access_index];
     END_PROGRAM
 
     FUNCTION foo : DINT
         VAR_INPUT
             vla : ARRAY[ * ] OF LINT;
+            access_index : DINT := -20;
         END_VAR
 
         vla[-21] := 2;
@@ -41,6 +45,7 @@ fn variable_length_array_single_dimension_access() {
         vla[2] := 6;
         vla[3] := 8;
         vla[4] := 10;
+        vla[access_index] := 42;
     END_FUNCTION
     "#;
 
@@ -50,6 +55,7 @@ fn variable_length_array_single_dimension_access() {
     assert_eq!(6, main_type.c);
     assert_eq!(8, main_type.d);
     assert_eq!(10, main_type.e);
+    assert_eq!(42, main_type.f);
 }
 
 #[test]

--- a/tests/lit/single/vla/vla_test.st
+++ b/tests/lit/single/vla/vla_test.st
@@ -1,0 +1,61 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+FUNCTION VlaInit
+VAR_IN_OUT
+	arr	: ARRAY [*] OF BYTE;
+	len	: ULINT;
+END_VAR
+
+VAR_TEMP
+	i	: ULINT;
+END_VAR
+
+FOR i := 0 TO len - 1 DO
+	arr[i] := i;
+    printf('arr[%d] = %d$N', i, arr[i]);
+END_FOR
+
+END_FUNCTION
+
+FUNCTION main : DINT
+VAR
+	arr1	: ARRAY [0..9] OF BYTE;
+	arr2	: ARRAY [0..19] OF BYTE;
+	l	: ULINT;
+END_VAR
+
+l := SIZEOF(arr1);
+VlaInit(arr := arr1, len := l);
+// CHECK: arr[0] = 0
+//CHECK-NEXT: arr[1] = 1
+//CHECK-NEXT: arr[2] = 2
+//CHECK-NEXT: arr[3] = 3
+//CHECK-NEXT: arr[4] = 4
+//CHECK-NEXT: arr[5] = 5
+//CHECK-NEXT: arr[6] = 6
+//CHECK-NEXT: arr[7] = 7
+//CHECK-NEXT: arr[8] = 8
+//CHECK-NEXT: arr[9] = 9
+
+l := SIZEOF(arr2);
+VlaInit(arr := arr2, len := l);
+//     CHECK: arr[0] = 0
+//CHECK-NEXT: arr[1] = 1
+//CHECK-NEXT: arr[2] = 2
+//CHECK-NEXT: arr[3] = 3
+//CHECK-NEXT: arr[4] = 4
+//CHECK-NEXT: arr[5] = 5
+//CHECK-NEXT: arr[6] = 6
+//CHECK-NEXT: arr[7] = 7
+//CHECK-NEXT: arr[8] = 8
+//CHECK-NEXT: arr[9] = 9
+//     CHECK: arr[10] = 10
+//CHECK-NEXT: arr[11] = 11
+//CHECK-NEXT: arr[12] = 12
+//CHECK-NEXT: arr[13] = 13
+//CHECK-NEXT: arr[14] = 14
+//CHECK-NEXT: arr[15] = 15
+//CHECK-NEXT: arr[16] = 16
+//CHECK-NEXT: arr[17] = 17
+//CHECK-NEXT: arr[18] = 18
+//CHECK-NEXT: arr[19] = 19
+END_FUNCTION


### PR DESCRIPTION
fixes #1504 

When accessing VLAs make sure the accessors are cast to 32bit