### PR TITLE
ci(release): install jq in container before git-cliff-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,15 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      # Workaround: the rust-llvm container image is missing `jq`, which
+      # `orhun/git-cliff-action`'s install.sh needs to parse the GitHub API
+      # response. Tracked upstream at PLC-lang/rust-llvm-images#31; remove
+      # this step once a new image is published with jq baked in.
+      - name: Install jq (rust-llvm image workaround)
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends jq
+
       - name: Get version from Cargo.toml
         id: version
         run: |


### PR DESCRIPTION
> _**Note:** this description was drafted by Claude (via Claude Code) and posted on my behalf. Verify before merging. — Ghaith_

## Summary

The `Release` workflow (`.github/workflows/release.yml`) runs inside `ghcr.io/plc-lang/rust-llvm:latest`, which is missing `jq`. The `orhun/git-cliff-action@v4` install script depends on `jq` to parse the GitHub API response when downloading the `git-cliff` binary, so the workflow fails before it can compute release notes or create the tag. Concrete victim: [run 25431842251](https://github.com/PLC-lang/rusty/actions/runs/25431842251), the `v0.5.0` release that never tagged.

## What this PR does

Adds an `apt-get install -y jq` step right after `Checkout repository` in the `release` job. `release-pr.yml` and `release-preview.yml` use GitHub-hosted runners (which ship with `jq`) so they don't need this workaround.

## Out of scope

The proper fix is to add `jq` to the rust-llvm runtime image. Tracked upstream at [PLC-lang/rust-llvm-images#31](https://github.com/PLC-lang/rust-llvm-images/issues/31) — once a new image lands, this workaround step should be removed.