### PR TITLE
fix: preprocess property datatypes

### DIFF
--- a/compiler/plc_ast/src/pre_processor.rs
+++ b/compiler/plc_ast/src/pre_processor.rs
@@ -7,8 +7,8 @@ use plc_util::convention::internal_type_name;
 use crate::{
     ast::{
         flatten_expression_list, Assignment, AstFactory, AstNode, AstStatement, CompilationUnit,
-        ConfigVariable, DataType, DataTypeDeclaration, LinkageType, Operator, Pou, UserTypeDeclaration,
-        Variable, VariableBlock, VariableBlockType,
+        ConfigVariable, DataType, DataTypeDeclaration, LinkageType, Operator, Pou, PropertyBlock,
+        UserTypeDeclaration, Variable, VariableBlock, VariableBlockType,
     },
     literals::AstLiteral,
     provider::IdProvider,
@@ -26,8 +26,14 @@ pub fn pre_process(unit: &mut CompilationUnit, mut id_provider: IdProvider) {
         process_pou_variables(pou, &mut unit.user_types);
     }
 
-    for interface in unit.interfaces.iter_mut().flat_map(|it| &mut it.methods) {
-        process_pou_variables(interface, &mut unit.user_types);
+    for interface in unit.interfaces.iter_mut() {
+        for method in &mut interface.methods {
+            process_pou_variables(method, &mut unit.user_types);
+        }
+
+        for property in &mut interface.properties {
+            process_property(property, &interface.ident.name, LinkageType::Internal, &mut unit.user_types);
+        }
     }
 
     // XXX: Track which hardware-backing globals (__PI_*, __M_*, __G_*) have already been created.
@@ -169,6 +175,10 @@ fn process_pou_variables(pou: &mut Pou, user_types: &mut Vec<UserTypeDeclaration
 
     for var in local_variables {
         pre_process_variable_data_type(pou.name.as_str(), var, user_types, pou.linkage)
+    }
+
+    for property in &mut pou.properties {
+        process_property(property, &pou.name, pou.linkage, user_types);
     }
 
     //Generate implicit type for returns
@@ -377,12 +387,24 @@ fn preprocess_generic_structs(pou: &mut Pou) -> Vec<UserTypeDeclaration> {
         types.push(data_type);
         generic_types.insert(binding.name.clone(), new_name);
     }
+
     for var in pou.variable_blocks.iter_mut().flat_map(|it| it.variables.iter_mut()) {
         replace_generic_type_name(&mut var.data_type_declaration, &generic_types);
     }
+
     if let Some(datatype) = pou.return_type.as_mut() {
         replace_generic_type_name(datatype, &generic_types);
     };
+
+    for property in &mut pou.properties {
+        for implementation in &mut property.implementations {
+            replace_generic_type_name(&mut implementation.datatype, &generic_types);
+            for var in implementation.variable_blocks.iter_mut().flat_map(|it| it.variables.iter_mut()) {
+                replace_generic_type_name(&mut var.data_type_declaration, &generic_types);
+            }
+        }
+    }
+
     types
 }
 
@@ -407,6 +429,65 @@ fn preprocess_return_type(pou: &mut Pou, types: &mut Vec<UserTypeDeclaration>) {
                     linkage,
                 };
                 types.push(data_type);
+            }
+        }
+    }
+}
+
+fn process_property(
+    property: &mut PropertyBlock,
+    container_name: &str,
+    linkage: LinkageType,
+    user_types: &mut Vec<UserTypeDeclaration>,
+) {
+    for (index, implementation) in property.implementations.iter_mut().enumerate() {
+        let property_container_name = format!(
+            "{container_name}_property_{}_{}_{}",
+            property.ident.name,
+            implementation.kind.to_string().to_ascii_lowercase(),
+            index,
+        );
+
+        for var in implementation
+            .variable_blocks
+            .iter_mut()
+            .flat_map(|it| it.variables.iter_mut())
+            .filter(|it| should_generate_implicit_type(it))
+        {
+            pre_process_variable_data_type(property_container_name.as_str(), var, user_types, linkage);
+        }
+
+        if should_generate_implicit(&implementation.datatype) {
+            let type_name = internal_type_name(
+                format!("{container_name}_property_"),
+                format!(
+                    "{}_{}_{}",
+                    property.ident.name,
+                    implementation.kind.to_string().to_ascii_lowercase(),
+                    index,
+                ),
+            );
+            let type_ref = DataTypeDeclaration::Reference {
+                referenced_type: type_name.clone(),
+                location: implementation.datatype.get_location(),
+            };
+            let datatype = std::mem::replace(&mut implementation.datatype, type_ref);
+            if let DataTypeDeclaration::Definition { mut data_type, location, scope } = datatype {
+                data_type.set_name(type_name);
+                add_nested_datatypes(
+                    property_container_name.as_str(),
+                    &mut data_type,
+                    user_types,
+                    &location,
+                    linkage,
+                );
+                user_types.push(UserTypeDeclaration {
+                    data_type: *data_type,
+                    initializer: None,
+                    location,
+                    scope,
+                    linkage,
+                });
             }
         }
     }

--- a/src/validation/property.rs
+++ b/src/validation/property.rs
@@ -15,6 +15,7 @@ use crate::{
     index::{Index, PouIndexEntry},
     resolver::AnnotationMap,
     typesystem::DataType,
+    validation::types,
 };
 
 use super::{ValidationContext, Validator, Validators};
@@ -50,11 +51,15 @@ fn property_datatype<'idx>(index: &'idx Index, property: &PropertyBlock) -> Opti
     })
 }
 
