### PR TITLE
fix(resolver): resolve ReferenceExpr base under default scopes

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2385,7 +2385,13 @@ impl<'i> TypeAnnotator<'i> {
     ) {
         // first resolve base
         if let Some(base) = base {
-            self.visit_statement(ctx, base);
+            // The base of a `ReferenceExpr` is a value-producing expression, never the call
+            // target itself (only the leaf is). When the outer expression is a call, `ctx`
+            // carries `call_operator_scopes` (FunctionsOnly first), which would otherwise let
+            // a builtin/function shadow a same-named local in expressions like `ref.foo()`.
+            // Resolve the base under default scopes; the leaf below still uses `ctx`.
+            let base_ctx = ctx.with_resolving_strategy(ResolvingStrategy::default_scopes());
+            self.visit_statement(&base_ctx, base);
         };
 
         match (

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2389,7 +2389,11 @@ impl<'i> TypeAnnotator<'i> {
             // target itself (only the leaf is). When the outer expression is a call, `ctx`
             // carries `call_operator_scopes` (FunctionsOnly first), which would otherwise let
             // a builtin/function shadow a same-named local in expressions like `ref.foo()`.
-            // Resolve the base under default scopes; the leaf below still uses `ctx`.
+            // `default_scopes()` (Variable → POU → DataType) is the right replacement here:
+            // a tighter strategy like `VariablesOnly` would reject a legitimate global
+            // function whose return value is itself dotted into (e.g. `someGlobalFn().m`).
+            // Leaf resolution below still inherits `ctx`, preserving the call/assignment
+            // asymmetry encoded in `call_operator_scopes`.
             let base_ctx = ctx.with_resolving_strategy(ResolvingStrategy::default_scopes());
             self.visit_statement(&base_ctx, base);
         };

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -7154,12 +7154,66 @@ fn fb_instance_shares_name_with_function_qualified_call() {
 }
 
 #[test]
+fn chained_qualified_call_resolves_through_recursive_bases() {
+    // Stress the recursive base-context propagation in `visit_reference_expr`.
+    // `h.inst.bar()`'s operator is a ReferenceExpr whose base is itself a
+    // ReferenceExpr (`h.inst`). The fix's `default_scopes()` switch must hold
+    // at every nested level so that:
+    //   * `h`        resolves to the local variable (Variable scope)
+    //   * `h.inst`   resolves to the struct field (FB instance) — base under
+    //                default scopes, leaf `inst` likewise
+    //   * `bar`      (the leaf of the outer ReferenceExpr) still resolves
+    //                under `call_operator_scopes`, so the method wins.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        FUNCTION_BLOCK SomeFb
+        METHOD bar : INT
+            bar := 7;
+        END_METHOD
+        END_FUNCTION_BLOCK
+
+        TYPE Holder : STRUCT inst : SomeFb; END_STRUCT END_TYPE
+
+        PROGRAM Main
+        VAR h : Holder; END_VAR
+        h.inst.bar();
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+
+    // implementations: [0]=SomeFb, [1]=SomeFb.bar, [2]=Main
+    // The leaf `bar` must annotate as the method (call_operator_scopes wins).
+    let operator = call_operator(&unit, 2, 0);
+    assert!(
+        matches!(annotations.get(operator), Some(StatementAnnotation::Function { qualified_name, .. }) if qualified_name == "SomeFb.bar"),
+        "expected `bar` to resolve to method SomeFb.bar, got {:?}",
+        annotations.get(operator),
+    );
+
+    // The base `h.inst` must annotate as the SomeFb-typed struct field.
+    let base = call_operator_base(&unit, 2, 0);
+    assert!(
+        matches!(
+            annotations.get(base),
+            Some(StatementAnnotation::Variable { qualified_name, resulting_type, .. })
+            if qualified_name == "Holder.inst" && resulting_type == "SomeFb"
+        ),
+        "expected `h.inst` to annotate as Holder.inst : SomeFb, got {:?}",
+        annotations.get(base),
+    );
+}
+
+#[test]
 fn fb_instance_shares_name_with_function_direct_call() {
-    // The user flagged this as undefined: when an FB instance's name collides with a global
-    // function name and the user writes `foo()` (unqualified call), which wins? The fix in
-    // visit_reference_expr only affects ReferenceExpr-base resolution, so this case should NOT
-    // change — `foo()` continues to resolve to the function (the existing call_operator_scopes
-    // semantics). Pinning the current behaviour so a future change is visible.
+    // Current behaviour, intentionally pinned: when an FB instance's name collides with a
+    // global function name and the user writes `foo()` (unqualified call), the function
+    // wins. The fix in visit_reference_expr only affects ReferenceExpr-base resolution, so
+    // this case is unchanged — `foo()` continues to resolve to the function (the existing
+    // call_operator_scopes semantics). Any change to this assertion is deliberate and
+    // should be motivated, not assumed safe.
     let id_provider = IdProvider::default();
     let (unit, index) = index_with_ids(
         r#"

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -6878,3 +6878,314 @@ fn array_literal_passed_to_function_var_input_gets_type_hint_propagated() {
         unreachable!("expected CallStatement");
     }
 }
+
+// Regression coverage for #1605: a local variable named `ref` (or any other name colliding with a
+// builtin function) must resolve to the variable when used as the base of a qualified call like
+// `ref.foo()`. The asymmetry between unqualified call resolution (function wins) and unqualified
+// assignment resolution (variable wins) must be preserved.
+
+/// Helper: extract the base of the operator of a CallStatement at `unit.implementations[impl_idx].statements[stmt_idx]`.
+fn call_operator_base<'a>(
+    unit: &'a plc_ast::ast::CompilationUnit,
+    impl_idx: usize,
+    stmt_idx: usize,
+) -> &'a AstNode {
+    let stmt = &unit.implementations[impl_idx].statements[stmt_idx];
+    let AstNode { stmt: AstStatement::CallStatement(CallStatement { operator, .. }), .. } = stmt else {
+        panic!("expected CallStatement, got {:?}", stmt);
+    };
+    let AstNode { stmt: AstStatement::ReferenceExpr(ReferenceExpr { base: Some(base), .. }), .. } =
+        operator.as_ref()
+    else {
+        panic!("expected ReferenceExpr with base, got {:?}", operator);
+    };
+    base.as_ref()
+}
+
+/// Helper: extract the operator of a CallStatement at `unit.implementations[impl_idx].statements[stmt_idx]`.
+fn call_operator<'a>(
+    unit: &'a plc_ast::ast::CompilationUnit,
+    impl_idx: usize,
+    stmt_idx: usize,
+) -> &'a AstNode {
+    let stmt = &unit.implementations[impl_idx].statements[stmt_idx];
+    let AstNode { stmt: AstStatement::CallStatement(CallStatement { operator, .. }), .. } = stmt else {
+        panic!("expected CallStatement, got {:?}", stmt);
+    };
+    operator.as_ref()
+}
+
+#[test]
+fn ref_builtin_resolves_to_function_with_plain_variable_arg() {
+    // Pin the existing semantics: REF(x) on a plain variable annotates the operator as the REF
+    // builtin. This must not change after the fix.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        PROGRAM Main
+        VAR x : INT; END_VAR
+        REF(x);
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    let operator = call_operator(&unit, 0, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Function {
+            return_type: "__POINTER_TO_INT".into(),
+            qualified_name: "REF".into(),
+            generic_name: None,
+            call_name: None,
+        }),
+        annotations.get(operator)
+    );
+}
+
+#[test]
+fn ref_builtin_still_resolves_when_no_variable_shadows_it() {
+    // Same as above but inside a POU that has no `ref` variable at all — guard against any
+    // accidental change to the unshadowed builtin path.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        PROGRAM Main
+        VAR a : INT; END_VAR
+        REF(a);
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    let operator = call_operator(&unit, 0, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Function {
+            return_type: "__POINTER_TO_INT".into(),
+            qualified_name: "REF".into(),
+            generic_name: None,
+            call_name: None,
+        }),
+        annotations.get(operator)
+    );
+}
+
+#[test]
+fn unqualified_call_with_shadowed_function_name_resolves_to_function() {
+    // Pre-existing rule the resolver intentionally encodes: when a local variable shares a name
+    // with a function in the same scope, an unqualified call site `foo()` resolves to the function.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        FUNCTION foo : INT
+            foo := 1;
+        END_FUNCTION
+
+        PROGRAM Main
+        VAR foo : INT; END_VAR
+        foo();
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    let operator = call_operator(&unit, 1, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Function {
+            return_type: "INT".into(),
+            qualified_name: "foo".into(),
+            generic_name: None,
+            call_name: None,
+        }),
+        annotations.get(operator)
+    );
+}
+
+#[test]
+fn unqualified_assignment_with_shadowed_function_name_resolves_to_variable() {
+    // Pre-existing rule the resolver intentionally encodes: when a local variable shares a name
+    // with a function, an unqualified assignment LHS `foo := …` resolves to the variable. This
+    // pins the asymmetry between call and assignment that the existing scope order encodes.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        FUNCTION foo : INT
+            foo := 1;
+        END_FUNCTION
+
+        PROGRAM Main
+        VAR foo : INT; END_VAR
+        foo := 2;
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    let assignment = &unit.implementations[1].statements[0];
+    let AstNode { stmt: AstStatement::Assignment(Assignment { left, .. }), .. } = assignment else {
+        panic!("expected Assignment, got {:?}", assignment);
+    };
+    assert_eq!(
+        Some(&StatementAnnotation::Variable {
+            qualified_name: "Main.foo".into(),
+            resulting_type: "INT".into(),
+            constant: false,
+            argument_type: ArgumentType::ByVal(VariableType::Local),
+            auto_deref: None,
+        }),
+        annotations.get(left.as_ref())
+    );
+}
+
+#[test]
+fn local_variable_named_ref_resolves_to_variable_in_call_operator() {
+    // Regression for #1605: `ref.foo()` must resolve `ref` to the local variable, not to the
+    // `REF` builtin.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        FUNCTION_BLOCK MyFb
+        METHOD foo : INT
+            foo := 1;
+        END_METHOD
+        END_FUNCTION_BLOCK
+
+        PROGRAM Main
+        VAR ref : MyFb; END_VAR
+        ref.foo();
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    let base = call_operator_base(&unit, 2, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Variable {
+            qualified_name: "Main.ref".into(),
+            resulting_type: "MyFb".into(),
+            constant: false,
+            argument_type: ArgumentType::ByVal(VariableType::Local),
+            auto_deref: None,
+        }),
+        annotations.get(base)
+    );
+    let operator = call_operator(&unit, 2, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Function {
+            return_type: "INT".into(),
+            qualified_name: "MyFb.foo".into(),
+            generic_name: None,
+            call_name: None,
+        }),
+        annotations.get(operator)
+    );
+}
+
+#[test]
+fn uppercase_variable_named_ref_resolves_to_variable_in_call_operator() {
+    // Same as the lowercase case — exercises the case-insensitive name lookup path.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        FUNCTION_BLOCK MyFb
+        METHOD foo : INT
+            foo := 1;
+        END_METHOD
+        END_FUNCTION_BLOCK
+
+        PROGRAM Main
+        VAR REF : MyFb; END_VAR
+        REF.foo();
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    let base = call_operator_base(&unit, 2, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Variable {
+            qualified_name: "Main.REF".into(),
+            resulting_type: "MyFb".into(),
+            constant: false,
+            argument_type: ArgumentType::ByVal(VariableType::Local),
+            auto_deref: None,
+        }),
+        annotations.get(base)
+    );
+}
+
+#[test]
+fn fb_instance_shares_name_with_function_qualified_call() {
+    // An FB instance whose name happens to collide with a global function should resolve to the
+    // FB instance when used as the base of a qualified call. The user has flagged this as the
+    // intended (post-fix) behaviour.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        FUNCTION foo : INT
+            foo := 1;
+        END_FUNCTION
+
+        FUNCTION_BLOCK SomeFb
+        METHOD bar : INT
+            bar := 2;
+        END_METHOD
+        END_FUNCTION_BLOCK
+
+        PROGRAM Main
+        VAR foo : SomeFb; END_VAR
+        foo.bar();
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    // implementations: [0]=foo, [1]=SomeFb, [2]=SomeFb.bar, [3]=Main
+    let base = call_operator_base(&unit, 3, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Variable {
+            qualified_name: "Main.foo".into(),
+            resulting_type: "SomeFb".into(),
+            constant: false,
+            argument_type: ArgumentType::ByVal(VariableType::Local),
+            auto_deref: None,
+        }),
+        annotations.get(base)
+    );
+}
+
+#[test]
+fn fb_instance_shares_name_with_function_direct_call() {
+    // The user flagged this as undefined: when an FB instance's name collides with a global
+    // function name and the user writes `foo()` (unqualified call), which wins? The fix in
+    // visit_reference_expr only affects ReferenceExpr-base resolution, so this case should NOT
+    // change — `foo()` continues to resolve to the function (the existing call_operator_scopes
+    // semantics). Pinning the current behaviour so a future change is visible.
+    let id_provider = IdProvider::default();
+    let (unit, index) = index_with_ids(
+        r#"
+        FUNCTION foo : INT
+            foo := 1;
+        END_FUNCTION
+
+        FUNCTION_BLOCK SomeFb
+        END_FUNCTION_BLOCK
+
+        PROGRAM Main
+        VAR foo : SomeFb; END_VAR
+        foo();
+        END_PROGRAM
+        "#,
+        id_provider.clone(),
+    );
+    let (annotations, ..) = TypeAnnotator::visit_unit(&index, &unit, id_provider);
+    let operator = call_operator(&unit, 2, 0);
+    assert_eq!(
+        Some(&StatementAnnotation::Function {
+            return_type: "INT".into(),
+            qualified_name: "foo".into(),
+            generic_name: None,
+            call_name: None,
+        }),
+        annotations.get(operator)
+    );
+}

