### PR TITLE
ci(release-pr): handle pre-existing -dev bump in version comparison

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -48,14 +48,34 @@ jobs:
       - name: Check if bump needed
         id: version
         run: |
+          # `release.yml` opens a post-release PR that preemptively bumps the
+          # workspace to `<patch+1>-dev` after every release, so master visibly
+          # diverges from the released tag. After that PR merges, this workflow
+          # must NOT fire until a real fix/feat lands — but git-cliff returns
+          # the last tag's version (e.g. `0.5.0`) which is *less than* CURRENT
+          # (`0.5.1-dev`), so a naive equality check would try to downgrade
+          # and break (#1690). Strip the `-dev` suffix before comparing, and
+          # explicitly handle the "drop -dev to release" case where cliff
+          # agrees with the version we'd preemptively bumped to.
           CURRENT=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           NEXT=$(echo "${{ steps.cliff-version.outputs.content }}" | sed 's/^v//')
+          CURRENT_BASE="${CURRENT%-dev}"
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-          if [ -z "$NEXT" ] || [ "$NEXT" = "$CURRENT" ]; then
+          if [ -z "$NEXT" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
+          elif printf '%s\n%s\n' "$CURRENT_BASE" "$NEXT" | sort -V -C \
+               && [ "$NEXT" != "$CURRENT_BASE" ]; then
+            # NEXT > CURRENT_BASE: real upgrade (overwrites any -dev).
             echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [ "$NEXT" = "$CURRENT_BASE" ] && [ "$CURRENT" != "$CURRENT_BASE" ]; then
+            # Master is at <NEXT>-dev and cliff agrees the next release is
+            # <NEXT>: drop the -dev suffix, open a release PR.
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            # NEXT < CURRENT_BASE, or NEXT == CURRENT with no -dev to drop:
+            # nothing warranted yet.
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump versions


### PR DESCRIPTION
> _**Note:** this description was drafted by Claude (via Claude Code) and posted on my behalf. Verify before merging. — Ghaith_

## Summary

Fixes #1690.

`release.yml` already opens a post-release PR that preemptively bumps the workspace to `<patch+1>-dev` after every release, so master visibly diverges from the released tag. After that PR merges, `release-pr.yml` must *not* fire until a real fix/feat lands — but the current logic compares git-cliff's next version against the raw `Cargo.toml` value:

```sh
if [ -z "$NEXT" ] || [ "$NEXT" = "$CURRENT" ]; then
  echo "skip=true" >> "$GITHUB_OUTPUT"
fi
```

When master is at `0.4.1-dev`, git-cliff (with no qualifying commits since `v0.4.0`) returns `0.4.0`. `NEXT (0.4.0) ≠ CURRENT (0.4.1-dev)` → workflow proceeds → `cargo set-version --workspace 0.4.0` rejects the implicit downgrade with exit 1.

Concrete failure: [run 24713036095](https://github.com/PLC-lang/rusty/actions/runs/24713036095) on commit `08c5848` (the `0.4.0` → `0.4.1-dev` post-release bump) — this is the failure that prompted #1690.

## What this PR does

Strips the `-dev` suffix from `CURRENT` before comparing, and splits the proceed-path into two cases:

- **`NEXT > CURRENT_BASE`** — a real upgrade (overwrites any `-dev` suffix).
- **`NEXT == CURRENT_BASE` while `CURRENT` carries `-dev`** — a fix landed that matches the version we'd preemptively bumped to; drop the `-dev` and open a release PR.

Anything else (`NEXT < CURRENT_BASE`, or `NEXT == CURRENT` with no `-dev`) is treated as "nothing warranted yet" and skipped.

`sort -V -C` returns 0 if input is already sorted (low → high); combined with `NEXT != CURRENT_BASE` it captures "NEXT > CURRENT_BASE".

## Lifecycle table

| State | CURRENT | NEXT | result |
|---|---|---|---|
| Just-released, post-release dev-bump merged, no commits | `0.5.1-dev` | `0.5.0` | skip |
| Same, docs-only commits land | `0.5.1-dev` | `0.5.0` | skip |
| **A fix lands** | `0.5.1-dev` | `0.5.1` | release-bump → `0.5.1` (drops `-dev`) |
| **A feat lands** | `0.5.1-dev` | `0.6.0` | real upgrade → `0.6.0` |
| Subsequent push after a real upgrade | `0.6.0` | `0.6.0` | skip (no `-dev`, no upgrade) |

## Out of scope

- The post-release preemptive bump itself — that already lives in `release.yml` (added in PR #1673, refined in #1686), unchanged here.
- The release-tagging side of `release.yml` — its `jq`-missing failure is a separate issue and is fixed in PR #1725.