### PR TITLE
fix(codegen,parser): correctly deref RValue pointers; allow ^ after a call

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -3250,23 +3250,32 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
 
             // `base^`
             (ReferenceAccess::Deref, Some(base)) => {
-                let base_lvalue = self.generate_expression_value(base)?;
+                let base_value = self.generate_expression_value(base)?;
 
-                let value = self.llvm.load_pointer(
-                    // Normally it wouldn't be safe to just assume the pointee in the `load_pointer` call to
-                    // be of type `ptr`. However, we call `into_pointer_value` on the result of it, as such
-                    // LLVM actually expects the type to be `ptr` as it will panic otherwise.
-                    self.llvm.context.ptr_type(
-                        AddressSpace::from(ADDRESS_SPACE_GENERIC)).into(),
-                        &base_lvalue.get_basic_value_enum().into_pointer_value(),
-                        "deref"
-                    )?;
+                // The dereference target is the pointer to load through. For a variable
+                // holding a pointer (LValue), the variable's slot holds the pointer and we
+                // need one load to extract it. For an RValue (e.g. `REF(x)` or a call that
+                // returns a pointer), the value is already the pointer — loading again
+                // would treat the pointee's bytes as a pointer and segfault.
+                let pointer = match base_value {
+                    ExpressionValue::LValue(addr, _) => self
+                        .llvm
+                        .load_pointer(
+                            // See note below: `load_pointer` is called with `ptr` here because
+                            // we immediately call `into_pointer_value` on the result.
+                            self.llvm.context.ptr_type(AddressSpace::from(ADDRESS_SPACE_GENERIC)).into(),
+                            &addr,
+                            "deref",
+                        )?
+                        .into_pointer_value(),
+                    ExpressionValue::RValue(value) => value.into_pointer_value(),
+                };
 
-                    let pointee = {
-                        let datatype = self.annotations.get_type(original_expression, self.index).unwrap();
-                        self.llvm_index.get_associated_type(&datatype.name).unwrap()
-                    };
-                Ok(ExpressionValue::LValue(value.into_pointer_value(), pointee))
+                let pointee = {
+                    let datatype = self.annotations.get_type(original_expression, self.index).unwrap();
+                    self.llvm_index.get_associated_type(&datatype.name).unwrap()
+                };
+                Ok(ExpressionValue::LValue(pointer, pointee))
             }
 
             // `&base`

--- a/src/parser/expressions_parser.rs
+++ b/src/parser/expressions_parser.rs
@@ -413,20 +413,27 @@ pub fn parse_call_statement(lexer: &mut ParseSession) -> Option<AstNode> {
         })
     };
 
