### PR TITLE
ci: pin dev container to a specific version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,9 @@
 # FROM mcr.microsoft.com/vscode/devcontainers/rust:latest
-FROM ghcr.io/plc-lang/rust-llvm:latest
+ARG LLVM_VER=14
+ARG RUST_VER=1.83
+ARG IMAGE_TAG=${LLVM_VER}-${RUST_VER}
+ARG BASE_IMAGE=ghcr.io/plc-lang/rust-llvm:${IMAGE_TAG}
+FROM ${BASE_IMAGE}
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Some devcontainer tools can't update if we always pull from latest
This change is pining the dev container version to the one we are currently using.
You can override this by passing parameters to the dev container to override the image but this should not be required.
This way we can also update the underlying images without breaking the current dev containers