### PR TITLE
fix: clean up profraw files and build artifacts to prevent disk space…

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,46 +39,15 @@ function set_cargo_options() {
 
 function run_coverage() {
     log "Exporting Flags"
-    # Disable incremental compilation to reduce disk usage during build
-    export CARGO_INCREMENTAL=0
     export RUSTFLAGS="-C instrument-coverage"
     export LLVM_PROFILE_FILE="rusty-%p-%m.profraw"
 
     log "Cleaning before build"
     cargo clean
-
-    log "Disk usage before build:"
-    df -h . || true
-
     log "Building coverage"
     cargo build --workspace
-
-    log "Disk usage after build:"
-    df -h . || true
-
-    log "Running coverage tests per package to reduce peak disk usage"
-
-    # Get list of workspace packages
-    packages=$(cargo metadata --no-deps --format-version 1 | grep -o '"name":"[^"]*"' | cut -d'"' -f4)
-
-    for pkg in $packages; do
-        log "Running tests for package: $pkg"
-        cargo test -p "$pkg" || log "Warning: Tests failed for package $pkg, continuing..."
-
-        # Clean up profraw files after each package to reduce peak disk usage
-        profraw_count=$(find . -name "*.profraw" -type f 2>/dev/null | wc -l)
-        if [ "$profraw_count" -gt 0 ]; then
-            log "Cleaning $profraw_count profraw files after $pkg tests"
-            find . -name "*.profraw" -type f -delete
-        fi
-
-        log "Disk usage after $pkg tests:"
-        df -h . || true
-    done
-
-    log "Disk usage after all tests:"
-    df -h . || true
-
+    log "Running coverage tests"
+    cargo test --workspace
     log "Collecting coverage results"
     grcov . --binary-path ./target/debug/ -s . -t lcov --branch \
         --ignore "/*" \
@@ -88,19 +57,6 @@ function run_coverage() {
         --ignore "tests/*" \
         --ignore "src/lexer/tokens.rs" \
         --ignore-not-existing -o lcov.info
-
-    log "Cleaning up any remaining profraw files"
-    profraw_count=$(find . -name "*.profraw" -type f 2>/dev/null | wc -l)
-    if [ "$profraw_count" -gt 0 ]; then
-        log "Found $profraw_count remaining profraw files to delete"
-        find . -name "*.profraw" -type f -delete
-    fi
-
-    log "Cleaning up build artifacts to free disk space"
-    cargo clean
-
-    log "Disk usage after cleanup:"
-    df -h . || true
 }
 
 


### PR DESCRIPTION
GitHub Actions runners were failing with for example:
- `llvm profile error: failed to write file "rusty-13009-116...profraw": No space left on device`
- `System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251215-101259-utc.log'`

This PR attempts to fix this by:
- Fix "No space left on device" errors during GitHub Actions coverage runs by freeing up runner disk space
- Add `free-disk-space` GitHub Action to free ~20-30GB before coverage job starts
- Restructure coverage job to run container explicitly instead of at job level
- Add apt cache cleanup in package-linux job
