### PR TITLE
fix(validation): detect case-insensitive POU name collisions with generics

### DIFF
--- a/src/validation/global.rs
+++ b/src/validation/global.rs
@@ -183,26 +183,30 @@ impl GlobalValidator {
 
     ///validate the uniqueness of POUs (programs, functions, function_blocks, classes)
     fn validate_unique_pous(&mut self, index: &Index) {
-        //inner filter
-        fn only_toplevel_pous(pou: &&PouIndexEntry) -> bool {
-            !pou.is_action() && !pou.is_method() && !pou.is_generic()
+        // Top-level POUs only — actions and methods belong to their parent and are
+        // uniqueness-checked elsewhere.
+        fn included_in_cluster(pou: &&PouIndexEntry) -> bool {
+            !pou.is_action() && !pou.is_method()
         }
 
-        let pou_clusters = index
-            .get_pous()
-            .entries()
-            .filter(|(_, entries_per_name)| entries_per_name.iter().filter(only_toplevel_pous).count() > 1)
-            .map(|(name, pous)| {
-                (
-                    name.as_str(),
-                    pous.iter()
-                        .filter(|p| only_toplevel_pous(p) && !p.is_generic())
-                        .map(|p| p.get_location()),
-                )
-            });
+        // Two POUs sharing a (case-insensitive) name are reported as a conflict UNLESS
+        // both are generic functions: per PR #1054 generic functions may share a name
+        // (overload by type parameters), e.g. ADD<T1,T2> and ADD<K,V>.
+        // A non-generic POU colliding with anything (generic or not) is always
+        // ambiguous — it would cause the codegen lookup to pick whichever entry the
+        // index merge happens to surface first.
+        let pou_clusters = index.get_pous().entries().filter_map(|(name, pous)| {
+            let cluster: Vec<&PouIndexEntry> = pous.iter().filter(included_in_cluster).collect();
+            let has_non_generic = cluster.iter().any(|p| !p.is_generic());
+            if cluster.len() > 1 && has_non_generic {
+                Some((name.as_str(), cluster.iter().map(|p| p.get_location()).collect::<Vec<_>>()))
+            } else {
+                None
+            }
+        });
 
-        for (name, cluster) in pou_clusters {
-            self.report_name_conflict(name, &cluster.collect::<Vec<_>>(), None);
+        for (name, locations) in pou_clusters {
+            self.report_name_conflict(name, &locations, None);
         }
     }
 

--- a/src/validation/tests/duplicates_validation_test.rs
+++ b/src/validation/tests/duplicates_validation_test.rs
@@ -713,3 +713,133 @@ fn duplicate_interfaces() {
       │               ^^^ foo: Ambiguous datatype.
     ");
 }
+
+#[test]
+fn user_function_block_clashing_with_generic_function_is_flagged() {
+    // Reproduces the case-insensitive POU name collision that previously crashed
+    // codegen with "Could not find generated stub for <X>": a user-declared
+    // top-level FB sharing a (case-insensitive) name with a generic stdlib-style
+    // function must be reported here, not silently accepted.
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        FUNCTION mid <T : ANY_STRING> : T
+        VAR_INPUT IN : T; END_VAR
+        END_FUNCTION
+
+        FUNCTION_BLOCK Mid
+        END_FUNCTION_BLOCK
+        "#,
+    );
+    assert_snapshot!(diagnostics, @r"
+    error[E004]: mid: Duplicate symbol.
+      ┌─ <internal>:2:18
+      │
+    2 │         FUNCTION mid <T : ANY_STRING> : T
+      │                  ^^^ mid: Duplicate symbol.
+      ·
+    6 │         FUNCTION_BLOCK Mid
+      │                        --- see also
+
+    error[E004]: mid: Duplicate symbol.
+      ┌─ <internal>:6:24
+      │
+    2 │         FUNCTION mid <T : ANY_STRING> : T
+      │                  --- see also
+      ·
+    6 │         FUNCTION_BLOCK Mid
+      │                        ^^^ mid: Duplicate symbol.
+    ");
+}
+
+#[test]
+fn user_function_clashing_with_generic_function_is_flagged() {
+    // Same root cause as the FB case but with a non-generic FUNCTION sharing
+    // a name with a generic FUNCTION.
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        FUNCTION mid <T : ANY_STRING> : T
+        VAR_INPUT IN : T; END_VAR
+        END_FUNCTION
+
+        FUNCTION mid : DINT
+        END_FUNCTION
+        "#,
+    );
+    assert_snapshot!(diagnostics, @r"
+    error[E004]: mid: Duplicate symbol.
+      ┌─ <internal>:2:18
+      │
+    2 │         FUNCTION mid <T : ANY_STRING> : T
+      │                  ^^^ mid: Duplicate symbol.
+      ·
+    6 │         FUNCTION mid : DINT
+      │                  --- see also
+
+    error[E004]: mid: Duplicate symbol.
+      ┌─ <internal>:6:18
+      │
+    2 │         FUNCTION mid <T : ANY_STRING> : T
+      │                  --- see also
+      ·
+    6 │         FUNCTION mid : DINT
+      │                  ^^^ mid: Duplicate symbol.
+    ");
+}
+
+#[test]
+fn non_generic_pou_in_a_three_way_cluster_with_generics_is_flagged() {
+    // Non-generic in a cluster also containing multiple generics: each pair
+    // (non-generic vs generic) is a real ambiguity — flag the whole cluster.
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        FUNCTION foo <T1: ANY, T2: ANY> : T1
+        VAR_INPUT IN1: T1; IN2: T2; END_VAR
+        END_FUNCTION
+
+        FUNCTION foo <K: ANY, V: ANY> : K
+        VAR_INPUT IN1: K; IN2: V; END_VAR
+        END_FUNCTION
+
+        FUNCTION_BLOCK foo
+        END_FUNCTION_BLOCK
+        "#,
+    );
+    // Three locations are reported at each site — both generics plus the FB.
+    assert_snapshot!(diagnostics, @"
+    error[E004]: foo: Duplicate symbol.
+       ┌─ <internal>:2:18
+       │
+     2 │         FUNCTION foo <T1: ANY, T2: ANY> : T1
+       │                  ^^^ foo: Duplicate symbol.
+       ·
+     6 │         FUNCTION foo <K: ANY, V: ANY> : K
+       │                  --- see also
+       ·
+    10 │         FUNCTION_BLOCK foo
+       │                        --- see also
+
+    error[E004]: foo: Duplicate symbol.
+       ┌─ <internal>:6:18
+       │
+     2 │         FUNCTION foo <T1: ANY, T2: ANY> : T1
+       │                  --- see also
+       ·
+     6 │         FUNCTION foo <K: ANY, V: ANY> : K
+       │                  ^^^ foo: Duplicate symbol.
+       ·
+    10 │         FUNCTION_BLOCK foo
+       │                        --- see also
+
+    error[E004]: foo: Duplicate symbol.
+       ┌─ <internal>:10:24
+       │
+     2 │         FUNCTION foo <T1: ANY, T2: ANY> : T1
+       │                  --- see also
+       ·
+     6 │         FUNCTION foo <K: ANY, V: ANY> : K
+       │                  --- see also
+       ·
+    10 │         FUNCTION_BLOCK foo
+       │                        ^^^ foo: Duplicate symbol.
+    ");
+}


### PR DESCRIPTION
A user-defined POU whose name case-insensitively matches a generic function (e.g. user `Mid` vs stdlib `MID < T : ANY_STRING > : T`) was silently accepted by `validate_unique_pous` and later crashed codegen with `Builder error: Could not find generated stub for <X>`.

`Index::import` is asymmetric: `pous` is a multi-map that preserves both entries (with `find_pou` returning the user FB), while `implementations` is a HashMap merged via `extend` so the stdlib generic wins. The codegen stub-generation pass filters out generics, so no stub is emitted for the clashing name; the body-generation pass then iterates `unit.implementations`, finds the user FB through `find_pou`, passes the linkage filter, and panics looking up the missing stub.

Surface the conflict at validation time instead. The previous predicate excluded all generics from the cluster check (added in #1054 to permit overloaded generic functions like `ADD<T1,T2>` vs `ADD<K,V>`). The fix keeps that case working — two generics sharing a name still coexist — but flags any cluster that contains at least one non-generic top-level POU alongside another entry. Diagnostic uses the existing E004 plumbing and reports both declaration sites.

New tests in `duplicates_validation_test.rs` cover:
- user FB clashing with a generic function
- user function clashing with a generic function
- non-generic POU in a three-way cluster with two generics

The pre-existing `generics_with_duplicate_symbol_dont_err` (PR #1054) still passes.