### PR TITLE
fix: Fetch virtual table dependencies in resolver

### DIFF
--- a/src/codegen/tests/initialization_test/complex_initializers.rs
+++ b/src/codegen/tests/initialization_test/complex_initializers.rs
@@ -414,10 +414,10 @@ fn nested_initializer_pous() {
     %foo = type { i32*, [81 x i8]*, %bar }
     %bar = type { i32*, %baz }
     %baz = type { i32*, [81 x i8]* }
-    %sideProg = type { [81 x i8]*, %foo }
-    %__vtable_foo = type { void (%foo*)* }
-    %__vtable_bar = type { void (%bar*)* }
     %__vtable_baz = type { void (%baz*)* }
+    %__vtable_bar = type { void (%bar*)* }
+    %__vtable_foo = type { void (%foo*)* }
+    %sideProg = type { [81 x i8]*, %foo }
 
     @str = global [81 x i8] c"hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
@@ -425,12 +425,12 @@ fn nested_initializer_pous() {
     @__foo__init = unnamed_addr constant %foo zeroinitializer
     @__bar__init = unnamed_addr constant %bar zeroinitializer
     @__baz__init = unnamed_addr constant %baz zeroinitializer
-    @sideProg_instance = global %sideProg zeroinitializer
-    @____vtable_foo__init = unnamed_addr constant %__vtable_foo zeroinitializer
-    @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @____vtable_bar__init = unnamed_addr constant %__vtable_bar zeroinitializer
-    @__vtable_bar_instance = global %__vtable_bar zeroinitializer
     @____vtable_baz__init = unnamed_addr constant %__vtable_baz zeroinitializer
+    @____vtable_bar__init = unnamed_addr constant %__vtable_bar zeroinitializer
+    @____vtable_foo__init = unnamed_addr constant %__vtable_foo zeroinitializer
+    @sideProg_instance = global %sideProg zeroinitializer
+    @__vtable_foo_instance = global %__vtable_foo zeroinitializer
+    @__vtable_bar_instance = global %__vtable_bar zeroinitializer
     @__vtable_baz_instance = global %__vtable_baz zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -1321,8 +1321,8 @@ fn global_instance() {
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
     @__foo__init = unnamed_addr constant %foo zeroinitializer
-    @fb = global %foo zeroinitializer
     @____vtable_foo__init = unnamed_addr constant %__vtable_foo zeroinitializer
+    @fb = global %foo zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -1448,8 +1448,8 @@ fn aliased_types() {
     @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 0, void ()* @__init___Test, i8* null }]
     @prog_instance = global %prog zeroinitializer
     @__foo__init = unnamed_addr constant %foo zeroinitializer
-    @global_alias = global %foo zeroinitializer
     @____vtable_foo__init = unnamed_addr constant %__vtable_foo zeroinitializer
+    @global_alias = global %foo zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
 
     define void @foo(%foo* %0) {
@@ -3174,8 +3174,8 @@ fn user_fb_init_in_global_struct() {
     @prog_instance = global %prog zeroinitializer
     @__bar__init = unnamed_addr constant %bar zeroinitializer
     @__foo__init = unnamed_addr constant %foo zeroinitializer
-    @str = global %bar zeroinitializer
     @____vtable_foo__init = unnamed_addr constant %__vtable_foo zeroinitializer
+    @str = global %bar zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
 
     define void @foo(%foo* %0) {

--- a/src/codegen/tests/oop_tests.rs
+++ b/src/codegen/tests/oop_tests.rs
@@ -1344,8 +1344,8 @@ fn pass_this_to_method() {
     @____vtable_FB_Test__init = unnamed_addr constant %__vtable_FB_Test zeroinitializer
     @__FB_Test__init = unnamed_addr constant %FB_Test { i32* null, i16 5 }
     @__FB_Test2__init = unnamed_addr constant %FB_Test2 zeroinitializer
-    @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
     @____vtable_FB_Test2__init = unnamed_addr constant %__vtable_FB_Test2 zeroinitializer
+    @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
     @__vtable_FB_Test2_instance = global %__vtable_FB_Test2 zeroinitializer
 
     define void @FB_Test(%FB_Test* %0) {

--- a/src/resolver/tests/const_resolver_tests.rs
+++ b/src/resolver/tests/const_resolver_tests.rs
@@ -1419,6 +1419,5 @@ fn leading_unary_plus_in_global_const_reference_is_resolvable() {
     );
 
     let (_, unresolvable) = evaluate_constants(index);
-    dbg!(&unresolvable);
     assert_eq!(unresolvable.len(), 0);
 }

--- a/src/tests/adr/initializer_functions_adr.rs
+++ b/src/tests/adr/initializer_functions_adr.rs
@@ -756,10 +756,10 @@ fn generating_init_functions() {
     @__bar__init = unnamed_addr constant %bar zeroinitializer
     @__foo__init = unnamed_addr constant %foo zeroinitializer
     @__myStruct__init = unnamed_addr constant %myStruct zeroinitializer
-    @s = global %myStruct zeroinitializer
     @____vtable_foo__init = unnamed_addr constant %__vtable_foo zeroinitializer
-    @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @____vtable_bar__init = unnamed_addr constant %__vtable_bar zeroinitializer
+    @s = global %myStruct zeroinitializer
+    @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
 
     define void @foo(%foo* %0) {

--- a/tests/lit/multi/polymorphism_class/a.st
+++ b/tests/lit/multi/polymorphism_class/a.st
@@ -1,0 +1,17 @@
+CLASS ClassA
+    METHOD alpha
+        printf('ClassA::alpha$N');
+    END_METHOD
+
+    METHOD bravo
+        printf('ClassA::bravo$N');
+    END_METHOD
+
+    METHOD charlie
+        printf('ClassA::charlie$N');
+    END_METHOD
+
+    METHOD delta
+        printf('ClassA::delta$N');
+    END_METHOD
+END_CLASS

--- a/tests/lit/multi/polymorphism_class/b.st
+++ b/tests/lit/multi/polymorphism_class/b.st
@@ -1,0 +1,5 @@
+CLASS ClassB EXTENDS ClassA
+    METHOD bravo
+        printf('ClassB::bravo$N');
+    END_METHOD
+END_CLASS

--- a/tests/lit/multi/polymorphism_class/c.st
+++ b/tests/lit/multi/polymorphism_class/c.st
@@ -1,0 +1,5 @@
+CLASS ClassC EXTENDS ClassB
+    METHOD charlie
+        printf('ClassC::charlie$N');
+    END_METHOD
+END_CLASS

--- a/tests/lit/multi/polymorphism_class/d.st
+++ b/tests/lit/multi/polymorphism_class/d.st
@@ -1,0 +1,17 @@
+CLASS ClassD EXTENDS ClassC
+    METHOD alpha
+        printf('ClassD::alpha$N');
+    END_METHOD
+
+    METHOD bravo
+        printf('ClassD::bravo$N');
+    END_METHOD
+
+    METHOD charlie
+        printf('ClassD::charlie$N');
+    END_METHOD
+
+    METHOD delta
+        printf('ClassD::delta$N');
+    END_METHOD
+END_CLASS

--- a/tests/lit/multi/polymorphism_class/main.st
+++ b/tests/lit/multi/polymorphism_class/main.st
@@ -1,0 +1,34 @@
+FUNCTION main
+    VAR
+        instanceA: ClassA;
+        instanceB: ClassB;
+        instanceC: ClassC;
+        instanceD: ClassD;
+
+        refInstanceA: POINTER TO ClassA;
+    END_VAR
+
+    refInstanceA := ADR(instanceA);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+
+    refInstanceA := ADR(instanceB);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+    
+    refInstanceA := ADR(instanceC);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+
+    refInstanceA := ADR(instanceD);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+END_FUNCTION

--- a/tests/lit/multi/polymorphism_class/run.test
+++ b/tests/lit/multi/polymorphism_class/run.test
@@ -1,0 +1,20 @@
+RUN: %COMPILE %S/main.st %S/a.st %S/b.st %S/c.st %S/d.st && %RUN | %CHECK %s
+CHECK: ClassA::alpha
+CHECK-NEXT: ClassA::bravo
+CHECK-NEXT: ClassA::charlie
+CHECK-NEXT: ClassA::delta
+
+CHECK-NEXT: ClassA::alpha
+CHECK-NEXT: ClassB::bravo
+CHECK-NEXT: ClassA::charlie
+CHECK-NEXT: ClassA::delta
+
+CHECK-NEXT: ClassA::alpha
+CHECK-NEXT: ClassB::bravo
+CHECK-NEXT: ClassC::charlie
+CHECK-NEXT: ClassA::delta
+
+CHECK-NEXT: ClassD::alpha
+CHECK-NEXT: ClassD::bravo
+CHECK-NEXT: ClassD::charlie
+CHECK-NEXT: ClassD::delta

--- a/tests/lit/multi/polymorphism_fb/a.st
+++ b/tests/lit/multi/polymorphism_fb/a.st
@@ -1,0 +1,17 @@
+FUNCTION_BLOCK FbA
+    METHOD alpha
+        printf('FbA::alpha$N');
+    END_METHOD
+
+    METHOD bravo
+        printf('FbA::bravo$N');
+    END_METHOD
+
+    METHOD charlie
+        printf('FbA::charlie$N');
+    END_METHOD
+
+    METHOD delta
+        printf('FbA::delta$N');
+    END_METHOD
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/polymorphism_fb/b.st
+++ b/tests/lit/multi/polymorphism_fb/b.st
@@ -1,0 +1,5 @@
+FUNCTION_BLOCK FbB EXTENDS FbA
+    METHOD bravo
+        printf('FbB::bravo$N');
+    END_METHOD
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/polymorphism_fb/c.st
+++ b/tests/lit/multi/polymorphism_fb/c.st
@@ -1,0 +1,5 @@
+FUNCTION_BLOCK FbC EXTENDS FbB
+    METHOD charlie
+        printf('FbC::charlie$N');
+    END_METHOD
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/polymorphism_fb/d.st
+++ b/tests/lit/multi/polymorphism_fb/d.st
@@ -1,0 +1,17 @@
+FUNCTION_BLOCK FbD EXTENDS FbC
+    METHOD alpha
+        printf('FbD::alpha$N');
+    END_METHOD
+
+    METHOD bravo
+        printf('FbD::bravo$N');
+    END_METHOD
+
+    METHOD charlie
+        printf('FbD::charlie$N');
+    END_METHOD
+
+    METHOD delta
+        printf('FbD::delta$N');
+    END_METHOD
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/polymorphism_fb/main.st
+++ b/tests/lit/multi/polymorphism_fb/main.st
@@ -1,0 +1,34 @@
+FUNCTION main
+    VAR
+        instanceA: FbA;
+        instanceB: FbB;
+        instanceC: FbC;
+        instanceD: FbD;
+
+        refInstanceA: POINTER TO FbA;
+    END_VAR
+
+    refInstanceA := ADR(instanceA);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+
+    refInstanceA := ADR(instanceB);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+    
+    refInstanceA := ADR(instanceC);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+
+    refInstanceA := ADR(instanceD);
+    refInstanceA^.alpha();
+    refInstanceA^.bravo();
+    refInstanceA^.charlie();
+    refInstanceA^.delta();
+END_FUNCTION

--- a/tests/lit/multi/polymorphism_fb/run.test
+++ b/tests/lit/multi/polymorphism_fb/run.test
@@ -1,0 +1,20 @@
+RUN: %COMPILE %S/main.st %S/a.st %S/b.st %S/c.st %S/d.st && %RUN | %CHECK %s
+CHECK: FbA::alpha
+CHECK-NEXT: FbA::bravo
+CHECK-NEXT: FbA::charlie
+CHECK-NEXT: FbA::delta
+
+CHECK-NEXT: FbA::alpha
+CHECK-NEXT: FbB::bravo
+CHECK-NEXT: FbA::charlie
+CHECK-NEXT: FbA::delta
+
+CHECK-NEXT: FbA::alpha
+CHECK-NEXT: FbB::bravo
+CHECK-NEXT: FbC::charlie
+CHECK-NEXT: FbA::delta
+
+CHECK-NEXT: FbD::alpha
+CHECK-NEXT: FbD::bravo
+CHECK-NEXT: FbD::charlie
+CHECK-NEXT: FbD::delta


### PR DESCRIPTION
Previously, when visiting the virtual-table pointer of a class or function block, the resolver added a dependency on the intrinsic `VOID` type but not on the concrete `__vtable_*` struct and its members. Codegen then failed with “unknown type” when expanding opaque types that reference vtable members.

This commit fixes that, such that the members of the virtual table are fetched and added as dependencies in the resolver module.

A minimal reproducible example would be
```
// file: main.st
FUNCTION main
    VAR
        baseInstance: base;
        baseRef: POINTER TO base;
    END_VAR

    baseRef := ADR(baseInstance);
    baseRef^.foo();
END_FUNCTION

// file: base.st
FUNCTION_BLOCK base
    METHOD foo
        printf('base::foo$N');
    END_METHOD
END_FUNCTION_BLOCK
```