### PR TITLE
fix: run each lit test in its own directory to avoid conflicts in tests

### DIFF
--- a/tests/lit/lit.cfg
+++ b/tests/lit/lit.cfg
@@ -9,12 +9,12 @@ compilerLocation = lit_config.params["COMPILER"]
 
 # ...to make the compile command more reable we build it over multiple lines
 compile = f'{compilerLocation}'
-compile = f'{compile} -o /tmp/%basename_t.out'
+compile = f'{compile} -o %T/%basename_t.out'
 compile = f'{compile} -liec61131std -L{stdlibLocation}/lib -i "{stdlibLocation}/include/*.st"'
 compile = f'{compile} -i {rustyRootDirectory}/tests/lit/util/*.pli'
 compile = f'{compile} --linker=cc'
 print(f'Compile command: {compile}')
 
 config.substitutions.append(('%COMPILE', f'{compile}'))
-config.substitutions.append(('%RUN', f'LD_LIBRARY_PATH="{stdlibLocation}/lib" /tmp/%basename_t.out'))
+config.substitutions.append(('%RUN', f'LD_LIBRARY_PATH="{stdlibLocation}/lib" %T/%basename_t.out'))
 config.substitutions.append(('%CHECK', f'FileCheck-14 --check-prefixes CHECK --allow-unused-prefixes --match-full-lines'))


### PR DESCRIPTION
Use `%T` instead of `/tmp` for the folder name, this way each test is unique