### PR TITLE
feat: support setting the reference to 0

### DIFF
--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -288,7 +288,11 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             let expr = exp.generate_reference_expression(&data.access, data.base.as_deref(), left)?;
             expr.get_basic_value_enum().into_pointer_value()
         };
-        let right_expr_val = ref_builtin.codegen(&exp, &[right], right.get_location())?;
+        let right_expr_val = if right.is_zero() {
+            exp.generate_literal(right)?
+        } else {
+            ref_builtin.codegen(&exp, &[right], right.get_location())?
+        };
 
         self.llvm.builder.build_store(left_ptr_val, right_expr_val.get_basic_value_enum());
         Ok(())

--- a/src/codegen/tests/statement_codegen_test.rs
+++ b/src/codegen/tests/statement_codegen_test.rs
@@ -220,6 +220,35 @@ fn ref_assignment() {
 }
 
 #[test]
+fn ref_assignment_to_null() {
+    let result = codegen(
+        r#"
+        FUNCTION main
+        VAR
+            a : REF_TO DINT;
+        END_VAR
+            a REF= 0;
+        END_PROGRAM
+        "#,
+    );
+
+    filtered_assert_snapshot!(result, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    define void @main() {
+    entry:
+      %a = alloca i32*, align 8
+      store i32* null, i32** %a, align 8
+      store i32 0, i32** %a, align 4
+      ret void
+    }
+    "#);
+}
+
+#[test]
 fn reference_to_assignment() {
     let auto_deref = codegen(
         r#"

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -999,7 +999,10 @@ fn validate_ref_assignment<T: AnnotationMap>(
     let type_rhs = context.annotations.get_type_or_void(&assignment.right, context.index);
 
     // Assert that the right-hand side is a reference
-    if !(assignment.right.is_reference() || assignment_location.is_builtin_internal()) {
+    if !(assignment.right.is_reference()
+        || assignment_location.is_builtin_internal()
+        || assignment.right.is_zero())
+    {
         validator.push_diagnostic(
             Diagnostic::new("Invalid assignment, expected a reference")
                 .with_location(&assignment.right.location)

--- a/src/validation/tests/assignment_validation_tests.rs
+++ b/src/validation/tests/assignment_validation_tests.rs
@@ -1234,6 +1234,7 @@ fn ref_assignments() {
 
             localRefTo          REF= localDINT;
             localReferenceTo    REF= localDINT;
+            localRefTo          REF= 0; // This is allowed, assigning to a null pointer
 
             // The following are invalid
             1                   REF= localDINT;
@@ -1248,62 +1249,61 @@ fn ref_assignments() {
         ",
     );
 
-    assert_snapshot!(diagnostics, @r###"
+    assert_snapshot!(diagnostics, @r"
     error[E098]: Invalid assignment, expected a pointer reference
-       ┌─ <internal>:16:13
+       ┌─ <internal>:17:13
        │
-    16 │             1                   REF= localDINT;
+    17 │             1                   REF= localDINT;
        │             ^ Invalid assignment, expected a pointer reference
 
     error[E098]: Invalid assignment, expected a pointer reference
-       ┌─ <internal>:17:13
+       ┌─ <internal>:18:13
        │
-    17 │             localINT            REF= localDINT;
+    18 │             localINT            REF= localDINT;
        │             ^^^^^^^^ Invalid assignment, expected a pointer reference
 
     error[E037]: Invalid assignment: cannot assign 'DINT' to 'INT'
-       ┌─ <internal>:17:13
+       ┌─ <internal>:18:13
        │
-    17 │             localINT            REF= localDINT;
+    18 │             localINT            REF= localDINT;
        │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'DINT' to 'INT'
-
-    error[E098]: Invalid assignment, expected a reference
-       ┌─ <internal>:18:38
-       │
-    18 │             localRefTo          REF= 1;
-       │                                      ^ Invalid assignment, expected a reference
 
     error[E098]: Invalid assignment, expected a reference
        ┌─ <internal>:19:38
        │
-    19 │             localReferenceTo    REF= 1;
+    19 │             localRefTo          REF= 1;
+       │                                      ^ Invalid assignment, expected a reference
+
+    error[E098]: Invalid assignment, expected a reference
+       ┌─ <internal>:20:38
+       │
+    20 │             localReferenceTo    REF= 1;
        │                                      ^ Invalid assignment, expected a reference
 
     error[E037]: Invalid assignment: cannot assign 'INT' to 'DINT'
-       ┌─ <internal>:21:13
-       │
-    21 │             localReferenceTo    REF= localINT;
-       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'DINT'
-
-    error[E037]: Invalid assignment: cannot assign 'STRING' to 'DINT'
        ┌─ <internal>:22:13
        │
-    22 │             localReferenceTo    REF= localSTRING;
-       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
-
-    error[E098]: Invalid assignment, expected a reference
-       ┌─ <internal>:23:38
-       │
-    23 │             localReferenceTo    REF= 'howdy';
-       │                                      ^^^^^^^ Invalid assignment, expected a reference
+    22 │             localReferenceTo    REF= localINT;
+       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'INT' to 'DINT'
 
     error[E037]: Invalid assignment: cannot assign 'STRING' to 'DINT'
        ┌─ <internal>:23:13
        │
-    23 │             localReferenceTo    REF= 'howdy';
-       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+    23 │             localReferenceTo    REF= localSTRING;
+       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
 
-    "###);
+    error[E098]: Invalid assignment, expected a reference
+       ┌─ <internal>:24:38
+       │
+    24 │             localReferenceTo    REF= 'howdy';
+       │                                      ^^^^^^^ Invalid assignment, expected a reference
+
+    error[E037]: Invalid assignment: cannot assign 'STRING' to 'DINT'
+       ┌─ <internal>:24:13
+       │
+    24 │             localReferenceTo    REF= 'howdy';
+       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'STRING' to 'DINT'
+    ");
 }
 
 #[test]
@@ -1466,7 +1466,7 @@ fn invalid_reference_to_declaration() {
         ",
     );
 
-    insta::assert_snapshot!(diagnostics, @r###"
+    insta::assert_snapshot!(diagnostics, @r"
     error[E007]: Unexpected token: expected DataTypeDefinition but found KeywordReferenceTo
       ┌─ <internal>:4:38
       │
@@ -1494,8 +1494,7 @@ fn invalid_reference_to_declaration() {
     6 │ │                 qux : REF_TO REFERENCE TO DINT;
       │ ╰───────────────────────────────────────────────^ Unexpected token: expected KeywordEndVar but found 'REFERENCE TO DINT;
                     qux : REF_TO REFERENCE TO DINT;'
-
-    "###);
+    ");
 }
 
 #[test]

--- a/tests/lit/single/pointer/reference_to_null.st
+++ b/tests/lit/single/pointer/reference_to_null.st
@@ -1,0 +1,31 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+FUNCTION main: DINT
+    VAR
+        foo : REFERENCE TO DINT;
+        bar,baz,qux : DINT;
+    END_VAR
+
+    // Set to null
+    foo REF= 0;
+    // Should not crash
+
+    foo REF= bar;
+    bar := 1;
+    baz := 2;
+    qux := 2;
+
+    // CHECK: 2
+    bar := bar + foo; // bar + bar => 1 + 1
+    printf('%d$N', foo);
+
+    // CHECK: 4
+    baz := baz + foo; // baz + foo => baz + bar => 2 + 2
+    foo REF= baz;
+    printf('%d$N', foo);
+
+    // CHECK: 6
+    qux := qux + foo; // qux + foo => qux + baz => 2 + 4
+    foo REF= qux;
+    printf('%d$N', foo);
+
+END_FUNCTION


### PR DESCRIPTION
`REF=` can not support 0 in addition to references.
Setting a reference to 0 means it is unassigned.