+fn property_types_match(index: &Index, left: Option<&DataType>, right: Option<&DataType>) -> bool {
+    matches!((left, right), (Some(left), Some(right)) if types::are_equal_types(index, left, right))
+}
+
 fn local_property_types_conflict(index: &Index, property: &PropertyBlock) -> bool {
     let get = property_accessor_datatype(index, property, PropertyKind::Get);
     let set = property_accessor_datatype(index, property, PropertyKind::Set);
 
-    matches!((get, set), (Some(get), Some(set)) if get != set)
+    matches!((get, set), (Some(get), Some(set)) if !types::are_equal_types(index, get, set))
 }
 
 fn validate_property_definition(validator: &mut Validator, index: &Index, property: &PropertyBlock) {
@@ -224,7 +229,7 @@ fn validate_overridden_signatures<T>(
                 let child_type = property_datatype(context.index, property_child);
                 let parent_type = property_datatype(context.index, property_parent);
 
-                if child_type != parent_type {
+                if !property_types_match(context.index, child_type, parent_type) {
                     validator.push_diagnostic(
                         Diagnostic::new(format!(
                             "Overridden property `{}` has different signatures in POU `{}` and `{}`",
@@ -279,7 +284,7 @@ pub(crate) fn validate_properties_in_interfaces<T>(
         let left_type = property_datatype(context.index, left_property);
         let right_type = property_datatype(context.index, right_property);
 
-        if left_type.is_none() || right_type.is_none() || left_type != right_type {
+        if !property_types_match(context.index, left_type, right_type) {
             validator.push_diagnostic(
                 Diagnostic::new(format!(
                     "Property `{}` defined in interface `{}` and `{}` have different datatypes",

--- a/src/validation/tests/property_validation_tests.rs
+++ b/src/validation/tests/property_validation_tests.rs
@@ -594,6 +594,72 @@ fn properties_with_same_name_but_different_datatypes_are_not_ok() {
 }
 
 #[test]
+fn properties_with_same_array_datatype_using_different_const_expressions_are_ok() {
+    let diagnostics = test_utils::parse_and_validate_buffered(
+        r"
+        VAR_GLOBAL CONSTANT
+            start_a : INT := 1;
+            end_a : INT := 5;
+            start_b : INT := 1;
+            end_b : INT := 5;
+        END_VAR
+
+        FUNCTION_BLOCK FbA
+            PROPERTY_GET foo: ARRAY[start_a..end_a] OF DINT END_PROPERTY
+            PROPERTY_SET foo: ARRAY[start_b..end_b] OF DINT END_PROPERTY
+        END_FUNCTION_BLOCK
+        ",
+    );
+
+    insta::assert_snapshot!(diagnostics, @"");
+}
+
+#[test]
+fn properties_with_same_struct_datatype_using_different_case_are_ok() {
+    let diagnostics = test_utils::parse_and_validate_buffered(
+        r"
+        TYPE Position:
+            STRUCT
+                x: DINT;
+                y: DINT;
+            END_STRUCT
+        END_TYPE
+
+        FUNCTION_BLOCK FbA
+            PROPERTY_GET position: Position END_PROPERTY
+            PROPERTY_SET position: position END_PROPERTY
+        END_FUNCTION_BLOCK
+        ",
+    );
+
+    insta::assert_snapshot!(diagnostics, @"");
+}
+
+#[test]
+fn properties_with_different_array_ranges_are_not_ok() {
+    let diagnostics = test_utils::parse_and_validate_buffered(
+        r"
+        VAR_GLOBAL CONSTANT
+            start_a : INT := 1;
+            end_a : INT := 5;
+            start_b : INT := 1;
+            end_b : INT := 6;
+        END_VAR
+
+        FUNCTION_BLOCK FbA
+            PROPERTY_GET foo: ARRAY[start_a..end_a] OF DINT END_PROPERTY
+            PROPERTY_SET foo: ARRAY[start_b..end_b] OF DINT END_PROPERTY
+        END_FUNCTION_BLOCK
+        ",
+    );
+
+    assert!(
+        diagnostics.contains("Property `foo` has conflicting datatypes across PROPERTY_GET / PROPERTY_SET"),
+        "{diagnostics}"
+    );
+}
+
+#[test]
 fn extending_interface_property_by_getter_with_same_datatype_is_ok() {
     let source = r"
     INTERFACE intf1

--- a/src/validation/types.rs
+++ b/src/validation/types.rs
@@ -11,7 +11,7 @@ use plc_source::source_location::SourceLocation;
 use crate::{
     index::Index,
     resolver::AnnotationMap,
-    typesystem::{DataTypeInformation, StructSource},
+    typesystem::{self, DataTypeInformation, Dimension, StructSource},
 };
 
 use super::{
@@ -265,4 +265,80 @@ pub fn data_type_is_fb_or_class_instance(type_name: &str, index: &Index) -> bool
         }
         _ => false,
     }
+}
+
+pub fn are_equal_types(index: &Index, left: &typesystem::DataType, right: &typesystem::DataType) -> bool {
+    let left_type_info = left.get_type_information();
+    let right_type_info = right.get_type_information();
+
+    if left_type_info == right_type_info {
+        return true;
+    }
+
+    match (left_type_info, right_type_info) {
+        (
+            DataTypeInformation::Array {
+                inner_type_name: left_inner_type_name,
+                dimensions: left_dimensions,
+                ..
+            },
+            DataTypeInformation::Array {
+                inner_type_name: right_inner_type_name,
+                dimensions: right_dimensions,
+                ..
+            },
+        ) => {
+            are_equal_array_dimensions(index, left_dimensions, right_dimensions)
+                && are_equal_types(
+                    index,
+                    index.get_effective_type_or_void_by_name(left_inner_type_name),
+                    index.get_effective_type_or_void_by_name(right_inner_type_name),
+                )
+        }
+        (
+            DataTypeInformation::Struct { name: left_name, .. },
+            DataTypeInformation::Struct { name: right_name, .. },
+        )
+        | (
+            DataTypeInformation::Enum { name: left_name, .. },
+            DataTypeInformation::Enum { name: right_name, .. },
+        ) => {
+            // Given we have a global namespace only, checking by names is sufficient for equality check
+            // for structs and enums. The "Ambiguous datatype" validation does the heavy lifting here.
+            left_name.eq_ignore_ascii_case(right_name)
+        }
+        (
+            DataTypeInformation::Alias { referenced_type: left_reference_type, .. },
+            DataTypeInformation::Alias { referenced_type: right_reference_type, .. },
+        ) => {
+            let left = index.find_effective_type_by_name(left_reference_type);
+            let right = index.find_effective_type_by_name(right_reference_type);
+
+            left == right
+        }
+
+        _ => false,
+    }
+}
+
+fn are_equal_array_dimensions(index: &Index, left: &[Dimension], right: &[Dimension]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+
+    for (left_dimension, right_dimension) in left.iter().zip(right) {
+        let Some(left_range) = left_dimension.get_range(index).ok() else {
+            return false;
+        };
+
+        let Some(right_range) = right_dimension.get_range(index).ok() else {
+            return false;
+        };
+
+        if left_range != right_range {
+            return false;
+        }
+    }
+
+    true
 }


### PR DESCRIPTION
Pre-process property datatypes such that they can be queried by the index and used in the valdiation.