### PR TITLE
fix(parser): focused diagnostic for reserved keywords in name slots

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -236,6 +236,7 @@ lazy_static! {
         E132,   Ignore,    include_str!("./error_codes/E132.md"),  // Mixing implicit and explicit call parameters
         E133,   Error,      include_str!("./error_codes/E133.md"),  // AND_THEN/OR_ELSE with non-boolean operands
         E136,   Error,      include_str!("./error_codes/E136.md"),  // Incomplete hardware address in FUNCTION/METHOD
+        E138,   Error,      include_str!("./error_codes/E138.md"),  // Reserved keyword used as a name
     );
 }
 

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E138.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E138.md
@@ -1,0 +1,30 @@
+# Reserved keyword used as a name
+
+A reserved keyword was used in a position that expects a user-defined name
+(variable, parameter, POU, type alias, enum variant, struct field, …).
+Reserved keywords carry syntactic meaning and cannot double as identifiers.
+
+Erroneous code example:
+```iecst
+FUNCTION main
+    VAR
+        retain : DINT; // `RETAIN` is reserved
+    END_VAR
+END_FUNCTION
+```
+
+Rename the variable to something that is not a reserved keyword:
+```iecst
+FUNCTION main
+    VAR
+        is_retained : DINT;
+    END_VAR
+END_FUNCTION
+```
+
+The same restriction applies to POU names, parameter names, type aliases,
+enum variants, struct fields, generic parameters, method names, and property
+names.
+
+Note that `VAR RETAIN ... END_VAR` is still valid — there `RETAIN` is the
+variable-block modifier, not a variable name.

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -5,7 +5,7 @@ use plc_ast::ast::{AstId, DirectAccessType, HardwareAccessType};
 use plc_ast::provider::IdProvider;
 use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::{SourceLocation, SourceLocationFactory};
-pub use tokens::Token;
+pub use tokens::{Token, TokenClass};
 
 #[cfg(test)]
 mod tests;
@@ -78,6 +78,13 @@ impl<'a> ParseSession<'a> {
         }
 
         false
