### PR TITLE
fix: preserve lowering diagnostics through validation

### DIFF
--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -474,17 +474,14 @@ impl<T: SourceContainer> Pipeline for BuildPipeline<T> {
         self.participants.iter().for_each(|p| {
             p.post_annotate(&annotated_project);
         });
-        let annotated_project = self
+        let mut annotated_project = self
             .mutable_participants
             .iter_mut()
             .fold(annotated_project, |project, p| p.post_annotate(project));
 
         // Collect diagnostics from participants that validated during lowering.
         for p in &mut self.mutable_participants {
-            let diags = p.diagnostics();
-            if !diags.is_empty() {
-                self.diagnostician.handle(&diags);
-            }
+            annotated_project.diagnostics.extend(p.diagnostics());
         }
 
         Ok(annotated_project)
@@ -760,7 +757,7 @@ impl IndexedProject {
 
         let annotations = AstAnnotations::new(all_annotations, id_provider.next_id());
 
-        AnnotatedProject { units: annotated_units, index, annotations }
+        AnnotatedProject { units: annotated_units, index, annotations, diagnostics: Vec::new() }
     }
 }
 
@@ -799,6 +796,9 @@ pub struct AnnotatedProject {
     pub units: Vec<AnnotatedUnit>,
     pub index: Index,
     pub annotations: AstAnnotations,
+    /// Diagnostics produced by lowering participants after annotation.
+    #[serde(skip)]
+    pub diagnostics: Vec<Diagnostic>,
 }
 
 impl AnnotatedProject {
@@ -808,11 +808,13 @@ impl AnnotatedProject {
         ctxt: &GlobalContext,
         diagnostician: &mut Diagnostician,
     ) -> Result<(), Diagnostic> {
+        let mut severity = diagnostician.handle(&self.diagnostics);
+
         // perform global validation
         let mut validator = Validator::new(ctxt);
         validator.perform_global_validation(&self.index);
         let diagnostics = validator.diagnostics();
-        let mut severity = diagnostician.handle(&diagnostics);
+        severity = severity.max(diagnostician.handle(&diagnostics));
 
         //Perform per unit validation
         self.units.iter().for_each(|AnnotatedUnit { unit, .. }| {

--- a/compiler/plc_driver/src/pipelines/participant.rs
+++ b/compiler/plc_driver/src/pipelines/participant.rs
@@ -280,26 +280,28 @@ impl PipelineParticipantMut for InheritanceLowerer {
     }
 
     fn post_annotate(&mut self, annotated_project: AnnotatedProject) -> AnnotatedProject {
-        let AnnotatedProject { mut units, index, annotations } = annotated_project;
+        let AnnotatedProject { mut units, index, annotations, diagnostics } = annotated_project;
         self.annotations = Some(Box::new(annotations));
         self.index = Some(index);
         units.iter_mut().for_each(|unit| self.visit_unit(&mut unit.unit));
         let index = self.index.take().expect("Index should be present");
         // re-resolve
-        IndexedProject {
+        let mut project = IndexedProject {
             project: ParsedProject {
                 units: units.into_iter().map(|AnnotatedUnit { unit, .. }| unit).collect(),
             },
             index,
             _unresolvables: vec![],
         }
-        .annotate(self.provider())
+        .annotate(self.provider());
+        project.diagnostics = diagnostics;
+        project
     }
 }
 
 impl PipelineParticipantMut for AggregateTypeLowerer {
     fn post_annotate(&mut self, annotated_project: AnnotatedProject) -> AnnotatedProject {
-        let AnnotatedProject { units, index, annotations } = annotated_project;
+        let AnnotatedProject { units, index, annotations, diagnostics } = annotated_project;
         self.index = Some(index);
         self.annotation = Some(Box::new(annotations));
 
@@ -314,7 +316,9 @@ impl PipelineParticipantMut for AggregateTypeLowerer {
         // Re-index from modified units so the index reflects POU signature
         // changes (e.g. aggregate returns converted to VAR_IN_OUT parameters).
         let project = ParsedProject { units };
-        project.index(self.id_provider.clone()).annotate(self.id_provider.clone())
+        let mut project = project.index(self.id_provider.clone()).annotate(self.id_provider.clone());
+        project.diagnostics = diagnostics;
+        project
     }
 }
 
@@ -328,17 +332,19 @@ impl PipelineParticipantMut for PolymorphismLowerer {
     }
 
     fn post_annotate(&mut self, annotated_project: AnnotatedProject) -> AnnotatedProject {
-        let AnnotatedProject { units, index, annotations } = annotated_project;
+        let AnnotatedProject { units, index, annotations, diagnostics } = annotated_project;
         let mut units: Vec<_> = units.into_iter().map(|AnnotatedUnit { unit, .. }| unit).collect();
 
-        let diagnostics = self.dispatch(index, annotations.annotation_map, &mut units);
-        self.stash_diagnostics(diagnostics);
+        let new_diagnostics = self.dispatch(index, annotations.annotation_map, &mut units);
+        self.stash_diagnostics(new_diagnostics);
         let project = ParsedProject { units };
 
         // Dispatch lowering may inject new types (e.g. `__FATPOINTER` and itables for interface
         // dispatch) into the compilation units' `user_types`. Re-indexing from the units ensures
         // these types are present in the index for the subsequent re-annotation.
-        project.index(self.ids.clone()).annotate(self.ids.clone())
+        let mut project = project.index(self.ids.clone()).annotate(self.ids.clone());
+        project.diagnostics = diagnostics;
+        project
     }
 
     fn diagnostics(&mut self) -> Vec<Diagnostic> {

--- a/compiler/plc_driver/src/pipelines/property.rs
+++ b/compiler/plc_driver/src/pipelines/property.rs
@@ -19,20 +19,22 @@ impl PipelineParticipantMut for PropertyLowerer {
     }
 
     fn post_annotate(&mut self, project: AnnotatedProject) -> AnnotatedProject {
-        let AnnotatedProject { mut units, index, annotations } = project;
+        let AnnotatedProject { mut units, index, annotations, diagnostics } = project;
         self.annotations = Some(annotations);
 
         for AnnotatedUnit { unit, .. } in &mut units.iter_mut() {
             self.properties_to_fncalls(unit);
         }
 
-        let project = IndexedProject {
+        let indexed_project = IndexedProject {
             project: ParsedProject { units: units.into_iter().map(|annotated| annotated.unit).collect() },
             index,
             _unresolvables: vec![],
         };
 
-        project.annotate(self.id_provider.clone())
+        let mut project = indexed_project.annotate(self.id_provider.clone());
+        project.diagnostics = diagnostics;
+        project
     }
 
     fn diagnostics(&mut self) -> Vec<Diagnostic> {

--- a/compiler/plc_lowering/src/tests/inheritance_tests.rs
+++ b/compiler/plc_lowering/src/tests/inheritance_tests.rs
@@ -2099,7 +2099,7 @@ mod resolve_bases_tests {
             "#
         .into();
 
-        let (_, AnnotatedProject { units, index: _index, annotations }) =
+        let (_, AnnotatedProject { units, index: _index, annotations, .. }) =
             parse_and_annotate("test", vec![src]).unwrap();
         let unit = &units[0].get_unit().implementations[3];
         let statement = &unit.statements[0];

--- a/tests/lit/single/polymorphism/direct_interface_call_does_not_emit_output.st
+++ b/tests/lit/single/polymorphism/direct_interface_call_does_not_emit_output.st
@@ -1,0 +1,23 @@
+// RUN: rm -f %T/%basename_t.out
+// RUN: not %COMPILE --error-format clang %s 2>&1 | %CHECK %s
+// RUN: test ! -e %T/%basename_t.out
+
+// Regression test: diagnostics emitted by lowering participants must not produce a binary.
+// Lowerers aggregate diagnostics and let the main validation step decide whether to abort,
+// so validation errors found during lowering must still stop the pipeline before codegen.
+
+// CHECK: {{.*}}direct_interface_call_does_not_emit_output.st:{{[0-9]+}}:{{[0-9]+}}:{{.*}}error[E129]: Interfaces cannot be called directly
+// CHECK: Compilation aborted due to critical errors
+
+INTERFACE IA
+    METHOD foo
+    END_METHOD
+END_INTERFACE
+
+FUNCTION main
+    VAR
+        refIA : IA;
+    END_VAR
+
+    refIA();
+END_FUNCTION


### PR DESCRIPTION
Carry diagnostics on AnnotatedProject across participant re-annotation so lowering errors are reported during validation and still abort codegen. Add a regression test for direct interface calls ensuring no output binary is emitted after the lowering diagnostic.