### PR TITLE
ci(release-assets): sparse-checkout scripts before dispatch backfill

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -22,6 +22,21 @@ jobs:
       actions: read
       contents: write
     steps:
+      # `workflow_dispatch` needs `resolve-tag-sha.sh` on disk before the
+      # `Resolve source request` step runs. The later `Checkout release commit`
+      # step depends on the SHA that step produces, so it cannot do the
+      # checkout itself (chicken-and-egg). Pull just `.github/scripts/` here;
+      # `Checkout release commit` then replaces the workspace with the source
+      # SHA as before.
+      - name: Checkout repository scripts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
       - name: Resolve source request
         id: source
         env:


### PR DESCRIPTION
> _**Note:** this description was drafted by Claude (via Claude Code) and posted on my behalf. Verify before merging. — Ghaith_

## Summary

Closes #1727.

`workflow_dispatch` (used to manually backfill assets to an existing release via `gh workflow run "Release Assets" -f tag=vX.Y.Z`) shells out to `.github/scripts/resolve-tag-sha.sh` in the first step. The later `Checkout release commit` step depends on the SHA that script produces — chicken and egg — so it cannot do the checkout itself. Without an earlier checkout the script isn't on disk and the run fails with `bash: .github/scripts/resolve-tag-sha.sh: No such file or directory`. The `workflow_run` path doesn't hit this because it gets `head_sha` directly from the event payload.

## Fix

Add a guarded `actions/checkout@v6` ahead of `Resolve source request` that pulls only `.github/scripts/` (sparse, depth 1) so the resolver is available. `Checkout release commit` then replaces the workspace with the source SHA as before. The `workflow_run` path is unchanged — the new checkout step is gated on `github.event_name == 'workflow_dispatch'`.

`@v6` matches the existing 15/15 checkout pins in this repo's workflows. `sparse-checkout-cone-mode: false` because the path isn't directory-aligned for cone mode. No new `permissions:` needed — the existing job-level `contents: write` covers the sparse-checkout's `contents: read` requirement.

## Test plan

- [ ] Merge to master.
- [ ] `gh workflow run "Release Assets" -f tag=v0.5.0` (v0.5.0 already has its assets uploaded manually, so a re-run won't break anything customer-visible — it'll re-upload the same artifacts).
- [ ] Confirm the run reaches `Checkout release commit` and proceeds through asset upload without the script-not-found error.
- [ ] Confirm the auto `workflow_run` path (after a successful Build Linux/Windows on master) still works unchanged.

## Acceptance criteria (per issue)

- `gh workflow run "Release Assets" -f tag=vX.Y.Z` succeeds and uploads the same set of artifacts as the auto `workflow_run` path.
- The `workflow_run` path (auto-fire after a successful Build Linux/Windows on master) is unchanged.