### PR TITLE
test(actions): cover VAR_IN_OUT stored on FB before action call

### DIFF
--- a/tests/lit/ir_tests/action_call_stores_var_in_out_address.st
+++ b/tests/lit/ir_tests/action_call_stores_var_in_out_address.st
@@ -1,0 +1,36 @@
+// RUN: %COMPILE_IR %s | %CHECK_IR %s
+//
+// Pin the IR shape that the #1576 fix (commit 2b3388f) put in place: when
+// calling an action that inherits a `VAR_IN_OUT` from its parent FB, the
+// caller must (a) GEP to the FB's in-out slot and (b) store the local's
+// address there before invoking the action. Skipping either step leaves the
+// pointer NULL and the action segfaults at runtime — runtime coverage lives
+// in `tests/lit/single/actions/action_call_with_var_in_out.st`; this test
+// is the structural guardrail.
+
+PROGRAM mainProg
+VAR
+    fb : fb_t;
+    localBool : BOOL;
+END_VAR
+    fb.foo(myInOut := localBool);
+END_PROGRAM
+
+FUNCTION_BLOCK fb_t
+VAR_IN_OUT
+    myInOut : BOOL;
+END_VAR
+END_FUNCTION_BLOCK
+
+ACTIONS
+    ACTION foo
+        myInOut := myInOut;
+    END_ACTION
+END_ACTIONS
+
+// CHECK-LABEL: define void @mainProg(
+// CHECK: %fb = getelementptr inbounds nuw %mainProg, {{.*}}, i32 0, i32 0
+// CHECK: %localBool = getelementptr inbounds nuw %mainProg, {{.*}}, i32 0, i32 1
+// CHECK: getelementptr inbounds %fb_t, ptr %fb, i32 0, i32 1
+// CHECK-NEXT: store ptr %localBool, ptr {{%[0-9]+}}, align 8
+// CHECK-NEXT: call void @fb_t__foo(ptr %fb)

--- a/tests/lit/single/actions/action_call_with_var_in_out.st
+++ b/tests/lit/single/actions/action_call_with_var_in_out.st
@@ -1,0 +1,37 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Regression coverage for #1576 (fixed in commit 2b3388f). Calling an action
+// that inherits a `VAR_IN_OUT` parameter from its parent FB must store the
+// caller's address into the FB's in-out slot before invoking the action.
+// Before the fix the slot stayed NULL — the action then dereferenced a null
+// pointer and segfaulted at runtime.
+
+PROGRAM mainProg
+VAR
+    fb : fb_t;
+    localBool : BOOL;
+END_VAR
+    localBool := TRUE;
+    fb.foo(myInOut := localBool);
+
+    localBool := FALSE;
+    fb.foo(myInOut := localBool);
+END_PROGRAM
+
+FUNCTION_BLOCK fb_t
+VAR_IN_OUT
+    myInOut : BOOL;
+END_VAR
+END_FUNCTION_BLOCK
+
+ACTIONS
+    ACTION foo
+        // CHECK: myInout = 1
+        // CHECK: myInout = 0
+        printf('myInout = %d$N', myInOut);
+    END_ACTION
+END_ACTIONS
+
+FUNCTION main : DINT
+    mainProg();
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Calling an action that inherits a `VAR_IN_OUT` parameter from its parent FB used to segfault: the generated IR loaded the caller's local but never stored its address into the FB's in-out slot, so the action dereferenced a NULL pointer. The bug was fixed indirectly by commit 2b3388f (PR #1545) but had no dedicated test coverage, leaving it open to silent regression.

Add two regression tests:

- `tests/lit/single/actions/action_call_with_var_in_out.st` — runtime guardrail using the issue's repro: `mainProg` writes `localBool := TRUE/FALSE` between two `fb.foo(myInOut := localBool)` calls and the action body prints `myInOut`. Asserts `1` then `0`, which only matches if the address store is in place; without the fix the binary segfaults instead of producing output.

- `tests/lit/ir_tests/action_call_stores_var_in_out_address.st` — structural guardrail: FILECHECK that `mainProg`'s body GEPs to the FB's in-out slot, stores `ptr %localBool` there, and only then calls `@fb_t__foo`. Ordering of the three lines is the regression signature.

Closes #1576