### PR TITLE
fix: ensuring that output variables cannot be set outside of their scope

### DIFF
--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -622,11 +622,7 @@ fn validate_reference<T: AnnotationMap>(
                     .and_then(|qualifier| context.index.find_pou(qualifier))
                     .map(|pou| (pou.get_name(), pou.get_container()))
                     .is_some_and(|(pou, container)| {
-                        !(qualified_name.starts_with(pou)
-                    || qualified_name.starts_with(container)
-                    || context.index.is_init_function(pou)
-                    //Hack: Avoid internal check here because of the super call
-                    || location.is_internal())
+                        !variable_is_in_pou_or_container(pou, container, context, qualified_name, location)
                     })
             {
                 validator.push_diagnostic(

--- a/src/validation/tests/variable_validation_tests.rs
+++ b/src/validation/tests/variable_validation_tests.rs
@@ -1345,7 +1345,7 @@ fn output_variables_must_not_be_assignable_outside_of_their_scope() {
 }
 
 #[test]
-fn output_variables_must_be_assignable_within_the_scope_of_inheritence() {
+fn output_variables_must_be_assignable_within_the_scope_of_inheritance() {
     let diagnostics = parse_and_validate_buffered(
         "
         FUNCTION_BLOCK function_block_0


### PR DESCRIPTION
**Changed**

- Ensuring that output variables cannot be set outside of their scope

**Testing**

- Added a test that proves that output variables can no longer be set outside of their scope

