### PR TITLE
test(lit): add regression coverage for fixed issues #1275 and #1239

### DIFF
--- a/tests/lit/single/function_blocks/array_of_ton_initialization.st
+++ b/tests/lit/single/function_blocks/array_of_ton_initialization.st
@@ -1,0 +1,18 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+// Regression test for https://github.com/PLC-lang/rusty/issues/1275
+// Initializing an ARRAY of TON with a repeat-initializer used to overflow the stack.
+TYPE TONs: ARRAY[1..50] OF TON := [50(PT:=T#100ms)]; END_TYPE
+
+FUNCTION main : DINT
+    VAR
+        timers : TONs;
+        outVal : BOOL;
+        outTime : TIME;
+    END_VAR
+
+    // Drive one of the array elements to confirm the initializer was applied.
+    timers[1](IN := FALSE, Q => outVal, ET => outTime);
+    PRINTF('PT=%lld$N', timers[1].PT);
+    // CHECK: PT=100000000
+END_FUNCTION

--- a/tests/lit/single/function_blocks/array_of_ton_initialization.st
+++ b/tests/lit/single/function_blocks/array_of_ton_initialization.st
@@ -13,6 +13,12 @@ FUNCTION main : DINT
 
     // Drive one of the array elements to confirm the initializer was applied.
     timers[1](IN := FALSE, Q => outVal, ET => outTime);
-    PRINTF('PT=%lld$N', timers[1].PT);
-    // CHECK: PT=100000000
+    PRINTF('PT_first=%lld$N', timers[1].PT);
+    // CHECK: PT_first=100000000
+
+    // Anchor that the repeat-initializer reached the *last* element too — a
+    // regression that initialized only the first slot would still pass the
+    // first PRINTF alone.
+    PRINTF('PT_last=%lld$N', timers[50].PT);
+    // CHECK: PT_last=100000000
 END_FUNCTION

--- a/tests/lit/single/functions/function_output_to_bit_direct_access.st
+++ b/tests/lit/single/functions/function_output_to_bit_direct_access.st
@@ -33,4 +33,12 @@ FUNCTION main : DINT
     myFb(foo => bar.4);
     PRINTF('after_fb=%d$N', bar);
     // CHECK: after_fb=16
+
+    // Non-zero seed: anchors that bits 0–3 are *preserved* when the FB output
+    // writes bit 4. A regression that clobbered the integer (e.g. wrote a full
+    // word instead of just the bit) would surface here as 16 instead of 17.
+    bar := 1;
+    myFb(foo => bar.4);
+    PRINTF('after_fb_seeded=%d$N', bar);
+    // CHECK: after_fb_seeded=17
 END_FUNCTION

--- a/tests/lit/single/functions/function_output_to_bit_direct_access.st
+++ b/tests/lit/single/functions/function_output_to_bit_direct_access.st
@@ -1,0 +1,36 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+// Regression test for https://github.com/PLC-lang/rusty/issues/1239
+// `fun(out => bar.4)` and `myFb(out => bar.4)` previously generated IR that
+// computed the bit address but never stored the function's output back into
+// the underlying integer.
+FUNCTION fun
+    VAR_OUTPUT
+        foo : BOOL;
+    END_VAR
+    foo := TRUE;
+END_FUNCTION
+
+FUNCTION_BLOCK fb
+    VAR_OUTPUT
+        foo : BOOL;
+    END_VAR
+    foo := TRUE;
+END_FUNCTION_BLOCK
+
+FUNCTION main : DINT
+    VAR
+        bar  : DINT;
+        myFb : fb;
+    END_VAR
+
+    bar := 0;
+    fun(foo => bar.4);
+    PRINTF('after_fun=%d$N', bar);
+    // CHECK: after_fun=16
+
+    bar := 0;
+    myFb(foo => bar.4);
+    PRINTF('after_fb=%d$N', bar);
+    // CHECK: after_fb=16
+END_FUNCTION


### PR DESCRIPTION
Adds two lit tests verifying that previously-broken behaviour now compiles and produces the expected runtime output, so future regressions surface in CI.

* `single/function_blocks/array_of_ton_initialization.st` Covers #1275. A 50-element `ARRAY[1..50] OF TON` with a repeat initializer (`[50(PT:=T#100ms)]`) used to overflow the stack during initialization. The test compiles the array, drives one of the timer instances, and asserts the per-element `PT` was applied (`PT=100000000` ns).

* `single/functions/function_output_to_bit_direct_access.st` Covers #1239. Output assignments with bit-level direct access in the call site (`fun(foo => bar.4)` and `myFb(foo => bar.4)`) used to compute the bit address but never store the function/FB output back into the underlying integer. The test exercises both the FUNCTION and FUNCTION_BLOCK forms and asserts `bar` becomes 16 (= 1 << 4) after each call.

Verification (master @ 689757d8e8) is recorded on the issues:
  - https://github.com/PLC-lang/rusty/issues/1275#issuecomment-4351209890
  - https://github.com/PLC-lang/rusty/issues/1239#issuecomment-4351210696

Issue #1033 (`--pic` segfault) was also verified as fixed-by- replacement (use `--fpic` / `--shared --fpic`); regression coverage already exists in `tests/lit/multi/pic_flags/run.test`, so no new test is added here. See:
  - https://github.com/PLC-lang/rusty/issues/1033#issuecomment-4351211676

Fixes #1275
Fixes #1239
Refs #1033