+    }
+
+    /// Returns the token that follows the current one without consuming the
+    /// current token.
+    pub fn peek(&self) -> Token {
+        let mut peeked = self.lexer.clone();
+        peeked.next().unwrap_or(Token::End)
     }
 
     pub fn try_consume_or_report(&mut self, token: Token) {

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -459,4 +459,39 @@ impl Token {
     pub fn is_identifier_like(&self) -> bool {
         matches!(self, Token::Identifier | Token::KeywordPropertyGet | Token::KeywordPropertySet)
     }
+
+    /// Linguistic classification of this token, returned as a slice so a
+    /// token can carry more than one class. Empty when nothing currently
+    /// classifies the token.
+    pub fn classes(&self) -> &'static [TokenClass] {
+        use TokenClass::*;
+        match self {
+            Token::KeywordConstant
+            | Token::KeywordRetain
+            | Token::KeywordNonRetain
+            | Token::KeywordAbstract
+            | Token::KeywordFinal
+            | Token::KeywordOverride
+            | Token::KeywordAccessPublic
+            | Token::KeywordAccessPrivate
+            | Token::KeywordAccessInternal
+            | Token::KeywordAccessProtected => &[Modifier],
+
+            Token::KeywordExit => &[ControlFlowJump],
+
+            Token::KeywordString | Token::KeywordWideString => &[BuiltinDatatype],
+
+            _ => &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenClass {
+    /// Declaration modifier that qualifies a following construct.
+    Modifier,
+    /// Standalone control-flow jump statement.
+    ControlFlowJump,
+    /// Built-in datatype keyword.
+    BuiltinDatatype,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,6 +28,7 @@ use crate::{
     lexer::{
         self, ParseSession,
         Token::{self, *},
+        TokenClass,
     },
     typesystem::DINT_TYPE,
 };
@@ -186,20 +187,18 @@ fn parse_interface(lexer: &mut ParseSession) -> (Interface, Vec<Implementation>)
     let location_start = lexer.range().start;
     lexer.try_consume_or_report(KeywordInterface);
 
-    let (name, location_name) = match lexer.token {
-        Token::Identifier => parse_identifier(lexer).expect("unreachable, already matched here"),
+    let (name, location_name) = if is_name_slot_candidate(lexer) {
+        expect_name_slot(lexer, "an interface name").expect("just checked")
+    } else {
+        lexer.accept_diagnostic(
+            Diagnostic::new("Expected a name for the interface definition but got nothing")
+                .with_error_code("E006")
+                .with_location(lexer.last_location()),
+        );
 
-        _ => {
-            lexer.accept_diagnostic(
-                Diagnostic::new("Expected a name for the interface definition but got nothing")
-                    .with_error_code("E006")
-                    .with_location(lexer.last_location()),
-            );
-
-            // We want to keep parsing, hence we return some undefined values; the parser will yield an
-            // unrecoverable error though
-            (String::new(), SourceLocation::undefined())
-        }
+        // We want to keep parsing, hence we return some undefined values; the parser will yield an
+        // unrecoverable error though
+        (String::new(), SourceLocation::undefined())
     };
 
     let mut extensions = Vec::new();
@@ -307,8 +306,17 @@ fn parse_pou(
         // check in validator if pou type allows polymorphism
         let poly_mode = parse_polymorphism_mode(lexer, &kind);
 
-        let (name, name_location) =
-            parse_identifier(lexer).unwrap_or_else(|| ("".to_string(), SourceLocation::undefined())); // parse POU name
+        let pou_slot_label: &'static str = match kind {
+            PouType::Program => "a program name",
+            PouType::Function => "a function name",
+            PouType::FunctionBlock => "a function block name",
+            PouType::Class => "a class name",
+            PouType::Action => "an action name",
+            PouType::Method { .. } => "a method name",
+            PouType::Init | PouType::ProjectInit => "a POU name",
+        };
+        let (name, name_location) = expect_name_slot(lexer, pou_slot_label)
+            .unwrap_or_else(|| ("".to_string(), SourceLocation::undefined()));
 
         let generics = parse_generics(lexer);
 
@@ -489,7 +497,7 @@ fn parse_generics(lexer: &mut ParseSession) -> Vec<GenericBinding> {
             let mut generics = vec![];
             loop {
                 //identifier
-                if let Some((name, _)) = parse_identifier(lexer) {
+                if let Some((name, _)) = expect_name_slot(lexer, "a generic parameter name") {
                     lexer.try_consume_or_report(Token::KeywordColon);
 
                     //Expect a type nature
@@ -684,7 +692,7 @@ fn parse_method(
         let pou_kind = PouType::Method { parent: parent.into(), property: None, declaration_kind };
         let poly_mode = parse_polymorphism_mode(lexer, &pou_kind);
         let overriding = lexer.try_consume(KeywordOverride);
-        let (name, name_location) = parse_identifier(lexer)?;
+        let (name, name_location) = expect_name_slot(lexer, "a method name")?;
         let generics = parse_generics(lexer);
         let return_type = parse_return_type(lexer);
 
@@ -748,9 +756,8 @@ fn parse_property(
     };
     lexer.advance();
 
-    let (name, name_location) = if lexer.token.is_identifier_like() {
-        let name = lexer.slice_and_advance();
-        (name, lexer.last_location())
+    let (name, name_location) = if is_name_slot_candidate(lexer) {
+        expect_name_slot(lexer, "a property name").expect("just checked")
     } else {
         lexer.accept_diagnostic(
             Diagnostic::new("Property definition is missing a name")
@@ -903,6 +910,37 @@ fn parse_identifier(lexer: &mut ParseSession) -> Option<(String, SourceLocation)
     }
 }
 
+/// Consumes the current token as a user-introduced name in a declaration slot.
+/// `slot_label` is the noun phrase used in the E138 message — pass it with its
+/// article, e.g. `"a variable name"`, `"an enum variant name"`.
+fn expect_name_slot(lexer: &mut ParseSession, slot_label: &'static str) -> Option<(String, SourceLocation)> {
+    let slice = lexer.slice().to_string();
+    let classes = lexer.token.classes();
+    if lexer.token.is_identifier_like() || classes.contains(&TokenClass::BuiltinDatatype) {
+        lexer.advance();
+        return Some((slice, lexer.last_location()));
+    }
+    if (classes.contains(&TokenClass::Modifier) || classes.contains(&TokenClass::ControlFlowJump))
+        && !lexer.closes_open_region(&lexer.token)
+    {
+        let location = lexer.location();
+        let upper = slice.to_uppercase();
+        lexer.accept_diagnostic(
+            Diagnostic::new(format!("`{upper}` is a reserved keyword and cannot be used as {slot_label}"))
+                .with_error_code("E138")
+                .with_location(location),
+        );
+        lexer.advance();
+        return Some((slice, lexer.last_location()));
+    }
+    lexer.accept_diagnostic(Diagnostic::unexpected_token_found(
+        "Identifier",
+        slice.as_str(),
+        lexer.location(),
+    ));
+    None
+}
+
 fn parse_implementation(
     lexer: &mut ParseSession,
     linkage: LinkageType,
@@ -986,8 +1024,11 @@ fn parse_type(lexer: &mut ParseSession, linkage: LinkageType) -> Vec<UserTypeDec
     parse_any_in_region(lexer, vec![KeywordEndType], |lexer| {
         let mut declarations = vec![];
         while !lexer.closes_open_region(&lexer.token) {
-            let name = lexer.slice_and_advance();
-            let name_location = lexer.last_location();
+            let Some((name, name_location)) = expect_name_slot(lexer, "a type name") else {
+                // unrecoverable: skip the offending token to avoid an infinite loop
+                lexer.advance();
+                continue;
+            };
             lexer.try_consume_or_report(KeywordColon);
 
             let result = parse_full_data_type_definition(lexer, Some(name));
@@ -1062,7 +1103,7 @@ fn parse_data_type_definition(
     let start = lexer.location();
     if lexer.try_consume(KeywordStruct) {
         // Parse struct
-        let variables = parse_variable_list(lexer);
+        let variables = parse_variable_list(lexer, "a struct field name");
         Some((
             DataTypeDeclaration::Definition {
                 data_type: Box::new(DataType::StructType { name, variables }),
@@ -1389,7 +1430,7 @@ fn parse_enum_elements(lexer: &mut ParseSession) -> Option<AstNode> {
 fn parse_enum_element(lexer: &mut ParseSession) -> Option<AstNode> {
     let start = lexer.location();
 
-    let idfr = parse_identifier(lexer)?;
+    let idfr = expect_name_slot(lexer, "an enum variant name")?;
 
     let identifier_node = AstFactory::create_identifier(&idfr.0, start, lexer.next_id());
     let ref_expr = AstFactory::create_member_reference(identifier_node, None, lexer.next_id());
@@ -1570,14 +1611,20 @@ fn parse_variable_block(lexer: &mut ParseSession, linkage: LinkageType) -> Varia
     let location = lexer.location();
     let variable_block_type = parse_variable_block_type(lexer);
 
-    let constant = lexer.try_consume(KeywordConstant);
-
-    let retain = lexer.try_consume(KeywordRetain);
-    lexer.try_consume(KeywordNonRetain);
+    let constant = try_consume_var_modifier(lexer, KeywordConstant);
+    let retain = try_consume_var_modifier(lexer, KeywordRetain);
+    try_consume_var_modifier(lexer, KeywordNonRetain);
 
     let access = parse_access_modifier(lexer);
 
-    let mut variables = parse_any_in_region(lexer, vec![KeywordEndVar], parse_variable_list);
+    let slot_label: &'static str = match variable_block_type {
+        VariableBlockType::Input(_) | VariableBlockType::Output | VariableBlockType::InOut => {
+            "a parameter name"
+        }
+        _ => "a variable name",
+    };
+    let mut variables =
+        parse_any_in_region(lexer, vec![KeywordEndVar], |lexer| parse_variable_list(lexer, slot_label));
 
     if constant && !matches!(variable_block_type, VariableBlockType::External) {
         // sneak in the DefaultValue-Statements if no initializers were defined
@@ -1589,13 +1636,40 @@ fn parse_variable_block(lexer: &mut ParseSession, linkage: LinkageType) -> Varia
     VariableBlock { access, constant, retain, variables, kind: variable_block_type, linkage, location }
 }
 
-fn parse_variable_list(lexer: &mut ParseSession) -> Vec<Variable> {
+/// Consumes a var-block modifier, but only if the following token is not a
+/// name terminator — otherwise the modifier keyword was meant as a variable
+/// name and is left for `parse_variable_line` to flag with E138.
+fn try_consume_var_modifier(lexer: &mut ParseSession, modifier: Token) -> bool {
+    if lexer.token != modifier {
+        return false;
+    }
+    if matches!(lexer.peek(), KeywordColon | KeywordComma | KeywordAt) {
+        return false;
+    }
+    lexer.advance();
+    true
+}
+
+fn parse_variable_list(lexer: &mut ParseSession, slot_label: &'static str) -> Vec<Variable> {
     let mut variables = vec![];
-    while lexer.token.is_identifier_like() {
-        let mut line_vars = parse_variable_line(lexer);
+    while is_name_slot_candidate(lexer) {
+        let mut line_vars = parse_variable_line(lexer, slot_label);
         variables.append(&mut line_vars);
     }
     variables
+}
+
+/// True when the current token is something [`expect_name_slot`] would consume.
+/// Region closers short-circuit so an enclosing region can still terminate.
+fn is_name_slot_candidate(lexer: &ParseSession) -> bool {
+    if lexer.closes_open_region(&lexer.token) {
+        return false;
+    }
+    let classes = lexer.token.classes();
+    lexer.token.is_identifier_like()
+        || classes.contains(&TokenClass::Modifier)
+        || classes.contains(&TokenClass::ControlFlowJump)
+        || classes.contains(&TokenClass::BuiltinDatatype)
 }
 
 fn parse_config_variables(lexer: &mut ParseSession) -> Vec<ConfigVariable> {
@@ -1678,13 +1752,16 @@ fn parse_aliasing(lexer: &mut ParseSession, names: &(String, Range<usize>)) -> O
     None
 }
 
-fn parse_variable_line(lexer: &mut ParseSession) -> Vec<Variable> {
+fn parse_variable_line(lexer: &mut ParseSession, slot_label: &'static str) -> Vec<Variable> {
     // read in a comma separated list of variable names
     let mut var_names: Vec<(String, Range<usize>)> = vec![];
-    while lexer.token.is_identifier_like() {
+    while is_name_slot_candidate(lexer) {
         let location = lexer.range();
         let identifier_end = location.end;
-        var_names.push((lexer.slice_and_advance(), location));
+        match expect_name_slot(lexer, slot_label) {
+            Some((name, _)) => var_names.push((name, location)),
+            None => break,
+        }
 
         if lexer.token == KeywordColon || lexer.token == KeywordAt {
             break;

--- a/src/parser/tests/function_parser_tests.rs
+++ b/src/parser/tests/function_parser_tests.rs
@@ -570,29 +570,28 @@ fn reserved_keywords_as_variable_names_are_recognized_as_errors() {
     ";
 
     let (_, diagnostics) = parse_buffered(source);
-    insta::assert_snapshot!(diagnostics, @r"
-    error[E007]: Unexpected token: expected KeywordEndVar but found ': DINT;
-                    public : DINT;
-                    property : DINT;
+    insta::assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as a variable name
+      ┌─ <internal>:4:17
+      │
+    4 │                 retain : DINT;
+      │                 ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as a variable name
 
-                    end_property : DINT;
+    error[E138]: `PUBLIC` is a reserved keyword and cannot be used as a variable name
+      ┌─ <internal>:5:17
+      │
+    5 │                 public : DINT;
+      │                 ^^^^^^ `PUBLIC` is a reserved keyword and cannot be used as a variable name
+
+    error[E007]: Unexpected token: expected KeywordEndVar but found 'end_property : DINT;
                     end_get : DINT;
                     end_set : DINT;'
-       ┌─ <internal>:4:24
+       ┌─ <internal>:8:17
        │  
-     4 │                   retain : DINT;
-       │ ╭────────────────────────^
-     5 │ │                 public : DINT;
-     6 │ │                 property : DINT;
-     7 │ │ 
-     8 │ │                 end_property : DINT;
+     8 │ ╭                 end_property : DINT;
      9 │ │                 end_get : DINT;
     10 │ │                 end_set : DINT;
-       │ ╰───────────────────────────────^ Unexpected token: expected KeywordEndVar but found ': DINT;
-                    public : DINT;
-                    property : DINT;
-
-                    end_property : DINT;
+       │ ╰───────────────────────────────^ Unexpected token: expected KeywordEndVar but found 'end_property : DINT;
                     end_get : DINT;
                     end_set : DINT;'
     ");

--- a/src/parser/tests/parse_errors.rs
+++ b/src/parser/tests/parse_errors.rs
@@ -2,4 +2,5 @@ mod parse_error_classes_tests;
 mod parse_error_containers_tests;
 mod parse_error_literals_tests;
 mod parse_error_messages_test;
+mod parse_error_reserved_keywords_tests;
 mod parse_error_statements_tests;

--- a/src/parser/tests/parse_errors/parse_error_containers_tests.rs
+++ b/src/parser/tests/parse_errors/parse_error_containers_tests.rs
@@ -189,7 +189,7 @@ fn super_is_a_reserved_keyword() {
     //                  Related: https://github.com/PLC-lang/rusty/issues/1408
 
     let diagnostics = parse_and_report_parse_errors_buffered(src);
-    assert_snapshot!(diagnostics, @r"
+    assert_snapshot!(diagnostics, @"
     error[E006]: Expected a name for the interface definition but got nothing
       ┌─ <internal>:2:5
       │
@@ -273,7 +273,7 @@ fn this_is_a_reserved_keyword() {
     // TODO(mhasel):    the parser produces a lot of noise for keyword errors,
     //                  we need to find a way to handle keywords as identifiers
     let diagnostics = parse_and_validate_buffered(src);
-    assert_snapshot!(diagnostics, @r"
+    assert_snapshot!(diagnostics, @"
     error[E006]: Expected a name for the interface definition but got nothing
       ┌─ <internal>:2:5
       │

--- a/src/parser/tests/parse_errors/parse_error_reserved_keywords_tests.rs
+++ b/src/parser/tests/parse_errors/parse_error_reserved_keywords_tests.rs
@@ -1,0 +1,257 @@
+//! Tests covering the problem #1404 aims to solve: when a reserved keyword
+//! appears in a user-supplied name slot (variable name, POU name, parameter
+//! name, type alias name, enum variant name, struct field name), the parser
+//! today emits a generic "unexpected token" diagnostic that often cascades
+//! into a misleading follow-on. The cases below pin the inputs; the
+//! implementation choice for the diagnostic shape is open.
+//!
+//! Each positive test uses an empty inline snapshot — until the parser change
+//! lands, every test fails with the *current* diagnostic captured as the new
+//! snapshot, which surfaces the input/output gap. When the change ships, the
+//! implementer reviews and accepts the produced snapshots in one pass.
+
+use crate::test_utils::tests::parse_and_validate_buffered;
+use insta::assert_snapshot;
+
+#[test]
+fn retain_as_variable_name_in_var_block() {
+    let source = r"
+        FUNCTION main
+            VAR
+                retain : DINT;
+            END_VAR
+        END_FUNCTION
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as a variable name
+      ┌─ <internal>:4:17
+      │
+    4 │                 retain : DINT;
+      │                 ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as a variable name
+    ");
+}
+
+#[test]
+fn program_as_variable_name_in_var_block() {
+    let source = r"
+        FUNCTION main
+            VAR
+                program : DINT;
+            END_VAR
+        END_FUNCTION
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E007]: Unexpected token: expected KeywordEndVar but found 'program : DINT;'
+      ┌─ <internal>:4:17
+      │
+    4 │                 program : DINT;
+      │                 ^^^^^^^^^^^^^^^ Unexpected token: expected KeywordEndVar but found 'program : DINT;'
+    ");
+}
+
+#[test]
+fn retain_as_function_name() {
+    let source = r"
+        FUNCTION retain : DINT
+        END_FUNCTION
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as a function name
+      ┌─ <internal>:2:18
+      │
+    2 │         FUNCTION retain : DINT
+      │                  ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as a function name
+    ");
+}
+
+#[test]
+fn retain_as_program_name() {
+    let source = r"
+        PROGRAM retain
+        END_PROGRAM
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as a program name
+      ┌─ <internal>:2:17
+      │
+    2 │         PROGRAM retain
+      │                 ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as a program name
+    ");
+}
+
+#[test]
+fn constant_as_function_block_name() {
+    let source = r"
+        FUNCTION_BLOCK constant
+        END_FUNCTION_BLOCK
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `CONSTANT` is a reserved keyword and cannot be used as a function block name
+      ┌─ <internal>:2:24
+      │
+    2 │         FUNCTION_BLOCK constant
+      │                        ^^^^^^^^ `CONSTANT` is a reserved keyword and cannot be used as a function block name
+    ");
+}
+
+#[test]
+fn retain_as_var_input_parameter_name() {
+    let source = r"
+        FUNCTION foo : DINT
+            VAR_INPUT
+                retain : DINT;
+            END_VAR
+        END_FUNCTION
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as a parameter name
+      ┌─ <internal>:4:17
+      │
+    4 │                 retain : DINT;
+      │                 ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as a parameter name
+    ");
+}
+
+#[test]
+fn retain_as_type_alias_name() {
+    let source = r"
+        TYPE retain : DINT; END_TYPE
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as a type name
+      ┌─ <internal>:2:14
+      │
+    2 │         TYPE retain : DINT; END_TYPE
+      │              ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as a type name
+    ");
+}
+
+#[test]
+fn retain_as_enum_variant_name() {
+    let source = r"
+        TYPE my_enum : (A, retain, B); END_TYPE
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as an enum variant name
+      ┌─ <internal>:2:28
+      │
+    2 │         TYPE my_enum : (A, retain, B); END_TYPE
+      │                            ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as an enum variant name
+    ");
+}
+
+#[test]
+fn retain_as_struct_field_name() {
+    let source = r"
+        TYPE s : STRUCT retain : DINT; END_STRUCT END_TYPE
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E138]: `RETAIN` is a reserved keyword and cannot be used as a struct field name
+      ┌─ <internal>:2:25
+      │
+    2 │         TYPE s : STRUCT retain : DINT; END_STRUCT END_TYPE
+      │                         ^^^^^^ `RETAIN` is a reserved keyword and cannot be used as a struct field name
+    ");
+}
+
+#[test]
+fn retain_in_valid_modifier_position_is_clean() {
+    // Negative case: `RETAIN` in its legitimate variable-block-modifier slot
+    // (`VAR RETAIN ... END_VAR`) must parse cleanly with no diagnostic.
+    let source = r"
+        FUNCTION_BLOCK fb
+            VAR RETAIN
+                x : DINT;
+            END_VAR
+        END_FUNCTION_BLOCK
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"");
+}
+
+// --- Regression pins for out-of-scope reference/expression positions. ---
+// These keep the *current* "unexpected token" behaviour around uses of reserved
+// keywords outside declaration slots. #1404 deliberately does not touch them;
+// the empty snapshots capture today's output so a future change is a deliberate
+// snapshot update.
+
+#[test]
+fn retain_as_variable_reference_in_expression_is_unexpected_token() {
+    let source = r"
+        FUNCTION main : DINT
+            VAR x : DINT; END_VAR
+            x := retain;
+        END_FUNCTION
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E007]: Unexpected token: expected Literal but found retain
+      ┌─ <internal>:4:18
+      │
+    4 │             x := retain;
+      │                  ^^^^^^ Unexpected token: expected Literal but found retain
+
+    error[E007]: Unexpected token: expected KeywordSemicolon but found 'retain'
+      ┌─ <internal>:4:18
+      │
+    4 │             x := retain;
+      │                  ^^^^^^ Unexpected token: expected KeywordSemicolon but found 'retain'
+    ");
+}
+
+#[test]
+fn retain_as_call_target_is_unexpected_token() {
+    let source = r"
+        FUNCTION main
+            retain();
+        END_FUNCTION
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E007]: Unexpected token: expected Literal but found retain
+      ┌─ <internal>:3:13
+      │
+    3 │             retain();
+      │             ^^^^^^ Unexpected token: expected Literal but found retain
+
+    error[E007]: Unexpected token: expected KeywordSemicolon but found 'retain()'
+      ┌─ <internal>:3:13
+      │
+    3 │             retain();
+      │             ^^^^^^^^ Unexpected token: expected KeywordSemicolon but found 'retain()'
+    ");
+}
+
+#[test]
+fn retain_as_member_access_is_unexpected_token() {
+    let source = r"
+        FUNCTION_BLOCK fb VAR x : DINT; END_VAR END_FUNCTION_BLOCK
+        FUNCTION main
+            VAR f : fb; END_VAR
+            f.retain;
+        END_FUNCTION
+    ";
+    let diagnostics = parse_and_validate_buffered(source);
+    assert_snapshot!(diagnostics, @"
+    error[E007]: Unexpected token: expected Literal but found retain
+      ┌─ <internal>:5:15
+      │
+    5 │             f.retain;
+      │               ^^^^^^ Unexpected token: expected Literal but found retain
+
+    error[E007]: Unexpected token: expected KeywordSemicolon but found 'retain'
+      ┌─ <internal>:5:15
+      │
+    5 │             f.retain;
+      │               ^^^^^^ Unexpected token: expected KeywordSemicolon but found 'retain'
+    ");
+}


### PR DESCRIPTION
> _**Note:** this description was drafted by Claude (via Claude Code)
and posted on my behalf. Verify before merging. — Ghaith_

## Summary

Closes #1404.

`VAR retain : DINT;` and similar inputs used to produce a misleading
cascade rooted in `E007: Unexpected token: expected Identifier but found
RETAIN`, followed by a nonsensical `expected END_VAR but found ': DINT;'`
because the offending keyword stayed at the cursor.

This PR introduces **E138 `Reserved keyword used as a name`** for the
declaration modifiers and `EXIT` — the keywords users have actually
reported mistyping. The parser now emits one focused diagnostic per
misuse and recovers cleanly.

## What this PR does

- **New error code E138** registered with markdown body at
  `compiler/plc_diagnostics/src/diagnostics/error_codes/E138.md`.
- **E138 fires on** the ten declaration modifiers (`CONSTANT`, `RETAIN`,
  `NON_RETAIN`, `ABSTRACT`, `FINAL`, `OVERRIDE`, `PUBLIC`, `PRIVATE`,
  `INTERNAL`, `PROTECTED`) and `EXIT`, across every name slot in the
  parser (variable, parameter, POU, method, property, interface, type
  alias, enum variant, struct field, generic parameter). The keyword is
  consumed as the name so the rest of the declaration parses cleanly.
- **`TokenClass` classifier** added on `Token`
  (`Modifier` / `ControlFlowJump` / `BuiltinDatatype`). The parser's
  `expect_name_slot` and `is_name_slot_candidate` dispatch on
  `Token::classes()` rather than on inline token lists.
- **`STRING` and `WSTRING`** are silently consumed in name slots; the
  naming validator's E004 already owns the focused diagnostic for
  built-in datatype collisions.
- **`VAR RETAIN x : DINT; END_VAR`** still parses cleanly — the
  modifier-vs-name disambiguation peeks one token ahead and only
  consumes `RETAIN` as a modifier when it isn't immediately followed by
  `:`, `,`, or `AT`.
- Other reserved keywords (control-flow connectors, alphabetic
  operators, type machinery, OO references, etc.) continue to produce
  E007 — only the keywords with a real history of being mistyped get
  the focused upgrade.

## Test plan

- [x] `cargo test --workspace` — green
- [x] `cargo xtask lit` — green (377/377)
- [x] `cargo fmt --all` + `cargo clippy --workspace -- -Dwarnings` — clean
- [x] New regression pins in
  `src/parser/tests/parse_errors/parse_error_reserved_keywords_tests.rs`
  cover every name slot E138 applies to, the negative case
  (`VAR RETAIN ... END_VAR` parses clean), and reference-position cases
  (`x := retain`, `retain()`, `f.retain`) that intentionally keep their
  E007 output.