### PR TITLE
fix(index): dedup synthetic hardware-backing globals across units

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -2501,18 +2501,22 @@ impl Index {
     }
 }
 
-/// Returns a default initialization name for a variable or type
 /// Returns true for the hardware-address-mangled synthetic globals emitted by
 /// the pre-processor (`__PI_*` for inputs, `__M_*` for memory, `__G_*` for
 /// globals). These deterministic names can legitimately appear in multiple
 /// units when they share a hardware address; index merging dedups them so they
-/// don't surface as ambiguous-global diagnostics. The check is
-/// case-insensitive because index keys are stored lowercased.
+/// don't surface as ambiguous-global diagnostics.
+///
+/// The `__` leading underscores are a reserved-identifier convention — any
+/// user-declared global colliding with these prefixes is *by design* subject
+/// to dedup at import time. The match is against lowercase prefixes because
+/// `Index::register_global_variable` lowercases keys on insert (see
+/// `src/index.rs:2166`), so the input name is already canonicalised.
 fn is_synthetic_hw_global(name: &str) -> bool {
-    let lower = name.to_lowercase();
-    lower.starts_with("__pi_") || lower.starts_with("__m_") || lower.starts_with("__g_")
+    name.starts_with("__pi_") || name.starts_with("__m_") || name.starts_with("__g_")
 }
 
+/// Returns a default initialization name for a variable or type
 pub fn get_initializer_name(name: &str) -> String {
     format!("__{name}__init")
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1338,6 +1338,14 @@ impl Index {
     pub fn import(&mut self, mut other: Index) {
         //global variables
         for (name, e) in other.global_variables.drain(..) {
+            // Synthetic hardware-backing globals (`__PI_*` / `__M_*` / `__G_*`) are
+            // generated per-unit by the pre-processor; when multiple units alias the
+            // same hardware address they each produce an entry with the identical
+            // mangled name. Dedup at import: keep the first one seen instead of
+            // surfacing them later as ambiguous-global diagnostics.
+            if is_synthetic_hw_global(&name) && self.global_variables.contains_key(&name) {
+                continue;
+            }
             let entries = e
                 .into_iter()
                 .map(|it| self.transfer_constants(it, &mut other.constant_expressions))
@@ -2494,6 +2502,17 @@ impl Index {
 }
 
 /// Returns a default initialization name for a variable or type
+/// Returns true for the hardware-address-mangled synthetic globals emitted by
+/// the pre-processor (`__PI_*` for inputs, `__M_*` for memory, `__G_*` for
+/// globals). These deterministic names can legitimately appear in multiple
+/// units when they share a hardware address; index merging dedups them so they
+/// don't surface as ambiguous-global diagnostics. The check is
+/// case-insensitive because index keys are stored lowercased.
+fn is_synthetic_hw_global(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.starts_with("__pi_") || lower.starts_with("__m_") || lower.starts_with("__g_")
+}
+
 pub fn get_initializer_name(name: &str) -> String {
     format!("__{name}__init")
 }

--- a/tests/lit/multi/cross_file_hardware_alias_1307/cross_file_hardware_alias_1307.test
+++ b/tests/lit/multi/cross_file_hardware_alias_1307/cross_file_hardware_alias_1307.test
@@ -1,0 +1,2 @@
+RUN: %COMPILE %S/file1.st %S/file2.st && %RUN | %CHECK %s
+CHECK: aliased

--- a/tests/lit/multi/cross_file_hardware_alias_1307/file1.st
+++ b/tests/lit/multi/cross_file_hardware_alias_1307/file1.st
@@ -1,0 +1,14 @@
+VAR_GLOBAL
+    foo AT %IX1.2.3.4 : BOOL;
+END_VAR
+
+FUNCTION main : DINT
+    // Confirm the alias is wired by writing through `foo` and reading it back.
+    // file2.st declares `bar` at the same hardware address, so the two names
+    // must share the same backing storage (`__PI_1_2_3_4`).
+    foo := TRUE;
+    IF foo THEN
+        printf('aliased$N');
+    END_IF;
+    main := 0;
+END_FUNCTION

--- a/tests/lit/multi/cross_file_hardware_alias_1307/file2.st
+++ b/tests/lit/multi/cross_file_hardware_alias_1307/file2.st
@@ -1,0 +1,7 @@
+// Declared in a separate compilation unit at the same hardware address as
+// file1.st's `foo`. Without the cross-unit dedup of synthetic `__PI_*`
+// globals, this used to fail to link with an ambiguous-symbol error
+// (#1307).
+VAR_GLOBAL
+    bar AT %IX1.2.3.4 : BOOL;
+END_VAR


### PR DESCRIPTION
Aliasing the same hardware address from two compilation units —

    // file1.st
    VAR_GLOBAL  foo AT %IX1.2.3.4 : BOOL; END_VAR

    // file2.st
    VAR_GLOBAL  bar AT %IX1.2.3.4 : BOOL; END_VAR

— failed with `E004: __PI_1_2_3_4: Ambiguous global variable.` even after PR #1301 fixed the within-file case. The pre-processor mangles hardware addresses into synthetic globals (`__PI_*`, `__M_*`, `__G_*`) deterministically, so both units independently emit a `__PI_1_2_3_4` entry. `Index::import` was merging them via `insert_many`, leaving two entries under one key for the validator to flag.

Mirror the existing "skip internally-auto-generated types that we already know" pattern that types use at index-merge time: when importing a global whose name has the synthetic-hardware prefix and the receiving index already holds an entry for it, drop the new one. The check is case-insensitive because index keys are stored lowercased.

Tests: new multi-file lit regression
`tests/lit/multi/cross_file_hardware_alias_1307/` declaring different names at the same hardware address across two files; build + run + assert the alias is wired (write through `foo`, observable from `file1.st`'s `main`). Without the fix the build fails before linking.

Closes #1307