### PR TITLE
ci: bump the version to 0.4.0-dev and add an auto bump

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -15,7 +15,10 @@ jobs:
       contents: write
       pull-requests: write
     # Skip if the push is a release PR merge; always run for manual triggers
-    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    if: >-
+      github.event_name != 'push' ||
+      (!startsWith(github.event.head_commit.message, 'chore(release):')
+       && !startsWith(github.event.head_commit.message, 'chore: bump version to'))
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -58,6 +61,10 @@ jobs:
       - name: Bump versions
         if: steps.version.outputs.skip == 'false'
         run: cargo set-version --workspace ${{ steps.version.outputs.next }}
+
+      - name: Update Cargo.lock
+        if: steps.version.outputs.skip == 'false'
+        run: cargo check --workspace
 
       - name: Generate changelog
         if: steps.version.outputs.skip == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -55,3 +56,40 @@ jobs:
           body: ${{ steps.changelog.outputs.content }}
           draft: false
           prerelease: ${{ startsWith(steps.version.outputs.version, '0.') }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit --locked --version 0.13.9
+
+      - name: Compute dev version
+        id: dev
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          DEV_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-dev"
+          echo "version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Bump to dev version
+        run: cargo set-version --workspace ${{ steps.dev.outputs.version }}
+
+      - name: Update Cargo.lock
+        run: cargo check --workspace
+
+      - name: Create dev-bump pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "chore: bump version to ${{ steps.dev.outputs.version }}"
+          branch: post-release/dev-bump
+          delete-branch: true
+          title: "chore: bump version to ${{ steps.dev.outputs.version }}"
+          body: |
+            Routine post-release version bump.
+
+            Sets the workspace version to `${{ steps.dev.outputs.version }}` so that
+            development builds on `master` are distinguishable from the
+            `${{ steps.version.outputs.tag }}` release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "errorcode_book_generator"
-version = "0.1.0"
+version = "0.4.0-dev"
 dependencies = [
  "clap 4.6.0",
  "mdbook-preprocessor",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "iec61131std"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "cc",
  "chrono",
@@ -2295,7 +2295,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plc-compiler"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "plc_ast"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "plc_derive"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "plc_diagnostics"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "plc_driver"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "clap 3.2.25",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "plc_header_generator"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "clap 3.2.25",
  "insta",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "plc_index"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "annotate-snippets",
  "encoding_rs",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "plc_llvm"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "cc",
  "inkwell",
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "plc_lowering"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "insta",
  "log",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "plc_project"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "encoding_rs",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "plc_source"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "encoding_rs",
  "encoding_rs_io",
@@ -2489,11 +2489,11 @@ dependencies = [
 
 [[package]]
 name = "plc_util"
-version = "0.3.0"
+version = "0.4.0-dev"
 
 [[package]]
 name = "plc_xml"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "html-escape",
  "indexmap 2.13.0",
@@ -2959,7 +2959,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "section_mangler"
-version = "0.3.0"
+version = "0.4.0-dev"
 dependencies = [
  "nom 7.1.3",
 ]
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "0.1.0"
+version = "0.4.0-dev"
 dependencies = [
  "plc-compiler",
  "plc_ast",
@@ -4512,7 +4512,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc-compiler"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = [
     "Ghaith Hachem <ghaith.hachem@gmail.com>",
     "Mathias Rieder <mathias.rieder@gmail.com>",
@@ -18,19 +18,19 @@ default = []
 verify = []
 
 [dependencies]
-plc_source = { path = "./compiler/plc_source", version = "0.3.0" }
-plc_ast = { path = "./compiler/plc_ast", version = "0.3.0" }
-plc_util = { path = "./compiler/plc_util", version = "0.3.0" }
-plc_diagnostics = { path = "./compiler/plc_diagnostics", version = "0.3.0" }
-plc_index = { path = "./compiler/plc_index", version = "0.3.0" }
-section_mangler = { path = "./compiler/section_mangler", version = "0.3.0" }
-plc_llvm = { path = "./compiler/plc_llvm", version = "0.3.0" }
+plc_source = { path = "./compiler/plc_source", version = "0.4.0-dev" }
+plc_ast = { path = "./compiler/plc_ast", version = "0.4.0-dev" }
+plc_util = { path = "./compiler/plc_util", version = "0.4.0-dev" }
+plc_diagnostics = { path = "./compiler/plc_diagnostics", version = "0.4.0-dev" }
+plc_index = { path = "./compiler/plc_index", version = "0.4.0-dev" }
+section_mangler = { path = "./compiler/section_mangler", version = "0.4.0-dev" }
+plc_llvm = { path = "./compiler/plc_llvm", version = "0.4.0-dev" }
 logos = "0.12.0"
 clap = { version = "3.0", features = ["derive"] }
 indexmap = { version = "2.0", features = ["serde"] }
 generational-arena = { version = "0.2.8", features = ["serde"] }
 shell-words = "1.1.0"
-plc_derive = { path = "./compiler/plc_derive", version = "0.3.0" }
+plc_derive = { path = "./compiler/plc_derive", version = "0.4.0-dev" }
 which = "4.2.5"
 log.workspace = true
 inkwell.workspace = true
@@ -47,13 +47,13 @@ rustc-hash.workspace = true
 num = "0.4"
 insta.workspace = true
 pretty_assertions = "1.3.0"
-driver = { path = "./compiler/plc_driver/", package = "plc_driver", version = "0.3.0" }
-project = { path = "./compiler/plc_project/", package = "plc_project", version = "0.3.0", features = [
+driver = { path = "./compiler/plc_driver/", package = "plc_driver", version = "0.4.0-dev" }
+project = { path = "./compiler/plc_project/", package = "plc_project", version = "0.4.0-dev", features = [
     "integration",
 ] }
-plc_xml = { path = "./compiler/plc_xml", version = "0.3.0" }
+plc_xml = { path = "./compiler/plc_xml", version = "0.4.0-dev" }
 test_utils = { path = "./tests/test_utils" }
-plc_lowering = { path = "./compiler/plc_lowering", version = "0.3.0" }
+plc_lowering = { path = "./compiler/plc_lowering", version = "0.4.0-dev" }
 serial_test = "*"
 tempfile = "3"
 encoding_rs.workspace = true

--- a/compiler/plc_ast/Cargo.toml
+++ b/compiler/plc_ast/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "plc_ast"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "AST types for the PLC Structured Text compiler"
 
 [dependencies]
-plc_util = { path = "../plc_util", version = "0.3.0" }
-plc_source = { path = "../plc_source", version = "0.3.0" }
+plc_util = { path = "../plc_util", version = "0.4.0-dev" }
+plc_source = { path = "../plc_source", version = "0.4.0-dev" }
 chrono = { version = "0.4", default-features = false }
 # Enabled the RC feature (for Arc<T>) see: https://serde.rs/feature-flags.html#-features-rc
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/compiler/plc_derive/Cargo.toml
+++ b/compiler/plc_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_derive"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Derive macros for the PLC Structured Text compiler"

--- a/compiler/plc_diagnostics/Cargo.toml
+++ b/compiler/plc_diagnostics/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "plc_diagnostics"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Diagnostics and error reporting for the PLC Structured Text compiler"
 
 [dependencies]
 codespan-reporting = "0.11.1"
-plc_ast = { path = "../plc_ast", version = "0.3.0" }
-plc_source = { path = "../plc_source", version = "0.3.0" }
+plc_ast = { path = "../plc_ast", version = "0.4.0-dev" }
+plc_source = { path = "../plc_source", version = "0.4.0-dev" }
 serde_json.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_driver"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 build = "build.rs"
 license = "LGPL-3.0"
@@ -9,15 +9,15 @@ description = "IEC 61131-3 Structured Text compiler"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "0.3.0" }
-ast = { path = "../plc_ast/", package = "plc_ast", version = "0.3.0" }
-project = { path = "../plc_project/", package = "plc_project", version = "0.3.0" }
-source_code = { path = "../plc_source/", package = "plc_source", version = "0.3.0" }
-cfc = { path = "../plc_xml/", package = "plc_xml", version = "0.3.0" }
-plc_diagnostics = { path = "../plc_diagnostics/", version = "0.3.0" }
-plc_index = { path = "../plc_index", version = "0.3.0" }
-plc_lowering = { path = "../plc_lowering", version = "0.3.0" }
-plc_header_generator = { path = "../plc_header_generator", version = "0.3.0" }
+plc = { path = "../..", package = "plc-compiler", version = "0.4.0-dev" }
+ast = { path = "../plc_ast/", package = "plc_ast", version = "0.4.0-dev" }
+project = { path = "../plc_project/", package = "plc_project", version = "0.4.0-dev" }
+source_code = { path = "../plc_source/", package = "plc_source", version = "0.4.0-dev" }
+cfc = { path = "../plc_xml/", package = "plc_xml", version = "0.4.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics/", version = "0.4.0-dev" }
+plc_index = { path = "../plc_index", version = "0.4.0-dev" }
+plc_lowering = { path = "../plc_lowering", version = "0.4.0-dev" }
+plc_header_generator = { path = "../plc_header_generator", version = "0.4.0-dev" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
@@ -36,7 +36,7 @@ itertools.workspace = true
 [dev-dependencies]
 pretty_assertions = "1.3.0"
 insta.workspace = true
-plc_util = { path = "../plc_util", version = "0.3.0" }
+plc_util = { path = "../plc_util", version = "0.4.0-dev" }
 
 
 [lib]

--- a/compiler/plc_header_generator/Cargo.toml
+++ b/compiler/plc_header_generator/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "plc_header_generator"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "C header file generator for the PLC Structured Text compiler"
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "0.3.0" }
-plc_diagnostics = { path = "../plc_diagnostics/", version = "0.3.0" }
-plc_ast = { path = "../plc_ast/", version = "0.3.0" }
-plc_source = { path = "../plc_source/", version = "0.3.0" }
+plc = { path = "../..", package = "plc-compiler", version = "0.4.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics/", version = "0.4.0-dev" }
+plc_ast = { path = "../plc_ast/", version = "0.4.0-dev" }
+plc_source = { path = "../plc_source/", version = "0.4.0-dev" }
 tera = "1"
 clap = { version = "3.0", features = ["derive"] }
 regex = "1"

--- a/compiler/plc_index/Cargo.toml
+++ b/compiler/plc_index/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "plc_index"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Symbol index and type system for the PLC Structured Text compiler"
 
 [dependencies]
-plc_ast = { path = "../plc_ast", version = "0.3.0" }
-plc_source = { path = "../plc_source", version = "0.3.0" }
-plc_diagnostics = { path = "../plc_diagnostics", version = "0.3.0" }
+plc_ast = { path = "../plc_ast", version = "0.4.0-dev" }
+plc_source = { path = "../plc_source", version = "0.4.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics", version = "0.4.0-dev" }
 #plc_project = { path = "../plc_project" } # TODO: This will create a circular dependency
 rustc-hash.workspace = true
 annotate-snippets = "0.11.5"

--- a/compiler/plc_llvm/Cargo.toml
+++ b/compiler/plc_llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_llvm"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2024"
 license = "LGPL-3.0"
 description = "LLVM Wrapper for C++ functions not exposed by inkwell or in the C API"

--- a/compiler/plc_lowering/Cargo.toml
+++ b/compiler/plc_lowering/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "plc_lowering"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "AST lowering passes for the PLC Structured Text compiler"
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "0.3.0" }
-plc_ast = { path = "../plc_ast", version = "0.3.0" }
-plc_source = { path = "../plc_source", version = "0.3.0" }
-plc_diagnostics = { path = "../plc_diagnostics", version = "0.3.0" }
+plc = { path = "../..", package = "plc-compiler", version = "0.4.0-dev" }
+plc_ast = { path = "../plc_ast", version = "0.4.0-dev" }
+plc_source = { path = "../plc_source", version = "0.4.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics", version = "0.4.0-dev" }
 log.workspace = true
 
 [dev-dependencies]
-plc_driver = { path = "../plc_driver", version = "0.3.0" }
+plc_driver = { path = "../plc_driver", version = "0.4.0-dev" }
 insta = "1.31.0"

--- a/compiler/plc_project/Cargo.toml
+++ b/compiler/plc_project/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "plc_project"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Project configuration and file resolution for the PLC Structured Text compiler"
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "0.3.0" }
-plc_diagnostics = { path = "../plc_diagnostics/", version = "0.3.0" }
-source_code = { path = "../plc_source/", package = "plc_source", version = "0.3.0" }
+plc = { path = "../..", package = "plc-compiler", version = "0.4.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics/", version = "0.4.0-dev" }
+source_code = { path = "../plc_source/", package = "plc_source", version = "0.4.0-dev" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 regex = "1"

--- a/compiler/plc_source/Cargo.toml
+++ b/compiler/plc_source/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_source"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Source file handling for the PLC Structured Text compiler"

--- a/compiler/plc_util/Cargo.toml
+++ b/compiler/plc_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_util"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Shared utilities for the PLC Structured Text compiler"

--- a/compiler/plc_xml/Cargo.toml
+++ b/compiler/plc_xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_xml"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "CFC/FBD XML format support for the PLC Structured Text compiler"
@@ -11,10 +11,10 @@ quick-xml = { version = "0.30", features = ["serialize"] }
 insta = "1.20"
 indexmap = "2.0"
 html-escape = "0.2"
-plc = { path = "../..", package = "plc-compiler", version = "0.3.0" }
-ast = { path = "../plc_ast/", package = "plc_ast", version = "0.3.0" }
-plc_diagnostics = { path = "../plc_diagnostics", version = "0.3.0" }
-plc_source = { path = "../plc_source", version = "0.3.0" }
+plc = { path = "../..", package = "plc-compiler", version = "0.4.0-dev" }
+ast = { path = "../plc_ast/", package = "plc_ast", version = "0.4.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics", version = "0.4.0-dev" }
+plc_source = { path = "../plc_source", version = "0.4.0-dev" }
 itertools.workspace = true
 rustc-hash.workspace = true
 

--- a/compiler/section_mangler/Cargo.toml
+++ b/compiler/section_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "section_mangler"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "ELF section name mangling for the PLC Structured Text compiler"

--- a/errorcode_book_generator/Cargo.toml
+++ b/errorcode_book_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "errorcode_book_generator"
-version = "0.1.0"
+version = "0.4.0-dev"
 edition = "2021"
 publish = false
 

--- a/libs/stdlib/Cargo.toml
+++ b/libs/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iec61131std"
-version = "0.3.0"
+version = "0.4.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "IEC 61131-3 standard library implementation"
@@ -10,21 +10,21 @@ glob = "0.3"
 
 [build-dependencies.plc_driver]
 path = "../../compiler/plc_driver"
-version = "0.3.0"
+version = "0.4.0-dev"
 
 
 [dev-dependencies.plc_driver]
 path = "../../compiler/plc_driver"
-version = "0.3.0"
+version = "0.4.0-dev"
 
 [dev-dependencies.plc_source]
 path = "../../compiler/plc_source"
-version = "0.3.0"
+version = "0.4.0-dev"
 
 [dev-dependencies.plc]
 package = "plc-compiler"
 path = "../.."
-version = "0.3.0"
+version = "0.4.0-dev"
 
 
 [dependencies]

--- a/tests/test_utils/Cargo.toml
+++ b/tests/test_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_utils"
-version = "0.1.0"
+version = "0.4.0-dev"
 edition = "2021"
 publish = false
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0"
+version = "0.4.0-dev"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
This pull request upgrades the entire workspace and all internal crates from version `0.3.0` to `0.4.0-dev`, ensuring that all dependencies are consistently updated. It also enhances the release automation workflows to support post-release version bumps and development versioning, including automatic creation of "dev-bump" pull requests after a release. The most important changes are summarized below.

**Workspace and crate version upgrades:**

* All workspace crates (including `plc-compiler`, `plc_ast`, `plc_util`, `plc_diagnostics`, `plc_index`, `plc_driver`, `plc_project`, `plc_source`, `plc_derive`, `plc_llvm`, `plc_lowering`, `plc_header_generator`, `plc_xml`, `section_mangler`, `iec61131std`, `errorcode_book_generator`, `test_utils`, and `xtask`) are bumped from version `0.3.0` (or previous) to `0.4.0-dev`. All internal crate dependencies are updated accordingly to reference version `0.4.0-dev`. 

**Release workflow improvements:**

* The `release.yml` workflow now automatically bumps the workspace version to a new development version (e.g., `0.4.0-dev`) after a release, updates `Cargo.lock`, and creates a pull request for the dev bump.
* The workflow permissions for `release.yml` are updated to include `pull-requests: write` for PR creation.

**Release PR workflow enhancements:**

* The `release-pr.yml` workflow is updated to skip execution not only for release PR merges but also for version bump commits, and it now ensures `Cargo.lock` is updated after version changes. 

These changes collectively streamline the release process and ensure version consistency across all workspace crates.