### PR TITLE
fix(preprocessor): bind POU-scoped AT addresses to backing __PI_* global

### DIFF
--- a/compiler/plc_ast/src/pre_processor.rs
+++ b/compiler/plc_ast/src/pre_processor.rs
@@ -344,6 +344,15 @@ fn process_struct_hardware_variables(
     update_generated_globals(unit, mangled_globals);
 }
 
+/// Processes POU-scoped variables declared with IEC hardware addresses (e.g. `AT %IX1.2.3.4`).
+/// For each such variable, creates a backing global (`__PI_1_2_3_4`) and sets the variable's
+/// initializer to reference it so the lowering emits the alias-pointer binding on entry.
+///
+/// Runs *before* `process_global_variables` and `process_struct_hardware_variables` in
+/// `pre_process`. When multiple declarations share one hardware address with different element
+/// types, whichever pass inserts into `known_hw_globals` first owns the backing global's
+/// allocation type, so today a POU declaration wins over a VAR_GLOBAL or struct member at the
+/// same address. TODO: cross-declaration type mismatches are not yet diagnosed.
 fn process_pou_hardware_variables(
     unit: &mut CompilationUnit,
     id_provider: &mut IdProvider,

--- a/compiler/plc_ast/src/pre_processor.rs
+++ b/compiler/plc_ast/src/pre_processor.rs
@@ -17,6 +17,25 @@ use crate::{
 use plc_source::source_location::SourceLocation;
 
 pub fn pre_process(unit: &mut CompilationUnit, mut id_provider: IdProvider) {
+    // XXX: Track which hardware-backing globals (__PI_*, __M_*, __G_*) have already been created.
+    // Seeded from existing globals so re-runs of the pipeline (e.g. lowering re-indexes) don't
+    // produce duplicates. This is a workaround for the fact that pre_process is called multiple
+    // times during the pipeline and should be removed when the lowering phase is refactored.
+    let mut known_hw_globals: rustc_hash::FxHashSet<String> = unit
+        .global_vars
+        .iter()
+        .flat_map(|block| &block.variables)
+        .filter(|var| {
+            var.name.starts_with("__PI_") || var.name.starts_with("__M_") || var.name.starts_with("__G_")
+        })
+        .map(|var| var.name.clone())
+        .collect();
+
+    // POU-scoped variables with a complete hardware address (FB / PROGRAM / FUNCTION / METHOD
+    // blocks) — handled before the data-type rewrite below so the still-inline alias-pointer
+    // definition unwraps to the pointee type for the synthesized backing global.
+    process_pou_hardware_variables(unit, &mut id_provider, &mut known_hw_globals);
+
     //process all local variables from POUs
     for pou in unit.pous.iter_mut() {
         //Find all generic types in that pou
@@ -35,20 +54,6 @@ pub fn pre_process(unit: &mut CompilationUnit, mut id_provider: IdProvider) {
             process_property(property, &interface.ident.name, LinkageType::Internal, &mut unit.user_types);
         }
     }
-
-    // XXX: Track which hardware-backing globals (__PI_*, __M_*, __G_*) have already been created.
-    // Seeded from existing globals so re-runs of the pipeline (e.g. lowering re-indexes) don't
-    // produce duplicates. This is a workaround for the fact that pre_process is called multiple
-    // times during the pipeline and should be removed when the lowering phase is refactored.
-    let mut known_hw_globals: rustc_hash::FxHashSet<String> = unit
-        .global_vars
-        .iter()
-        .flat_map(|block| &block.variables)
-        .filter(|var| {
-            var.name.starts_with("__PI_") || var.name.starts_with("__M_") || var.name.starts_with("__G_")
-        })
-        .map(|var| var.name.clone())
-        .collect();
 
     //process all variables from GVLs
     process_global_variables(unit, &mut id_provider, &mut known_hw_globals);
@@ -332,6 +337,50 @@ fn process_struct_hardware_variables(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    update_generated_globals(unit, mangled_globals);
+}
+
+fn process_pou_hardware_variables(
+    unit: &mut CompilationUnit,
+    id_provider: &mut IdProvider,
+    known_hw_globals: &mut rustc_hash::FxHashSet<String>,
+) {
+    let mut mangled_globals = Vec::new();
+
+    for pou in unit.pous.iter_mut() {
+        for var in pou.variable_blocks.iter_mut().flat_map(|b| b.variables.iter_mut()) {
+            let Some(ref node) = var.address else { continue };
+            let AstStatement::HardwareAccess(hardware) = &node.stmt else { continue };
+
+            // Incomplete `AT %I*` placeholders are bound at runtime via VAR_CONFIG; E136 already
+            // rejects them in FUNCTION / METHOD.
+            if hardware.is_template() {
+                continue;
+            }
+
+            let name = hardware.get_mangled_variable_name();
+            let ref_ty = var.data_type_declaration.get_inner_pointer_ty();
+
+            let mangled_initializer = AstFactory::create_member_reference(
+                AstFactory::create_identifier(&name, SourceLocation::internal(), id_provider.next_id()),
+                None,
+                id_provider.next_id(),
+            );
+
+            var.initializer = Some(mangled_initializer);
+
+            if known_hw_globals.insert(name.clone()) {
+                mangled_globals.push(Variable {
+                    name,
+                    data_type_declaration: ref_ty.unwrap_or(var.data_type_declaration.clone()),
+                    initializer: None,
+                    address: None,
+                    location: node.location.clone(),
+                });
             }
         }
     }

--- a/src/codegen/tests/address_tests.rs
+++ b/src/codegen/tests/address_tests.rs
@@ -163,3 +163,96 @@ fn struct_member_with_hardware_address() {
     @__PI_1_2_3_4 = global i8 0
     "#);
 }
+
+#[test]
+fn aliased_address_on_function_block_member_generates_backing_global() {
+    // Issue #1736: A complete hardware address (AT %IX...) on a POU-scoped variable used to be
+    // silently dropped — the FB field stayed null and the first access SIGSEGV'd at runtime.
+    // The preprocessor now mirrors the VAR_GLOBAL / STRUCT-member path: it synthesises the
+    // backing __PI_1_2_3_4 global and sets the member's initializer so the FB instance ctor
+    // (emitted in the lowering pass) binds the field with a `store ptr @__PI_..., ptr %in1`.
+    // This snapshot covers the codegen-visible artifacts (alias-pointer field and backing
+    // global); the lit test `var_global_and_fb_share_hw_address.st` covers the runtime binding.
+    let res = codegen(
+        r"
+            FUNCTION_BLOCK probe
+            VAR_INPUT
+                in1 AT %IX1.2.3.4 : BOOL;
+            END_VAR
+            END_FUNCTION_BLOCK
+
+            PROGRAM mainProg
+            VAR p : probe; END_VAR
+                p();
+            END_PROGRAM
+        ",
+    );
+
+    filtered_assert_snapshot!(res, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %mainProg = type { %probe }
+    %probe = type { ptr }
+
+    @__PI_1_2_3_4 = global i8 0
+    @mainProg_instance = global %mainProg zeroinitializer
+
+    define void @probe(ptr %0) {
+    entry:
+      %this = alloca ptr, align [filtered]
+      store ptr %0, ptr %this, align [filtered]
+      %in1 = getelementptr inbounds nuw %probe, ptr %0, i32 0, i32 0
+      ret void
+    }
+
+    define void @mainProg(ptr %0) {
+    entry:
+      %p = getelementptr inbounds nuw %mainProg, ptr %0, i32 0, i32 0
+      call void @probe(ptr %p)
+      ret void
+    }
+    "#);
+}
+
+#[test]
+fn aliased_address_shared_across_var_global_and_function_block() {
+    // Issue #1736: a VAR_GLOBAL and an FB VAR_INPUT at the same address must share one backing
+    // global. The known_hw_globals dedup in the preprocessor ensures `__PI_1_2_3_4` is emitted
+    // exactly once even though both declarations would otherwise synthesise it.
+    let res = codegen(
+        r"
+            VAR_GLOBAL
+                slot AT %IX1.2.3.4 : BOOL;
+            END_VAR
+
+            FUNCTION_BLOCK probe
+            VAR_INPUT
+                shadow AT %IX1.2.3.4 : BOOL;
+            END_VAR
+            END_FUNCTION_BLOCK
+        ",
+    );
+
+    filtered_assert_snapshot!(res, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %probe = type { ptr }
+
+    @slot = global ptr null
+    @__PI_1_2_3_4 = global i8 0
+
+    define void @probe(ptr %0) {
+    entry:
+      %this = alloca ptr, align [filtered]
+      store ptr %0, ptr %this, align [filtered]
+      %shadow = getelementptr inbounds nuw %probe, ptr %0, i32 0, i32 0
+      ret void
+    }
+    "#);
+}

--- a/tests/lit/single/address/fn_local_at_round_trip.st
+++ b/tests/lit/single/address/fn_local_at_round_trip.st
@@ -1,0 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Probe for #1737 follow-up: a FUNCTION-scoped VAR with `AT %M...` should bind its alias
+// pointer to the synthesised backing global on entry, so the write below ends up at the
+// same hardware slot a VAR_GLOBAL alias would observe.
+
+VAR_GLOBAL
+    g AT %MX1.2.3.4 : BYTE;
+END_VAR
+
+FUNCTION writer : DINT
+VAR
+    local AT %MX1.2.3.4 : BYTE;
+END_VAR
+    local := 7;
+    writer := DINT#0;
+END_FUNCTION
+
+FUNCTION main : DINT
+    writer();
+    // CHECK: 7
+    printf('%d$N', g);
+END_FUNCTION

--- a/tests/lit/single/address/method_var_at_round_trip.st
+++ b/tests/lit/single/address/method_var_at_round_trip.st
@@ -1,0 +1,29 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// #1737 coverage: a METHOD-scoped VAR with `AT %M...` should alias-bind on method
+// entry and round-trip a write to the backing hardware slot.
+
+VAR_GLOBAL
+    g AT %MX3.4.5.6 : BYTE;
+END_VAR
+
+FUNCTION_BLOCK probeFb
+    METHOD writer
+    VAR
+        local AT %MX3.4.5.6 : BYTE;
+    END_VAR
+        local := 17;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+PROGRAM mainProg
+VAR
+    p : probeFb;
+END_VAR
+    p.writer();
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+    // CHECK: 17
+    printf('%d$N', g);
+END_FUNCTION

--- a/tests/lit/single/address/method_var_temp_at_round_trip.st
+++ b/tests/lit/single/address/method_var_temp_at_round_trip.st
@@ -1,0 +1,29 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// #1737 coverage: a METHOD-scoped VAR_TEMP with `AT %M...` (temporary, per-call) should
+// alias-bind on entry and round-trip a write to the backing hardware slot.
+
+VAR_GLOBAL
+    g AT %MX4.5.6.7 : BYTE;
+END_VAR
+
+FUNCTION_BLOCK probeFb
+    METHOD writer
+    VAR_TEMP
+        local AT %MX4.5.6.7 : BYTE;
+    END_VAR
+        local := 23;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+PROGRAM mainProg
+VAR
+    p : probeFb;
+END_VAR
+    p.writer();
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+    // CHECK: 23
+    printf('%d$N', g);
+END_FUNCTION

--- a/tests/lit/single/address/program_local_at_round_trip.st
+++ b/tests/lit/single/address/program_local_at_round_trip.st
@@ -1,0 +1,21 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// #1737 coverage: a PROGRAM-scoped VAR with `AT %M...` should bind its alias on the
+// per-instance ctor, so the write below ends up at the same hardware slot a
+// VAR_GLOBAL alias at the same address observes.
+
+VAR_GLOBAL
+    g AT %MX2.3.4.5 : BYTE;
+END_VAR
+
+PROGRAM probeProg
+VAR
+    local AT %MX2.3.4.5 : BYTE;
+END_VAR
+    local := 11;
+END_PROGRAM
+
+FUNCTION main : DINT
+    probeProg();
+    // CHECK: 11
+    printf('%d$N', g);
+END_FUNCTION

--- a/tests/lit/single/address/var_global_and_fb_share_hw_address.st
+++ b/tests/lit/single/address/var_global_and_fb_share_hw_address.st
@@ -1,0 +1,30 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Issue #1736: a complete hardware address (AT %MX1.2.3.4) on a POU-scoped variable used to be
+// silently dropped at codegen — the FB field stayed null and the first access SIGSEGV'd at
+// runtime. The preprocessor now synthesises the backing __M_1_2_3_4 global and the existing
+// alias-pointer lowering binds the FB field in the per-instance ctor. The VAR_GLOBAL `slot`
+// and the FB `shadow` must end up bound to the *same* `__M_1_2_3_4` slot.
+
+VAR_GLOBAL
+    slot AT %MX1.2.3.4 : BYTE;
+END_VAR
+
+FUNCTION_BLOCK probe
+VAR_INPUT
+    shadow AT %MX1.2.3.4 : BYTE;
+END_VAR
+    shadow := 42;
+END_FUNCTION_BLOCK
+
+PROGRAM mainProg
+VAR
+    p : probe;
+END_VAR
+    p();
+    // CHECK: 42
+    printf('%d$N', slot);
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+END_FUNCTION


### PR DESCRIPTION
## Summary

Fixes #1736 — a complete hardware-address binding (`AT %IX...`,
`AT %MX...`) on any POU-scoped variable used to compile silently
with the alias pointer unbound. The first access SIGSEGV'd at
`-O none -g`, even when the same address was correctly declared in
a `VAR_GLOBAL` elsewhere.

`process_global_variables` and `process_struct_hardware_variables`
already auto-create the backing `__PI_*` global and set the
declaring variable's initializer so the lowering emits a `REF=`
binding in the per-unit / per-instance ctor. The analogous handler
for POU members never existed.

## Fix

New `process_pou_hardware_variables` in
`compiler/plc_ast/src/pre_processor.rs` mirrors the existing paths
and runs **before** `process_pou_variables` (so the still-inline
alias-pointer definition unwraps cleanly to the pointee type for
the synthesised backing global).

The `known_hw_globals` dedup set is shared with the existing global
/ struct paths, so a `VAR_GLOBAL` and an FB / PROGRAM / FUNCTION /
METHOD declaration at the same address end up bound to **one**
backing slot.

## Scope notes (revised during design review)

Two earlier proposals from the issue body were dropped:

- **Strict "must originate in VAR_GLOBAL" rule.** Too strict — the
  canonical declaration of an address can legitimately be a STRUCT
  member nested inside a VAR_GLOBAL instance. Auto-create instead
  (same as struct / global today).
- **Reject complete addresses in FUNCTION / METHOD.** Wrong — a
  complete address works fine in a function (the alias pointer
  binds and the body reads / writes correctly). Only incomplete
  `AT %I*` is invalid in functions; existing E136 already covers
  that.

A consistency diagnostic for cross-declaration type mismatches
(VAR_GLOBAL says BOOL, FB says DINT at the same address) and
proper cross-unit dependency routing for the synthesised backing
global (today: relies on BSS coalescing, same as the existing
VAR_GLOBAL path) are noted as follow-ups.

## Test plan

- [x] `cargo test --workspace` — clean
- [x] `cargo xtask lit` — 364 PASS / 14 expected-fail / no
      regressions
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace -- -Dwarnings`
- [x] Issue's repro (`FUNCTION_BLOCK foo VAR_INPUT in1 AT %MX...`
      + mainProg) — segfault (exit 139) before, exit 0 after
- [x] New IR snapshot
      `aliased_address_on_function_block_member_generates_backing_global`
      and `aliased_address_shared_across_var_global_and_function_block`
      in `src/codegen/tests/address_tests.rs`
- [x] New lit test
      `tests/lit/single/address/var_global_and_fb_share_hw_address.st`
      writes via the FB alias and reads via the global; expects 42

## Files changed

- `compiler/plc_ast/src/pre_processor.rs` — new
  `process_pou_hardware_variables`; reordered `pre_process` so
  `known_hw_globals` initialises before the new pass runs.
- `src/codegen/tests/address_tests.rs` — two new IR snapshots.
- `tests/lit/single/address/var_global_and_fb_share_hw_address.st` —
  new runtime lit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
