### PR TITLE
test(lit): add OPT_LEVEL matrix and silence -Onone failures

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -159,10 +159,20 @@ function run_lit_test() {
     run_package_std
 
     if [[ $release -eq 0 ]]; then
-        lit -v -DLIB=$project_location/output -DCOMPILER=$project_location/target/debug/plc tests/lit/
+        local plc_bin="$project_location/target/debug/plc"
     else
-        lit -v -DLIB=$project_location/output -DCOMPILER=$project_location/target/release/plc tests/lit/
+        local plc_bin="$project_location/target/release/plc"
     fi
+
+    # Optimization-level matrix. Each cell must pass; tests that legitimately
+    # cannot (yet) handle a non-default level must declare `// UNSUPPORTED:
+    # opt-none` (or equivalent feature) in their RUN-line preamble. See #1345.
+    local opt_levels="${OPT_LEVELS:-default,none}"
+    IFS=',' read -ra _opt_levels <<< "$opt_levels"
+    for opt_level in "${_opt_levels[@]}"; do
+        log "Running lit with OPT_LEVEL=$opt_level"
+        lit -v -DLIB=$project_location/output -DCOMPILER=$plc_bin -DOPT_LEVEL=$opt_level tests/lit/
+    done
 }
 
 function run_test() {

--- a/tests/lit/correctness/control/for/nested_for_loop_allocas_are_hoisted.st
+++ b/tests/lit/correctness/control/for/nested_for_loop_allocas_are_hoisted.st
@@ -1,4 +1,4 @@
-// RUN: (%COMPILE -Onone %s && %RUN) | %CHECK %s
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
 //
 // Regression test for stack growth caused by lowered loop temporaries.
 // Nested FOR loops are desugared into nested WHILE TRUE loops with synthetic

--- a/tests/lit/lit.cfg
+++ b/tests/lit/lit.cfg
@@ -14,6 +14,14 @@ rustyRootDirectory = subprocess.check_output("dirname `cargo locate-project --me
 stdlibLocation = lit_config.params["LIB"]
 compilerLocation = lit_config.params["COMPILER"]
 
+# Optimization level passed to plc when compiling test STs. Default ("default")
+# mirrors how plc itself runs without an explicit `-O`. The matrix run also
+# exercises OPT_LEVEL=none, which surfaces broken IR LLVM's optimizer would
+# otherwise mask. See #1345 (`tests/lit/single/init/function_locals.st` is the
+# named example of code that passes the default cell but segfaults under
+# `-Onone`).
+optLevel = lit_config.params.get("OPT_LEVEL", "default")
+
 # Detect available FileCheck command
 filecheckCmd = None
 for cmd in ['FileCheck', 'FileCheck-21', 'filecheck', 'filecheck-21']:
@@ -34,6 +42,12 @@ compile_base = f'{compile_base} --debug'
 compile_base = f'{compile_base} --linker=cc'
 compile_base = f'{compile_base} --error-config {rustyRootDirectory}/tests/lit/util/diagnostics.json'
 
+# Inject `-O` only when the matrix cell is not the default. plc rejects a
+# duplicate `-O` (clap), so omitting it at the default level lets tests opt
+# in via their own RUN line if they truly need a fixed level.
+if optLevel != "default":
+    compile_base = f'{compile_base} -O{optLevel}'
+
 compile = f'{compile_base} -o %T/%basename_t.out'
 print(f'Compile command: {compile}')
 
@@ -43,6 +57,8 @@ compile_ir = f'{compile_ir} --ir --debug'
 compile_ir = f'{compile_ir} -o -'
 compile_ir = f'{compile_ir} -liec61131std -L{stdlibLocation}/lib -i "{stdlibLocation}/include/*.st"'
 compile_ir = f'{compile_ir} -i "{rustyRootDirectory}/tests/lit/util/*.pli"'
+if optLevel != "default":
+    compile_ir = f'{compile_ir} -O{optLevel}'
 
 stdlibLibDir = f'{stdlibLocation}/lib'
 
@@ -62,4 +78,10 @@ elif platform.system() == 'Darwin':
     config.available_features.add('system-darwin')
 elif platform.system() == 'Windows':
     config.available_features.add('system-windows')
+
+# Optimization-level features for REQUIRES:/UNSUPPORTED: guards. A test that
+# fails (segfaults, miscompiles, etc.) under `-Onone` should mark itself
+# `// UNSUPPORTED: opt-none` until the underlying bug is addressed.
+if optLevel == "none":
+    config.available_features.add('opt-none')
 

--- a/tests/lit/multi/pic_flags/run.test
+++ b/tests/lit/multi/pic_flags/run.test
@@ -1,4 +1,7 @@
 // REQUIRES: system-linux
+// UNSUPPORTED: opt-none
+// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): builds
+// and runs under default optimization; runtime fails under `-Onone`.
 
 // === Part 1: Compile multi-file objects with PIC and no-PIC, link to executables ===
 

--- a/tests/lit/single/init/var_input_defaults_function_array_string.st
+++ b/tests/lit/single/init/var_input_defaults_function_array_string.st
@@ -1,4 +1,7 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// UNSUPPORTED: opt-none
+// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): segfaults
+// when compiled with `-Onone`; passes at the default optimization level.
 
 // Test VAR_INPUT defaults with STRING/ARRAY and mixed overrides
 

--- a/tests/lit/single/init/var_input_defaults_function_wstring.st
+++ b/tests/lit/single/init/var_input_defaults_function_wstring.st
@@ -1,5 +1,8 @@
 
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// UNSUPPORTED: opt-none
+// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): segfaults
+// when compiled with `-Onone`; passes at the default optimization level.
 // Test VAR_INPUT defaults with WSTRING and overrides
 
 TYPE ArrType : ARRAY[1..3] OF DINT;

--- a/tests/lit/single/var_input/var_input_arrays.st
+++ b/tests/lit/single/var_input/var_input_arrays.st
@@ -1,4 +1,8 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// UNSUPPORTED: opt-none
+// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): segfaults
+// when compiled with `-Onone`; passes at the default optimization level.
+
 FUNCTION foo
    VAR_INPUT
        in_literal: ARRAY[1..5] OF DINT;

--- a/tests/lit/single/variadics/bitaccess_xor_printf.st
+++ b/tests/lit/single/variadics/bitaccess_xor_printf.st
@@ -1,4 +1,4 @@
-// RUN: (%COMPILE -Onone %s && %RUN) | %CHECK %s
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
 // Verifies that a boolean XOR expression involving a direct bit-access is
 // correctly promoted to i32 when passed as a variadic argument.
 // Without the promotion the i1 result can be clobbered by the subsequent MUX

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,7 +25,14 @@ enum Command {
         #[arg(value_enum, long, global = true, default_value_t = ReporterType::Sysout)]
         reporter: ReporterType,
     },
-    Lit,
+    Lit {
+        /// Comma-separated optimization levels to exercise. Each cell runs the
+        /// full lit suite with `-O<level>`; defaults match the CI matrix.
+        /// Tests that cannot handle a non-default level should declare
+        /// `// UNSUPPORTED: opt-none` (or equivalent) in their RUN-line preamble.
+        #[arg(long, value_delimiter = ',', default_values_t = ["default".to_string(), "none".to_string()])]
+        opt_levels: Vec<String>,
+    },
 }
 
 #[derive(Subcommand, Clone)]
@@ -43,16 +50,16 @@ fn main() -> anyhow::Result<()> {
     let params = Parameters::parse();
     match params.command {
         Command::Metrics { action, reporter } => run_metrics(action, reporter)?,
-        Command::Lit => run_lit()?,
+        Command::Lit { opt_levels } => run_lit(&opt_levels)?,
     };
 
     Ok(())
 }
 
-fn run_lit() -> Result<()> {
+fn run_lit(opt_levels: &[String]) -> Result<()> {
     let sh = Shell::new()?;
 
-    // Run compile
+    let _env = sh.push_env("OPT_LEVELS", opt_levels.join(","));
     sh.cmd("scripts/build.sh").args(&["--lit"]).run()?;
     Ok(())
 }


### PR DESCRIPTION
LLVM's optimizer at default level can mask broken IR that segfaults under `-Onone`, leaving a coverage gap that lets codegen bugs slip through CI. Add an `OPT_LEVEL` parameter to the lit harness and run the suite at both `default` and `none` so future regressions are caught earlier.

Pieces:
- `tests/lit/lit.cfg` reads `OPT_LEVEL` from `lit_config.params`, appends `-O{level}` to `compile_base` and `compile_ir` only when the level is non-default (plc rejects a duplicate `-O`), and registers the `opt-none` lit feature for `// UNSUPPORTED:` guards.
- `scripts/build.sh::run_lit_test` loops over `${OPT_LEVELS:-default,none}`, invoking lit once per cell. Both cells must pass.
- `xtask/src/main.rs` accepts `--opt-levels` (comma-separated, defaults to `default,none`) and pipes through to the build script.

Triage of the new `-Onone` cell:
- `tests/lit/correctness/control/for/nested_for_loop_allocas_are_hoisted.st` and `tests/lit/single/variadics/bitaccess_xor_printf.st` previously passed `-Onone` themselves on their `RUN:` line; the matrix now exercises that cell uniformly so the explicit flag was removed (also it conflicted with the lit-cfg-injected `-O`).
- Four tests segfault or misbehave under `-Onone` while passing at default opt and are silenced with `// UNSUPPORTED: opt-none`: `tests/lit/multi/pic_flags/run.test`, `tests/lit/single/init/var_input_defaults_function_array_string.st`, `tests/lit/single/init/var_input_defaults_function_wstring.st`, `tests/lit/single/var_input/var_input_arrays.st`. The underlying bugs are tracked in #1718 so each can be unblocked by removing its directive in a focused PR.

Closes #1345
Refs #1718