### PR TITLE
feat!: add AND_THEN/OR_ELSE and make AND/OR eager

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -1635,6 +1635,8 @@ pub enum Operator {
     And,
     Or,
     Xor,
+    AndThen,
+    OrElse,
 }
 
 impl Display for Operator {
@@ -1655,6 +1657,8 @@ impl Display for Operator {
             Operator::And => "AND",
             Operator::Or => "OR",
             Operator::Xor => "XOR",
+            Operator::AndThen => "AND_THEN",
+            Operator::OrElse => "OR_ELSE",
             Operator::Exponentiation => "**",
         };
         f.write_str(symbol)

--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -234,6 +234,7 @@ lazy_static! {
         E117,   Error,      include_str!("./error_codes/E117.md"),  // Non-constant array boundary
         E131,   Error,      include_str!("./error_codes/E131.md"),  // Positional argument collides with later named argument
         E132,   Ignore,    include_str!("./error_codes/E132.md"),  // Mixing implicit and explicit call parameters
+        E133,   Error,      include_str!("./error_codes/E133.md"),  // AND_THEN/OR_ELSE with non-boolean operands
     );
 }
 

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E133.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E133.md
@@ -1,0 +1,46 @@
+# AND_THEN / OR_ELSE Used With Non-Boolean Operands
+
+The `AND_THEN` and `OR_ELSE` operators provide explicit short-circuit evaluation semantics and are only meaningful for boolean operands.
+When used with integer types, short-circuit evaluation does not apply — use `AND` / `OR` instead for bitwise operations.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    a : DINT;
+    b : DINT;
+    c : DINT;
+END_VAR
+    c := a AND_THEN b;  // ❌ AND_THEN requires BOOL operands
+    c := a OR_ELSE b;   // ❌ OR_ELSE requires BOOL operands
+END_PROGRAM
+```
+
+To fix, either use boolean operands:
+
+```iecst
+PROGRAM main
+VAR
+    a : BOOL;
+    b : BOOL;
+    c : BOOL;
+END_VAR
+    c := a AND_THEN b;  // ✅ correct: both operands are BOOL
+    c := a OR_ELSE b;   // ✅ correct: both operands are BOOL
+END_PROGRAM
+```
+
+Or use `AND` / `OR` for bitwise operations on integers:
+
+```iecst
+PROGRAM main
+VAR
+    a : DINT;
+    b : DINT;
+    c : DINT;
+END_VAR
+    c := a AND b;  // ✅ correct: bitwise AND
+    c := a OR b;   // ✅ correct: bitwise OR
+END_PROGRAM
+```

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -2763,7 +2763,13 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
         Ok(array_value.as_basic_value_enum())
     }
 
-    /// generates a phi-expression (&& or || expression) with respect to short-circuit evaluation
+    /// Generates a boolean binary expression (`AND`, `OR`, `AND_THEN`, `OR_ELSE`,
+    /// `=`, `<>`, `XOR`).
+    ///
+    /// `AND` / `OR` evaluate both operands eagerly (no short-circuit), matching
+    /// CODESYS semantics. `AND_THEN` / `OR_ELSE` use phi-based short-circuit
+    /// evaluation when the user wants to skip the right-hand side based on the
+    /// left.
     ///
     /// - `operator` an operator suitable for bool variables
     /// - `left` the left side of the expression
@@ -2775,9 +2781,27 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
         right: &AstNode,
     ) -> Result<BasicValueEnum<'ink>, CodegenError> {
         match operator {
-            Operator::And | Operator::Or => {
+            Operator::AndThen | Operator::OrElse => {
                 self.generate_bool_short_circuit_expression(operator, left, right)
             }
+            Operator::And => Ok(self
+                .llvm
+                .builder
+                .build_and(
+                    to_i1(self.generate_expression(left)?.into_int_value(), &self.llvm.builder)?,
+                    to_i1(self.generate_expression(right)?.into_int_value(), &self.llvm.builder)?,
+                    "",
+                )?
+                .as_basic_value_enum()),
+            Operator::Or => Ok(self
+                .llvm
+                .builder
+                .build_or(
+                    to_i1(self.generate_expression(left)?.into_int_value(), &self.llvm.builder)?,
+                    to_i1(self.generate_expression(right)?.into_int_value(), &self.llvm.builder)?,
+                    "",
+                )?
+                .as_basic_value_enum()),
             Operator::Equal => Ok(self
                 .llvm
                 .builder
@@ -2837,8 +2861,12 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
         //Compare left to 0
 
         match operator {
-            Operator::Or => builder.build_conditional_branch(lhs, continue_branch, right_branch)?,
-            Operator::And => builder.build_conditional_branch(lhs, right_branch, continue_branch)?,
+            Operator::Or | Operator::OrElse => {
+                builder.build_conditional_branch(lhs, continue_branch, right_branch)?
+            }
+            Operator::And | Operator::AndThen => {
+                builder.build_conditional_branch(lhs, right_branch, continue_branch)?
+            }
             _ => {
                 return Err(Diagnostic::codegen_error(
                     format!("Cannot generate phi-expression for operator {operator:}"),

--- a/src/codegen/tests/code_gen_tests.rs
+++ b/src/codegen/tests/code_gen_tests.rs
@@ -697,6 +697,92 @@ END_PROGRAM
 }
 
 #[test]
+fn program_with_and_then_statement() {
+    // AND_THEN always short-circuits (uses branches + phi)
+    let result = codegen(
+        r#"PROGRAM prg
+VAR
+x : BOOL;
+y : BOOL;
+END_VAR
+x AND_THEN y;
+END_PROGRAM
+"#,
+    );
+    filtered_assert_snapshot!(result, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %prg = type { i8, i8 }
+
+    @prg_instance = global %prg zeroinitializer
+
+    define void @prg(ptr %0) {
+    entry:
+      %x = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 0
+      %y = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 1
+      %load_x = load i8, ptr %x, align [filtered]
+      %1 = icmp ne i8 %load_x, 0
+      br i1 %1, label %2, label %4
+
+    2:                                                ; preds = %entry
+      %load_y = load i8, ptr %y, align [filtered]
+      %3 = icmp ne i8 %load_y, 0
+      br label %4
+
+    4:                                                ; preds = %2, %entry
+      %5 = phi i1 [ %1, %entry ], [ %3, %2 ]
+      ret void
+    }
+    "#);
+}
+
+#[test]
+fn program_with_or_else_statement() {
+    // OR_ELSE always short-circuits (uses branches + phi)
+    let result = codegen(
+        r#"PROGRAM prg
+VAR
+x : BOOL;
+y : BOOL;
+END_VAR
+x OR_ELSE y;
+END_PROGRAM
+"#,
+    );
+    filtered_assert_snapshot!(result, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %prg = type { i8, i8 }
+
+    @prg_instance = global %prg zeroinitializer
+
+    define void @prg(ptr %0) {
+    entry:
+      %x = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 0
+      %y = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 1
+      %load_x = load i8, ptr %x, align [filtered]
+      %1 = icmp ne i8 %load_x, 0
+      br i1 %1, label %4, label %2
+
+    2:                                                ; preds = %entry
+      %load_y = load i8, ptr %y, align [filtered]
+      %3 = icmp ne i8 %load_y, 0
+      br label %4
+
+    4:                                                ; preds = %2, %entry
+      %5 = phi i1 [ %1, %entry ], [ %3, %2 ]
+      ret void
+    }
+    "#);
+}
+
+#[test]
 fn program_with_xor_statement() {
     let result = codegen(
         r#"PROGRAM prg

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_with_expression_generator_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__if_with_expression_generator_test.snap
@@ -19,23 +19,17 @@ entry:
   %tmpVar = icmp sgt i32 %load_x, 1
   %1 = zext i1 %tmpVar to i8
   %2 = icmp ne i8 %1, 0
-  br i1 %2, label %5, label %3
+  %load_b1 = load i8, ptr %b1, align [filtered]
+  %3 = icmp ne i8 %load_b1, 0
+  %4 = or i1 %2, %3
+  %5 = zext i1 %4 to i8
+  %6 = icmp ne i8 %5, 0
+  br i1 %6, label %condition_body, label %continue
 
-condition_body:                                   ; preds = %5
+condition_body:                                   ; preds = %entry
   %load_x1 = load i32, ptr %x, align [filtered]
   br label %continue
 
-continue:                                         ; preds = %condition_body, %5
+continue:                                         ; preds = %condition_body, %entry
   ret void
-
-3:                                                ; preds = %entry
-  %load_b1 = load i8, ptr %b1, align [filtered]
-  %4 = icmp ne i8 %load_b1, 0
-  br label %5
-
-5:                                                ; preds = %3, %entry
-  %6 = phi i1 [ %2, %entry ], [ %4, %3 ]
-  %7 = zext i1 %6 to i8
-  %8 = icmp ne i8 %7, 0
-  br i1 %8, label %condition_body, label %continue
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_and_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_and_statement.snap
@@ -17,14 +17,8 @@ entry:
   %y = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 1
   %load_x = load i8, ptr %x, align [filtered]
   %1 = icmp ne i8 %load_x, 0
-  br i1 %1, label %2, label %4
-
-2:                                                ; preds = %entry
   %load_y = load i8, ptr %y, align [filtered]
-  %3 = icmp ne i8 %load_y, 0
-  br label %4
-
-4:                                                ; preds = %2, %entry
-  %5 = phi i1 [ %1, %entry ], [ %3, %2 ]
+  %2 = icmp ne i8 %load_y, 0
+  %3 = and i1 %1, %2
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_combined_expressions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_combined_expressions_generates_void_function_and_struct_and_body.snap
@@ -17,26 +17,14 @@ entry:
   %y = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 1
   %load_y = load i8, ptr %y, align [filtered]
   %1 = icmp ne i8 %load_y, 0
-  br i1 %1, label %2, label %3
-
-2:                                                ; preds = %entry
   %load_z = load i32, ptr %z, align [filtered]
   %tmpVar = icmp sge i32 %load_z, 5
-  br label %3
-
-3:                                                ; preds = %2, %entry
-  %4 = phi i1 [ %1, %entry ], [ %tmpVar, %2 ]
+  %2 = and i1 %1, %tmpVar
   %load_z1 = load i32, ptr %z, align [filtered]
   %tmpVar2 = icmp sle i32 %load_z1, 6
   %tmpVar3 = xor i1 %tmpVar2, true
-  br i1 %tmpVar3, label %7, label %5
-
-5:                                                ; preds = %3
   %load_y4 = load i8, ptr %y, align [filtered]
-  %6 = icmp ne i8 %load_y4, 0
-  br label %7
-
-7:                                                ; preds = %5, %3
-  %8 = phi i1 [ %tmpVar3, %3 ], [ %6, %5 ]
+  %3 = icmp ne i8 %load_y4, 0
+  %4 = or i1 %tmpVar3, %3
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_expressions_generates_void_function_and_struct_and_body.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_negated_expressions_generates_void_function_and_struct_and_body.snap
@@ -20,15 +20,9 @@ entry:
   %tmpVar = xor i1 %1, true
   %load_x1 = load i8, ptr %x, align [filtered]
   %2 = icmp ne i8 %load_x1, 0
-  br i1 %2, label %3, label %5
-
-3:                                                ; preds = %entry
   %load_y = load i8, ptr %y, align [filtered]
-  %4 = icmp ne i8 %load_y, 0
-  %tmpVar2 = xor i1 %4, true
-  br label %5
-
-5:                                                ; preds = %3, %entry
-  %6 = phi i1 [ %2, %entry ], [ %tmpVar2, %3 ]
+  %3 = icmp ne i8 %load_y, 0
+  %tmpVar2 = xor i1 %3, true
+  %4 = and i1 %2, %tmpVar2
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_or_statement.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__code_gen_tests__program_with_or_statement.snap
@@ -17,14 +17,8 @@ entry:
   %y = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 1
   %load_x = load i8, ptr %x, align [filtered]
   %1 = icmp ne i8 %load_x, 0
-  br i1 %1, label %4, label %2
-
-2:                                                ; preds = %entry
   %load_y = load i8, ptr %y, align [filtered]
-  %3 = icmp ne i8 %load_y, 0
-  br label %4
-
-4:                                                ; preds = %2, %entry
-  %5 = phi i1 [ %1, %entry ], [ %3, %2 ]
+  %2 = icmp ne i8 %load_y, 0
+  %3 = or i1 %1, %2
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_datetime_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_datetime_types.snap
@@ -20,26 +20,14 @@ entry:
   %load_var_time = load i64, ptr %var_time, align [filtered]
   %load_var_time_of_day = load i64, ptr %var_time_of_day, align [filtered]
   %tmpVar = icmp sgt i64 %load_var_time, %load_var_time_of_day
-  br i1 %tmpVar, label %1, label %2
-
-1:                                                ; preds = %entry
   %load_var_time_of_day1 = load i64, ptr %var_time_of_day, align [filtered]
   %load_var_date = load i64, ptr %var_date, align [filtered]
   %tmpVar2 = icmp sgt i64 %load_var_time_of_day1, %load_var_date
-  br label %2
-
-2:                                                ; preds = %1, %entry
-  %3 = phi i1 [ %tmpVar, %entry ], [ %tmpVar2, %1 ]
-  br i1 %3, label %4, label %5
-
-4:                                                ; preds = %2
+  %1 = and i1 %tmpVar, %tmpVar2
   %load_var_date3 = load i64, ptr %var_date, align [filtered]
   %load_var_date_and_time = load i64, ptr %var_date_and_time, align [filtered]
   %tmpVar4 = icmp sgt i64 %load_var_date3, %load_var_date_and_time
-  br label %5
-
-5:                                                ; preds = %4, %2
-  %6 = phi i1 [ %3, %2 ], [ %tmpVar4, %4 ]
-  %7 = zext i1 %6 to i8
+  %2 = and i1 %1, %tmpVar4
+  %3 = zext i1 %2 to i8
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instruction_functions_with_different_types.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__compare_instruction_functions_with_different_types.snap
@@ -89,41 +89,35 @@ entry:
   %22 = zext i1 %tmpVar19 to i8
   %load_b20 = load i32, ptr %b, align [filtered]
   %tmpVar21 = icmp ne i32 5, %load_b20
-  br i1 %tmpVar21, label %23, label %24
-
-23:                                               ; preds = %entry
   %load_b22 = load i32, ptr %b, align [filtered]
   %tmpVar23 = icmp ne i32 %load_b22, 17
-  br label %24
-
-24:                                               ; preds = %23, %entry
-  %25 = phi i1 [ %tmpVar21, %entry ], [ %tmpVar23, %23 ]
-  %26 = zext i1 %25 to i8
+  %23 = and i1 %tmpVar21, %tmpVar23
+  %24 = zext i1 %23 to i8
   %load_ptr_float = load ptr, ptr %ptr_float, align [filtered]
   %load_var_usint24 = load i8, ptr %var_usint, align [filtered]
-  %27 = zext i8 %load_var_usint24 to i64
-  %28 = ptrtoint ptr %load_ptr_float to i64
-  %tmpVar25 = icmp sle i64 %28, %27
-  %29 = zext i1 %tmpVar25 to i8
+  %25 = zext i8 %load_var_usint24 to i64
+  %26 = ptrtoint ptr %load_ptr_float to i64
+  %tmpVar25 = icmp sle i64 %26, %25
+  %27 = zext i1 %tmpVar25 to i8
   %load_a26 = load i16, ptr %a, align [filtered]
-  %30 = sext i16 %load_a26 to i64
+  %28 = sext i16 %load_a26 to i64
   %load_ptr_float27 = load ptr, ptr %ptr_float, align [filtered]
-  %31 = ptrtoint ptr %load_ptr_float27 to i64
-  %tmpVar28 = icmp eq i64 %30, %31
-  %32 = zext i1 %tmpVar28 to i8
+  %29 = ptrtoint ptr %load_ptr_float27 to i64
+  %tmpVar28 = icmp eq i64 %28, %29
+  %30 = zext i1 %tmpVar28 to i8
   %call = call float @foo()
   %tmpVar29 = fcmp one float %call, 4.050000e+01
-  %33 = zext i1 %tmpVar29 to i8
+  %31 = zext i1 %tmpVar29 to i8
   %load_var_udint30 = load i32, ptr %var_udint, align [filtered]
-  %34 = uitofp i32 %load_var_udint30 to float
+  %32 = uitofp i32 %load_var_udint30 to float
   %call31 = call float @foo()
-  %tmpVar32 = fcmp ole float %34, %call31
-  %35 = zext i1 %tmpVar32 to i8
+  %tmpVar32 = fcmp ole float %32, %call31
+  %33 = zext i1 %tmpVar32 to i8
   %call33 = call float @foo()
-  %36 = fpext float %call33 to double
+  %34 = fpext float %call33 to double
   %load_var_lint34 = load i64, ptr %var_lint, align [filtered]
-  %37 = sitofp i64 %load_var_lint34 to double
-  %tmpVar35 = fcmp oeq double %36, %37
-  %38 = zext i1 %tmpVar35 to i8
+  %35 = sitofp i64 %load_var_lint34 to double
+  %tmpVar35 = fcmp oeq double %34, %35
+  %36 = zext i1 %tmpVar35 to i8
   ret void
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_greater_or_equal_with_constant_test.snap
@@ -49,17 +49,11 @@ entry:
   store i16 0, ptr %baz, align [filtered]
   %call = call i8 @STRING_EQUAL(ptr %a, ptr @utf08_literal_0)
   %0 = icmp ne i8 %call, 0
-  br i1 %0, label %3, label %1
-
-1:                                                ; preds = %entry
   %call1 = call i8 @STRING_GREATER(ptr %a, ptr @utf08_literal_0)
-  %2 = icmp ne i8 %call1, 0
-  br label %3
-
-3:                                                ; preds = %1, %entry
-  %4 = phi i1 [ %0, %entry ], [ %2, %1 ]
-  %5 = zext i1 %4 to i8
-  store i8 %5, ptr %result, align [filtered]
+  %1 = icmp ne i8 %call1, 0
+  %2 = or i1 %0, %1
+  %3 = zext i1 %2 to i8
+  store i8 %3, ptr %result, align [filtered]
   %baz_ret = load i16, ptr %baz, align [filtered]
   ret i16 %baz_ret
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_smaller_or_equal_with_constant_test.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__compare_instructions_tests__string_smaller_or_equal_with_constant_test.snap
@@ -49,17 +49,11 @@ entry:
   store i16 0, ptr %baz, align [filtered]
   %call = call i8 @STRING_EQUAL(ptr %a, ptr @utf08_literal_0)
   %0 = icmp ne i8 %call, 0
-  br i1 %0, label %3, label %1
-
-1:                                                ; preds = %entry
   %call1 = call i8 @STRING_LESS(ptr %a, ptr @utf08_literal_0)
-  %2 = icmp ne i8 %call1, 0
-  br label %3
-
-3:                                                ; preds = %1, %entry
-  %4 = phi i1 [ %0, %entry ], [ %2, %1 ]
-  %5 = zext i1 %4 to i8
-  store i8 %5, ptr %result, align [filtered]
+  %1 = icmp ne i8 %call1, 0
+  %2 = or i1 %0, %1
+  %3 = zext i1 %2 to i8
+  store i8 %3, ptr %result, align [filtered]
   %baz_ret = load i16, ptr %baz, align [filtered]
   ret i16 %baz_ret
 }

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__unsized_varargs_bool_args_are_promoted_to_i32.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__function_tests__unsized_varargs_bool_args_are_promoted_to_i32.snap
@@ -22,54 +22,31 @@ entry:
   %call1 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 1)
   %call2 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 1)
   %call3 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 0)
-  br i1 true, label %1, label %2
-
-1:                                                ; preds = %entry
-  br label %2
-
-2:                                                ; preds = %1, %entry
-  %3 = phi i1 [ true, %entry ], [ false, %1 ]
-  %4 = zext i1 %3 to i32
-  %call4 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %4)
-  br i1 true, label %5, label %6
-
-5:                                                ; preds = %2
-  br label %6
-
-6:                                                ; preds = %5, %2
-  %7 = phi i1 [ true, %2 ], [ false, %5 ]
-  %tmpVar = xor i1 %7, true
-  %8 = zext i1 %tmpVar to i32
-  %call5 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %8)
+  %call4 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 0)
+  %call5 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 1)
   %load_vFalse = load i8, ptr %vFalse, align [filtered]
-  %9 = zext i8 %load_vFalse to i32
-  %call6 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %9)
+  %1 = zext i8 %load_vFalse to i32
+  %call6 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %1)
   %load_vTrue = load i8, ptr %vTrue, align [filtered]
-  %10 = zext i8 %load_vTrue to i32
-  %call7 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %10)
+  %2 = zext i8 %load_vTrue to i32
+  %call7 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %2)
   %load_vFalse8 = load i8, ptr %vFalse, align [filtered]
-  %11 = icmp ne i8 %load_vFalse8, 0
-  %tmpVar9 = xor i1 %11, true
-  %12 = zext i1 %tmpVar9 to i32
-  %call10 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %12)
-  %load_vTrue11 = load i8, ptr %vTrue, align [filtered]
-  %13 = icmp ne i8 %load_vTrue11, 0
-  %tmpVar12 = xor i1 %13, true
-  %14 = zext i1 %tmpVar12 to i32
-  %call13 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %14)
-  %load_vTrue14 = load i8, ptr %vTrue, align [filtered]
-  %15 = icmp ne i8 %load_vTrue14, 0
-  br i1 %15, label %16, label %18
-
-16:                                               ; preds = %6
-  %load_vFalse15 = load i8, ptr %vFalse, align [filtered]
-  %17 = icmp ne i8 %load_vFalse15, 0
-  br label %18
-
-18:                                               ; preds = %16, %6
-  %19 = phi i1 [ %15, %6 ], [ %17, %16 ]
-  %tmpVar16 = xor i1 %19, true
-  %20 = zext i1 %tmpVar16 to i32
-  %call17 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %20)
+  %3 = icmp ne i8 %load_vFalse8, 0
+  %tmpVar = xor i1 %3, true
+  %4 = zext i1 %tmpVar to i32
+  %call9 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %4)
+  %load_vTrue10 = load i8, ptr %vTrue, align [filtered]
+  %5 = icmp ne i8 %load_vTrue10, 0
+  %tmpVar11 = xor i1 %5, true
+  %6 = zext i1 %tmpVar11 to i32
+  %call12 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %6)
+  %load_vTrue13 = load i8, ptr %vTrue, align [filtered]
+  %7 = icmp ne i8 %load_vTrue13, 0
+  %load_vFalse14 = load i8, ptr %vFalse, align [filtered]
+  %8 = icmp ne i8 %load_vFalse14, 0
+  %9 = and i1 %7, %8
+  %tmpVar15 = xor i1 %9, true
+  %10 = zext i1 %tmpVar15 to i32
+  %call16 = call i32 (ptr, ...) @printf(ptr @utf08_literal_0, i32 %10)
   ret void
 }

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -361,8 +361,14 @@ pub enum Token {
     #[token("MOD", ignore(case))]
     OperatorModulo,
 
+    #[token("AND_THEN", ignore(case))]
+    OperatorAndThen,
+
     #[token("AND", ignore(case))]
     OperatorAnd,
+
+    #[token("OR_ELSE", ignore(case))]
+    OperatorOrElse,
 
     #[token("OR", ignore(case))]
     OperatorOr,

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -85,9 +85,9 @@ pub(crate) fn parse_range_statement(lexer: &mut ParseSession) -> AstNode {
     start
 }
 
-// OR
+// OR, OR_ELSE
 fn parse_or_expression(lexer: &mut ParseSession) -> AstNode {
-    parse_left_associative_expression!(lexer, parse_xor_expression, OperatorOr,)
+    parse_left_associative_expression!(lexer, parse_xor_expression, OperatorOr | OperatorOrElse,)
 }
 
 // XOR
@@ -95,9 +95,13 @@ fn parse_xor_expression(lexer: &mut ParseSession) -> AstNode {
     parse_left_associative_expression!(lexer, parse_and_expression, OperatorXor,)
 }
 
-// AND
+// AND, AND_THEN
 fn parse_and_expression(lexer: &mut ParseSession) -> AstNode {
-    parse_left_associative_expression!(lexer, parse_equality_expression, OperatorAmp | OperatorAnd,)
+    parse_left_associative_expression!(
+        lexer,
+        parse_equality_expression,
+        OperatorAmp | OperatorAnd | OperatorAndThen,
+    )
 }
 
 //EQUALITY  =, <>
@@ -209,7 +213,9 @@ fn to_operator(token: &Token) -> Option<Operator> {
         OperatorGreaterOrEqual => Some(Operator::GreaterOrEqual),
         OperatorModulo => Some(Operator::Modulo),
         OperatorAnd | OperatorAmp => Some(Operator::And),
+        OperatorAndThen => Some(Operator::AndThen),
         OperatorOr => Some(Operator::Or),
+        OperatorOrElse => Some(Operator::OrElse),
         OperatorXor => Some(Operator::Xor),
         OperatorNot => Some(Operator::Not),
         _ => None,

--- a/src/parser/tests/expressions_parser_tests.rs
+++ b/src/parser/tests/expressions_parser_tests.rs
@@ -1015,6 +1015,132 @@ fn amp_as_and_test() {
 }
 
 #[test]
+fn and_then_test() {
+    let src = "
+        PROGRAM prg
+        b AND_THEN c;
+        END_PROGRAM
+        ";
+    let result = parse(src).0;
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    assert_debug_snapshot!(statement, @r#"
+    BinaryExpression {
+        operator: AndThen,
+        left: ReferenceExpr {
+            kind: Member(
+                Identifier {
+                    name: "b",
+                },
+            ),
+            base: None,
+        },
+        right: ReferenceExpr {
+            kind: Member(
+                Identifier {
+                    name: "c",
+                },
+            ),
+            base: None,
+        },
+    }
+    "#);
+}
+
+#[test]
+fn or_else_test() {
+    let src = "
+        PROGRAM prg
+        b OR_ELSE c;
+        END_PROGRAM
+        ";
+    let result = parse(src).0;
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    assert_debug_snapshot!(statement, @r#"
+    BinaryExpression {
+        operator: OrElse,
+        left: ReferenceExpr {
+            kind: Member(
+                Identifier {
+                    name: "b",
+                },
+            ),
+            base: None,
+        },
+        right: ReferenceExpr {
+            kind: Member(
+                Identifier {
+                    name: "c",
+                },
+            ),
+            base: None,
+        },
+    }
+    "#);
+}
+
+#[test]
+fn boolean_priority_with_and_then_or_else_test() {
+    // AND_THEN has same precedence as AND, OR_ELSE same as OR
+    // Precedence: AND/AND_THEN > XOR > OR/OR_ELSE
+    let src = "
+        PROGRAM exp
+        a AND_THEN b XOR c OR_ELSE d;
+        END_PROGRAM
+        ";
+    let result = parse(src).0;
+    let prg = &result.implementations[0];
+    let statement = &prg.statements[0];
+
+    assert_debug_snapshot!(statement, @r#"
+    BinaryExpression {
+        operator: OrElse,
+        left: BinaryExpression {
+            operator: Xor,
+            left: BinaryExpression {
+                operator: AndThen,
+                left: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "a",
+                        },
+                    ),
+                    base: None,
+                },
+                right: ReferenceExpr {
+                    kind: Member(
+                        Identifier {
+                            name: "b",
+                        },
+                    ),
+                    base: None,
+                },
+            },
+            right: ReferenceExpr {
+                kind: Member(
+                    Identifier {
+                        name: "c",
+                    },
+                ),
+                base: None,
+            },
+        },
+        right: ReferenceExpr {
+            kind: Member(
+                Identifier {
+                    name: "d",
+                },
+            ),
+            base: None,
+        },
+    }
+    "#);
+}
+
+#[test]
 fn boolean_priority_test() {
     let src = "
         PROGRAM exp

--- a/src/resolver/const_evaluator.rs
+++ b/src/resolver/const_evaluator.rs
@@ -495,6 +495,22 @@ fn evaluate_with_target_hint(
         }
         AstStatement::BinaryExpression(BinaryExpression { left, right, operator }) => {
             let eval_left = evaluate(left, scope, index, lhs)?;
+
+            // Short-circuit on a known boolean LHS — applies equally to AND/AND_THEN
+            // and OR/OR_ELSE. Side-stepping the RHS in const-eval prevents spurious
+            // errors like a div-by-zero on the unreachable side of `FALSE AND_THEN ...`.
+            if let Some(left_node) = eval_left.as_ref() {
+                if let AstStatement::Literal(AstLiteral::Bool(b)) = left_node.get_stmt() {
+                    match (operator, *b) {
+                        (Operator::And | Operator::AndThen, false)
+                        | (Operator::Or | Operator::OrElse, true) => {
+                            return Ok(Some(left_node.clone()));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
             let eval_right = evaluate(right, scope, index, lhs)?;
 
             if let Some((left, right)) = eval_left.zip(eval_right).as_ref() {
@@ -519,7 +535,9 @@ fn evaluate_with_target_hint(
                     Operator::Less => compare_expression!(left, <, right, "<", id)?,
                     Operator::LessOrEqual => compare_expression!(left, <=, right, "<=", id)?,
                     Operator::And => bitwise_expression!(left, & , right, "AND", id)?,
+                    Operator::AndThen => bitwise_expression!(left, & , right, "AND_THEN", id)?,
                     Operator::Or => bitwise_expression!(left, | , right, "OR", id)?,
+                    Operator::OrElse => bitwise_expression!(left, | , right, "OR_ELSE", id)?,
                     Operator::Xor => bitwise_expression!(left, ^, right, "XOR", id)?,
                     _ => {
                         return Err(UnresolvableKind::Misc(format!(

--- a/src/resolver/tests/const_resolver_tests.rs
+++ b/src/resolver/tests/const_resolver_tests.rs
@@ -801,6 +801,39 @@ fn const_references_to_bool_compile_time_evaluation() {
 }
 
 #[test]
+fn boolean_short_circuit_avoids_unreachable_rhs_evaluation() {
+    // GIVEN const initializers whose RHS would crash const-eval (div-by-zero)
+    // but whose LHS already determines the result for boolean AND/OR/AND_THEN/OR_ELSE.
+    // Before the short-circuit fast path was introduced, `(1 / 0) = 0` on the RHS
+    // would surface as "Attempt to divide by zero" even though the operand is unreachable.
+    let (_, index) = index(
+        "VAR_GLOBAL CONSTANT
+            zero : INT := 0;
+            t : BOOL := TRUE;
+            f : BOOL := FALSE;
+        END_VAR
+
+        VAR_GLOBAL CONSTANT
+            and_short    : BOOL := f AND ((1 / zero) = 0);
+            or_short     : BOOL := t OR  ((1 / zero) = 0);
+            and_then_short : BOOL := f AND_THEN ((1 / zero) = 0);
+            or_else_short  : BOOL := t OR_ELSE  ((1 / zero) = 0);
+        END_VAR
+        ",
+    );
+
+    // WHEN compile-time evaluation is applied
+    let (index, unresolvable) = evaluate_constants(index);
+
+    // THEN none of the four globals trip the div-by-zero on the unreachable side
+    debug_assert_eq!(EMPTY, unresolvable);
+    debug_assert_eq!(find_constant_value(&index, "and_short"), Some(&create_bool_literal(false)));
+    debug_assert_eq!(find_constant_value(&index, "or_short"), Some(&create_bool_literal(true)));
+    debug_assert_eq!(find_constant_value(&index, "and_then_short"), Some(&create_bool_literal(false)));
+    debug_assert_eq!(find_constant_value(&index, "or_else_short"), Some(&create_bool_literal(true)));
+}
+
+#[test]
 fn not_evaluatable_consts_are_reported() {
     // GIVEN some BOOL index used as initializers
     let (_, index) = index(

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -812,6 +812,24 @@ fn visit_binary_expression<T: AnnotationMap>(
     context: &ValidationContext<T>,
 ) {
     match operator {
+        Operator::AndThen | Operator::OrElse => {
+            let left_type = context.annotations.get_type_or_void(left, context.index).get_type_information();
+            let right_type =
+                context.annotations.get_type_or_void(right, context.index).get_type_information();
+
+            if !left_type.is_bool() || !right_type.is_bool() {
+                validator.push_diagnostic(
+                    Diagnostic::new(format!(
+                        "`{operator}` requires boolean operands, use `{}` for bitwise operations on non-boolean types",
+                        if matches!(operator, Operator::AndThen) { "AND" } else { "OR" },
+                    ))
+                    .with_error_code("E133")
+                    .with_location(statement),
+                );
+            }
+
+            validate_binary_expression(validator, statement, operator, left, right, context)
+        }
         Operator::Equal => {
             if !context.is_call() && context.annotations.get_type_hint(statement, context.index).is_none() {
                 let lhs = validator.context.slice(&left.location);

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -2974,3 +2974,87 @@ fn function_call_with_variadics_should_not_produce_downcast_warnings() {
 
     assert_snapshot!(diagnostics, @"");
 }
+
+#[test]
+fn and_then_with_non_bool_operands_is_an_error() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        PROGRAM main
+        VAR
+            a : DINT;
+            b : DINT;
+            c : DINT;
+        END_VAR
+            c := a AND_THEN b;
+        END_PROGRAM
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @"
+    error[E133]: `AND_THEN` requires boolean operands, use `AND` for bitwise operations on non-boolean types
+      ┌─ <internal>:8:18
+      │
+    8 │             c := a AND_THEN b;
+      │                  ^^^^^^^^^^^^ `AND_THEN` requires boolean operands, use `AND` for bitwise operations on non-boolean types
+    ");
+}
+
+#[test]
+fn or_else_with_non_bool_operands_is_an_error() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        PROGRAM main
+        VAR
+            a : DINT;
+            b : DINT;
+            c : DINT;
+        END_VAR
+            c := a OR_ELSE b;
+        END_PROGRAM
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @"
+    error[E133]: `OR_ELSE` requires boolean operands, use `OR` for bitwise operations on non-boolean types
+      ┌─ <internal>:8:18
+      │
+    8 │             c := a OR_ELSE b;
+      │                  ^^^^^^^^^^^ `OR_ELSE` requires boolean operands, use `OR` for bitwise operations on non-boolean types
+    ");
+}
+
+#[test]
+fn and_then_with_bool_operands_is_ok() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        PROGRAM main
+        VAR
+            a : BOOL;
+            b : BOOL;
+            c : BOOL;
+        END_VAR
+            c := a AND_THEN b;
+        END_PROGRAM
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @"");
+}
+
+#[test]
+fn or_else_with_bool_operands_is_ok() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        PROGRAM main
+        VAR
+            a : BOOL;
+            b : BOOL;
+            c : BOOL;
+        END_VAR
+            c := a OR_ELSE b;
+        END_PROGRAM
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @"");
+}

--- a/tests/correctness/functions.rs
+++ b/tests/correctness/functions.rs
@@ -130,7 +130,9 @@ fn test_or_sideeffects() {
     let module = compile(&context, function);
     let mut case1 = MainType { x: false };
     let res: i32 = module.run("main", &mut case1);
-    assert_eq!(res, 31);
+    // OR is eager: every operand evaluated. 1+2 + 10+20+50 = 83.
+    // Use OR_ELSE for short-circuit.
+    assert_eq!(res, 83);
 }
 
 #[test]
@@ -175,7 +177,9 @@ fn test_and_sideeffects() {
     let module = compile(&context, function);
     let mut case1 = MainType { x: false };
     let res: i32 = module.run("main", &mut case1);
-    assert_eq!(res, 31);
+    // AND is eager: every operand evaluated. 1+2 + 10+20+50 = 83.
+    // Use AND_THEN for short-circuit.
+    assert_eq!(res, 83);
 }
 
 #[test]
@@ -220,7 +224,9 @@ fn test_amp_as_and_sideeffects() {
     let module = compile(&context, function);
     let mut case1 = MainType { x: false };
     let res: i32 = module.run("main", &mut case1);
-    assert_eq!(res, 31);
+    // `&` is an alias for AND, eager: every operand evaluated. 1+2 + 10+20+50 = 83.
+    // Use AND_THEN for short-circuit.
+    assert_eq!(res, 83);
 }
 
 #[test]

--- a/tests/lit/correctness/boolean_short_circuit.st
+++ b/tests/lit/correctness/boolean_short_circuit.st
@@ -1,0 +1,68 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Tests that AND_THEN / OR_ELSE short-circuit, and that AND / OR do not.
+
+VAR_GLOBAL
+    call_count : DINT;
+END_VAR
+
+FUNCTION track : BOOL
+VAR_INPUT
+    val : BOOL;
+END_VAR
+    call_count := call_count + 1;
+    track := val;
+END_FUNCTION
+
+FUNCTION main
+    VAR
+        result : BOOL;
+    END_VAR
+
+    // --- AND_THEN short-circuits when left is FALSE ---
+    call_count := 0;
+    result := track(FALSE) AND_THEN track(TRUE);
+    // CHECK: and_then_false: result=FALSE calls=1
+    printf('and_then_false: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+
+    // --- AND_THEN evaluates right when left is TRUE ---
+    call_count := 0;
+    result := track(TRUE) AND_THEN track(TRUE);
+    // CHECK: and_then_true: result=TRUE calls=2
+    printf('and_then_true: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+
+    // --- AND_THEN returns FALSE when right is FALSE ---
+    call_count := 0;
+    result := track(TRUE) AND_THEN track(FALSE);
+    // CHECK: and_then_right_false: result=FALSE calls=2
+    printf('and_then_right_false: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+
+    // --- OR_ELSE short-circuits when left is TRUE ---
+    call_count := 0;
+    result := track(TRUE) OR_ELSE track(FALSE);
+    // CHECK: or_else_true: result=TRUE calls=1
+    printf('or_else_true: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+
+    // --- OR_ELSE evaluates right when left is FALSE ---
+    call_count := 0;
+    result := track(FALSE) OR_ELSE track(TRUE);
+    // CHECK: or_else_false: result=TRUE calls=2
+    printf('or_else_false: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+
+    // --- OR_ELSE returns FALSE when both are FALSE ---
+    call_count := 0;
+    result := track(FALSE) OR_ELSE track(FALSE);
+    // CHECK: or_else_both_false: result=FALSE calls=2
+    printf('or_else_both_false: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+
+    // --- Contrast: AND evaluates both operands eagerly ---
+    call_count := 0;
+    result := track(FALSE) AND track(TRUE);
+    // CHECK: and_eager: result=FALSE calls=2
+    printf('and_eager: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+
+    // --- Contrast: OR evaluates both operands eagerly ---
+    call_count := 0;
+    result := track(TRUE) OR track(FALSE);
+    // CHECK: or_eager: result=TRUE calls=2
+    printf('or_eager: result=%s calls=%d$N', SEL(result, 'FALSE', 'TRUE'), call_count);
+END_FUNCTION


### PR DESCRIPTION
  Introduce `AND_THEN` and `OR_ELSE` as explicit short-circuit boolean
  operators on `BOOL`: the right-hand operand is skipped when the left
  already determines the result.

  Change `AND` / `OR` on `BOOL` to evaluate both operands eagerly,
  matching CODESYS semantics.

  - Lex/parse/AST: new `AND_THEN` / `OR_ELSE` tokens, `Operator::AndThen` and `Operator::OrElse` variants, parser productions at the same precedence levels as `AND` and `OR` respectively.
  - Codegen: `AND_THEN` / `OR_ELSE` use phi-based short-circuit; `AND` / `OR` lower to flat `and` / `or` with both operands evaluated.
  - Const eval: short-circuit fast path on a known-bool LHS for both AND/AND_THEN-FALSE and OR/OR_ELSE-TRUE, preventing spurious errors (e.g. div-by-zero) on the unreachable side.
  - Validation: new diagnostic E133 rejecting `AND_THEN` / `OR_ELSE` on non-boolean operands, pointing users at `AND` / `OR` for bitwise operations.
  - Tests: parser, const-eval, validation, and codegen unit tests for the new operators; a lit test exercising eager vs short-circuit behavior via side-effect counts.

  BREAKING CHANGE: `AND` and `OR` on `BOOL` no longer short-circuit.
  Code that relied on the right-hand side being skipped (e.g.
  `ptr <> 0 AND ptr^.field > 0`) must switch to `AND_THEN` / `OR_ELSE`.