-    // Are we dealing with an array-index access directly after the call, e.g. `foo()[...]`?
-    if lexer.try_consume(KeywordSquareParensOpen) {
-        let index = parse_any_in_region(lexer, vec![KeywordSquareParensClose], parse_expression);
-        let statement = AstFactory::create_index_reference(
-            index,
-            Some(call),
-            lexer.next_id(),
-            SourceLocation::undefined(),
-        );
-
-        return Some(statement);
+    // Postfix chain after the call: `foo()[...]`, `foo()^`, or combinations
+    // like `foo()[...]^` and `foo()^[...]`.
+    let mut result = call;
+    loop {
+        if lexer.try_consume(KeywordSquareParensOpen) {
+            let index = parse_any_in_region(lexer, vec![KeywordSquareParensClose], parse_expression);
+            result = AstFactory::create_index_reference(
+                index,
+                Some(result),
+                lexer.next_id(),
+                SourceLocation::undefined(),
+            );
+        } else if lexer.try_consume(OperatorDeref) {
+            let deref_loc = lexer.last_location();
+            result =
+                AstFactory::create_deref_reference(result, lexer.next_id(), reference_loc.span(&deref_loc));
+        } else {
+            break;
+        }
     }
-
-    Some(call)
+    Some(result)
 }
 
 pub fn parse_qualified_reference(lexer: &mut ParseSession) -> Option<AstNode> {

--- a/src/validation/tests/pointer_validation_tests.rs
+++ b/src/validation/tests/pointer_validation_tests.rs
@@ -1030,3 +1030,28 @@ fn reference_to_constant_aggregate_types_is_allowed() {
 
     insta::assert_snapshot!(diagnostics, @"")
 }
+
+#[test]
+fn double_deref_of_single_level_pointer_errors() {
+    // Regression for #1448: a single-level pointer must reject `p^^` at
+    // validation rather than panicking in codegen.
+    let diagnostics = parse_and_validate_buffered(
+        r"
+        FUNCTION main : DINT
+        VAR
+            p : REF_TO INT;
+        END_VAR
+            p^^;
+            main := 0;
+        END_FUNCTION
+        ",
+    );
+
+    insta::assert_snapshot!(diagnostics, @r"
+    error[E068]: Dereferencing requires a pointer-value.
+      ┌─ <internal>:6:13
+      │
+    6 │             p^^;
+      │             ^^^ Dereferencing requires a pointer-value.
+    ");
+}

--- a/tests/lit/single/pointer/method_call_deref_assign.st
+++ b/tests/lit/single/pointer/method_call_deref_assign.st
@@ -1,0 +1,26 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression for #1463: `methodCall()^ := value` must parse and write through
+// the returned pointer. Prior to the fix, the parser closed the call and
+// rejected `^` with E007.
+
+FUNCTION_BLOCK Holder
+VAR
+    x : DINT := 0;
+END_VAR
+METHOD GetPtr : REF_TO DINT
+    GetPtr := REF(x);
+END_METHOD
+METHOD Read : DINT
+    Read := x;
+END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION main : DINT
+VAR
+    h : Holder;
+END_VAR
+    h.GetPtr()^ := 17;
+    // CHECK: 17
+    printf('%d$N', h.Read());
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/pointer/paren_ref_arith_deref.st
+++ b/tests/lit/single/pointer/paren_ref_arith_deref.st
@@ -1,0 +1,14 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression for #1443: pointer arithmetic on a paren-REF result followed by
+// a deref must read the adjacent slot, not segfault.
+
+FUNCTION main : DINT
+VAR
+    arr : ARRAY[0..1] OF DINT := [10, 20];
+    out_val : DINT;
+END_VAR
+    out_val := (REF(arr[0]) + 1)^;
+    // CHECK: 20
+    printf('%d$N', out_val);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/pointer/paren_ref_deref_assign.st
+++ b/tests/lit/single/pointer/paren_ref_deref_assign.st
@@ -1,0 +1,14 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression for #1463: writing through `(REF(x))^ := value` must reach `x`
+// instead of segfaulting. The codegen change extracts the pointer directly
+// from the RValue produced by REF instead of loading through it.
+
+FUNCTION main : DINT
+VAR
+    x : DINT := 0;
+END_VAR
+    (REF(x))^ := 99;
+    // CHECK: 99
+    printf('%d$N', x);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/pointer/paren_ref_deref_read.st
+++ b/tests/lit/single/pointer/paren_ref_deref_read.st
@@ -1,0 +1,15 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression for #1443: reading through `(REF(x))^` must dereference the
+// returned pointer, not load through the variable holding it. Prior to the
+// fix this silently miscompiled to a segfault at runtime.
+
+FUNCTION main : DINT
+VAR
+    x : DINT := 42;
+    y : DINT;
+END_VAR
+    y := (REF(x))^;
+    // CHECK: 42
+    printf('%d$N', y);
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Two related deref bugs that together caused four reported issues:

Codegen — `(REF(x))^`, `(REF(x))^ := value`, and pointer arithmetic through a paren-REF used to silently miscompile to a runtime segfault (originally reported as a codegen panic that some prior change suppressed without fixing the underlying load). The deref arm in `expression_generator.rs` unconditionally `load_pointer`-ed the base, which is correct when the base is an LValue holding a pointer (load once to extract the pointer) but treats the dereferenced bytes as a pointer when the base is already an RValue carrying the pointer directly (REF/ADR builtins, calls returning a pointer, pointer arithmetic). Branch on `ExpressionValue::LValue` vs `RValue` and skip the redundant load for RValues.

Parser — `methodCall()^ := value` was rejected with a confusing E007 ("expected KeywordSemicolon") because `parse_call_statement` only accepted `[...]` as a postfix after a closed call. Replace the single `[...]` check with a small loop that also accepts `^`, supporting chains like `foo()^[i]` and `foo()[i]^`. AST shape: `Deref(Call(...))`.

Tests:
- 4 runnable lit tests under `tests/lit/single/pointer/` covering `(REF(x))^` read, `(REF(arr[0]) + 1)^` arithmetic, `(REF(x))^ := …` write, and `methodCall()^ := …`.
- Inline-snapshot validator test in `pointer_validation_tests.rs` for `p^^` on a single-level pointer (E068), preventing the codegen panic reported in the original issue from returning.

Refs #1443
Refs #1448
Refs #1463