### PR TITLE
fix: relax enum variant validation to warning for compatibility

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -141,7 +141,7 @@ lazy_static! {
         E037,   Error,      include_str!("./error_codes/E037.md"),
         E038,   Error,      include_str!("./error_codes/E038.md"), // Missing type
         E039,   Warning,    include_str!("./error_codes/E039.md"),
-        E040,   Error,      include_str!("./error_codes/E040.md"),
+        E040,   Warning,    include_str!("./error_codes/E040.md"),
         E041,   Error,      include_str!("./error_codes/E041.md"),
         E042,   Warning,    include_str!("./error_codes/E042.md"), // Assignment to reference
         E043,   Error,      include_str!("./error_codes/E043.md"),

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E040.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E040.md
@@ -1,5 +1,5 @@
-# Invalid Enum Variant
+# Non-Standard Enum Variant
 
-This error indicates the right-hand side in an enum assignment is invalid.
-For example an enum such as `TYPE Color : (red := 0, green := 1, blue := 2); END_TYPE` can only take values 
+This warning indicates the right-hand side in an enum assignment does not match a defined variant.
+For example an enum such as `TYPE Color : (red := 0, green := 1, blue := 2); END_TYPE` is expected to take values
 which (internally) yield a literal integer 0, 1 or 2.

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -1266,7 +1266,7 @@ pub(crate) fn validate_enum_variant_assignment<T: AnnotationMap>(
         None => {
             validator.push_diagnostic(
                 Diagnostic::new(format!(
-                    "Invalid enum value `{}` for `{}`",
+                    "Non-standard enum value `{}` for `{}`",
                     validator.context.slice(&right.location),
                     validator.get_type_name_or_slice(left_dt)
                 ))

--- a/src/validation/tests/enum_validation_test.rs
+++ b/src/validation/tests/enum_validation_test.rs
@@ -12,7 +12,7 @@ fn enum_variants_mismatch() {
         PROGRAM main
                 VAR
                     color       : (red := 0, green := 1, blue := 2);
-                    localState  : State;
+                    localState  : State := 99;
 
                     validReferenceForEnum   : DINT := 0;
                     invalidReferenceForEnum : DINT := 99; // ...problems but a ~~bi-~~ validation ain't one

--- a/src/validation/tests/snapshots/rusty__validation__tests__enum_validation_test__enum_mismatch_error_with_many_variants_truncates_values_for_better_readability.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__enum_validation_test__enum_mismatch_error_with_many_variants_truncates_values_for_better_readability.snap
@@ -1,14 +1,13 @@
 ---
 source: src/validation/tests/enum_validation_test.rs
 expression: diagnostics
+snapshot_kind: text
 ---
-error[E040]: Invalid enum value `1000` for `Color`
+warning[E040]: Non-standard enum value `1000` for `Color`
   ┌─ <internal>:7:24
   │
 2 │         TYPE Color : (red, green, blue, yellow, cyan, orange, purple, violet); END_TYPE
   │              ----- see also
   ·
 7 │             myColor := 1000;
-  │                        ^^^^ Invalid enum value `1000` for `Color`
-
-
+  │                        ^^^^ Non-standard enum value `1000` for `Color`

--- a/src/validation/tests/snapshots/rusty__validation__tests__enum_validation_test__enum_variants_mismatch.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__enum_validation_test__enum_variants_mismatch.snap
@@ -1,7 +1,17 @@
 ---
 source: src/validation/tests/enum_validation_test.rs
 expression: diagnostics
+snapshot_kind: text
 ---
+warning[E040]: Non-standard enum value `99` for `State`
+  ┌─ <internal>:9:44
+  │
+2 │         TYPE State : (Idle := 0, Working := 100); END_TYPE
+  │              ----- see also
+  ·
+9 │                     localState  : State := 99;
+  │                                            ^^ Non-standard enum value `99` for `State`
+
 note[E092]: Replace `0` with `Idle`
    ┌─ <internal>:18:31
    │
@@ -83,32 +93,32 @@ note[E092]: Replace `validReferenceForEnum` with `Idle`
 32 │                 localState := validReferenceForEnum;
    │                               ^^^^^^^^^^^^^^^^^^^^^ Replace `validReferenceForEnum` with `Idle`
 
-error[E040]: Invalid enum value `99` for `(red := 0, green := 1, blue := 2)`
+warning[E040]: Non-standard enum value `99` for `(red := 0, green := 1, blue := 2)`
    ┌─ <internal>:38:26
    │
  8 │                     color       : (red := 0, green := 1, blue := 2);
    │                                   --------------------------------- see also
    ·
 38 │                 color := 99;
-   │                          ^^ Invalid enum value `99` for `(red := 0, green := 1, blue := 2)`
+   │                          ^^ Non-standard enum value `99` for `(red := 0, green := 1, blue := 2)`
 
-error[E040]: Invalid enum value `State.Working` for `(red := 0, green := 1, blue := 2)`
+warning[E040]: Non-standard enum value `State.Working` for `(red := 0, green := 1, blue := 2)`
    ┌─ <internal>:39:26
    │
  8 │                     color       : (red := 0, green := 1, blue := 2);
    │                                   --------------------------------- see also
    ·
 39 │                 color := State.Working;
-   │                          ^^^^^^^^^^^^^ Invalid enum value `State.Working` for `(red := 0, green := 1, blue := 2)`
+   │                          ^^^^^^^^^^^^^ Non-standard enum value `State.Working` for `(red := 0, green := 1, blue := 2)`
 
-error[E040]: Invalid enum value `invalidReferenceForEnum` for `(red := 0, green := 1, blue := 2)`
+warning[E040]: Non-standard enum value `invalidReferenceForEnum` for `(red := 0, green := 1, blue := 2)`
    ┌─ <internal>:40:26
    │
  8 │                     color       : (red := 0, green := 1, blue := 2);
    │                                   --------------------------------- see also
    ·
 40 │                 color := invalidReferenceForEnum;
-   │                          ^^^^^^^^^^^^^^^^^^^^^^^ Invalid enum value `invalidReferenceForEnum` for `(red := 0, green := 1, blue := 2)`
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^ Non-standard enum value `invalidReferenceForEnum` for `(red := 0, green := 1, blue := 2)`
 
 warning[E091]: Value evaluated at run-time, use an enum variant from `(red := 0, green := 1, blue := 2)`
    ┌─ <internal>:41:26
@@ -119,38 +129,38 @@ warning[E091]: Value evaluated at run-time, use an enum variant from `(red := 0,
 41 │                 color := foo(); // Value of `foo()` unknown, might be outside of variants range
    │                          ^^^^^^ Value evaluated at run-time, use an enum variant from `(red := 0, green := 1, blue := 2)`
 
-error[E040]: Invalid enum value `99` for `State`
+warning[E040]: Non-standard enum value `99` for `State`
    ┌─ <internal>:43:31
    │
  2 │         TYPE State : (Idle := 0, Working := 100); END_TYPE
    │              ----- see also
    ·
 43 │                 localState := 99;
-   │                               ^^ Invalid enum value `99` for `State`
+   │                               ^^ Non-standard enum value `99` for `State`
 
-error[E040]: Invalid enum value `green` for `State`
+warning[E040]: Non-standard enum value `green` for `State`
    ┌─ <internal>:44:31
    │
  2 │         TYPE State : (Idle := 0, Working := 100); END_TYPE
    │              ----- see also
    ·
 44 │                 localState := green;
-   │                               ^^^^^ Invalid enum value `green` for `State`
+   │                               ^^^^^ Non-standard enum value `green` for `State`
 
-error[E040]: Invalid enum value `blue` for `State`
+warning[E040]: Non-standard enum value `blue` for `State`
    ┌─ <internal>:45:31
    │
  2 │         TYPE State : (Idle := 0, Working := 100); END_TYPE
    │              ----- see also
    ·
 45 │                 localState := blue;
-   │                               ^^^^ Invalid enum value `blue` for `State`
+   │                               ^^^^ Non-standard enum value `blue` for `State`
 
-error[E040]: Invalid enum value `invalidReferenceForEnum` for `State`
+warning[E040]: Non-standard enum value `invalidReferenceForEnum` for `State`
    ┌─ <internal>:46:31
    │
  2 │         TYPE State : (Idle := 0, Working := 100); END_TYPE
    │              ----- see also
    ·
 46 │                 localState := invalidReferenceForEnum;
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^ Invalid enum value `invalidReferenceForEnum` for `State`
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^ Non-standard enum value `invalidReferenceForEnum` for `State`

--- a/src/validation/tests/snapshots/rusty__validation__tests__enum_validation_test__validate_enum_variant_initializer.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__enum_validation_test__validate_enum_variant_initializer.snap
@@ -1,14 +1,15 @@
 ---
 source: src/validation/tests/enum_validation_test.rs
 expression: diagnostics
+snapshot_kind: text
 ---
-error[E040]: Invalid enum value `red` for `(metallic := 1, matte := 2, neon := 3) := red`
+warning[E040]: Non-standard enum value `red` for `(metallic := 1, matte := 2, neon := 3) := red`
   ┌─ <internal>:7:63
   │
 7 │                 y : (metallic := 1, matte := 2, neon := 3) := red; // error
   │                     ------------------------------------------^^^
   │                     │                                         │
-  │                     │                                         Invalid enum value `red` for `(metallic := 1, matte := 2, neon := 3) := red`
+  │                     │                                         Non-standard enum value `red` for `(metallic := 1, matte := 2, neon := 3) := red`
   │                     see also
 
 note[E092]: Replace `yellow` with `x1`
@@ -20,22 +21,22 @@ note[E092]: Replace `yellow` with `x1`
    │                        │                              Replace `yellow` with `x1`
    │                        see also
 
-error[E040]: Invalid enum value `neon` for `(x5, x6, x7) := neon`
+warning[E040]: Non-standard enum value `neon` for `(x5, x6, x7) := neon`
    ┌─ <internal>:11:40
    │
 11 │                 var2 : (x5, x6, x7) := neon;                    // error
    │                        ----------------^^^^
    │                        │               │
-   │                        │               Invalid enum value `neon` for `(x5, x6, x7) := neon`
+   │                        │               Non-standard enum value `neon` for `(x5, x6, x7) := neon`
    │                        see also
 
-error[E040]: Invalid enum value `7` for `(a, b, c) := 7`
+warning[E040]: Non-standard enum value `7` for `(a, b, c) := 7`
    ┌─ <internal>:12:37
    │
 12 │                 var3 : (a, b, c) := 7;                          // error
    │                        -------------^
    │                        │            │
-   │                        │            Invalid enum value `7` for `(a, b, c) := 7`
+   │                        │            Non-standard enum value `7` for `(a, b, c) := 7`
    │                        see also
 
 note[E092]: Replace `2` with `green`
@@ -46,5 +47,3 @@ note[E092]: Replace `2` with `green`
   │                     │                       │
   │                     │                       Replace `2` with `green`
   │                     see also
-
-


### PR DESCRIPTION
Change error E040 from an error to a warning when assigning non-standard values to enum types. This allows code that uses enum values outside the defined variants to work, while still alerting developers to potentially problematic usage.