--- a/tests/lit/single/oop/method_call_through_struct_field.st
+++ b/tests/lit/single/oop/method_call_through_struct_field.st
@@ -1,0 +1,24 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+// Anchors that a chained qualified call (`h.inst.bar()`) resolves end-to-end
+// when the call's operator is a multi-level ReferenceExpr whose base is itself
+// a ReferenceExpr. Counterpart to the resolver-only unit test
+// `chained_qualified_call_resolves_through_recursive_bases`.
+FUNCTION_BLOCK SomeFb
+    METHOD bar : INT
+        bar := 7;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+TYPE Holder : STRUCT inst : SomeFb; END_STRUCT END_TYPE
+
+FUNCTION main : DINT
+    VAR
+        h : Holder;
+        x : INT;
+    END_VAR
+
+    x := h.inst.bar();
+    printf('chained=%d$N', x);
+    // CHECK: chained=7
+END_FUNCTION

--- a/tests/lit/single/variable/reserved_name_ref_as_variable.st
+++ b/tests/lit/single/variable/reserved_name_ref_as_variable.st
@@ -1,0 +1,16 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression for #1605: a local variable named `ref` must not be shadowed by the `REF` builtin
+// when used as the base of a qualified call like `ref.foo()`.
+
+FUNCTION_BLOCK MyFb
+    METHOD foo
+        printf('MyFb::foo$N');
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION main : DINT
+VAR
+    ref : MyFb;
+END_VAR
+    ref.foo(); // CHECK: MyFb::foo
+END_FUNCTION


### PR DESCRIPTION
The base of a `ReferenceExpr` is a value-producing expression, never the call target itself. When the outer expression is a call, the visitor context carries `call_operator_scopes` (FunctionsOnly first), which would otherwise let a builtin or global function shadow a same-named local in expressions like `ref.foo()` — the leaf `foo` would be searched as a member of the `REF` builtin instead of the local FB instance, producing `E048: Could not resolve reference to foo`.

Switch the base context to `default_scopes()` (Variable first) while leaving the leaf resolution untouched. The existing asymmetry — function wins on unqualified call `foo()`, variable wins on unqualified assignment `foo := …` — is preserved because the leaf still inherits `ctx`. As a side effect, an FB instance whose name collides with a global function now correctly resolves to the FB instance when used as a qualified-call base; unqualified calls are unchanged.

Adds resolver-level tests pinning both the bug regression and the pre-existing call/assignment asymmetry, and a lit test covering the end-to-end `ref.foo()` path.

Fixes #1605