### PR TITLE
fix: avoid duplicate inherited FB initialization

### DIFF
--- a/compiler/plc_lowering/src/initializer.rs
+++ b/compiler/plc_lowering/src/initializer.rs
@@ -232,6 +232,9 @@ impl AstVisitor for Initializer {
         let index = self.index.as_ref().expect("index is set at this stage");
         let variable_block_type =
             self.context.current_variable_block.expect("variable block is set at this stage");
+        if is_injected_base_member(variable, self.context.current_pou.as_deref(), index) {
+            return;
+        }
         // Find if the parent is stateful
         let is_stateful = if let Some(pou_name) = &self.context.current_pou {
             index.find_pou(pou_name).is_some_and(|it| it.is_stateful())
@@ -556,6 +559,24 @@ fn is_simple_identifier_address(address: &AstNode) -> bool {
     matches!(address.get_stmt(), plc_ast::ast::AstStatement::Identifier(_))
 }
 
+/// Inheritance lowering injects a hidden `__<Super>` member into derived POUs (see
+/// `inheritance.rs`). The derived constructor already emits an explicit base-constructor call
+/// before walking members, so this synthetic field must not be initialized as a regular member
+/// as well.
+fn is_injected_base_member(variable: &Variable, current_pou: Option<&str>, index: &Index) -> bool {
+    let Some(current_pou) = current_pou else { return false };
+    let Some(super_class) = index.find_pou(current_pou).and_then(|pou| pou.get_super_class()) else {
+        return false;
+    };
+
+    variable.location.is_internal()
+        && variable.get_name() == format!("__{super_class}")
+        && variable
+            .data_type_declaration
+            .get_referenced_type()
+            .is_some_and(|referenced_type| referenced_type == super_class)
+}
+
 impl Initializer {
     pub fn new(id_provider: IdProvider, generate_externals: bool) -> Initializer {
         Initializer {
@@ -795,9 +816,12 @@ impl Initializer {
     /// if one is registered and exists as a method in the index.
     fn get_user_defined_constructor_call(&mut self, type_name: &str, var_name: &str) -> Option<AstNode> {
         if let Some(index) = self.index.as_ref() {
-            // Search for the user defined constructor for the given struct
+            // Search for the user defined constructor for the given struct.
+            // Use `find_pou` (exact match), not `find_method` (which walks the super class):
+            // an inherited FB_INIT is already invoked by the base ctor we emitted in
+            // `visit_pou`, and recursing here would call it a second time.
             if let Some(user_defined_ctor_name) = self.user_defined_constructors.get(type_name) {
-                if let Some(_pou) = index.find_method(type_name, user_defined_ctor_name) {
+                if let Some(_pou) = index.find_pou(&format!("{type_name}.{user_defined_ctor_name}")) {
                     // Create an explicit base reference (e.g., "self")
                     // Wrap in a ReferenceExpr with Member access for consistency
                     let base_ident = AstFactory::create_identifier(
@@ -958,6 +982,188 @@ mod tests {
         }
         initializer.index = None;
         initializer
+    }
+
+    fn parse_with_default_lowering(src: &str) -> AnnotatedProject {
+        let diagnostician = Diagnostician::buffered();
+        let sources: Vec<SourceCode> = vec![src.into()];
+        let mut pipeline = BuildPipeline::from_sources("test.st", sources, diagnostician).unwrap();
+        pipeline.register_default_mut_participants();
+        pipeline.parse_and_annotate().unwrap()
+    }
+
+    fn lowered_implementation_body(project: &AnnotatedProject, implementation_name: &str) -> String {
+        let implementation = project
+            .units
+            .iter()
+            .flat_map(|unit| unit.get_unit().implementations.iter())
+            .find(|implementation| implementation.name == implementation_name)
+            .unwrap_or_else(|| panic!("implementation `{implementation_name}` not found"));
+
+        print_to_string(&implementation.statements)
+    }
+
+    #[test]
+    fn inherited_function_block_base_constructor_is_emitted_once_after_full_lowering() {
+        let src = r#"
+        FUNCTION_BLOCK Base
+        VAR
+            x : DINT;
+        END_VAR
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Child EXTENDS Base
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        VAR_GLOBAL
+            gChild : Child;
+        END_VAR
+        "#;
+
+        let project = parse_with_default_lowering(src);
+        let body = lowered_implementation_body(&project, "Child__ctor");
+        let base_ctor_calls = body.matches("Base__ctor(").count();
+
+        assert_eq!(base_ctor_calls, 1, "Child__ctor should call Base__ctor exactly once; body:\n{body}");
+    }
+
+    #[test]
+    fn inherited_fb_init_is_not_called_again_after_base_constructor() {
+        let src = r#"
+        FUNCTION_BLOCK Base
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Child EXTENDS Base
+        END_FUNCTION_BLOCK
+
+        VAR_GLOBAL
+            gChild : Child;
+        END_VAR
+        "#;
+
+        let project = parse_with_default_lowering(src);
+        let body = lowered_implementation_body(&project, "Child__ctor");
+
+        assert!(body.contains("Base__ctor("), "Child__ctor should call Base__ctor; body:\n{body}");
+        assert!(
+            !body.contains("FB_INIT"),
+            "Child__ctor must not call inherited FB_INIT again; body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn child_ctor_does_not_double_initialize_base_when_no_fb_init_exists() {
+        // Isolates issue #1 (duplicate `Base__ctor` from the synthetic `__Base` member walk):
+        // neither POU declares `FB_INIT`, so only the base-ctor duplication can regress here.
+        let src = r#"
+        FUNCTION_BLOCK Base
+        VAR
+            x : DINT;
+        END_VAR
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Child EXTENDS Base
+        END_FUNCTION_BLOCK
+
+        VAR_GLOBAL
+            gChild : Child;
+        END_VAR
+        "#;
+
+        let project = parse_with_default_lowering(src);
+        let body = lowered_implementation_body(&project, "Child__ctor");
+
+        insta::assert_snapshot!(body, @"
+        Base__ctor(self.__Base)
+        self.__Base.__vtable := ADR(__vtable_Child_instance)
+        ");
+    }
+
+    #[test]
+    fn fb_init_is_emitted_only_at_the_level_that_declares_it() {
+        // Multi-level chain with `FB_INIT` only at the leaf. Verifies that switching
+        // `find_method` -> `find_pou` did not regress the legitimate emit at the
+        // declaring level, and that intermediate levels stay clean.
+        let src = r#"
+        FUNCTION_BLOCK Base
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Mid EXTENDS Base
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Leaf EXTENDS Mid
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        VAR_GLOBAL
+            gLeaf : Leaf;
+        END_VAR
+        "#;
+
+        let project = parse_with_default_lowering(src);
+        insta::assert_snapshot!(lowered_implementation_body(&project, "Base__ctor"), @"
+        __Base___vtable__ctor(self.__vtable)
+        self.__vtable := ADR(__vtable_Base_instance)
+        ");
+        insta::assert_snapshot!(lowered_implementation_body(&project, "Mid__ctor"), @"
+        Base__ctor(self.__Base)
+        self.__Base.__vtable := ADR(__vtable_Mid_instance)
+        ");
+        insta::assert_snapshot!(lowered_implementation_body(&project, "Leaf__ctor"), @"
+        Mid__ctor(self.__Mid)
+        self.__Mid.__Base.__vtable := ADR(__vtable_Leaf_instance)
+        self.FB_INIT()
+        ");
+    }
+
+    #[test]
+    fn each_level_calls_only_its_own_fb_init() {
+        // Multi-level chain with `FB_INIT` declared at every level. Each ctor must
+        // emit exactly one FB_INIT call (its own) and one base-ctor chain call.
+        let src = r#"
+        FUNCTION_BLOCK Base
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Mid EXTENDS Base
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK Leaf EXTENDS Mid
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        VAR_GLOBAL
+            gLeaf : Leaf;
+        END_VAR
+        "#;
+
+        let project = parse_with_default_lowering(src);
+        insta::assert_snapshot!(lowered_implementation_body(&project, "Base__ctor"), @"
+        __Base___vtable__ctor(self.__vtable)
+        self.__vtable := ADR(__vtable_Base_instance)
+        self.FB_INIT()
+        ");
+        insta::assert_snapshot!(lowered_implementation_body(&project, "Mid__ctor"), @"
+        Base__ctor(self.__Base)
+        self.__Base.__vtable := ADR(__vtable_Mid_instance)
+        self.FB_INIT()
+        ");
+        insta::assert_snapshot!(lowered_implementation_body(&project, "Leaf__ctor"), @"
+        Mid__ctor(self.__Mid)
+        self.__Mid.__Base.__vtable := ADR(__vtable_Leaf_instance)
+        self.FB_INIT()
+        ");
     }
 
     #[test]
@@ -1529,12 +1735,12 @@ mod tests {
         self.FB_INIT()
         ");
 
-        // child constructor calls baseFb__ctor first, then sets up its own vtable
+        // child constructor calls baseFb__ctor first, then sets up its own vtable.
+        // It must not call the inherited FB_INIT again; baseFb__ctor already does that.
         insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("child").unwrap()), @"
         intern:
         baseFb__ctor(self.__baseFb)
         self.__vtable := ADR(__vtable_child_instance)
-        self.FB_INIT()
         ");
     }
 

--- a/src/codegen/tests/oop_tests.rs
+++ b/src/codegen/tests/oop_tests.rs
@@ -78,10 +78,7 @@ fn members_from_base_class_are_available_in_subclasses() {
       call void @foo__ctor(ptr %__foo)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__foo2 = getelementptr inbounds nuw %bar, ptr %deref1, i32 0, i32 0
-      call void @foo__ctor(ptr %__foo2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__foo4 = getelementptr inbounds nuw %bar, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo2, i32 0, i32 0
       store ptr @__vtable_bar_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -242,10 +239,7 @@ fn write_to_parent_variable_qualified_access() {
       call void @fb__ctor(ptr %__fb)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__fb2 = getelementptr inbounds nuw %fb2, ptr %deref1, i32 0, i32 0
-      call void @fb__ctor(ptr %__fb2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__fb4 = getelementptr inbounds nuw %fb2, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %fb, ptr %__fb4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %fb, ptr %__fb2, i32 0, i32 0
       store ptr @__vtable_fb2_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -458,10 +452,7 @@ fn write_to_parent_variable_in_instance() {
       call void @foo__ctor(ptr %__foo)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__foo2 = getelementptr inbounds nuw %bar, ptr %deref1, i32 0, i32 0
-      call void @foo__ctor(ptr %__foo2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__foo4 = getelementptr inbounds nuw %bar, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo2, i32 0, i32 0
       store ptr @__vtable_bar_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -696,14 +687,11 @@ fn array_in_parent_generated() {
       %__grandparent = getelementptr inbounds nuw %parent, ptr %deref, i32 0, i32 0
       call void @grandparent__ctor(ptr %__grandparent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__grandparent2 = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 0
-      call void @grandparent__ctor(ptr %__grandparent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %x = getelementptr inbounds nuw %parent, ptr %deref3, i32 0, i32 1
+      %x = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 1
       call void @__parent_x__ctor(ptr %x)
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__grandparent5 = getelementptr inbounds nuw %parent, ptr %deref4, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__grandparent3 = getelementptr inbounds nuw %parent, ptr %deref2, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent3, i32 0, i32 0
       store ptr @__vtable_parent_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -716,14 +704,11 @@ fn array_in_parent_generated() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %z = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1
+      %z = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1
       call void @__child_z__ctor(ptr %z)
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0
-      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0
+      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0
       %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
@@ -961,14 +946,11 @@ fn complex_array_access_generated() {
       %__grandparent = getelementptr inbounds nuw %parent, ptr %deref, i32 0, i32 0
       call void @grandparent__ctor(ptr %__grandparent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__grandparent2 = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 0
-      call void @grandparent__ctor(ptr %__grandparent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %x = getelementptr inbounds nuw %parent, ptr %deref3, i32 0, i32 1
+      %x = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 1
       call void @__parent_x__ctor(ptr %x)
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__grandparent5 = getelementptr inbounds nuw %parent, ptr %deref4, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__grandparent3 = getelementptr inbounds nuw %parent, ptr %deref2, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent3, i32 0, i32 0
       store ptr @__vtable_parent_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -981,14 +963,11 @@ fn complex_array_access_generated() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %z = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1
+      %z = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1
       call void @__child_z__ctor(ptr %z)
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0
-      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0
+      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0
       %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
@@ -2557,10 +2536,7 @@ fn fb_extension_with_output() {
       call void @foo__ctor(ptr %__foo)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__foo2 = getelementptr inbounds nuw %foo2, ptr %deref1, i32 0, i32 0
-      call void @foo__ctor(ptr %__foo2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__foo4 = getelementptr inbounds nuw %foo2, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo2, i32 0, i32 0
       store ptr @__vtable_foo2_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -2781,10 +2757,7 @@ fn function_with_output_used_in_main_by_extension() {
       call void @foo__ctor(ptr %__foo)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__foo2 = getelementptr inbounds nuw %foo2, ptr %deref1, i32 0, i32 0
-      call void @foo__ctor(ptr %__foo2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__foo4 = getelementptr inbounds nuw %foo2, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo2, i32 0, i32 0
       store ptr @__vtable_foo2_instance, ptr %__vtable, align [filtered]
       ret void
     }

--- a/src/codegen/tests/oop_tests/debug_tests.rs
+++ b/src/codegen/tests/oop_tests/debug_tests.rs
@@ -78,10 +78,7 @@ fn members_from_base_class_are_available_in_subclasses() {
       call void @foo__ctor(ptr %__foo), !dbg !35
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !35
       %__foo2 = getelementptr inbounds nuw %bar, ptr %deref1, i32 0, i32 0, !dbg !35
-      call void @foo__ctor(ptr %__foo2), !dbg !35
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !35
-      %__foo4 = getelementptr inbounds nuw %bar, ptr %deref3, i32 0, i32 0, !dbg !35
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo4, i32 0, i32 0, !dbg !35
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo2, i32 0, i32 0, !dbg !35
       store ptr @__vtable_bar_instance, ptr %__vtable, align [filtered], !dbg !35
       ret void, !dbg !35
     }
@@ -285,10 +282,7 @@ fn write_to_parent_variable_qualified_access() {
       call void @fb__ctor(ptr %__fb), !dbg !38
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !38
       %__fb2 = getelementptr inbounds nuw %fb2, ptr %deref1, i32 0, i32 0, !dbg !38
-      call void @fb__ctor(ptr %__fb2), !dbg !38
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !38
-      %__fb4 = getelementptr inbounds nuw %fb2, ptr %deref3, i32 0, i32 0, !dbg !38
-      %__vtable = getelementptr inbounds nuw %fb, ptr %__fb4, i32 0, i32 0, !dbg !38
+      %__vtable = getelementptr inbounds nuw %fb, ptr %__fb2, i32 0, i32 0, !dbg !38
       store ptr @__vtable_fb2_instance, ptr %__vtable, align [filtered], !dbg !38
       ret void, !dbg !38
     }
@@ -549,10 +543,7 @@ fn write_to_parent_variable_in_instance() {
       call void @foo__ctor(ptr %__foo), !dbg !45
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !45
       %__foo2 = getelementptr inbounds nuw %bar, ptr %deref1, i32 0, i32 0, !dbg !45
-      call void @foo__ctor(ptr %__foo2), !dbg !45
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !45
-      %__foo4 = getelementptr inbounds nuw %bar, ptr %deref3, i32 0, i32 0, !dbg !45
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo4, i32 0, i32 0, !dbg !45
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo2, i32 0, i32 0, !dbg !45
       store ptr @__vtable_bar_instance, ptr %__vtable, align [filtered], !dbg !45
       ret void, !dbg !45
     }
@@ -841,14 +832,11 @@ fn array_in_parent_generated() {
       %__grandparent = getelementptr inbounds nuw %parent, ptr %deref, i32 0, i32 0, !dbg !56
       call void @grandparent__ctor(ptr %__grandparent), !dbg !56
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !56
-      %__grandparent2 = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 0, !dbg !56
-      call void @grandparent__ctor(ptr %__grandparent2), !dbg !56
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !56
-      %x = getelementptr inbounds nuw %parent, ptr %deref3, i32 0, i32 1, !dbg !56
+      %x = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 1, !dbg !56
       call void @__parent_x__ctor(ptr %x), !dbg !56
-      %deref4 = load ptr, ptr %self, align [filtered], !dbg !56
-      %__grandparent5 = getelementptr inbounds nuw %parent, ptr %deref4, i32 0, i32 0, !dbg !56
-      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent5, i32 0, i32 0, !dbg !56
+      %deref2 = load ptr, ptr %self, align [filtered], !dbg !56
+      %__grandparent3 = getelementptr inbounds nuw %parent, ptr %deref2, i32 0, i32 0, !dbg !56
+      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent3, i32 0, i32 0, !dbg !56
       store ptr @__vtable_parent_instance, ptr %__vtable, align [filtered], !dbg !56
       ret void, !dbg !56
     }
@@ -861,14 +849,11 @@ fn array_in_parent_generated() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0, !dbg !56
       call void @parent__ctor(ptr %__parent), !dbg !56
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !56
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0, !dbg !56
-      call void @parent__ctor(ptr %__parent2), !dbg !56
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !56
-      %z = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1, !dbg !56
+      %z = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1, !dbg !56
       call void @__child_z__ctor(ptr %z), !dbg !56
-      %deref4 = load ptr, ptr %self, align [filtered], !dbg !56
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0, !dbg !56
-      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0, !dbg !56
+      %deref2 = load ptr, ptr %self, align [filtered], !dbg !56
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0, !dbg !56
+      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0, !dbg !56
       %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent, i32 0, i32 0, !dbg !56
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered], !dbg !56
       ret void, !dbg !56
@@ -1170,14 +1155,11 @@ fn complex_array_access_generated() {
       %__grandparent = getelementptr inbounds nuw %parent, ptr %deref, i32 0, i32 0, !dbg !44
       call void @grandparent__ctor(ptr %__grandparent), !dbg !44
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !44
-      %__grandparent2 = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 0, !dbg !44
-      call void @grandparent__ctor(ptr %__grandparent2), !dbg !44
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !44
-      %x = getelementptr inbounds nuw %parent, ptr %deref3, i32 0, i32 1, !dbg !44
+      %x = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 1, !dbg !44
       call void @__parent_x__ctor(ptr %x), !dbg !44
-      %deref4 = load ptr, ptr %self, align [filtered], !dbg !44
-      %__grandparent5 = getelementptr inbounds nuw %parent, ptr %deref4, i32 0, i32 0, !dbg !44
-      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent5, i32 0, i32 0, !dbg !44
+      %deref2 = load ptr, ptr %self, align [filtered], !dbg !44
+      %__grandparent3 = getelementptr inbounds nuw %parent, ptr %deref2, i32 0, i32 0, !dbg !44
+      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent3, i32 0, i32 0, !dbg !44
       store ptr @__vtable_parent_instance, ptr %__vtable, align [filtered], !dbg !44
       ret void, !dbg !44
     }
@@ -1190,14 +1172,11 @@ fn complex_array_access_generated() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0, !dbg !44
       call void @parent__ctor(ptr %__parent), !dbg !44
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !44
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0, !dbg !44
-      call void @parent__ctor(ptr %__parent2), !dbg !44
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !44
-      %z = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1, !dbg !44
+      %z = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1, !dbg !44
       call void @__child_z__ctor(ptr %z), !dbg !44
-      %deref4 = load ptr, ptr %self, align [filtered], !dbg !44
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0, !dbg !44
-      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0, !dbg !44
+      %deref2 = load ptr, ptr %self, align [filtered], !dbg !44
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0, !dbg !44
+      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0, !dbg !44
       %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent, i32 0, i32 0, !dbg !44
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered], !dbg !44
       ret void, !dbg !44
@@ -1427,10 +1406,7 @@ fn function_block_method_debug_info() {
       call void @foo__ctor(ptr %__foo), !dbg !26
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !26
       %__foo2 = getelementptr inbounds nuw %bar, ptr %deref1, i32 0, i32 0, !dbg !26
-      call void @foo__ctor(ptr %__foo2), !dbg !26
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !26
-      %__foo4 = getelementptr inbounds nuw %bar, ptr %deref3, i32 0, i32 0, !dbg !26
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo4, i32 0, i32 0, !dbg !26
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo2, i32 0, i32 0, !dbg !26
       store ptr @__vtable_bar_instance, ptr %__vtable, align [filtered], !dbg !26
       ret void, !dbg !26
     }
@@ -1795,10 +1771,7 @@ END_FUNCTION
       call void @parent__ctor(ptr %__parent), !dbg !83
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !83
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0, !dbg !83
-      call void @parent__ctor(ptr %__parent2), !dbg !83
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !83
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0, !dbg !83
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0, !dbg !83
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0, !dbg !83
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered], !dbg !83
       ret void, !dbg !83
     }
@@ -1812,10 +1785,7 @@ END_FUNCTION
       call void @child__ctor(ptr %__child), !dbg !83
       %deref1 = load ptr, ptr %self, align [filtered], !dbg !83
       %__child2 = getelementptr inbounds nuw %grandchild, ptr %deref1, i32 0, i32 0, !dbg !83
-      call void @child__ctor(ptr %__child2), !dbg !83
-      %deref3 = load ptr, ptr %self, align [filtered], !dbg !83
-      %__child4 = getelementptr inbounds nuw %grandchild, ptr %deref3, i32 0, i32 0, !dbg !83
-      %__parent = getelementptr inbounds nuw %child, ptr %__child4, i32 0, i32 0, !dbg !83
+      %__parent = getelementptr inbounds nuw %child, ptr %__child2, i32 0, i32 0, !dbg !83
       %__vtable = getelementptr inbounds nuw %parent, ptr %__parent, i32 0, i32 0, !dbg !83
       store ptr @__vtable_grandchild_instance, ptr %__vtable, align [filtered], !dbg !83
       ret void, !dbg !83

--- a/src/codegen/tests/oop_tests/super_tests.rs
+++ b/src/codegen/tests/oop_tests/super_tests.rs
@@ -76,10 +76,7 @@ fn super_keyword_basic_access() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -217,14 +214,11 @@ fn super_without_deref() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %p = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1
+      %p = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1
       call void @__child_p__ctor(ptr %p)
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -422,10 +416,7 @@ fn super_in_method_calls() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -616,14 +607,11 @@ fn super_in_complex_expressions() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %z = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1
+      %z = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1
       store i16 30, ptr %z, align [filtered]
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -772,14 +760,11 @@ fn super_with_array_access() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %index = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1
+      %index = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1
       store i16 3, ptr %index, align [filtered]
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -1004,14 +989,11 @@ fn super_in_multi_level_inheritance() {
       %__grandparent = getelementptr inbounds nuw %parent, ptr %deref, i32 0, i32 0
       call void @grandparent__ctor(ptr %__grandparent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__grandparent2 = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 0
-      call void @grandparent__ctor(ptr %__grandparent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %p_val = getelementptr inbounds nuw %parent, ptr %deref3, i32 0, i32 1
+      %p_val = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 1
       store i16 20, ptr %p_val, align [filtered]
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__grandparent5 = getelementptr inbounds nuw %parent, ptr %deref4, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__grandparent3 = getelementptr inbounds nuw %parent, ptr %deref2, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent3, i32 0, i32 0
       store ptr @__vtable_parent_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -1024,14 +1006,11 @@ fn super_in_multi_level_inheritance() {
       %__parent = getelementptr inbounds nuw %child, ptr %deref, i32 0, i32 0
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %c_val = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 1
+      %c_val = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 1
       store i16 30, ptr %c_val, align [filtered]
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__parent5 = getelementptr inbounds nuw %child, ptr %deref4, i32 0, i32 0
-      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__parent3 = getelementptr inbounds nuw %child, ptr %deref2, i32 0, i32 0
+      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent3, i32 0, i32 0
       %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
@@ -1283,10 +1262,7 @@ fn super_with_pointer_operations() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -1495,10 +1471,7 @@ fn super_in_conditionals() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -1651,10 +1624,7 @@ fn super_with_const_variables() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -1840,10 +1810,7 @@ fn super_as_function_parameter() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -2074,10 +2041,7 @@ fn super_with_deeply_nested_expressions() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -2454,10 +2418,7 @@ fn super_in_loop_constructs() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -2702,10 +2663,7 @@ fn super_with_method_overrides_in_three_levels() {
       call void @grandparent__ctor(ptr %__grandparent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__grandparent2 = getelementptr inbounds nuw %parent, ptr %deref1, i32 0, i32 0
-      call void @grandparent__ctor(ptr %__grandparent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__grandparent4 = getelementptr inbounds nuw %parent, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent2, i32 0, i32 0
       store ptr @__vtable_parent_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -2719,10 +2677,7 @@ fn super_with_method_overrides_in_three_levels() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__grandparent = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       %__vtable = getelementptr inbounds nuw %grandparent, ptr %__grandparent, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
@@ -3049,10 +3004,7 @@ fn super_with_structured_types() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -3244,10 +3196,7 @@ fn super_in_action_blocks() {
       call void @parent__ctor(ptr %__parent)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__parent2 = getelementptr inbounds nuw %child, ptr %deref1, i32 0, i32 0
-      call void @parent__ctor(ptr %__parent2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__parent4 = getelementptr inbounds nuw %child, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %parent, ptr %__parent2, i32 0, i32 0
       store ptr @__vtable_child_instance, ptr %__vtable, align [filtered]
       ret void
     }

--- a/src/codegen/tests/polymorphism.rs
+++ b/src/codegen/tests/polymorphism.rs
@@ -162,10 +162,7 @@ fn simple_overridden_method() {
       call void @A__ctor(ptr %__A)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__A2 = getelementptr inbounds nuw %B, ptr %deref1, i32 0, i32 0
-      call void @A__ctor(ptr %__A2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__A4 = getelementptr inbounds nuw %B, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %A, ptr %__A4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %A, ptr %__A2, i32 0, i32 0
       store ptr @__vtable_B_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -566,10 +563,7 @@ fn this_is_untouched() {
       call void @A__ctor(ptr %__A)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__A2 = getelementptr inbounds nuw %B, ptr %deref1, i32 0, i32 0
-      call void @A__ctor(ptr %__A2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__A4 = getelementptr inbounds nuw %B, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %A, ptr %__A4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %A, ptr %__A2, i32 0, i32 0
       store ptr @__vtable_B_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -583,10 +577,7 @@ fn this_is_untouched() {
       call void @A__ctor(ptr %__A)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__A2 = getelementptr inbounds nuw %C, ptr %deref1, i32 0, i32 0
-      call void @A__ctor(ptr %__A2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__A4 = getelementptr inbounds nuw %C, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %A, ptr %__A4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %A, ptr %__A2, i32 0, i32 0
       store ptr @__vtable_C_instance, ptr %__vtable, align [filtered]
       ret void
     }
@@ -879,10 +870,7 @@ fn super_is_untouched() {
       call void @A__ctor(ptr %__A)
       %deref1 = load ptr, ptr %self, align [filtered]
       %__A2 = getelementptr inbounds nuw %B, ptr %deref1, i32 0, i32 0
-      call void @A__ctor(ptr %__A2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %__A4 = getelementptr inbounds nuw %B, ptr %deref3, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %A, ptr %__A4, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %A, ptr %__A2, i32 0, i32 0
       store ptr @__vtable_B_instance, ptr %__vtable, align [filtered]
       ret void
     }

--- a/src/tests/adr/initializer_functions_adr.rs
+++ b/src/tests/adr/initializer_functions_adr.rs
@@ -1318,14 +1318,11 @@ fn external_inherited_initializers() {
       %__foo = getelementptr inbounds nuw %bar, ptr %deref, i32 0, i32 0
       call void @foo__ctor(ptr %__foo)
       %deref1 = load ptr, ptr %self, align [filtered]
-      %__foo2 = getelementptr inbounds nuw %bar, ptr %deref1, i32 0, i32 0
-      call void @foo__ctor(ptr %__foo2)
-      %deref3 = load ptr, ptr %self, align [filtered]
-      %y = getelementptr inbounds nuw %bar, ptr %deref3, i32 0, i32 1
+      %y = getelementptr inbounds nuw %bar, ptr %deref1, i32 0, i32 1
       store i32 10, ptr %y, align [filtered]
-      %deref4 = load ptr, ptr %self, align [filtered]
-      %__foo5 = getelementptr inbounds nuw %bar, ptr %deref4, i32 0, i32 0
-      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo5, i32 0, i32 0
+      %deref2 = load ptr, ptr %self, align [filtered]
+      %__foo3 = getelementptr inbounds nuw %bar, ptr %deref2, i32 0, i32 0
+      %__vtable = getelementptr inbounds nuw %foo, ptr %__foo3, i32 0, i32 0
       store ptr @__vtable_bar_instance, ptr %__vtable, align [filtered]
       ret void
     }

--- a/tests/lit/single/oop/fb_init_at_both_levels_runs_once.st
+++ b/tests/lit/single/oop/fb_init_at_both_levels_runs_once.st
@@ -1,0 +1,29 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression: when both Base and Child declare `FB_INIT`, each must run
+// exactly once during construction. Pre-fix the doubled base-ctor (issue 1)
+// and the inherited FB_INIT re-emit (issue 2) inflated these counts.
+FUNCTION_BLOCK Base
+VAR
+    base_calls : DINT := 0;
+END_VAR
+    METHOD FB_INIT
+        base_calls := base_calls + 1;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK Child EXTENDS Base
+VAR
+    child_calls : DINT := 0;
+END_VAR
+    METHOD FB_INIT
+        child_calls := child_calls + 1;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION main : DINT
+VAR
+    c : Child;
+END_VAR
+    printf('%d$N', c.base_calls);  // CHECK: 1
+    printf('%d$N', c.child_calls); // CHECK: 1
+END_FUNCTION

--- a/tests/lit/single/oop/fb_init_base_runs_before_child.st
+++ b/tests/lit/single/oop/fb_init_base_runs_before_child.st
@@ -1,0 +1,32 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Sequencing: `Base.FB_INIT` must run before `Child.FB_INIT`, so that the
+// child's body can rely on initialized base state. Pre-fix, the doubled base
+// ctor would still produce the right value here, but the inherited-FB_INIT
+// re-emit ran the base FB_INIT after derived members were touched, which
+// could clobber values written by the child. We pin the post-fix order.
+FUNCTION_BLOCK Base
+VAR
+    x : DINT := 0;
+END_VAR
+    METHOD FB_INIT
+        x := 10;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK Child EXTENDS Base
+VAR
+    y : DINT := 0;
+END_VAR
+    METHOD FB_INIT
+        // Base.FB_INIT must have already run, so x == 10 here.
+        y := x * 2;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION main : DINT
+VAR
+    c : Child;
+END_VAR
+    printf('%d$N', c.x); // CHECK: 10
+    printf('%d$N', c.y); // CHECK: 20
+END_FUNCTION

--- a/tests/lit/single/oop/fb_init_inherited_runs_once.st
+++ b/tests/lit/single/oop/fb_init_inherited_runs_once.st
@@ -1,0 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression: an inherited `FB_INIT` must only run once per construction.
+// Pre-fix the derived ctor invoked it both via the base ctor chain and via a
+// spurious second emit (find_method walked up the super class).
+FUNCTION_BLOCK Base
+VAR
+    init_calls : DINT := 0;
+END_VAR
+    METHOD FB_INIT
+        init_calls := init_calls + 1;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK Child EXTENDS Base
+END_FUNCTION_BLOCK
+
+FUNCTION main : DINT
+VAR
+    c : Child;
+END_VAR
+    printf('%d$N', c.init_calls); // CHECK: 1
+END_FUNCTION

--- a/tests/lit/single/oop/fb_init_runs_per_instance.st
+++ b/tests/lit/single/oop/fb_init_runs_per_instance.st
@@ -1,0 +1,24 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Sanity: the fix for double base-ctor / inherited FB_INIT must not
+// over-correct. Each constructed instance must still run the inherited
+// `FB_INIT` once. Two instances => count of 2.
+VAR_GLOBAL
+    base_init_count : DINT := 0;
+END_VAR
+
+FUNCTION_BLOCK Base
+    METHOD FB_INIT
+        base_init_count := base_init_count + 1;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK Child EXTENDS Base
+END_FUNCTION_BLOCK
+
+FUNCTION main : DINT
+VAR
+    a : Child;
+    b : Child;
+END_VAR
+    printf('%d$N', base_init_count); // CHECK: 2
+END_FUNCTION


### PR DESCRIPTION
Skip constructor generation for the synthetic inherited base member since the derived constructor already initializes the base subobject explicitly. Also restrict FB_INIT constructor hooks to methods declared directly on the current POU so inherited FB_INIT methods are not called twice.

Update codegen snapshots and add initializer tests covering duplicate base constructors and inherited FB_INIT handling.