### PR TITLE
fix(validation): report typedef of unknown type at the typedef site

### DIFF
--- a/compiler/plc_ast/src/ast.rs
+++ b/compiler/plc_ast/src/ast.rs
@@ -811,6 +811,9 @@ pub enum DataType {
     SubRangeType {
         name: Option<String>,
         referenced_type: String,
+        /// Source location of `referenced_type`. Used by validation to point at
+        /// the actual offending token when the referenced type is unknown.
+        referenced_type_location: SourceLocation,
         bounds: Option<AstNode>,
     },
     ArrayType {

--- a/src/index/indexer/user_type_indexer.rs
+++ b/src/index/indexer/user_type_indexer.rs
@@ -67,7 +67,7 @@ impl AstVisitor for UserTypeIndexer<'_, '_> {
             DataType::EnumType { name: Some(name), numeric_type, elements } => {
                 self.index_enum_type(name, numeric_type, elements)
             }
-            DataType::SubRangeType { name: Some(name), referenced_type, bounds } => {
+            DataType::SubRangeType { name: Some(name), referenced_type, bounds, .. } => {
                 self.index_sub_range_type(name, referenced_type, bounds.as_ref())
             }
             DataType::ArrayType { name: Some(name), bounds, referenced_type, is_variable_length: false } => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1151,11 +1151,16 @@ fn parse_type_reference_type_definition(
 ) -> Option<(DataTypeDeclaration, Option<AstNode>)> {
     let start = lexer.range().start;
 
+    let referenced_type_start = lexer.range().start;
     let mut referenced_type = lexer.slice_and_advance();
+    let mut referenced_type_end = lexer.last_range.end;
 
     if lexer.try_consume(KeywordDot) {
         referenced_type = format!("{referenced_type}.{}", lexer.slice_and_advance());
+        referenced_type_end = lexer.last_range.end;
     }
+    let referenced_type_location =
+        lexer.source_range_factory.create_range(referenced_type_start..referenced_type_end);
 
     let bounds = if lexer.try_consume(KeywordParensOpen) {
         // INT (..) :=
@@ -1207,7 +1212,12 @@ fn parse_type_reference_type_definition(
             }
             _ => DataTypeDeclaration::Definition {
                 //something else inside the brackets -> probably a subrange?
-                data_type: Box::new(DataType::SubRangeType { name, referenced_type, bounds }),
+                data_type: Box::new(DataType::SubRangeType {
+                    name,
+                    referenced_type,
+                    referenced_type_location,
+                    bounds,
+                }),
                 location: lexer.source_range_factory.create_range(start..end),
                 scope: lexer.scope.clone(),
             },
@@ -1297,6 +1307,7 @@ fn parse_string_type_definition(
             data_type: Box::new(DataType::SubRangeType {
                 name: Some(name.into()),
                 referenced_type: text,
+                referenced_type_location: location.clone(),
                 bounds: None,
             }),
             location,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1307,6 +1307,12 @@ fn parse_string_type_definition(
             data_type: Box::new(DataType::SubRangeType {
                 name: Some(name.into()),
                 referenced_type: text,
+                // TODO: shortcut — the STRING-fallback path reuses the whole-decl
+                // location rather than the referenced-type token's span. Practically
+                // never user-visible (string types here only reference synthesised
+                // internal types), but a future use-site validation that surfaces
+                // this would underline the entire declaration instead of the type
+                // name. Refactor when a real consumer needs the tight span.
                 referenced_type_location: location.clone(),
                 bounds: None,
             }),

--- a/src/parser/tests/initializer_parser_tests.rs
+++ b/src/parser/tests/initializer_parser_tests.rs
@@ -96,6 +96,9 @@ fn initial_scalar_values_can_be_parsed() {
             "MyInt",
         ),
         referenced_type: "INT",
+        referenced_type_location: SourceLocation {
+            span: Range(13:25 - 13:28),
+        },
         bounds: None,
     },
     initializer: Some(

--- a/src/parser/tests/snapshots/rusty__parser__tests__type_parser_tests__subrangetype_can_be_parsed.snap
+++ b/src/parser/tests/snapshots/rusty__parser__tests__type_parser_tests__subrangetype_can_be_parsed.snap
@@ -8,6 +8,9 @@ Variable {
         data_type: SubRangeType {
             name: None,
             referenced_type: "UINT",
+            referenced_type_location: SourceLocation {
+                span: Range(2:20 - 2:24),
+            },
             bounds: Some(
                 RangeStatement {
                     start: LiteralInteger {

--- a/src/parser/tests/type_parser_tests.rs
+++ b/src/parser/tests/type_parser_tests.rs
@@ -188,23 +188,22 @@ fn type_alias_can_be_parsed() {
         "#,
     );
 
-    let ast_string = format!("{:#?}", &result.user_types[0]);
-    let exptected_ast = format!(
-        "{:#?}",
-        &UserTypeDeclaration {
-            data_type: DataType::SubRangeType {
-                name: Some("MyInt".to_string()),
-                referenced_type: "INT".to_string(),
-                bounds: None,
+    assert_debug_snapshot!(result.user_types[0], @r#"
+    UserTypeDeclaration {
+        data_type: SubRangeType {
+            name: Some(
+                "MyInt",
+            ),
+            referenced_type: "INT",
+            referenced_type_location: SourceLocation {
+                span: Range(2:20 - 2:23),
             },
-            initializer: None,
-            location: SourceLocation::internal(),
-            scope: None,
-            linkage: plc_ast::ast::LinkageType::Internal,
-        }
-    );
-
-    assert_eq!(ast_string, exptected_ast);
+            bounds: None,
+        },
+        initializer: None,
+        scope: None,
+    }
+    "#);
 }
 
 #[test]
@@ -934,6 +933,9 @@ fn enum_with_no_elements_produces_syntax_error() {
                 "EMPTY_ENUM",
             ),
             referenced_type: "INT",
+            referenced_type_location: SourceLocation {
+                span: Range(1:26 - 1:29),
+            },
             bounds: Some(
                 EmptyStatement,
             ),

--- a/src/validation/tests.rs
+++ b/src/validation/tests.rs
@@ -19,5 +19,6 @@ mod reference_resolve_tests;
 mod statement_validation_tests;
 mod super_keyword_validation_tests;
 mod this_keyword_validation_tests;
+mod types_validation_tests;
 mod variable_length_array_test;
 mod variable_validation_tests;

--- a/src/validation/tests/types_validation_tests.rs
+++ b/src/validation/tests/types_validation_tests.rs
@@ -29,7 +29,7 @@ fn typedef_of_unknown_type_is_reported_at_the_typedef_site() {
 }
 
 #[test]
-fn typedef_chain_reports_only_the_broken_link() {
+fn typedef_chain_flags_only_the_failing_typedef_then_each_use_site() {
     let diagnostics = parse_and_validate_buffered(
         "
         TYPE alias_a : alias_b; END_TYPE
@@ -78,6 +78,74 @@ fn typedef_used_in_struct_member_still_reports_typedef_site() {
       │
     4 │             m : myType;
       │                 ^^^^^^ Type 'myType' references an unknown type
+    ");
+}
+
+#[test]
+fn self_referential_typedef_is_caught() {
+    // `TYPE a : a;` — direct cycle. Pin the diagnostic shape so cycle handling
+    // doesn't silently regress as the typedef-site check evolves.
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE my_alias : my_alias; END_TYPE
+        VAR_GLOBAL
+            a : my_alias;
+        END_VAR
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @r"
+    error[E052]: Type 'my_alias' references an unknown type
+      ┌─ <internal>:4:17
+      │
+    4 │             a : my_alias;
+      │                 ^^^^^^^^ Type 'my_alias' references an unknown type
+
+    error[E121]: Recursive type alias `my_alias -> my_alias`
+      ┌─ <internal>:2:14
+      │
+    2 │         TYPE my_alias : my_alias; END_TYPE
+      │              ^^^^^^^^ Recursive type alias `my_alias -> my_alias`
+    ");
+}
+
+#[test]
+fn mutually_referential_typedef_chain_is_caught() {
+    // Indirect cycle: `TYPE a : b; TYPE b : a;`. Same anchor purpose as the
+    // self-referential case — confirm cycle resolution doesn't loop or hide
+    // the diagnostic when the chain re-enters itself.
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE alias_a : alias_b; END_TYPE
+        TYPE alias_b : alias_a; END_TYPE
+        VAR_GLOBAL
+            a : alias_a;
+        END_VAR
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @r"
+    error[E052]: Type 'alias_a' references an unknown type
+      ┌─ <internal>:5:17
+      │
+    5 │             a : alias_a;
+      │                 ^^^^^^^ Type 'alias_a' references an unknown type
+
+    error[E121]: Recursive type alias `alias_a -> alias_b -> alias_a`
+      ┌─ <internal>:2:14
+      │
+    2 │         TYPE alias_a : alias_b; END_TYPE
+      │              ^^^^^^^ Recursive type alias `alias_a -> alias_b -> alias_a`
+    3 │         TYPE alias_b : alias_a; END_TYPE
+      │              ------- see also
+
+    error[E121]: Recursive type alias `alias_b -> alias_a -> alias_b`
+      ┌─ <internal>:3:14
+      │
+    2 │         TYPE alias_a : alias_b; END_TYPE
+      │              ------- see also
+    3 │         TYPE alias_b : alias_a; END_TYPE
+      │              ^^^^^^^ Recursive type alias `alias_b -> alias_a -> alias_b`
     ");
 }
 

--- a/src/validation/tests/types_validation_tests.rs
+++ b/src/validation/tests/types_validation_tests.rs
@@ -1,0 +1,96 @@
+use insta::assert_snapshot;
+
+use crate::test_utils::tests::parse_and_validate_buffered;
+
+#[test]
+fn typedef_of_unknown_type_is_reported_at_the_typedef_site() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE myType : undeclaredType; END_TYPE
+        VAR_GLOBAL
+            a : myType;
+        END_VAR
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @r"
+    error[E052]: Unknown type: undeclaredType
+      ┌─ <internal>:2:23
+      │
+    2 │         TYPE myType : undeclaredType; END_TYPE
+      │                       ^^^^^^^^^^^^^^ Unknown type: undeclaredType
+
+    error[E052]: Type 'myType' references an unknown type
+      ┌─ <internal>:4:17
+      │
+    4 │             a : myType;
+      │                 ^^^^^^ Type 'myType' references an unknown type
+    ");
+}
+
+#[test]
+fn typedef_chain_reports_only_the_broken_link() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE alias_a : alias_b; END_TYPE
+        TYPE alias_b : undeclaredType; END_TYPE
+        VAR_GLOBAL
+            a : alias_a;
+        END_VAR
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @r"
+    error[E052]: Unknown type: undeclaredType
+      ┌─ <internal>:3:24
+      │
+    3 │         TYPE alias_b : undeclaredType; END_TYPE
+      │                        ^^^^^^^^^^^^^^ Unknown type: undeclaredType
+
+    error[E052]: Type 'alias_a' references an unknown type
+      ┌─ <internal>:5:17
+      │
+    5 │             a : alias_a;
+      │                 ^^^^^^^ Type 'alias_a' references an unknown type
+    ");
+}
+
+#[test]
+fn typedef_used_in_struct_member_still_reports_typedef_site() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE myType : undeclaredType; END_TYPE
+        TYPE myStruct : STRUCT
+            m : myType;
+        END_STRUCT END_TYPE
+        ",
+    );
+
+    assert_snapshot!(diagnostics, @r"
+    error[E052]: Unknown type: undeclaredType
+      ┌─ <internal>:2:23
+      │
+    2 │         TYPE myType : undeclaredType; END_TYPE
+      │                       ^^^^^^^^^^^^^^ Unknown type: undeclaredType
+
+    error[E052]: Type 'myType' references an unknown type
+      ┌─ <internal>:4:17
+      │
+    4 │             m : myType;
+      │                 ^^^^^^ Type 'myType' references an unknown type
+    ");
+}
+
+#[test]
+fn typedef_of_known_type_is_clean() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE myAlias : DINT; END_TYPE
+        VAR_GLOBAL
+            a : myAlias;
+        END_VAR
+        ",
+    );
+
+    assert!(diagnostics.is_empty(), "expected clean diagnostics, got:\n{diagnostics}");
+}

--- a/src/validation/tests/variable_validation_tests.rs
+++ b/src/validation/tests/variable_validation_tests.rs
@@ -898,11 +898,17 @@ fn aliasing_to_undeclared_type_is_an_error() {
     );
 
     assert_snapshot!(diagnostics, @r"
-    error[E052]: Unknown type: myDeclaredType
+    error[E052]: Unknown type: undeclaredType
+      ┌─ <internal>:2:31
+      │
+    2 │         TYPE myDeclaredType : undeclaredType; END_TYPE
+      │                               ^^^^^^^^^^^^^^ Unknown type: undeclaredType
+
+    error[E052]: Type 'myDeclaredType' references an unknown type
       ┌─ <internal>:4:16
       │
     4 │             a: myDeclaredType;
-      │                ^^^^^^^^^^^^^^ Unknown type: myDeclaredType
+      │                ^^^^^^^^^^^^^^ Type 'myDeclaredType' references an unknown type
     ");
 }
 

--- a/src/validation/types.rs
+++ b/src/validation/types.rs
@@ -30,7 +30,18 @@ pub fn visit_data_type_declaration<T: AnnotationMap>(
     match declaration {
         DataTypeDeclaration::Reference { referenced_type, location } => {
             if context.index.find_effective_type_by_name(referenced_type).is_none() {
-                validator.push_diagnostic(Diagnostic::unknown_type(referenced_type, location));
+                if context.index.find_type(referenced_type).is_some() {
+                    // Name is registered but its alias chain bottoms out at an unknown type.
+                    // The typedef site already reports the missing target; here we flag the
+                    // alias as unusable without claiming the name itself is unknown.
+                    validator.push_diagnostic(
+                        Diagnostic::new(format!("Type '{referenced_type}' references an unknown type"))
+                            .with_error_code("E052")
+                            .with_location(location),
+                    );
+                } else {
+                    validator.push_diagnostic(Diagnostic::unknown_type(referenced_type, location));
+                }
             };
         }
         DataTypeDeclaration::Definition { data_type, location, .. } => {
@@ -141,6 +152,12 @@ pub fn visit_data_type<T: AnnotationMap>(
                 }
             } else {
                 validator.push_diagnostic(Diagnostic::unknown_type(numeric_type, location));
+            }
+        }
+        DataType::SubRangeType { referenced_type, referenced_type_location, .. } => {
+            if context.index.find_type(referenced_type).is_none() {
+                validator
+                    .push_diagnostic(Diagnostic::unknown_type(referenced_type, referenced_type_location));
             }
         }
         _ => {}

--- a/src/validation/types.rs
+++ b/src/validation/types.rs
@@ -154,11 +154,10 @@ pub fn visit_data_type<T: AnnotationMap>(
                 validator.push_diagnostic(Diagnostic::unknown_type(numeric_type, location));
             }
         }
-        DataType::SubRangeType { referenced_type, referenced_type_location, .. } => {
-            if context.index.find_type(referenced_type).is_none() {
-                validator
-                    .push_diagnostic(Diagnostic::unknown_type(referenced_type, referenced_type_location));
-            }
+        DataType::SubRangeType { referenced_type, referenced_type_location, .. }
+            if context.index.find_type(referenced_type).is_none() =>
+        {
+            validator.push_diagnostic(Diagnostic::unknown_type(referenced_type, referenced_type_location));
         }
         _ => {}
     }


### PR DESCRIPTION
When a typedef aliased an undeclared type (e.g. `TYPE myType : undeclaredType; END_TYPE`), the only diagnostic emitted was at the *use* site (`a : myType`), and it claimed `myType` itself was unknown. That message is misleading — `myType` is registered, just transitively unresolvable — and points the user away from the real problem.

Two changes:

1. Add a `DataType::SubRangeType` arm to `visit_data_type` that looks up `referenced_type` in the index and emits an `Unknown type` diagnostic at the typedef site when the lookup fails. To make the underline land on the actual offending token instead of the alias name, store a new `referenced_type_location: SourceLocation` on `DataType::SubRangeType` and populate it from the parser.

2. Differentiate the use-site message: when a referenced type is registered but its alias chain bottoms out at an unknown type, emit `Type 'X' references an unknown type` instead of `Unknown type: X`. Genuinely unregistered names still produce the original message.

Tests: a new `types_validation_tests.rs` covers the typedef site (unknown target, chain through another typedef, used in a struct member, known target as regression). The existing
`aliasing_to_undeclared_type_is_an_error` snapshot in `variable_validation_tests.rs` is updated for the new dual-error output. Parser fixtures for `SubRangeType` are updated to include the new location field.

Closes #1344