### PR TITLE
fix(lowering): disambiguate per-unit ctor symbols by path hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,6 +2330,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "shell-words",
+ "siphasher",
  "tabled",
  "tempfile",
  "test_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ generational-arena = { version = "0.2.8", features = ["serde"] }
 shell-words = "1.1.0"
 plc_derive = { path = "./compiler/plc_derive", version = "0.5.0" }
 which = "4.2.5"
+siphasher = "1"
 log.workspace = true
 inkwell.workspace = true
 chrono.workspace = true

--- a/compiler/plc_driver/src/tests/debug_paths.rs
+++ b/compiler/plc_driver/src/tests/debug_paths.rs
@@ -365,7 +365,7 @@ END_PROGRAM
         !16 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !17, splitDebugInlining: false)
         "#);
 
-        assert!(ir.contains("@__unit_test_st__ctor"), "expected constructor function in IR, got:\n{ir}");
+        assert!(ir.contains("@__unit_test_st_"), "expected constructor function in IR, got:\n{ir}");
         assert!(
             !ir.contains("declare !dbg"),
             "expected constructors-only declarations without !dbg attachments, got:\n{ir}"
@@ -951,7 +951,7 @@ END_PROGRAM
         !17 = distinct !DICompileUnit(language: DW_LANG_C, file: !10, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !18, splitDebugInlining: false)
         "#);
 
-        assert!(ir.contains("@__unit_test_st__ctor"), "expected constructor function in IR, got:\n{ir}");
+        assert!(ir.contains("@__unit_test_st_"), "expected constructor function in IR, got:\n{ir}");
         assert!(
             !ir.contains("declare !dbg"),
             "expected constructors-only declarations without !dbg attachments, got:\n{ir}"

--- a/compiler/plc_util/src/lib.rs
+++ b/compiler/plc_util/src/lib.rs
@@ -23,6 +23,13 @@ macro_rules! __plc_add_common_snapshot_filters {
         $settings.add_filter(r#"target datalayout = ".*""#, r#"target datalayout = "[filtered]""#);
         $settings.add_filter(r#"target triple = ".*""#, r#"target triple = "[filtered]""#);
 
+        // The 8-hex-char suffix in `__unit_<basename>_<hash>__ctor` symbols
+        // is derived from the full source path (see
+        // `src/lowering/helper.rs::get_unit_name`), so it differs between
+        // build environments (e.g. local `/home/<user>/...` vs CI
+        // `/workspace/...`). Mask it so codegen snapshots stay stable.
+        $settings.add_filter(r"(__unit_[A-Za-z0-9_]+?)_[0-9a-f]{8}(__ctor)", r"${1}_[ctor-hash]${2}");
+
         if let Ok(cwd) = std::env::current_dir() {
             let cwd = cwd.to_string_lossy().to_string();
             for path in [cwd.clone(), cwd.replace('\\', "/"), format!(r"\\?\{}", cwd)].into_iter() {

--- a/src/codegen/tests/debug_tests.rs
+++ b/src/codegen/tests/debug_tests.rs
@@ -72,7 +72,7 @@ fn test_global_var_enum_added_to_debug_info() {
     @__global_en3.a = unnamed_addr constant i64 0
     @__global_en3.b = unnamed_addr constant i64 1
     @__global_en3.c = unnamed_addr constant i64 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @en1__ctor(ptr %0) {
     entry:
@@ -95,7 +95,7 @@ fn test_global_var_enum_added_to_debug_info() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__global_en3__ctor(ptr @en3)
       ret void
@@ -164,7 +164,7 @@ fn test_global_var_enum_with_explicit_values_added_to_debug_info() {
     @Flags.Read = unnamed_addr constant i8 4
     @Flags.Write = unnamed_addr constant i8 8
     @Flags.Execute = unnamed_addr constant i8 16
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @Colors__ctor(ptr %0) {
     entry:
@@ -187,7 +187,7 @@ fn test_global_var_enum_with_explicit_values_added_to_debug_info() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @Colors__ctor(ptr @color)
       call void @Status__ctor(ptr @status)
@@ -269,7 +269,7 @@ fn test_global_var_struct_with_enum_members_added_to_debug_info() {
     @Priority.Low = unnamed_addr constant i8 1
     @Priority.Medium = unnamed_addr constant i8 5
     @Priority.High = unnamed_addr constant i8 10
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @Status__ctor(ptr %0) {
     entry:
@@ -298,7 +298,7 @@ fn test_global_var_struct_with_enum_members_added_to_debug_info() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @Device__ctor(ptr @device)
       ret void
@@ -648,7 +648,7 @@ fn dbg_declare_has_valid_metadata_references_for_methods() {
     %fb = type { ptr }
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @fb(ptr %0) !dbg !4 {
     entry:
@@ -721,7 +721,7 @@ fn dbg_declare_has_valid_metadata_references_for_methods() {
       ret void, !dbg !15
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance), !dbg !15
       ret void, !dbg !15
@@ -786,7 +786,7 @@ fn action_with_var_temp() {
     %PLC_PRG = type {}
 
     @PLC_PRG_instance = global %PLC_PRG zeroinitializer, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define i32 @main() !dbg !9 {
     entry:
@@ -816,7 +816,7 @@ fn action_with_var_temp() {
       ret void, !dbg !26
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @PLC_PRG__ctor(ptr @PLC_PRG_instance), !dbg !26
       ret void, !dbg !26
@@ -1205,7 +1205,7 @@ fn constants_are_tagged_as_such() {
     @s = unnamed_addr constant [81 x i8] zeroinitializer, !dbg !5
     @f = unnamed_addr constant %foo zeroinitializer, !dbg !13
     @prog_instance = global %prog zeroinitializer, !dbg !19
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @prog(ptr %0) !dbg !30 {
     entry:
@@ -1242,7 +1242,7 @@ fn constants_are_tagged_as_such() {
       ret void, !dbg !43
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance), !dbg !43
       ret void, !dbg !43
@@ -1325,7 +1325,7 @@ fn test_debug_info_regular_pointer_types() {
     @array_ptr = global ptr null, !dbg !6
     @struct_ptr = global ptr null, !dbg !13
     @string_ptr = global ptr null, !dbg !22
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @myStruct__ctor(ptr %0) {
     entry:
@@ -1369,7 +1369,7 @@ fn test_debug_info_regular_pointer_types() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__global_basic_ptr__ctor(ptr @basic_ptr)
       call void @__global_array_ptr__ctor(ptr @array_ptr)
@@ -1452,7 +1452,7 @@ fn test_debug_info_auto_deref_parameters() {
     %test_with_ref_params = type { ptr, ptr, ptr, ptr, ptr }
 
     @test_with_ref_params_instance = global %test_with_ref_params zeroinitializer, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @test_with_ref_params(ptr %0) !dbg !38 {
     entry:
@@ -1500,7 +1500,7 @@ fn test_debug_info_auto_deref_parameters() {
       ret void, !dbg !43
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @test_with_ref_params__ctor(ptr @test_with_ref_params_instance), !dbg !43
       ret void, !dbg !43
@@ -1586,7 +1586,7 @@ fn test_debug_info_auto_deref_alias_pointers() {
     @alias_int = global ptr null, !dbg !4
     @global_struct = global %myStruct zeroinitializer, !dbg !8
     @alias_struct = global ptr null, !dbg !15
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @myStruct__ctor(ptr %0) {
     entry:
@@ -1609,7 +1609,7 @@ fn test_debug_info_auto_deref_alias_pointers() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       store i32 42, ptr @global_var, align [filtered]
       %deref = load ptr, ptr @alias_int, align [filtered]
@@ -1685,7 +1685,7 @@ fn test_debug_info_mixed_pointer_types() {
     @regular_ptr = global ptr null, !dbg !0
     @alias_var = global ptr null, !dbg !6
     @mixed_ptr_instance = global %mixed_ptr zeroinitializer, !dbg !12
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @mixed_ptr(ptr %0) !dbg !38 {
     entry:
@@ -1745,7 +1745,7 @@ fn test_debug_info_mixed_pointer_types() {
       ret void, !dbg !43
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__global_regular_ptr__ctor(ptr @regular_ptr), !dbg !43
       %deref = load ptr, ptr @alias_var, align [filtered], !dbg !43
@@ -1845,7 +1845,7 @@ fn test_debug_info_auto_deref_reference_to_pointers() {
     @struct_reference = global ptr null, !dbg !13
     @string_reference = global ptr null, !dbg !22
     @test_with_reference_params_instance = global %test_with_reference_params zeroinitializer, !dbg !31
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @test_with_reference_params(ptr %0) !dbg !51 {
     entry:
@@ -1945,7 +1945,7 @@ fn test_debug_info_auto_deref_reference_to_pointers() {
       ret void, !dbg !56
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       %deref = load ptr, ptr @basic_reference, align [filtered], !dbg !56
       call void @__global_basic_reference__ctor(ptr %deref), !dbg !56
@@ -2203,7 +2203,7 @@ fn range_datatype_fqn_reference_bounds_debug() {
     %prog = type { i32, i32 }
 
     @prog_instance = global %prog { i32 10, i32 0 }, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @prog(ptr %0) !dbg !14 {
     entry:
@@ -2232,7 +2232,7 @@ fn range_datatype_fqn_reference_bounds_debug() {
       ret void, !dbg !19
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance), !dbg !19
       ret void, !dbg !19
@@ -2293,7 +2293,7 @@ fn range_datatype_debug_alias_reused() {
     %prog = type { i32, i32, i32, i32 }
 
     @prog_instance = global %prog { i32 10, i32 0, i32 0, i32 0 }, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @prog(ptr %0) !dbg !16 {
     entry:
@@ -2337,7 +2337,7 @@ fn range_datatype_debug_alias_reused() {
       ret void, !dbg !21
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance), !dbg !21
       ret void, !dbg !21

--- a/src/codegen/tests/debug_tests.rs
+++ b/src/codegen/tests/debug_tests.rs
@@ -72,7 +72,7 @@ fn test_global_var_enum_added_to_debug_info() {
     @__global_en3.a = unnamed_addr constant i64 0
     @__global_en3.b = unnamed_addr constant i64 1
     @__global_en3.c = unnamed_addr constant i64 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @en1__ctor(ptr %0) {
     entry:
@@ -95,7 +95,7 @@ fn test_global_var_enum_added_to_debug_info() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__global_en3__ctor(ptr @en3)
       ret void
@@ -164,7 +164,7 @@ fn test_global_var_enum_with_explicit_values_added_to_debug_info() {
     @Flags.Read = unnamed_addr constant i8 4
     @Flags.Write = unnamed_addr constant i8 8
     @Flags.Execute = unnamed_addr constant i8 16
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @Colors__ctor(ptr %0) {
     entry:
@@ -187,7 +187,7 @@ fn test_global_var_enum_with_explicit_values_added_to_debug_info() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @Colors__ctor(ptr @color)
       call void @Status__ctor(ptr @status)
@@ -269,7 +269,7 @@ fn test_global_var_struct_with_enum_members_added_to_debug_info() {
     @Priority.Low = unnamed_addr constant i8 1
     @Priority.Medium = unnamed_addr constant i8 5
     @Priority.High = unnamed_addr constant i8 10
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @Status__ctor(ptr %0) {
     entry:
@@ -298,7 +298,7 @@ fn test_global_var_struct_with_enum_members_added_to_debug_info() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @Device__ctor(ptr @device)
       ret void
@@ -648,7 +648,7 @@ fn dbg_declare_has_valid_metadata_references_for_methods() {
     %fb = type { ptr }
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @fb(ptr %0) !dbg !4 {
     entry:
@@ -721,7 +721,7 @@ fn dbg_declare_has_valid_metadata_references_for_methods() {
       ret void, !dbg !15
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance), !dbg !15
       ret void, !dbg !15
@@ -786,7 +786,7 @@ fn action_with_var_temp() {
     %PLC_PRG = type {}
 
     @PLC_PRG_instance = global %PLC_PRG zeroinitializer, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define i32 @main() !dbg !9 {
     entry:
@@ -816,7 +816,7 @@ fn action_with_var_temp() {
       ret void, !dbg !26
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @PLC_PRG__ctor(ptr @PLC_PRG_instance), !dbg !26
       ret void, !dbg !26
@@ -1205,7 +1205,7 @@ fn constants_are_tagged_as_such() {
     @s = unnamed_addr constant [81 x i8] zeroinitializer, !dbg !5
     @f = unnamed_addr constant %foo zeroinitializer, !dbg !13
     @prog_instance = global %prog zeroinitializer, !dbg !19
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @prog(ptr %0) !dbg !30 {
     entry:
@@ -1242,7 +1242,7 @@ fn constants_are_tagged_as_such() {
       ret void, !dbg !43
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance), !dbg !43
       ret void, !dbg !43
@@ -1325,7 +1325,7 @@ fn test_debug_info_regular_pointer_types() {
     @array_ptr = global ptr null, !dbg !6
     @struct_ptr = global ptr null, !dbg !13
     @string_ptr = global ptr null, !dbg !22
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @myStruct__ctor(ptr %0) {
     entry:
@@ -1369,7 +1369,7 @@ fn test_debug_info_regular_pointer_types() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__global_basic_ptr__ctor(ptr @basic_ptr)
       call void @__global_array_ptr__ctor(ptr @array_ptr)
@@ -1452,7 +1452,7 @@ fn test_debug_info_auto_deref_parameters() {
     %test_with_ref_params = type { ptr, ptr, ptr, ptr, ptr }
 
     @test_with_ref_params_instance = global %test_with_ref_params zeroinitializer, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @test_with_ref_params(ptr %0) !dbg !38 {
     entry:
@@ -1500,7 +1500,7 @@ fn test_debug_info_auto_deref_parameters() {
       ret void, !dbg !43
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @test_with_ref_params__ctor(ptr @test_with_ref_params_instance), !dbg !43
       ret void, !dbg !43
@@ -1586,7 +1586,7 @@ fn test_debug_info_auto_deref_alias_pointers() {
     @alias_int = global ptr null, !dbg !4
     @global_struct = global %myStruct zeroinitializer, !dbg !8
     @alias_struct = global ptr null, !dbg !15
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @myStruct__ctor(ptr %0) {
     entry:
@@ -1609,7 +1609,7 @@ fn test_debug_info_auto_deref_alias_pointers() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       store i32 42, ptr @global_var, align [filtered]
       %deref = load ptr, ptr @alias_int, align [filtered]
@@ -1685,7 +1685,7 @@ fn test_debug_info_mixed_pointer_types() {
     @regular_ptr = global ptr null, !dbg !0
     @alias_var = global ptr null, !dbg !6
     @mixed_ptr_instance = global %mixed_ptr zeroinitializer, !dbg !12
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @mixed_ptr(ptr %0) !dbg !38 {
     entry:
@@ -1745,7 +1745,7 @@ fn test_debug_info_mixed_pointer_types() {
       ret void, !dbg !43
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__global_regular_ptr__ctor(ptr @regular_ptr), !dbg !43
       %deref = load ptr, ptr @alias_var, align [filtered], !dbg !43
@@ -1845,7 +1845,7 @@ fn test_debug_info_auto_deref_reference_to_pointers() {
     @struct_reference = global ptr null, !dbg !13
     @string_reference = global ptr null, !dbg !22
     @test_with_reference_params_instance = global %test_with_reference_params zeroinitializer, !dbg !31
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @test_with_reference_params(ptr %0) !dbg !51 {
     entry:
@@ -1945,7 +1945,7 @@ fn test_debug_info_auto_deref_reference_to_pointers() {
       ret void, !dbg !56
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       %deref = load ptr, ptr @basic_reference, align [filtered], !dbg !56
       call void @__global_basic_reference__ctor(ptr %deref), !dbg !56
@@ -2203,7 +2203,7 @@ fn range_datatype_fqn_reference_bounds_debug() {
     %prog = type { i32, i32 }
 
     @prog_instance = global %prog { i32 10, i32 0 }, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @prog(ptr %0) !dbg !14 {
     entry:
@@ -2232,7 +2232,7 @@ fn range_datatype_fqn_reference_bounds_debug() {
       ret void, !dbg !19
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance), !dbg !19
       ret void, !dbg !19
@@ -2293,7 +2293,7 @@ fn range_datatype_debug_alias_reused() {
     %prog = type { i32, i32, i32, i32 }
 
     @prog_instance = global %prog { i32 10, i32 0, i32 0, i32 0 }, !dbg !0
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @prog(ptr %0) !dbg !16 {
     entry:
@@ -2337,7 +2337,7 @@ fn range_datatype_debug_alias_reused() {
       ret void, !dbg !21
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance), !dbg !21
       ret void, !dbg !21

--- a/src/codegen/tests/initialization_test/complex_initializers.rs
+++ b/src/codegen/tests/initialization_test/complex_initializers.rs
@@ -25,7 +25,7 @@ fn simple_global() {
 
     @s = global [81 x i8] c"hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @ps = global ptr null
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
     define void @__global_ps__ctor(ptr %0) {
@@ -35,7 +35,7 @@ fn simple_global() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       call void @__global_ps__ctor(ptr @ps)
@@ -73,7 +73,7 @@ fn global_alias() {
 
     @s = global [81 x i8] c"hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @ps = global ptr null
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
     define void @__global_ps__ctor(ptr %0) {
@@ -83,7 +83,7 @@ fn global_alias() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       %deref = load ptr, ptr @ps, align [filtered]
@@ -122,7 +122,7 @@ fn global_reference_to() {
 
     @s = global [81 x i8] c"hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @ps = global ptr null
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
     define void @__global_ps__ctor(ptr %0) {
@@ -132,7 +132,7 @@ fn global_reference_to() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       %deref = load ptr, ptr @ps, align [filtered]
@@ -178,7 +178,7 @@ fn init_functions_generated_for_programs() {
 
     @s = global [81 x i8] zeroinitializer
     @PLC_PRG_instance = global %PLC_PRG zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @PLC_PRG(ptr %0) {
     entry:
@@ -206,7 +206,7 @@ fn init_functions_generated_for_programs() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @PLC_PRG__ctor(ptr @PLC_PRG_instance)
       ret void
@@ -244,7 +244,7 @@ fn init_functions_work_with_adr() {
 
     @s = global [81 x i8] zeroinitializer
     @PLC_PRG_instance = global %PLC_PRG zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @PLC_PRG(ptr %0) {
     entry:
@@ -262,7 +262,7 @@ fn init_functions_work_with_adr() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @PLC_PRG__ctor(ptr @PLC_PRG_instance)
       ret void
@@ -301,7 +301,7 @@ fn init_functions_generated_for_function_blocks() {
 
     @s = global [81 x i8] zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -365,7 +365,7 @@ fn init_functions_generated_for_function_blocks() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -459,7 +459,7 @@ fn nested_initializer_pous() {
     @__vtable_baz_instance = global %__vtable_baz zeroinitializer
     @mainProg_instance = global %mainProg zeroinitializer
     @sideProg_instance = global %sideProg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
     define void @foo(ptr %0) {
@@ -707,7 +707,7 @@ fn nested_initializer_pous() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @str, ptr align [filtered] @utf08_literal_0, i32 6, i1 false)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -780,7 +780,7 @@ fn local_address() {
     %foo = type { ptr, i16, ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -847,7 +847,7 @@ fn local_address() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -892,7 +892,7 @@ fn user_init_called_for_variables_on_stack() {
     %foo = type { ptr, i16, ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -989,7 +989,7 @@ fn user_init_called_for_variables_on_stack() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -1117,7 +1117,7 @@ fn struct_types() {
     @s = global [81 x i8] c"Hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @s2 = global [2 x [81 x i8]] [[81 x i8] c"hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"world\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"]
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"Hello world!\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_2 = private unnamed_addr constant [6 x i8] c"world\00"
@@ -1187,7 +1187,7 @@ fn struct_types() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       call void @__global_s2__ctor(ptr @s2)
@@ -1255,7 +1255,7 @@ fn stateful_pous_methods_and_structs_get_init_functions() {
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_cl_instance = global %__vtable_cl zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1397,7 +1397,7 @@ fn stateful_pous_methods_and_structs_get_init_functions() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_cl__ctor(ptr @__vtable_cl_instance)
@@ -1454,7 +1454,7 @@ fn global_instance() {
     @fb = global %foo zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1531,7 +1531,7 @@ fn global_instance() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @foo__ctor(ptr @fb)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -1585,7 +1585,7 @@ fn aliased_types() {
     @global_alias = global %foo zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1675,7 +1675,7 @@ fn aliased_types() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @alias__ctor(ptr @global_alias)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -1794,7 +1794,7 @@ fn var_config_aliased_variables_initialized() {
     @__PI_1_2_2 = global i32 0
     @__vtable_FB_instance = global %__vtable_FB zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB(ptr %0) {
     entry:
@@ -1876,7 +1876,7 @@ fn var_config_aliased_variables_initialized() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB__ctor(ptr @__vtable_FB_instance)
       store ptr @__PI_1_2_1, ptr getelementptr inbounds nuw (%FB, ptr @prog_instance, i32 0, i32 1), align [filtered]
@@ -1925,7 +1925,7 @@ fn var_external_blocks_are_ignored_in_init_functions() {
     @s = global [81 x i8] zeroinitializer
     @refString = global ptr null
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1987,7 +1987,7 @@ fn var_external_blocks_are_ignored_in_init_functions() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       %deref = load ptr, ptr @refString, align [filtered]
       call void @__global_refString__ctor(ptr %deref)
@@ -2026,7 +2026,7 @@ fn ref_to_local_member() {
     %foo = type { ptr, [81 x i8], ptr, ptr, ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2127,7 +2127,7 @@ fn ref_to_local_member() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2168,7 +2168,7 @@ fn ref_to_local_member_shadows_global() {
 
     @s = global [81 x i8] zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2269,7 +2269,7 @@ fn ref_to_local_member_shadows_global() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2307,7 +2307,7 @@ fn temporary_variable_ref_to_local_member() {
     %foo = type { ptr, [81 x i8] }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2393,7 +2393,7 @@ fn temporary_variable_ref_to_local_member() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2505,7 +2505,7 @@ fn initializing_method_variables_with_refs() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2590,7 +2590,7 @@ fn initializing_method_variables_with_refs() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2629,7 +2629,7 @@ fn initializing_method_variables_with_refs_referencing_parent_pou_variable() {
     %foo = type { ptr, i32 }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2716,7 +2716,7 @@ fn initializing_method_variables_with_refs_referencing_parent_pou_variable() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2756,7 +2756,7 @@ fn initializing_method_variables_with_refs_referencing_global_variable() {
 
     @x = global i32 0
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2838,7 +2838,7 @@ fn initializing_method_variables_with_refs_referencing_global_variable() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2879,7 +2879,7 @@ fn initializing_method_variables_with_refs_shadowing() {
 
     @x = global i32 0
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2963,7 +2963,7 @@ fn initializing_method_variables_with_refs_shadowing() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2999,7 +2999,7 @@ fn initializing_method_variables_with_alias() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3084,7 +3084,7 @@ fn initializing_method_variables_with_alias() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -3120,7 +3120,7 @@ fn initializing_method_variables_with_reference_to() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3205,7 +3205,7 @@ fn initializing_method_variables_with_reference_to() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -3251,7 +3251,7 @@ fn methods_call_init_functions_for_their_members() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3391,7 +3391,7 @@ fn methods_call_init_functions_for_their_members() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
@@ -3445,7 +3445,7 @@ fn user_fb_init_is_added_and_called_if_it_exists() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3547,7 +3547,7 @@ fn user_fb_init_is_added_and_called_if_it_exists() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @prog__ctor(ptr @prog_instance)
@@ -3608,7 +3608,7 @@ fn user_fb_init_in_global_struct() {
     @str = global %bar zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3721,7 +3721,7 @@ fn user_fb_init_in_global_struct() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @bar__ctor(ptr @str)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -3770,7 +3770,7 @@ fn user_init_called_when_declared_as_external() {
 
     @__vtable_foo_instance = external global %__vtable_foo
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     declare void @foo(ptr)
 
@@ -3803,7 +3803,7 @@ fn user_init_called_when_declared_as_external() {
 
     declare void @____vtable_foo_FB_INIT__ctor(ptr)
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance)
       ret void
@@ -3856,7 +3856,7 @@ fn constructors_only_emits_only_ctor_definitions() {
 
     @__vtable_MyFB_instance = global %__vtable_MyFB zeroinitializer
     @main_instance = global %main { %MyFB { ptr null, %MyStruct { i32 10, i32 0 } } }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     declare void @MyFB(ptr)
 
@@ -3925,7 +3925,7 @@ fn constructors_only_emits_only_ctor_definitions() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_MyFB__ctor(ptr @__vtable_MyFB_instance)
       call void @main__ctor(ptr @main_instance)

--- a/src/codegen/tests/initialization_test/complex_initializers.rs
+++ b/src/codegen/tests/initialization_test/complex_initializers.rs
@@ -25,7 +25,7 @@ fn simple_global() {
 
     @s = global [81 x i8] c"hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @ps = global ptr null
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
     define void @__global_ps__ctor(ptr %0) {
@@ -35,7 +35,7 @@ fn simple_global() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       call void @__global_ps__ctor(ptr @ps)
@@ -73,7 +73,7 @@ fn global_alias() {
 
     @s = global [81 x i8] c"hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @ps = global ptr null
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
     define void @__global_ps__ctor(ptr %0) {
@@ -83,7 +83,7 @@ fn global_alias() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       %deref = load ptr, ptr @ps, align [filtered]
@@ -122,7 +122,7 @@ fn global_reference_to() {
 
     @s = global [81 x i8] c"hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @ps = global ptr null
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"hello world!\00"
 
     define void @__global_ps__ctor(ptr %0) {
@@ -132,7 +132,7 @@ fn global_reference_to() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       %deref = load ptr, ptr @ps, align [filtered]
@@ -178,7 +178,7 @@ fn init_functions_generated_for_programs() {
 
     @s = global [81 x i8] zeroinitializer
     @PLC_PRG_instance = global %PLC_PRG zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @PLC_PRG(ptr %0) {
     entry:
@@ -206,7 +206,7 @@ fn init_functions_generated_for_programs() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @PLC_PRG__ctor(ptr @PLC_PRG_instance)
       ret void
@@ -244,7 +244,7 @@ fn init_functions_work_with_adr() {
 
     @s = global [81 x i8] zeroinitializer
     @PLC_PRG_instance = global %PLC_PRG zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @PLC_PRG(ptr %0) {
     entry:
@@ -262,7 +262,7 @@ fn init_functions_work_with_adr() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @PLC_PRG__ctor(ptr @PLC_PRG_instance)
       ret void
@@ -301,7 +301,7 @@ fn init_functions_generated_for_function_blocks() {
 
     @s = global [81 x i8] zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -365,7 +365,7 @@ fn init_functions_generated_for_function_blocks() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -459,7 +459,7 @@ fn nested_initializer_pous() {
     @__vtable_baz_instance = global %__vtable_baz zeroinitializer
     @mainProg_instance = global %mainProg zeroinitializer
     @sideProg_instance = global %sideProg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
 
     define void @foo(ptr %0) {
@@ -707,7 +707,7 @@ fn nested_initializer_pous() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @str, ptr align [filtered] @utf08_literal_0, i32 6, i1 false)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -780,7 +780,7 @@ fn local_address() {
     %foo = type { ptr, i16, ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -847,7 +847,7 @@ fn local_address() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -892,7 +892,7 @@ fn user_init_called_for_variables_on_stack() {
     %foo = type { ptr, i16, ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -989,7 +989,7 @@ fn user_init_called_for_variables_on_stack() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -1117,7 +1117,7 @@ fn struct_types() {
     @s = global [81 x i8] c"Hello world!\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
     @s2 = global [2 x [81 x i8]] [[81 x i8] c"hello\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [81 x i8] c"world\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"]
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [13 x i8] c"Hello world!\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_2 = private unnamed_addr constant [6 x i8] c"world\00"
@@ -1187,7 +1187,7 @@ fn struct_types() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @s, ptr align [filtered] @utf08_literal_0, i32 13, i1 false)
       call void @__global_s2__ctor(ptr @s2)
@@ -1255,7 +1255,7 @@ fn stateful_pous_methods_and_structs_get_init_functions() {
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_cl_instance = global %__vtable_cl zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1397,7 +1397,7 @@ fn stateful_pous_methods_and_structs_get_init_functions() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_cl__ctor(ptr @__vtable_cl_instance)
@@ -1454,7 +1454,7 @@ fn global_instance() {
     @fb = global %foo zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1531,7 +1531,7 @@ fn global_instance() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @foo__ctor(ptr @fb)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -1585,7 +1585,7 @@ fn aliased_types() {
     @global_alias = global %foo zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1675,7 +1675,7 @@ fn aliased_types() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @alias__ctor(ptr @global_alias)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -1794,7 +1794,7 @@ fn var_config_aliased_variables_initialized() {
     @__PI_1_2_2 = global i32 0
     @__vtable_FB_instance = global %__vtable_FB zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB(ptr %0) {
     entry:
@@ -1876,7 +1876,7 @@ fn var_config_aliased_variables_initialized() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB__ctor(ptr @__vtable_FB_instance)
       store ptr @__PI_1_2_1, ptr getelementptr inbounds nuw (%FB, ptr @prog_instance, i32 0, i32 1), align [filtered]
@@ -1925,7 +1925,7 @@ fn var_external_blocks_are_ignored_in_init_functions() {
     @s = global [81 x i8] zeroinitializer
     @refString = global ptr null
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1987,7 +1987,7 @@ fn var_external_blocks_are_ignored_in_init_functions() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       %deref = load ptr, ptr @refString, align [filtered]
       call void @__global_refString__ctor(ptr %deref)
@@ -2026,7 +2026,7 @@ fn ref_to_local_member() {
     %foo = type { ptr, [81 x i8], ptr, ptr, ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2127,7 +2127,7 @@ fn ref_to_local_member() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2168,7 +2168,7 @@ fn ref_to_local_member_shadows_global() {
 
     @s = global [81 x i8] zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2269,7 +2269,7 @@ fn ref_to_local_member_shadows_global() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2307,7 +2307,7 @@ fn temporary_variable_ref_to_local_member() {
     %foo = type { ptr, [81 x i8] }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2393,7 +2393,7 @@ fn temporary_variable_ref_to_local_member() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2505,7 +2505,7 @@ fn initializing_method_variables_with_refs() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2590,7 +2590,7 @@ fn initializing_method_variables_with_refs() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2629,7 +2629,7 @@ fn initializing_method_variables_with_refs_referencing_parent_pou_variable() {
     %foo = type { ptr, i32 }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2716,7 +2716,7 @@ fn initializing_method_variables_with_refs_referencing_parent_pou_variable() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2756,7 +2756,7 @@ fn initializing_method_variables_with_refs_referencing_global_variable() {
 
     @x = global i32 0
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2838,7 +2838,7 @@ fn initializing_method_variables_with_refs_referencing_global_variable() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2879,7 +2879,7 @@ fn initializing_method_variables_with_refs_shadowing() {
 
     @x = global i32 0
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2963,7 +2963,7 @@ fn initializing_method_variables_with_refs_shadowing() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -2999,7 +2999,7 @@ fn initializing_method_variables_with_alias() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3084,7 +3084,7 @@ fn initializing_method_variables_with_alias() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -3120,7 +3120,7 @@ fn initializing_method_variables_with_reference_to() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3205,7 +3205,7 @@ fn initializing_method_variables_with_reference_to() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -3251,7 +3251,7 @@ fn methods_call_init_functions_for_their_members() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3391,7 +3391,7 @@ fn methods_call_init_functions_for_their_members() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
@@ -3445,7 +3445,7 @@ fn user_fb_init_is_added_and_called_if_it_exists() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3547,7 +3547,7 @@ fn user_fb_init_is_added_and_called_if_it_exists() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @prog__ctor(ptr @prog_instance)
@@ -3608,7 +3608,7 @@ fn user_fb_init_in_global_struct() {
     @str = global %bar zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -3721,7 +3721,7 @@ fn user_fb_init_in_global_struct() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @bar__ctor(ptr @str)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -3770,7 +3770,7 @@ fn user_init_called_when_declared_as_external() {
 
     @__vtable_foo_instance = external global %__vtable_foo
     @prog_instance = global %prog zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     declare void @foo(ptr)
 
@@ -3803,7 +3803,7 @@ fn user_init_called_when_declared_as_external() {
 
     declare void @____vtable_foo_FB_INIT__ctor(ptr)
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prog__ctor(ptr @prog_instance)
       ret void
@@ -3856,7 +3856,7 @@ fn constructors_only_emits_only_ctor_definitions() {
 
     @__vtable_MyFB_instance = global %__vtable_MyFB zeroinitializer
     @main_instance = global %main { %MyFB { ptr null, %MyStruct { i32 10, i32 0 } } }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     declare void @MyFB(ptr)
 
@@ -3925,7 +3925,7 @@ fn constructors_only_emits_only_ctor_definitions() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_MyFB__ctor(ptr @__vtable_MyFB_instance)
       call void @main__ctor(ptr @main_instance)

--- a/src/codegen/tests/oop_tests.rs
+++ b/src/codegen/tests/oop_tests.rs
@@ -32,7 +32,7 @@ fn members_from_base_class_are_available_in_subclasses() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -137,7 +137,7 @@ fn members_from_base_class_are_available_in_subclasses() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
@@ -185,7 +185,7 @@ fn write_to_parent_variable_qualified_access() {
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
     @__vtable_fb2_instance = global %__vtable_fb2 zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -334,7 +334,7 @@ fn write_to_parent_variable_qualified_access() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       call void @__vtable_fb2__ctor(ptr @__vtable_fb2_instance)
@@ -384,7 +384,7 @@ fn write_to_parent_variable_in_instance() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
@@ -530,7 +530,7 @@ fn write_to_parent_variable_in_instance() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
@@ -600,7 +600,7 @@ fn array_in_parent_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -809,7 +809,7 @@ fn array_in_parent_generated() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -867,7 +867,7 @@ fn complex_array_access_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -1061,7 +1061,7 @@ fn complex_array_access_generated() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -1145,7 +1145,7 @@ fn this_in_method_call_chain() {
     %FB_Test = type { ptr }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1239,7 +1239,7 @@ fn this_in_method_call_chain() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1274,7 +1274,7 @@ fn this_in_method_and_body_in_function_block() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1365,7 +1365,7 @@ fn this_in_method_and_body_in_function_block() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1414,7 +1414,7 @@ fn pass_this_to_method() {
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
     @__vtable_FB_Test2_instance = global %__vtable_FB_Test2 zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1582,7 +1582,7 @@ fn pass_this_to_method() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       call void @__vtable_FB_Test2__ctor(ptr @__vtable_FB_Test2_instance)
@@ -1626,7 +1626,7 @@ fn this_with_shadowed_variable() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1715,7 +1715,7 @@ fn this_with_shadowed_variable() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1751,7 +1751,7 @@ fn this_calling_function_and_passing_this() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1825,7 +1825,7 @@ fn this_calling_function_and_passing_this() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1865,7 +1865,7 @@ fn this_in_property_and_calling_method() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -2008,7 +2008,7 @@ fn this_in_property_and_calling_method() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -2043,7 +2043,7 @@ fn this_with_self_pointer() {
     %FB_Test = type { ptr, ptr }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -2132,7 +2132,7 @@ fn this_with_self_pointer() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -2165,7 +2165,7 @@ fn this_in_variable_initialization() {
     %FB = type { ptr, i16, ptr, i16 }
 
     @__vtable_FB_instance = global %__vtable_FB zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @FB(ptr %0) {
     entry:
@@ -2231,7 +2231,7 @@ fn this_in_variable_initialization() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_FB__ctor(ptr @__vtable_FB_instance)
       ret void
@@ -2261,7 +2261,7 @@ fn this_in_action_in_functionblock() {
     %fb = type { ptr }
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -2311,7 +2311,7 @@ fn this_in_action_in_functionblock() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       ret void
@@ -2350,7 +2350,7 @@ fn this_calling_functionblock_body_from_method() {
     %fb = type { ptr }
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -2426,7 +2426,7 @@ fn this_calling_functionblock_body_from_method() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       ret void
@@ -2470,7 +2470,7 @@ fn fb_extension_with_output() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_foo2_instance = global %__vtable_foo2 zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2614,7 +2614,7 @@ fn fb_extension_with_output() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_foo2__ctor(ptr @__vtable_foo2_instance)
@@ -2672,7 +2672,7 @@ fn function_with_output_used_in_main_by_extension() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_foo2_instance = global %__vtable_foo2 zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2835,7 +2835,7 @@ fn function_with_output_used_in_main_by_extension() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_foo2__ctor(ptr @__vtable_foo2_instance)

--- a/src/codegen/tests/oop_tests.rs
+++ b/src/codegen/tests/oop_tests.rs
@@ -32,7 +32,7 @@ fn members_from_base_class_are_available_in_subclasses() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -137,7 +137,7 @@ fn members_from_base_class_are_available_in_subclasses() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
@@ -185,7 +185,7 @@ fn write_to_parent_variable_qualified_access() {
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
     @__vtable_fb2_instance = global %__vtable_fb2 zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -334,7 +334,7 @@ fn write_to_parent_variable_qualified_access() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       call void @__vtable_fb2__ctor(ptr @__vtable_fb2_instance)
@@ -384,7 +384,7 @@ fn write_to_parent_variable_in_instance() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
@@ -530,7 +530,7 @@ fn write_to_parent_variable_in_instance() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
@@ -600,7 +600,7 @@ fn array_in_parent_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -809,7 +809,7 @@ fn array_in_parent_generated() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -867,7 +867,7 @@ fn complex_array_access_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -1061,7 +1061,7 @@ fn complex_array_access_generated() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -1145,7 +1145,7 @@ fn this_in_method_call_chain() {
     %FB_Test = type { ptr }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1239,7 +1239,7 @@ fn this_in_method_call_chain() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1274,7 +1274,7 @@ fn this_in_method_and_body_in_function_block() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1365,7 +1365,7 @@ fn this_in_method_and_body_in_function_block() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1414,7 +1414,7 @@ fn pass_this_to_method() {
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
     @__vtable_FB_Test2_instance = global %__vtable_FB_Test2 zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1582,7 +1582,7 @@ fn pass_this_to_method() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       call void @__vtable_FB_Test2__ctor(ptr @__vtable_FB_Test2_instance)
@@ -1626,7 +1626,7 @@ fn this_with_shadowed_variable() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1715,7 +1715,7 @@ fn this_with_shadowed_variable() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1751,7 +1751,7 @@ fn this_calling_function_and_passing_this() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -1825,7 +1825,7 @@ fn this_calling_function_and_passing_this() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -1865,7 +1865,7 @@ fn this_in_property_and_calling_method() {
     %FB_Test = type { ptr, i16 }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -2008,7 +2008,7 @@ fn this_in_property_and_calling_method() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -2043,7 +2043,7 @@ fn this_with_self_pointer() {
     %FB_Test = type { ptr, ptr }
 
     @__vtable_FB_Test_instance = global %__vtable_FB_Test zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB_Test(ptr %0) {
     entry:
@@ -2132,7 +2132,7 @@ fn this_with_self_pointer() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB_Test__ctor(ptr @__vtable_FB_Test_instance)
       ret void
@@ -2165,7 +2165,7 @@ fn this_in_variable_initialization() {
     %FB = type { ptr, i16, ptr, i16 }
 
     @__vtable_FB_instance = global %__vtable_FB zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @FB(ptr %0) {
     entry:
@@ -2231,7 +2231,7 @@ fn this_in_variable_initialization() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_FB__ctor(ptr @__vtable_FB_instance)
       ret void
@@ -2261,7 +2261,7 @@ fn this_in_action_in_functionblock() {
     %fb = type { ptr }
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -2311,7 +2311,7 @@ fn this_in_action_in_functionblock() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       ret void
@@ -2350,7 +2350,7 @@ fn this_calling_functionblock_body_from_method() {
     %fb = type { ptr }
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -2426,7 +2426,7 @@ fn this_calling_functionblock_body_from_method() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       ret void
@@ -2470,7 +2470,7 @@ fn fb_extension_with_output() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_foo2_instance = global %__vtable_foo2 zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2614,7 +2614,7 @@ fn fb_extension_with_output() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_foo2__ctor(ptr @__vtable_foo2_instance)
@@ -2672,7 +2672,7 @@ fn function_with_output_used_in_main_by_extension() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_foo2_instance = global %__vtable_foo2 zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -2835,7 +2835,7 @@ fn function_with_output_used_in_main_by_extension() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       call void @__vtable_foo2__ctor(ptr @__vtable_foo2_instance)

--- a/src/codegen/tests/oop_tests/debug_tests.rs
+++ b/src/codegen/tests/oop_tests/debug_tests.rs
@@ -30,7 +30,7 @@ fn members_from_base_class_are_available_in_subclasses() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) !dbg !4 {
     entry:
@@ -137,7 +137,7 @@ fn members_from_base_class_are_available_in_subclasses() {
       ret void, !dbg !35
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance), !dbg !35
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance), !dbg !35
@@ -225,7 +225,7 @@ fn write_to_parent_variable_qualified_access() {
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
     @__vtable_fb2_instance = global %__vtable_fb2 zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @fb(ptr %0) !dbg !4 {
     entry:
@@ -377,7 +377,7 @@ fn write_to_parent_variable_qualified_access() {
       ret void, !dbg !38
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance), !dbg !38
       call void @__vtable_fb2__ctor(ptr @__vtable_fb2_instance), !dbg !38
@@ -470,7 +470,7 @@ fn write_to_parent_variable_in_instance() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
@@ -621,7 +621,7 @@ fn write_to_parent_variable_in_instance() {
       ret void, !dbg !45
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance), !dbg !45
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance), !dbg !45
@@ -741,7 +741,7 @@ fn array_in_parent_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @grandparent(ptr %0) !dbg !4 {
     entry:
@@ -954,7 +954,7 @@ fn array_in_parent_generated() {
       ret void, !dbg !56
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance), !dbg !56
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance), !dbg !56
@@ -1073,7 +1073,7 @@ fn complex_array_access_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @grandparent(ptr %0) !dbg !4 {
     entry:
@@ -1270,7 +1270,7 @@ fn complex_array_access_generated() {
       ret void, !dbg !44
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance), !dbg !44
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance), !dbg !44
@@ -1355,7 +1355,7 @@ fn function_block_method_debug_info() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) !dbg !4 {
     entry:
@@ -1484,7 +1484,7 @@ fn function_block_method_debug_info() {
       ret void, !dbg !26
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance), !dbg !26
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance), !dbg !26
@@ -1602,7 +1602,7 @@ END_FUNCTION
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
     @__vtable_grandchild_instance = global %__vtable_grandchild zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) !dbg !4 {
     entry:
@@ -1879,7 +1879,7 @@ END_FUNCTION
       ret void, !dbg !83
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance), !dbg !83
       call void @__vtable_child__ctor(ptr @__vtable_child_instance), !dbg !83

--- a/src/codegen/tests/oop_tests/debug_tests.rs
+++ b/src/codegen/tests/oop_tests/debug_tests.rs
@@ -30,7 +30,7 @@ fn members_from_base_class_are_available_in_subclasses() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) !dbg !4 {
     entry:
@@ -137,7 +137,7 @@ fn members_from_base_class_are_available_in_subclasses() {
       ret void, !dbg !35
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance), !dbg !35
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance), !dbg !35
@@ -225,7 +225,7 @@ fn write_to_parent_variable_qualified_access() {
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
     @__vtable_fb2_instance = global %__vtable_fb2 zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @fb(ptr %0) !dbg !4 {
     entry:
@@ -377,7 +377,7 @@ fn write_to_parent_variable_qualified_access() {
       ret void, !dbg !38
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance), !dbg !38
       call void @__vtable_fb2__ctor(ptr @__vtable_fb2_instance), !dbg !38
@@ -470,7 +470,7 @@ fn write_to_parent_variable_in_instance() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
@@ -621,7 +621,7 @@ fn write_to_parent_variable_in_instance() {
       ret void, !dbg !45
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance), !dbg !45
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance), !dbg !45
@@ -741,7 +741,7 @@ fn array_in_parent_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @grandparent(ptr %0) !dbg !4 {
     entry:
@@ -954,7 +954,7 @@ fn array_in_parent_generated() {
       ret void, !dbg !56
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance), !dbg !56
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance), !dbg !56
@@ -1073,7 +1073,7 @@ fn complex_array_access_generated() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @grandparent(ptr %0) !dbg !4 {
     entry:
@@ -1270,7 +1270,7 @@ fn complex_array_access_generated() {
       ret void, !dbg !44
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance), !dbg !44
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance), !dbg !44
@@ -1355,7 +1355,7 @@ fn function_block_method_debug_info() {
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) !dbg !4 {
     entry:
@@ -1484,7 +1484,7 @@ fn function_block_method_debug_info() {
       ret void, !dbg !26
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance), !dbg !26
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance), !dbg !26
@@ -1602,7 +1602,7 @@ END_FUNCTION
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
     @__vtable_grandchild_instance = global %__vtable_grandchild zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) !dbg !4 {
     entry:
@@ -1879,7 +1879,7 @@ END_FUNCTION
       ret void, !dbg !83
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance), !dbg !83
       call void @__vtable_child__ctor(ptr @__vtable_child_instance), !dbg !83

--- a/src/codegen/tests/oop_tests/super_tests.rs
+++ b/src/codegen/tests/oop_tests/super_tests.rs
@@ -30,7 +30,7 @@ fn super_keyword_basic_access() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -128,7 +128,7 @@ fn super_keyword_basic_access() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -169,7 +169,7 @@ fn super_without_deref() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -277,7 +277,7 @@ fn super_without_deref() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -325,7 +325,7 @@ fn super_in_method_calls() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -507,7 +507,7 @@ fn super_in_method_calls() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -549,7 +549,7 @@ fn super_in_complex_expressions() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -663,7 +663,7 @@ fn super_in_complex_expressions() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -704,7 +704,7 @@ fn super_with_array_access() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @__parent.arr__init = unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
     @.const_init = private unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
 
@@ -823,7 +823,7 @@ fn super_with_array_access() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -889,7 +889,7 @@ fn super_in_multi_level_inheritance() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -1161,7 +1161,7 @@ fn super_in_multi_level_inheritance() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -1203,7 +1203,7 @@ fn super_with_pointer_operations() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1321,7 +1321,7 @@ fn super_with_pointer_operations() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1372,7 +1372,7 @@ fn super_in_conditionals() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1536,7 +1536,7 @@ fn super_in_conditionals() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1577,7 +1577,7 @@ fn super_with_const_variables() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1676,7 +1676,7 @@ fn super_with_const_variables() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1731,7 +1731,7 @@ fn super_as_function_parameter() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1882,7 +1882,7 @@ fn super_as_function_parameter() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1933,7 +1933,7 @@ fn super_with_deeply_nested_expressions() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -2132,7 +2132,7 @@ fn super_with_deeply_nested_expressions() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -2196,7 +2196,7 @@ fn super_in_loop_constructs() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @__parent.arr__init = unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
     @.const_init = private unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
 
@@ -2516,7 +2516,7 @@ fn super_in_loop_constructs() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -2571,7 +2571,7 @@ fn super_with_method_overrides_in_three_levels() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -2789,7 +2789,7 @@ fn super_with_method_overrides_in_three_levels() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -2892,7 +2892,7 @@ fn super_with_structured_types() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @__parent.data__init = unnamed_addr constant %Complex_Type { i16 10, i16 20, float 3.050000e+01 }
     @.const_init = private unnamed_addr constant %Complex_Type { i16 1, i16 2, float 3.500000e+00 }
     @.const_init.1 = private unnamed_addr constant %Complex_Type { i16 4, i16 5, float 6.500000e+00 }
@@ -3083,7 +3083,7 @@ fn super_with_structured_types() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -3138,7 +3138,7 @@ fn super_in_action_blocks() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -3274,7 +3274,7 @@ fn super_in_action_blocks() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)

--- a/src/codegen/tests/oop_tests/super_tests.rs
+++ b/src/codegen/tests/oop_tests/super_tests.rs
@@ -30,7 +30,7 @@ fn super_keyword_basic_access() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -128,7 +128,7 @@ fn super_keyword_basic_access() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -169,7 +169,7 @@ fn super_without_deref() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -277,7 +277,7 @@ fn super_without_deref() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -325,7 +325,7 @@ fn super_in_method_calls() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -507,7 +507,7 @@ fn super_in_method_calls() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -549,7 +549,7 @@ fn super_in_complex_expressions() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -663,7 +663,7 @@ fn super_in_complex_expressions() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -704,7 +704,7 @@ fn super_with_array_access() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @__parent.arr__init = unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
     @.const_init = private unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
 
@@ -823,7 +823,7 @@ fn super_with_array_access() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -889,7 +889,7 @@ fn super_in_multi_level_inheritance() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -1161,7 +1161,7 @@ fn super_in_multi_level_inheritance() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -1203,7 +1203,7 @@ fn super_with_pointer_operations() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1321,7 +1321,7 @@ fn super_with_pointer_operations() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1372,7 +1372,7 @@ fn super_in_conditionals() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1536,7 +1536,7 @@ fn super_in_conditionals() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1577,7 +1577,7 @@ fn super_with_const_variables() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1676,7 +1676,7 @@ fn super_with_const_variables() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1731,7 +1731,7 @@ fn super_as_function_parameter() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -1882,7 +1882,7 @@ fn super_as_function_parameter() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -1933,7 +1933,7 @@ fn super_with_deeply_nested_expressions() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -2132,7 +2132,7 @@ fn super_with_deeply_nested_expressions() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -2196,7 +2196,7 @@ fn super_in_loop_constructs() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @__parent.arr__init = unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
     @.const_init = private unnamed_addr constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
 
@@ -2516,7 +2516,7 @@ fn super_in_loop_constructs() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -2571,7 +2571,7 @@ fn super_with_method_overrides_in_three_levels() {
     @__vtable_grandparent_instance = global %__vtable_grandparent zeroinitializer
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @grandparent(ptr %0) {
     entry:
@@ -2789,7 +2789,7 @@ fn super_with_method_overrides_in_three_levels() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_grandparent__ctor(ptr @__vtable_grandparent_instance)
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
@@ -2892,7 +2892,7 @@ fn super_with_structured_types() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @__parent.data__init = unnamed_addr constant %Complex_Type { i16 10, i16 20, float 3.050000e+01 }
     @.const_init = private unnamed_addr constant %Complex_Type { i16 1, i16 2, float 3.500000e+00 }
     @.const_init.1 = private unnamed_addr constant %Complex_Type { i16 4, i16 5, float 6.500000e+00 }
@@ -3083,7 +3083,7 @@ fn super_with_structured_types() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)
@@ -3138,7 +3138,7 @@ fn super_in_action_blocks() {
 
     @__vtable_parent_instance = global %__vtable_parent zeroinitializer
     @__vtable_child_instance = global %__vtable_child zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @parent(ptr %0) {
     entry:
@@ -3274,7 +3274,7 @@ fn super_in_action_blocks() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_parent__ctor(ptr @__vtable_parent_instance)
       call void @__vtable_child__ctor(ptr @__vtable_child_instance)

--- a/src/codegen/tests/polymorphism.rs
+++ b/src/codegen/tests/polymorphism.rs
@@ -58,7 +58,7 @@ fn simple_overridden_method() {
 
     @__vtable_A_instance = global %__vtable_A zeroinitializer
     @__vtable_B_instance = global %__vtable_B zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -247,7 +247,7 @@ fn simple_overridden_method() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       call void @__vtable_B__ctor(ptr @__vtable_B_instance)
@@ -291,7 +291,7 @@ fn method_call_within_method() {
     %A = type { ptr }
 
     @__vtable_A_instance = global %__vtable_A zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -395,7 +395,7 @@ fn method_call_within_method() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       ret void
@@ -458,7 +458,7 @@ fn this_is_untouched() {
     @__vtable_A_instance = global %__vtable_A zeroinitializer
     @__vtable_B_instance = global %__vtable_B zeroinitializer
     @__vtable_C_instance = global %__vtable_C zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -727,7 +727,7 @@ fn this_is_untouched() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       call void @__vtable_B__ctor(ptr @__vtable_B_instance)
@@ -784,7 +784,7 @@ fn super_is_untouched() {
 
     @__vtable_A_instance = global %__vtable_A zeroinitializer
     @__vtable_B_instance = global %__vtable_B zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -974,7 +974,7 @@ fn super_is_untouched() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       call void @__vtable_B__ctor(ptr @__vtable_B_instance)

--- a/src/codegen/tests/polymorphism.rs
+++ b/src/codegen/tests/polymorphism.rs
@@ -58,7 +58,7 @@ fn simple_overridden_method() {
 
     @__vtable_A_instance = global %__vtable_A zeroinitializer
     @__vtable_B_instance = global %__vtable_B zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -247,7 +247,7 @@ fn simple_overridden_method() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       call void @__vtable_B__ctor(ptr @__vtable_B_instance)
@@ -291,7 +291,7 @@ fn method_call_within_method() {
     %A = type { ptr }
 
     @__vtable_A_instance = global %__vtable_A zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -395,7 +395,7 @@ fn method_call_within_method() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       ret void
@@ -458,7 +458,7 @@ fn this_is_untouched() {
     @__vtable_A_instance = global %__vtable_A zeroinitializer
     @__vtable_B_instance = global %__vtable_B zeroinitializer
     @__vtable_C_instance = global %__vtable_C zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -727,7 +727,7 @@ fn this_is_untouched() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       call void @__vtable_B__ctor(ptr @__vtable_B_instance)
@@ -784,7 +784,7 @@ fn super_is_untouched() {
 
     @__vtable_A_instance = global %__vtable_A zeroinitializer
     @__vtable_B_instance = global %__vtable_B zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @A(ptr %0) {
     entry:
@@ -974,7 +974,7 @@ fn super_is_untouched() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_A__ctor(ptr @__vtable_A_instance)
       call void @__vtable_B__ctor(ptr @__vtable_B_instance)

--- a/src/codegen/tests/retain_tests.rs
+++ b/src/codegen/tests/retain_tests.rs
@@ -47,7 +47,7 @@ fn retain_variables_in_programs_are_in_retain_linker_section() {
     @__main_x__retain = global i16 0, section ".retain"
     @__main_y__retain = global [81 x i8] zeroinitializer, section ".retain"
     @main_instance = global %main zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @main(ptr %0) {
     entry:
@@ -91,7 +91,7 @@ fn retain_variables_in_programs_are_in_retain_linker_section() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @main__ctor(ptr @main_instance)
       ret void
@@ -126,7 +126,7 @@ fn nested_retain_variables_are_in_the_retain_section() {
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
     @fb_instance = global %fb zeroinitializer, section ".retain"
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -178,7 +178,7 @@ fn nested_retain_variables_are_in_the_retain_section() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       call void @fb__ctor(ptr @fb_instance)

--- a/src/codegen/tests/retain_tests.rs
+++ b/src/codegen/tests/retain_tests.rs
@@ -47,7 +47,7 @@ fn retain_variables_in_programs_are_in_retain_linker_section() {
     @__main_x__retain = global i16 0, section ".retain"
     @__main_y__retain = global [81 x i8] zeroinitializer, section ".retain"
     @main_instance = global %main zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @main(ptr %0) {
     entry:
@@ -91,7 +91,7 @@ fn retain_variables_in_programs_are_in_retain_linker_section() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @main__ctor(ptr @main_instance)
       ret void
@@ -126,7 +126,7 @@ fn nested_retain_variables_are_in_the_retain_section() {
 
     @__vtable_fb_instance = global %__vtable_fb zeroinitializer
     @fb_instance = global %fb zeroinitializer, section ".retain"
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @fb(ptr %0) {
     entry:
@@ -178,7 +178,7 @@ fn nested_retain_variables_are_in_the_retain_section() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_fb__ctor(ptr @__vtable_fb_instance)
       call void @fb__ctor(ptr @fb_instance)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__dwarf_version_override.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__dwarf_version_override.snap
@@ -8,7 +8,7 @@ target datalayout = "[filtered]"
 target triple = "[filtered]"
 
 @gInt = global i32 0, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
 define void @myInt__ctor(ptr %0) {
 entry:
@@ -17,7 +17,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal____ctor() {
+define void @__unit___internal___bd9efc6f__ctor() {
 entry:
   call void @myInt__ctor(ptr @gInt)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__dwarf_version_override.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__dwarf_version_override.snap
@@ -8,7 +8,7 @@ target datalayout = "[filtered]"
 target triple = "[filtered]"
 
 @gInt = global i32 0, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
 define void @myInt__ctor(ptr %0) {
 entry:
@@ -17,7 +17,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___bd9efc6f__ctor() {
+define void @__unit___internal___[ctor-hash]__ctor() {
 entry:
   call void @myInt__ctor(ptr @gInt)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_alias_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_alias_type.snap
@@ -8,7 +8,7 @@ target datalayout = "[filtered]"
 target triple = "[filtered]"
 
 @gInt = global i32 0, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
 define void @myInt__ctor(ptr %0) {
 entry:
@@ -17,7 +17,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal____ctor() {
+define void @__unit___internal___bd9efc6f__ctor() {
 entry:
   call void @myInt__ctor(ptr @gInt)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_alias_type.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_alias_type.snap
@@ -8,7 +8,7 @@ target datalayout = "[filtered]"
 target triple = "[filtered]"
 
 @gInt = global i32 0, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
 define void @myInt__ctor(ptr %0) {
 entry:
@@ -17,7 +17,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___bd9efc6f__ctor() {
+define void @__unit___internal___[ctor-hash]__ctor() {
 entry:
   call void @myInt__ctor(ptr @gInt)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_array_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_array_added_to_debug_info.snap
@@ -10,7 +10,7 @@ target triple = "[filtered]"
 @a = global [11 x i32] zeroinitializer, !dbg !0
 @b = global [110 x i32] zeroinitializer, !dbg !7
 @c = global [11 x [10 x i32]] zeroinitializer, !dbg !12
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
 define void @__global_a__ctor(ptr %0) {
 entry:
@@ -40,7 +40,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal____ctor() {
+define void @__unit___internal___bd9efc6f__ctor() {
 entry:
   call void @__global_a__ctor(ptr @a)
   call void @__global_b__ctor(ptr @b)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_array_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_array_added_to_debug_info.snap
@@ -10,7 +10,7 @@ target triple = "[filtered]"
 @a = global [11 x i32] zeroinitializer, !dbg !0
 @b = global [110 x i32] zeroinitializer, !dbg !7
 @c = global [11 x [10 x i32]] zeroinitializer, !dbg !12
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
 define void @__global_a__ctor(ptr %0) {
 entry:
@@ -40,7 +40,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___bd9efc6f__ctor() {
+define void @__unit___internal___[ctor-hash]__ctor() {
 entry:
   call void @__global_a__ctor(ptr @a)
   call void @__global_b__ctor(ptr @b)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_nested_struct_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_nested_struct_added_to_debug_info.snap
@@ -11,7 +11,7 @@ target triple = "[filtered]"
 %myStruct2 = type { i32, double }
 
 @gStruct = global %myStruct zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
 define void @myStruct__ctor(ptr %0) {
 entry:
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___bd9efc6f__ctor() {
+define void @__unit___internal___[ctor-hash]__ctor() {
 entry:
   call void @myStruct__ctor(ptr @gStruct)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_nested_struct_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_nested_struct_added_to_debug_info.snap
@@ -11,7 +11,7 @@ target triple = "[filtered]"
 %myStruct2 = type { i32, double }
 
 @gStruct = global %myStruct zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
 define void @myStruct__ctor(ptr %0) {
 entry:
@@ -30,7 +30,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal____ctor() {
+define void @__unit___internal___bd9efc6f__ctor() {
 entry:
   call void @myStruct__ctor(ptr @gStruct)
   ret void

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_pointer_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_pointer_added_to_debug_info.snap
@@ -9,7 +9,7 @@ target triple = "[filtered]"
 
 @a = global ptr null, !dbg !0
 @b = global ptr null, !dbg !6
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
 define void @__global_a__ctor(ptr %0) {
 entry:
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___bd9efc6f__ctor() {
+define void @__unit___internal___[ctor-hash]__ctor() {
 entry:
   call void @__global_a__ctor(ptr @a)
   call void @__global_b__ctor(ptr @b)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_pointer_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_pointer_added_to_debug_info.snap
@@ -9,7 +9,7 @@ target triple = "[filtered]"
 
 @a = global ptr null, !dbg !0
 @b = global ptr null, !dbg !6
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
 define void @__global_a__ctor(ptr %0) {
 entry:
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal____ctor() {
+define void @__unit___internal___bd9efc6f__ctor() {
 entry:
   call void @__global_a__ctor(ptr @a)
   call void @__global_b__ctor(ptr @b)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
@@ -11,7 +11,7 @@ target triple = "[filtered]"
 
 @gStruct = global %myStruct zeroinitializer, !dbg !0
 @b = global [11 x %myStruct] zeroinitializer, !dbg !13
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
 define void @myStruct__ctor(ptr %0) {
 entry:
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___bd9efc6f__ctor() {
+define void @__unit___internal___[ctor-hash]__ctor() {
 entry:
   call void @myStruct__ctor(ptr @gStruct)
   call void @__global_b__ctor(ptr @b)

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
@@ -11,7 +11,7 @@ target triple = "[filtered]"
 
 @gStruct = global %myStruct zeroinitializer, !dbg !0
 @b = global [11 x %myStruct] zeroinitializer, !dbg !13
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
 define void @myStruct__ctor(ptr %0) {
 entry:
@@ -37,7 +37,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal____ctor() {
+define void @__unit___internal___bd9efc6f__ctor() {
 entry:
   call void @myStruct__ctor(ptr @gStruct)
   call void @__global_b__ctor(ptr @b)

--- a/src/lowering/helper.rs
+++ b/src/lowering/helper.rs
@@ -479,6 +479,14 @@ pub fn get_unit_name(unit: &CompilationUnit) -> String {
     let path: PathBuf = (&unit.file).into();
     let basename = path.file_name().map(|it| it.to_string_lossy().into_owned()).unwrap_or_default();
     let basename_slug = sanitize_to_identifier(&basename);
+    // Hash the full path. The whole path is needed for uniqueness — any
+    // shorter key (basename, parent/basename, ...) collides for ordinary
+    // hierarchies (e.g. `b/global.st` vs `a/b/global.st`). Absolute paths
+    // are unique on any single host, and the linker only cares about
+    // uniqueness within a single compilation; differences across build
+    // environments (CI vs developer machine) are masked in test snapshots
+    // by the `__unit_..._<hex>__ctor` filter in
+    // `__plc_add_common_snapshot_filters`.
     let suffix = path_hash_suffix(&path.to_string_lossy());
     format!("{basename_slug}_{suffix}")
 }
@@ -571,14 +579,32 @@ mod tests {
         // deterministic (same input always renders to the same suffix),
         // path-sensitive (`a/globals.st` and `b/globals.st` differ — this is
         // the #1723 regression), and uniformly 8 lowercase hex chars.
-        let table =
-            render_table(["a/globals.st", "b/globals.st", "__internal__", "anything", ""], path_hash_suffix);
+        //
+        // Note that any *prefix* of the path matters too: `a/globals.st`,
+        // `a/a/globals.st` and `a/b/globals.st` are all distinct, which is
+        // why `get_unit_name` must hash the whole path rather than just the
+        // basename or a single parent component (the latter would collide
+        // `b/globals.st` with `a/b/globals.st`).
+        let table = render_table(
+            [
+                "a/globals.st",
+                "b/globals.st",
+                "a/a/globals.st",
+                "a/b/globals.st",
+                "__internal__",
+                "anything",
+                "",
+            ],
+            path_hash_suffix,
+        );
         assert_snapshot!(table, @r"
-        a/globals.st -> 944ecddc
-        b/globals.st -> 411895b6
-        __internal__ -> bd9efc6f
-            anything -> 63269c94
-                     -> d1fba762
+          a/globals.st -> 944ecddc
+          b/globals.st -> 411895b6
+        a/a/globals.st -> 631efcc1
+        a/b/globals.st -> 20ee0f2e
+          __internal__ -> bd9efc6f
+              anything -> 63269c94
+                       -> d1fba762
         ");
     }
 }

--- a/src/lowering/helper.rs
+++ b/src/lowering/helper.rs
@@ -557,6 +557,15 @@ mod tests {
     }
 
     #[test]
+    fn path_hash_suffix_is_deterministic() {
+        // Same input must yield the same suffix on every call so re-compiling
+        // the same project produces stable symbol names across runs.
+        let first = path_hash_suffix("a/globals.st");
+        let second = path_hash_suffix("a/globals.st");
+        assert_eq!(first, second);
+    }
+
+    #[test]
     fn path_hash_suffix_examples() {
         // The table demonstrates three properties at once: outputs are
         // deterministic (same input always renders to the same suffix),

--- a/src/lowering/helper.rs
+++ b/src/lowering/helper.rs
@@ -458,9 +458,118 @@ pub fn new_implementation(
     }
 }
 
-/// Returns a sanitized unit name suitable for use as an identifier (e.g. in generated code)
+/// Returns a unit identifier suitable for embedding in synthesized symbols
+/// (currently the `__unit_<name>__ctor` per-unit constructor; see
+/// `new_unit_constructor`).
+///
+/// The name is built as `<sanitized basename>_<siphash-suffix>` where the
+/// SipHash-1-3 suffix is derived from the **full path** of the source file.
+/// This keeps the human-readable basename in the symbol (useful in linker
+/// errors and stack traces) while guaranteeing that two source files sharing
+/// a basename across different directories — e.g. `a/globals.st` and
+/// `b/globals.st` — mint distinct names instead of colliding at link time.
+/// See #1723. SipHash with a fixed zero key is deterministic and stable
+/// across runs/platforms; cryptographic strength isn't required here.
+///
+/// The mangled name only flows into internal symbols. `PouType::ProjectInit`
+/// POUs are filtered out of the generated C header (see
+/// `compiler/plc_header_generator/src/header_generator/header_generator_c.rs`),
+/// so the new shape has no effect on the user-facing C interface.
 pub fn get_unit_name(unit: &CompilationUnit) -> String {
     let path: PathBuf = (&unit.file).into();
-    let name = path.file_name().map(|it| it.to_string_lossy()).unwrap_or_default();
-    name.replace(['*', '.'], "_")
+    let basename = path.file_name().map(|it| it.to_string_lossy().into_owned()).unwrap_or_default();
+    let basename_slug = sanitize_to_identifier(&basename);
+    let suffix = path_hash_suffix(&path.to_string_lossy());
+    format!("{basename_slug}_{suffix}")
+}
+
+/// Replaces every character that isn't a C-identifier byte (`[A-Za-z0-9_]`)
+/// with `_`, so the resulting string is safe to embed in a synthesized symbol.
+fn sanitize_to_identifier(raw: &str) -> String {
+    raw.chars().map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' }).collect()
+}
+
+/// Returns 8 lowercase-hex characters (32 bits) from a SipHash-1-3 digest of
+/// `input`, keyed with `(0, 0)` so the result is deterministic and stable
+/// across runs, platforms, and processes. Used by [`get_unit_name`] to
+/// disambiguate per-source-file constructor symbols when two units share a
+/// basename.
+///
+/// 32 bits of suffix space is plenty for typical PLC projects: the
+/// birthday-paradox 50%-collision threshold is ~65 k files, and a collision
+/// would manifest as the same loud "duplicate symbol" linker error this fix
+/// is closing — not a silent miscompile — so the worst-case failure mode is
+/// graceful. We take the high 32 bits of the SipHash output for the suffix.
+fn path_hash_suffix(input: &str) -> String {
+    use std::hash::Hasher;
+    let mut hasher = siphasher::sip::SipHasher13::new_with_keys(0, 0);
+    hasher.write(input.as_bytes());
+    let truncated = (hasher.finish() >> 32) as u32;
+    format!("{truncated:08x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{path_hash_suffix, sanitize_to_identifier};
+    use insta::assert_snapshot;
+
+    fn render_table<I, F>(cases: I, f: F) -> String
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+        F: Fn(&str) -> String,
+    {
+        cases
+            .into_iter()
+            .map(|c| {
+                let input = c.as_ref();
+                format!("{input:>22} -> {}", f(input))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn sanitize_to_identifier_examples() {
+        let table = render_table(
+            [
+                "globals_st",
+                "MyFile_42",
+                "__internal__",
+                "globals.st",
+                "a/b.st",
+                "a\\b.st",
+                "foo*bar",
+                "file with spaces.st",
+            ],
+            sanitize_to_identifier,
+        );
+        assert_snapshot!(table, @r"
+                 globals_st -> globals_st
+                  MyFile_42 -> MyFile_42
+               __internal__ -> __internal__
+                 globals.st -> globals_st
+                     a/b.st -> a_b_st
+                     a\b.st -> a_b_st
+                    foo*bar -> foo_bar
+        file with spaces.st -> file_with_spaces_st
+        ");
+    }
+
+    #[test]
+    fn path_hash_suffix_examples() {
+        // The table demonstrates three properties at once: outputs are
+        // deterministic (same input always renders to the same suffix),
+        // path-sensitive (`a/globals.st` and `b/globals.st` differ — this is
+        // the #1723 regression), and uniformly 8 lowercase hex chars.
+        let table =
+            render_table(["a/globals.st", "b/globals.st", "__internal__", "anything", ""], path_hash_suffix);
+        assert_snapshot!(table, @r"
+        a/globals.st -> 944ecddc
+        b/globals.st -> 411895b6
+        __internal__ -> bd9efc6f
+            anything -> 63269c94
+                     -> d1fba762
+        ");
+    }
 }

--- a/src/resolver/tests/resolve_and_lower_init_functions.rs
+++ b/src/resolver/tests/resolve_and_lower_init_functions.rs
@@ -118,22 +118,22 @@ fn init_wrapper_function_created() {
     .unwrap();
     let AnnotatedProject { units, .. } = annotated_project;
 
-    // we expect to find a `__unit___internal__ctor` function in the compilation unit
+    // we expect to find a `__unit___internal___bd9efc6f__ctor` function in the compilation unit
     // Note: the name has multiple underscores because the source path is "<internal>"
     let unit = units[0].get_unit();
     let implementation = unit
         .implementations
         .iter()
-        .find(|impl_| dbg!(&impl_.name) == "__unit___internal____ctor")
-        .expect("__unit___internal____ctor implementation not found in unit");
+        .find(|impl_| dbg!(&impl_.name) == "__unit___internal___bd9efc6f__ctor")
+        .expect("__unit___internal___bd9efc6f__ctor implementation not found in unit");
     assert_eq!(implementation.pou_type, PouType::ProjectInit);
 
     // The ProjectInit function should have no parameters
     let project_init_pou = unit
         .pous
         .iter()
-        .find(|pou| pou.name == "__unit___internal____ctor")
-        .expect("__unit___internal____ctor POU not found");
+        .find(|pou| pou.name == "__unit___internal___bd9efc6f__ctor")
+        .expect("__unit___internal___bd9efc6f__ctor POU not found");
     assert!(project_init_pou.variable_blocks.is_empty());
 
     // Verify it has initialization statements

--- a/src/tests/adr/arrays_adr.rs
+++ b/src/tests/adr/arrays_adr.rs
@@ -21,7 +21,7 @@ fn declaring_an_array() {
     target triple = "[filtered]"
 
     @d = global [10 x i32] zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @Data__ctor(ptr %0) {
     entry:
@@ -30,7 +30,7 @@ fn declaring_an_array() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @Data__ctor(ptr @d)
       ret void
@@ -59,7 +59,7 @@ fn initializing_an_array() {
     target triple = "[filtered]"
 
     @d = global [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @.const_init = private unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
 
     define void @Data__ctor(ptr %0) {
@@ -71,7 +71,7 @@ fn initializing_an_array() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @Data__ctor(ptr @d)
       ret void
@@ -112,7 +112,7 @@ fn assigning_full_arrays() {
     %prg = type { [10 x i32], [10 x i32] }
 
     @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9] }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @.const_init = private unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
 
     define void @prg(ptr %0) {
@@ -145,7 +145,7 @@ fn assigning_full_arrays() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -193,7 +193,7 @@ fn accessing_array_elements() {
     %prg = type { [10 x i32], [3 x i32] }
 
     @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [3 x i32] [i32 3, i32 4, i32 5] }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @__prg.b__init = unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
     @__prg.b__init.1 = unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
     @.const_init = private unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
@@ -242,7 +242,7 @@ fn accessing_array_elements() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void

--- a/src/tests/adr/arrays_adr.rs
+++ b/src/tests/adr/arrays_adr.rs
@@ -21,7 +21,7 @@ fn declaring_an_array() {
     target triple = "[filtered]"
 
     @d = global [10 x i32] zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @Data__ctor(ptr %0) {
     entry:
@@ -30,7 +30,7 @@ fn declaring_an_array() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @Data__ctor(ptr @d)
       ret void
@@ -59,7 +59,7 @@ fn initializing_an_array() {
     target triple = "[filtered]"
 
     @d = global [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @.const_init = private unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
 
     define void @Data__ctor(ptr %0) {
@@ -71,7 +71,7 @@ fn initializing_an_array() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @Data__ctor(ptr @d)
       ret void
@@ -112,7 +112,7 @@ fn assigning_full_arrays() {
     %prg = type { [10 x i32], [10 x i32] }
 
     @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9] }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @.const_init = private unnamed_addr constant [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9]
 
     define void @prg(ptr %0) {
@@ -145,7 +145,7 @@ fn assigning_full_arrays() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -193,7 +193,7 @@ fn accessing_array_elements() {
     %prg = type { [10 x i32], [3 x i32] }
 
     @prg_instance = global %prg { [10 x i32] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9], [3 x i32] [i32 3, i32 4, i32 5] }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @__prg.b__init = unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
     @__prg.b__init.1 = unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
     @.const_init = private unnamed_addr constant [3 x i32] [i32 3, i32 4, i32 5]
@@ -242,7 +242,7 @@ fn accessing_array_elements() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void

--- a/src/tests/adr/enum_adr.rs
+++ b/src/tests/adr/enum_adr.rs
@@ -28,7 +28,7 @@ fn enums_generate_a_global_constants_for_each_element() {
     @Color.red = unnamed_addr constant i32 0
     @Color.yellow = unnamed_addr constant i32 1
     @Color.green = unnamed_addr constant i32 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @Color__ctor(ptr %0) {
     entry:
@@ -37,7 +37,7 @@ fn enums_generate_a_global_constants_for_each_element() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @Color__ctor(ptr @myColor)
       ret void
@@ -80,7 +80,7 @@ fn enums_constants_are_automatically_numbered_or_user_defined() {
     @State.closed = unnamed_addr constant i8 4
     @State.idle = unnamed_addr constant i8 5
     @State.running = unnamed_addr constant i8 6
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @Color__ctor(ptr %0) {
     entry:
@@ -96,7 +96,7 @@ fn enums_constants_are_automatically_numbered_or_user_defined() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @Color__ctor(ptr @myColor)
       call void @State__ctor(ptr @myState)
@@ -130,7 +130,7 @@ fn inline_declaration_of_enum_types() {
     @__global_backColor.red = unnamed_addr constant i32 0
     @__global_backColor.green = unnamed_addr constant i32 1
     @__global_backColor.yellow = unnamed_addr constant i32 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @__global_frontColor__ctor(ptr %0) {
     entry:
@@ -146,7 +146,7 @@ fn inline_declaration_of_enum_types() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__global_frontColor__ctor(ptr @frontColor)
       call void @__global_backColor__ctor(ptr @backColor)
@@ -194,7 +194,7 @@ fn using_enums() {
     @ProcessState.running = unnamed_addr constant i32 6
     @Door.open = unnamed_addr constant i32 8
     @Door.closed = unnamed_addr constant i32 16
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -228,7 +228,7 @@ fn using_enums() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -263,7 +263,7 @@ fn enum_with_zero_element_no_default_initializes_to_zero() {
     @STATE_WITH_ZERO.idle = unnamed_addr constant i8 0
     @STATE_WITH_ZERO.running = unnamed_addr constant i8 1
     @STATE_WITH_ZERO.stopped = unnamed_addr constant i8 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @STATE_WITH_ZERO__ctor(ptr %0) {
     entry:
@@ -272,7 +272,7 @@ fn enum_with_zero_element_no_default_initializes_to_zero() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @STATE_WITH_ZERO__ctor(ptr @myState)
       ret void
@@ -307,7 +307,7 @@ fn enum_with_zero_element_and_default_initializes_to_default() {
     @STATE_WITH_DEFAULT.idle = unnamed_addr constant i8 0
     @STATE_WITH_DEFAULT.running = unnamed_addr constant i8 1
     @STATE_WITH_DEFAULT.stopped = unnamed_addr constant i8 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @STATE_WITH_DEFAULT__ctor(ptr %0) {
     entry:
@@ -318,7 +318,7 @@ fn enum_with_zero_element_and_default_initializes_to_default() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @STATE_WITH_DEFAULT__ctor(ptr @myState)
       ret void
@@ -353,7 +353,7 @@ fn enum_without_zero_no_default_initializes_to_first_element() {
     @PRIORITY.low = unnamed_addr constant i16 10
     @PRIORITY.medium = unnamed_addr constant i16 20
     @PRIORITY.high = unnamed_addr constant i16 30
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @PRIORITY__ctor(ptr %0) {
     entry:
@@ -362,7 +362,7 @@ fn enum_without_zero_no_default_initializes_to_first_element() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @PRIORITY__ctor(ptr @myPriority)
       ret void
@@ -397,7 +397,7 @@ fn enum_without_zero_with_default_initializes_to_default() {
     @PRIORITY_WITH_DEFAULT.low = unnamed_addr constant i16 10
     @PRIORITY_WITH_DEFAULT.medium = unnamed_addr constant i16 20
     @PRIORITY_WITH_DEFAULT.high = unnamed_addr constant i16 30
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @PRIORITY_WITH_DEFAULT__ctor(ptr %0) {
     entry:
@@ -408,7 +408,7 @@ fn enum_without_zero_with_default_initializes_to_default() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @PRIORITY_WITH_DEFAULT__ctor(ptr @myPriority)
       ret void
@@ -446,7 +446,7 @@ fn enum_61131_standard_style_with_type_before_list() {
     @COLOR.green = unnamed_addr constant i32 -16711936
     @COLOR.blue = unnamed_addr constant i32 -16776961
     @COLOR.black = unnamed_addr constant i32 -2013265920
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @COLOR__ctor(ptr %0) {
     entry:
@@ -457,7 +457,7 @@ fn enum_61131_standard_style_with_type_before_list() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @COLOR__ctor(ptr @myColor)
       ret void
@@ -495,7 +495,7 @@ fn enum_codesys_style_with_type_after_list() {
     @COLOR_CODESYS.green = unnamed_addr constant i32 -16711936
     @COLOR_CODESYS.blue = unnamed_addr constant i32 -16776961
     @COLOR_CODESYS.black = unnamed_addr constant i32 -2013265920
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @COLOR_CODESYS__ctor(ptr %0) {
     entry:
@@ -506,7 +506,7 @@ fn enum_codesys_style_with_type_after_list() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @COLOR_CODESYS__ctor(ptr @myColor)
       ret void

--- a/src/tests/adr/enum_adr.rs
+++ b/src/tests/adr/enum_adr.rs
@@ -28,7 +28,7 @@ fn enums_generate_a_global_constants_for_each_element() {
     @Color.red = unnamed_addr constant i32 0
     @Color.yellow = unnamed_addr constant i32 1
     @Color.green = unnamed_addr constant i32 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @Color__ctor(ptr %0) {
     entry:
@@ -37,7 +37,7 @@ fn enums_generate_a_global_constants_for_each_element() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @Color__ctor(ptr @myColor)
       ret void
@@ -80,7 +80,7 @@ fn enums_constants_are_automatically_numbered_or_user_defined() {
     @State.closed = unnamed_addr constant i8 4
     @State.idle = unnamed_addr constant i8 5
     @State.running = unnamed_addr constant i8 6
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @Color__ctor(ptr %0) {
     entry:
@@ -96,7 +96,7 @@ fn enums_constants_are_automatically_numbered_or_user_defined() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @Color__ctor(ptr @myColor)
       call void @State__ctor(ptr @myState)
@@ -130,7 +130,7 @@ fn inline_declaration_of_enum_types() {
     @__global_backColor.red = unnamed_addr constant i32 0
     @__global_backColor.green = unnamed_addr constant i32 1
     @__global_backColor.yellow = unnamed_addr constant i32 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @__global_frontColor__ctor(ptr %0) {
     entry:
@@ -146,7 +146,7 @@ fn inline_declaration_of_enum_types() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__global_frontColor__ctor(ptr @frontColor)
       call void @__global_backColor__ctor(ptr @backColor)
@@ -194,7 +194,7 @@ fn using_enums() {
     @ProcessState.running = unnamed_addr constant i32 6
     @Door.open = unnamed_addr constant i32 8
     @Door.closed = unnamed_addr constant i32 16
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -228,7 +228,7 @@ fn using_enums() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -263,7 +263,7 @@ fn enum_with_zero_element_no_default_initializes_to_zero() {
     @STATE_WITH_ZERO.idle = unnamed_addr constant i8 0
     @STATE_WITH_ZERO.running = unnamed_addr constant i8 1
     @STATE_WITH_ZERO.stopped = unnamed_addr constant i8 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @STATE_WITH_ZERO__ctor(ptr %0) {
     entry:
@@ -272,7 +272,7 @@ fn enum_with_zero_element_no_default_initializes_to_zero() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @STATE_WITH_ZERO__ctor(ptr @myState)
       ret void
@@ -307,7 +307,7 @@ fn enum_with_zero_element_and_default_initializes_to_default() {
     @STATE_WITH_DEFAULT.idle = unnamed_addr constant i8 0
     @STATE_WITH_DEFAULT.running = unnamed_addr constant i8 1
     @STATE_WITH_DEFAULT.stopped = unnamed_addr constant i8 2
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @STATE_WITH_DEFAULT__ctor(ptr %0) {
     entry:
@@ -318,7 +318,7 @@ fn enum_with_zero_element_and_default_initializes_to_default() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @STATE_WITH_DEFAULT__ctor(ptr @myState)
       ret void
@@ -353,7 +353,7 @@ fn enum_without_zero_no_default_initializes_to_first_element() {
     @PRIORITY.low = unnamed_addr constant i16 10
     @PRIORITY.medium = unnamed_addr constant i16 20
     @PRIORITY.high = unnamed_addr constant i16 30
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @PRIORITY__ctor(ptr %0) {
     entry:
@@ -362,7 +362,7 @@ fn enum_without_zero_no_default_initializes_to_first_element() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @PRIORITY__ctor(ptr @myPriority)
       ret void
@@ -397,7 +397,7 @@ fn enum_without_zero_with_default_initializes_to_default() {
     @PRIORITY_WITH_DEFAULT.low = unnamed_addr constant i16 10
     @PRIORITY_WITH_DEFAULT.medium = unnamed_addr constant i16 20
     @PRIORITY_WITH_DEFAULT.high = unnamed_addr constant i16 30
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @PRIORITY_WITH_DEFAULT__ctor(ptr %0) {
     entry:
@@ -408,7 +408,7 @@ fn enum_without_zero_with_default_initializes_to_default() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @PRIORITY_WITH_DEFAULT__ctor(ptr @myPriority)
       ret void
@@ -446,7 +446,7 @@ fn enum_61131_standard_style_with_type_before_list() {
     @COLOR.green = unnamed_addr constant i32 -16711936
     @COLOR.blue = unnamed_addr constant i32 -16776961
     @COLOR.black = unnamed_addr constant i32 -2013265920
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @COLOR__ctor(ptr %0) {
     entry:
@@ -457,7 +457,7 @@ fn enum_61131_standard_style_with_type_before_list() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @COLOR__ctor(ptr @myColor)
       ret void
@@ -495,7 +495,7 @@ fn enum_codesys_style_with_type_after_list() {
     @COLOR_CODESYS.green = unnamed_addr constant i32 -16711936
     @COLOR_CODESYS.blue = unnamed_addr constant i32 -16776961
     @COLOR_CODESYS.black = unnamed_addr constant i32 -2013265920
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @COLOR_CODESYS__ctor(ptr %0) {
     entry:
@@ -506,7 +506,7 @@ fn enum_codesys_style_with_type_after_list() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @COLOR_CODESYS__ctor(ptr @myColor)
       ret void

--- a/src/tests/adr/initializer_functions_adr.rs
+++ b/src/tests/adr/initializer_functions_adr.rs
@@ -326,7 +326,7 @@ fn generating_init_functions() {
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
     @baz_instance = global %baz zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -465,7 +465,7 @@ fn generating_init_functions() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @myStruct__ctor(ptr @s)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -521,7 +521,7 @@ fn intializing_temporary_variables() {
     @ps = global [81 x i8] zeroinitializer
     @ps2 = global [81 x i8] zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -632,7 +632,7 @@ fn intializing_temporary_variables() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -675,7 +675,7 @@ fn initializing_method_variables() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -760,7 +760,7 @@ fn initializing_method_variables() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -805,7 +805,7 @@ fn initializing_method_variables() {
 
     @y = global i32 0
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -925,7 +925,7 @@ fn initializing_method_variables() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -959,7 +959,7 @@ fn initializing_method_variables() {
     %foo = type { ptr, i32 }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1049,7 +1049,7 @@ fn initializing_method_variables() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -1093,7 +1093,7 @@ fn external_initializers() {
 
     @fb_global = global %foo { ptr null, i32 5 }
     @__vtable_foo_instance = external global %__vtable_foo
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     declare void @foo(ptr)
 
@@ -1117,7 +1117,7 @@ fn external_initializers() {
 
     declare void @____vtable_foo___body__ctor(ptr)
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @foo__ctor(ptr @fb_global)
       ret void
@@ -1170,7 +1170,7 @@ fn external_initializers_in_fbs() {
     @main_inst = global %main { ptr null, %foo { ptr null, i32 5 } }
     @__vtable_main_instance = global %__vtable_main zeroinitializer
     @__vtable_foo_instance = external global %__vtable_foo
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @main(ptr %0) {
     entry:
@@ -1235,7 +1235,7 @@ fn external_initializers_in_fbs() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @main__ctor(ptr @main_inst)
       call void @__vtable_main__ctor(ptr @__vtable_main_instance)
@@ -1283,7 +1283,7 @@ fn external_inherited_initializers() {
 
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
     @__vtable_foo_instance = external global %__vtable_foo
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @bar(ptr %0) {
     entry:
@@ -1353,7 +1353,7 @@ fn external_inherited_initializers() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
       ret void
@@ -1397,7 +1397,7 @@ fn external_struct_and_program_initializers() {
     %myStruct = type { i32 }
 
     @baz_instance = external global %baz
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     declare void @baz(ptr)
 
@@ -1414,7 +1414,7 @@ fn external_struct_and_program_initializers() {
 
     declare void @myStruct__ctor(ptr)
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @baz__ctor(ptr @baz_instance)
       ret void

--- a/src/tests/adr/initializer_functions_adr.rs
+++ b/src/tests/adr/initializer_functions_adr.rs
@@ -195,26 +195,26 @@ fn global_initializers_are_wrapped_in_single_init_function() {
     let AnnotatedProject { units, index, .. } = annotated_project;
     let units = units.iter().map(|unit| unit.get_unit()).collect::<Vec<_>>();
 
-    // The ProjectInit should be named __unit___internal____ctor
+    // The ProjectInit should be named __unit___internal___bd9efc6f__ctor
     // (unit name is derived from file path which is "<internal>" for SourceCode::from)
-    assert!(index.find_pou("__unit___internal____ctor").is_some());
+    assert!(index.find_pou("__unit___internal___bd9efc6f__ctor").is_some());
 
     // The ProjectInit should be in the first (and only) unit
     let unit = &units[0];
     let init_pou = unit
         .pous
         .iter()
-        .find(|pou| pou.name == "__unit___internal____ctor")
-        .expect("__unit___internal____ctor POU not found");
+        .find(|pou| pou.name == "__unit___internal___bd9efc6f__ctor")
+        .expect("__unit___internal___bd9efc6f__ctor POU not found");
     assert_eq!(init_pou.kind, plc_ast::ast::PouType::ProjectInit);
     assert!(init_pou.variable_blocks.is_empty());
 
     let init_impl = unit
         .implementations
         .iter()
-        .find(|impl_| impl_.name == "__unit___internal____ctor")
-        .expect("__unit___internal____ctor implementation not found");
-    assert_eq!(&init_impl.name, "__unit___internal____ctor");
+        .find(|impl_| impl_.name == "__unit___internal___bd9efc6f__ctor")
+        .expect("__unit___internal___bd9efc6f__ctor implementation not found");
+    assert_eq!(&init_impl.name, "__unit___internal___bd9efc6f__ctor");
     // Just verify it has some initialization statements
     assert!(!init_impl.statements.is_empty());
 }
@@ -326,7 +326,7 @@ fn generating_init_functions() {
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
     @baz_instance = global %baz zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -465,7 +465,7 @@ fn generating_init_functions() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @myStruct__ctor(ptr @s)
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
@@ -521,7 +521,7 @@ fn intializing_temporary_variables() {
     @ps = global [81 x i8] zeroinitializer
     @ps2 = global [81 x i8] zeroinitializer
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -632,7 +632,7 @@ fn intializing_temporary_variables() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -675,7 +675,7 @@ fn initializing_method_variables() {
     %foo = type { ptr }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -760,7 +760,7 @@ fn initializing_method_variables() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -805,7 +805,7 @@ fn initializing_method_variables() {
 
     @y = global i32 0
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -925,7 +925,7 @@ fn initializing_method_variables() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -959,7 +959,7 @@ fn initializing_method_variables() {
     %foo = type { ptr, i32 }
 
     @__vtable_foo_instance = global %__vtable_foo zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @foo(ptr %0) {
     entry:
@@ -1049,7 +1049,7 @@ fn initializing_method_variables() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_foo__ctor(ptr @__vtable_foo_instance)
       ret void
@@ -1093,7 +1093,7 @@ fn external_initializers() {
 
     @fb_global = global %foo { ptr null, i32 5 }
     @__vtable_foo_instance = external global %__vtable_foo
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     declare void @foo(ptr)
 
@@ -1117,7 +1117,7 @@ fn external_initializers() {
 
     declare void @____vtable_foo___body__ctor(ptr)
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @foo__ctor(ptr @fb_global)
       ret void
@@ -1170,7 +1170,7 @@ fn external_initializers_in_fbs() {
     @main_inst = global %main { ptr null, %foo { ptr null, i32 5 } }
     @__vtable_main_instance = global %__vtable_main zeroinitializer
     @__vtable_foo_instance = external global %__vtable_foo
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @main(ptr %0) {
     entry:
@@ -1235,7 +1235,7 @@ fn external_initializers_in_fbs() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @main__ctor(ptr @main_inst)
       call void @__vtable_main__ctor(ptr @__vtable_main_instance)
@@ -1283,7 +1283,7 @@ fn external_inherited_initializers() {
 
     @__vtable_bar_instance = global %__vtable_bar zeroinitializer
     @__vtable_foo_instance = external global %__vtable_foo
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @bar(ptr %0) {
     entry:
@@ -1353,7 +1353,7 @@ fn external_inherited_initializers() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__vtable_bar__ctor(ptr @__vtable_bar_instance)
       ret void
@@ -1397,7 +1397,7 @@ fn external_struct_and_program_initializers() {
     %myStruct = type { i32 }
 
     @baz_instance = external global %baz
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     declare void @baz(ptr)
 
@@ -1414,7 +1414,7 @@ fn external_struct_and_program_initializers() {
 
     declare void @myStruct__ctor(ptr)
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @baz__ctor(ptr @baz_instance)
       ret void

--- a/src/tests/adr/strings_adr.rs
+++ b/src/tests/adr/strings_adr.rs
@@ -22,7 +22,7 @@ fn declaring_a_string() {
 
     @myUtf8 = global [21 x i8] zeroinitializer
     @myUtf16 = global [21 x i16] zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @__global_myUtf8__ctor(ptr %0) {
     entry:
@@ -38,7 +38,7 @@ fn declaring_a_string() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__global_myUtf8__ctor(ptr @myUtf8)
       call void @__global_myUtf16__ctor(ptr @myUtf16)
@@ -69,7 +69,7 @@ fn strings_are_terminated_with_0byte() {
 
     @myUtf8 = global [6 x i8] c"Hello\00"
     @myUtf16 = global [6 x i16] [i16 87, i16 111, i16 114, i16 108, i16 100, i16 0]
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"Hello\00"
     @utf16_literal_0 = private unnamed_addr constant [6 x i16] [i16 87, i16 111, i16 114, i16 108, i16 100, i16 0]
 
@@ -87,7 +87,7 @@ fn strings_are_terminated_with_0byte() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @__global_myUtf8__ctor(ptr @myUtf8)
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @myUtf8, ptr align [filtered] @utf08_literal_0, i32 5, i1 false)
@@ -128,7 +128,7 @@ fn assigning_strings() {
     %prg = type { [11 x i8], [11 x i8] }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -165,7 +165,7 @@ fn assigning_strings() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -203,7 +203,7 @@ fn assigning_string_literals() {
     %prg = type { [11 x i8], [11 x i8] }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
@@ -243,7 +243,7 @@ fn assigning_string_literals() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void

--- a/src/tests/adr/strings_adr.rs
+++ b/src/tests/adr/strings_adr.rs
@@ -22,7 +22,7 @@ fn declaring_a_string() {
 
     @myUtf8 = global [21 x i8] zeroinitializer
     @myUtf16 = global [21 x i16] zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @__global_myUtf8__ctor(ptr %0) {
     entry:
@@ -38,7 +38,7 @@ fn declaring_a_string() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__global_myUtf8__ctor(ptr @myUtf8)
       call void @__global_myUtf16__ctor(ptr @myUtf16)
@@ -69,7 +69,7 @@ fn strings_are_terminated_with_0byte() {
 
     @myUtf8 = global [6 x i8] c"Hello\00"
     @myUtf16 = global [6 x i16] [i16 87, i16 111, i16 114, i16 108, i16 100, i16 0]
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"Hello\00"
     @utf16_literal_0 = private unnamed_addr constant [6 x i16] [i16 87, i16 111, i16 114, i16 108, i16 100, i16 0]
 
@@ -87,7 +87,7 @@ fn strings_are_terminated_with_0byte() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @__global_myUtf8__ctor(ptr @myUtf8)
       call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] @myUtf8, ptr align [filtered] @utf08_literal_0, i32 5, i1 false)
@@ -128,7 +128,7 @@ fn assigning_strings() {
     %prg = type { [11 x i8], [11 x i8] }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -165,7 +165,7 @@ fn assigning_strings() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -203,7 +203,7 @@ fn assigning_string_literals() {
     %prg = type { [11 x i8], [11 x i8] }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [6 x i8] c"hello\00"
     @utf08_literal_1 = private unnamed_addr constant [6 x i8] c"world\00"
 
@@ -243,7 +243,7 @@ fn assigning_string_literals() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void

--- a/src/tests/adr/structs_adr.rs
+++ b/src/tests/adr/structs_adr.rs
@@ -84,7 +84,7 @@ fn default_values_of_a_struct() {
     %Person = type { [6 x i8], [6 x i8], i16, i8 }
 
     @p = global %Person { [6 x i8] c"Jane\00\00", [6 x i8] c"Row\00\00\00", i16 1988, i8 0 }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [5 x i8] c"Jane\00"
     @utf08_literal_1 = private unnamed_addr constant [4 x i8] c"Row\00"
 
@@ -127,7 +127,7 @@ fn default_values_of_a_struct() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @Person__ctor(ptr @p)
       ret void
@@ -181,7 +181,7 @@ fn initializing_a_struct() {
     %Point = type { i16, i16 }
 
     @prg_instance = global %prg { %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }, %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } } }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
     @__prg.rect1__init = unnamed_addr constant %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }
     @__prg.rect2__init = unnamed_addr constant %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } }
     @__prg.rect1__init.1 = unnamed_addr constant %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }
@@ -267,7 +267,7 @@ fn initializing_a_struct() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -309,7 +309,7 @@ fn assigning_structs() {
     %Point = type { i16, i16 }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -339,7 +339,7 @@ fn assigning_structs() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -392,7 +392,7 @@ fn accessing_struct_members() {
     %Point = type { i16, i16 }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -440,7 +440,7 @@ fn accessing_struct_members() {
       ret void
     }
 
-    define void @__unit___internal___bd9efc6f__ctor() {
+    define void @__unit___internal___[ctor-hash]__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void

--- a/src/tests/adr/structs_adr.rs
+++ b/src/tests/adr/structs_adr.rs
@@ -84,7 +84,7 @@ fn default_values_of_a_struct() {
     %Person = type { [6 x i8], [6 x i8], i16, i8 }
 
     @p = global %Person { [6 x i8] c"Jane\00\00", [6 x i8] c"Row\00\00\00", i16 1988, i8 0 }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @utf08_literal_0 = private unnamed_addr constant [5 x i8] c"Jane\00"
     @utf08_literal_1 = private unnamed_addr constant [4 x i8] c"Row\00"
 
@@ -127,7 +127,7 @@ fn default_values_of_a_struct() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @Person__ctor(ptr @p)
       ret void
@@ -181,7 +181,7 @@ fn initializing_a_struct() {
     %Point = type { i16, i16 }
 
     @prg_instance = global %prg { %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }, %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } } }
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
     @__prg.rect1__init = unnamed_addr constant %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }
     @__prg.rect2__init = unnamed_addr constant %Rect { %Point { i16 4, i16 6 }, %Point { i16 16, i16 22 } }
     @__prg.rect1__init.1 = unnamed_addr constant %Rect { %Point { i16 1, i16 5 }, %Point { i16 10, i16 15 } }
@@ -267,7 +267,7 @@ fn initializing_a_struct() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -309,7 +309,7 @@ fn assigning_structs() {
     %Point = type { i16, i16 }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -339,7 +339,7 @@ fn assigning_structs() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void
@@ -392,7 +392,7 @@ fn accessing_struct_members() {
     %Point = type { i16, i16 }
 
     @prg_instance = global %prg zeroinitializer
-    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal____ctor, ptr null }]
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___bd9efc6f__ctor, ptr null }]
 
     define void @prg(ptr %0) {
     entry:
@@ -440,7 +440,7 @@ fn accessing_struct_members() {
       ret void
     }
 
-    define void @__unit___internal____ctor() {
+    define void @__unit___internal___bd9efc6f__ctor() {
     entry:
       call void @prg__ctor(ptr @prg_instance)
       ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %main = type { i32, i32 }
 
 @main_instance = global %main zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_b2fe9d6d__ctor, ptr null }]
 
 define void @main(ptr %0) !dbg !12 {
 entry:
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___cfc__ctor() {
+define void @__unit___internal___cfc_b2fe9d6d__ctor() {
 entry:
   call void @main__ctor(ptr @main_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__actions_debug.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %main = type { i32, i32 }
 
 @main_instance = global %main zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_b2fe9d6d__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_[ctor-hash]__ctor, ptr null }]
 
 define void @main(ptr %0) !dbg !12 {
 entry:
@@ -27,7 +27,7 @@ entry:
   ret void
 }
 
-define void @__unit___internal___cfc_b2fe9d6d__ctor() {
+define void @__unit___internal___cfc_[ctor-hash]__ctor() {
 entry:
   call void @main__ctor(ptr @main_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
@@ -8,7 +8,7 @@ target triple = "[filtered]"
 %conditional_return = type { ptr, i32 }
 
 @__vtable_conditional_return_instance = global %__vtable_conditional_return zeroinitializer
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc_68dc5a26__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc_[ctor-hash]__ctor, ptr null }]
 
 define void @conditional_return(ptr %0) {
 entry:
@@ -68,7 +68,7 @@ entry:
   ret void
 }
 
-define void @__unit_conditional_return_cfc_68dc5a26__ctor() {
+define void @__unit_conditional_return_cfc_[ctor-hash]__ctor() {
 entry:
   call void @__vtable_conditional_return__ctor(ptr @__vtable_conditional_return_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return.snap
@@ -8,7 +8,7 @@ target triple = "[filtered]"
 %conditional_return = type { ptr, i32 }
 
 @__vtable_conditional_return_instance = global %__vtable_conditional_return zeroinitializer
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc_68dc5a26__ctor, ptr null }]
 
 define void @conditional_return(ptr %0) {
 entry:
@@ -68,7 +68,7 @@ entry:
   ret void
 }
 
-define void @__unit_conditional_return_cfc__ctor() {
+define void @__unit_conditional_return_cfc_68dc5a26__ctor() {
 entry:
   call void @__vtable_conditional_return__ctor(ptr @__vtable_conditional_return_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %__vtable_conditional_return.1 = type { ptr }
 %conditional_return = type { ptr, i32 }
 
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc_68dc5a26__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc_[ctor-hash]__ctor, ptr null }]
 @__vtable_conditional_return_instance = global %__vtable_conditional_return.1 zeroinitializer
 
 define i32 @main() {
@@ -34,7 +34,7 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #0
 
-define void @__unit_conditional_return_cfc_68dc5a26__ctor() {
+define void @__unit_conditional_return_cfc_[ctor-hash]__ctor() {
 entry:
   call void @__vtable_conditional_return__ctor(ptr @__vtable_conditional_return_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %__vtable_conditional_return.1 = type { ptr }
 %conditional_return = type { ptr, i32 }
 
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_cfc_68dc5a26__ctor, ptr null }]
 @__vtable_conditional_return_instance = global %__vtable_conditional_return.1 zeroinitializer
 
 define i32 @main() {
@@ -34,7 +34,7 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #0
 
-define void @__unit_conditional_return_cfc__ctor() {
+define void @__unit_conditional_return_cfc_68dc5a26__ctor() {
 entry:
   call void @__vtable_conditional_return__ctor(ptr @__vtable_conditional_return_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %__vtable_conditional_return.1 = type { ptr }
 %conditional_return = type { ptr, i32 }
 
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_negated_cfc__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_negated_cfc_09044428__ctor, ptr null }]
 @__vtable_conditional_return_instance = global %__vtable_conditional_return.1 zeroinitializer
 
 define i32 @main() {
@@ -34,7 +34,7 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #0
 
-define void @__unit_conditional_return_negated_cfc__ctor() {
+define void @__unit_conditional_return_negated_cfc_09044428__ctor() {
 entry:
   call void @__vtable_conditional_return__ctor(ptr @__vtable_conditional_return_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__conditional_return_evaluating_true_negated.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %__vtable_conditional_return.1 = type { ptr }
 %conditional_return = type { ptr, i32 }
 
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_negated_cfc_09044428__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit_conditional_return_negated_cfc_[ctor-hash]__ctor, ptr null }]
 @__vtable_conditional_return_instance = global %__vtable_conditional_return.1 zeroinitializer
 
 define i32 @main() {
@@ -34,7 +34,7 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #0
 
-define void @__unit_conditional_return_negated_cfc_09044428__ctor() {
+define void @__unit_conditional_return_negated_cfc_[ctor-hash]__ctor() {
 entry:
   call void @__vtable_conditional_return__ctor(ptr @__vtable_conditional_return_instance)
   ret void

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %foo = type { i32 }
 
 @foo_instance = global %foo zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_b2fe9d6d__ctor, ptr null }]
 
 define void @foo(ptr %0) !dbg !11 {
 entry:
@@ -35,7 +35,7 @@ entry:
   ret void, !dbg !20
 }
 
-define void @__unit___internal___cfc__ctor() {
+define void @__unit___internal___cfc_b2fe9d6d__ctor() {
 entry:
   call void @foo__ctor(ptr @foo_instance), !dbg !20
   ret void, !dbg !20

--- a/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__jump_debug.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %foo = type { i32 }
 
 @foo_instance = global %foo zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_b2fe9d6d__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_[ctor-hash]__ctor, ptr null }]
 
 define void @foo(ptr %0) !dbg !11 {
 entry:
@@ -35,7 +35,7 @@ entry:
   ret void, !dbg !20
 }
 
-define void @__unit___internal___cfc_b2fe9d6d__ctor() {
+define void @__unit___internal___cfc_[ctor-hash]__ctor() {
 entry:
   call void @foo__ctor(ptr @foo_instance), !dbg !20
   ret void, !dbg !20

--- a/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %main = type { i32 }
 
 @main_instance = global %main zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_b2fe9d6d__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_[ctor-hash]__ctor, ptr null }]
 
 define void @main(ptr %0) !dbg !11 {
 entry:
@@ -24,7 +24,7 @@ entry:
   ret void, !dbg !18
 }
 
-define void @__unit___internal___cfc_b2fe9d6d__ctor() {
+define void @__unit___internal___cfc_[ctor-hash]__ctor() {
 entry:
   call void @main__ctor(ptr @main_instance), !dbg !18
   ret void, !dbg !18

--- a/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
+++ b/tests/integration/snapshots/tests__integration__cfc__ir__sink_source_debug.snap
@@ -7,7 +7,7 @@ target triple = "[filtered]"
 %main = type { i32 }
 
 @main_instance = global %main zeroinitializer, !dbg !0
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc__ctor, ptr null }]
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___cfc_b2fe9d6d__ctor, ptr null }]
 
 define void @main(ptr %0) !dbg !11 {
 entry:
@@ -24,7 +24,7 @@ entry:
   ret void, !dbg !18
 }
 
-define void @__unit___internal___cfc__ctor() {
+define void @__unit___internal___cfc_b2fe9d6d__ctor() {
 entry:
   call void @main__ctor(ptr @main_instance), !dbg !18
   ret void, !dbg !18

--- a/tests/lit/multi/duplicate_unit_ctor_basename_1723/a/globals.st
+++ b/tests/lit/multi/duplicate_unit_ctor_basename_1723/a/globals.st
@@ -1,0 +1,3 @@
+VAR_GLOBAL
+    g_in_a : DINT := 11;
+END_VAR

--- a/tests/lit/multi/duplicate_unit_ctor_basename_1723/b/globals.st
+++ b/tests/lit/multi/duplicate_unit_ctor_basename_1723/b/globals.st
@@ -1,0 +1,3 @@
+VAR_GLOBAL
+    g_in_b : DINT := 22;
+END_VAR

--- a/tests/lit/multi/duplicate_unit_ctor_basename_1723/duplicate_unit_ctor_basename_1723.test
+++ b/tests/lit/multi/duplicate_unit_ctor_basename_1723/duplicate_unit_ctor_basename_1723.test
@@ -1,0 +1,9 @@
+// Regression for #1723: two source files sharing a basename across different
+// directories used to mint the same `__unit_<basename>__ctor` symbol and
+// fail to link with a duplicate-symbol error. Each file's per-unit
+// constructor now carries an 8-hex-char path-derived suffix, so the symbols
+// are distinct. The two `globals.st` files declare disjoint globals; main
+// reads both — if either constructor were missing or the wiring went wrong,
+// the runtime sum would be different and the test would not print `ok`.
+RUN: %COMPILE %S/main.st %S/a/globals.st %S/b/globals.st && %RUN | %CHECK %s
+CHECK: ok

--- a/tests/lit/multi/duplicate_unit_ctor_basename_1723/main.st
+++ b/tests/lit/multi/duplicate_unit_ctor_basename_1723/main.st
@@ -1,0 +1,6 @@
+FUNCTION main : DINT
+    main := g_in_a + g_in_b;
+    IF main = 33 THEN
+        printf('ok$N');
+    END_IF;
+END_FUNCTION


### PR DESCRIPTION
> _**Note:** this description was drafted by Claude (via Claude Code) and posted on my behalf. Verify before merging. — Ghaith_

## Summary

Fixes #1723.

Two source files sharing a basename across different directories — e.g. `a/globals.st` and `b/globals.st` — used to mint the same `__unit_<basename>__ctor` symbol and fail to link with:

```
ld.lld: error: duplicate symbol: __unit_globals_st__ctor
```

The bug was in `src/lowering/helper.rs::get_unit_name`, which derived the unit identifier from the source file's basename only, dropping any directory component.

## What this PR does

`get_unit_name` now combines the sanitised basename with an 8-hex-char path-derived suffix:

```
a/globals.st  →  globals_st_944ecddc
b/globals.st  →  globals_st_411895b6
```

The suffix is the high 32 bits of a SipHash-1-3 digest of the **full path**, keyed with `(0, 0)`. SipHash with a fixed key is deterministic and stable across runs, platforms, and processes; cryptographic strength isn't required for a uniqueness suffix and a hash collision would surface as the same loud "duplicate symbol" linker error this PR is closing — not a silent miscompile — so the worst-case failure mode is graceful even at unrealistic file counts.

The mangled name only flows into `PouType::ProjectInit` POUs, which the C header generator filters out (`compiler/plc_header_generator/src/header_generator/header_generator_c.rs`), so this has no effect on the user-facing C interface.

## Why SipHash and not SHA-1?

Initial drafts used `sha1`, but its crate-level README explicitly flags it as "cryptographically broken" and recommends users avoid it. We don't need cryptographic guarantees here — only deterministic, stable, version-pinned hashing — so we switched to `siphasher` with a fixed `(0, 0)` key. `siphasher` is already a transitive dep via `phf_shared`; we just promoted it to a direct dep.

## Why 8 hex chars?

Birthday-paradox 50%-collision threshold for 32 bits (8 hex chars) is ~65 k files, which is far beyond any realistic project. The collision penalty is graceful (loud duplicate-symbol error pointing at the colliding paths); we can lengthen the suffix later if a project ever genuinely outgrows that. 16 chars is overkill.

## Tests

- `tests/lit/multi/duplicate_unit_ctor_basename_1723/` — multi-file lit fixture: `a/globals.st` + `b/globals.st` + `main.st`, compiled together. Without this fix the fixture would fail to link; with it, `main` reads both globals and prints `ok` to stdout.
- `src/lowering/helper.rs::tests` — two table-form `assert_snapshot!` tests pinning the input → output mapping for both helpers (`sanitize_to_identifier` and `path_hash_suffix`). The snapshot for `path_hash_suffix` documents three properties at once: deterministic, path-sensitive (the #1723 regression), and uniformly 8 lowercase hex chars.

## Snapshot churn

22 existing tests reference the legacy `__unit___internal____ctor` symbol (the `<internal>` test fixture name mangled). These were swept to the new shape `__unit___internal___bd9efc6f__ctor` (the deterministic SipHash of `__internal__`). One assertion in `compiler/plc_driver/src/tests/debug_paths.rs` was relaxed from a literal `@__unit_test_st__ctor` match to a `@__unit_test_st_` prefix match because the suffix now depends on the per-test tempdir.