### PR TITLE
ci(release-assets): drop sparse-checkout from workflow_dispatch backfill

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -25,16 +25,14 @@ jobs:
       # `workflow_dispatch` needs `resolve-tag-sha.sh` on disk before the
       # `Resolve source request` step runs. The later `Checkout release commit`
       # step depends on the SHA that step produces, so it cannot do the
-      # checkout itself (chicken-and-egg). Pull just `.github/scripts/` here;
-      # `Checkout release commit` then replaces the workspace with the source
-      # SHA as before.
+      # checkout itself (chicken-and-egg). Do a plain checkout of the default
+      # branch here; `Checkout release commit` then re-checks out at the
+      # source SHA (`actions/checkout` defaults to `clean: true`, so the
+      # workspace is fully replaced).
       - name: Checkout repository scripts
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            .github/scripts
-          sparse-checkout-cone-mode: false
           fetch-depth: 1
 
       - name: Resolve source request


### PR DESCRIPTION
## Summary

Follow-up to #1734 (the #1727 fix). The first dispatch run after
that PR merged caught a regression I'd missed:
[run #25806608759](https://github.com/PLC-lang/rusty/actions/runs/25806608759)
exercised `gh workflow run "Release Assets" -f tag=v0.5.0`. The
previously-broken steps (`Resolve source request`,
`Checkout release commit`) cleared cleanly — but a *different* step
failed:

```
grep: Cargo.toml: No such file or directory
Requested tag v0.5.0 does not match Cargo.toml version v
##[error]Process completed with exit code 1.
```

## Root cause

PR #1734 added an early `Checkout repository scripts` step that uses
`sparse-checkout: .github/scripts`. `actions/checkout` writes
`.git/info/sparse-checkout` into the workspace; the subsequent
`Checkout release commit` step in the same job inherited that
filter, so it only re-fetched `.github/scripts/` at the source SHA.
`Cargo.toml` was therefore absent when the next step tried to
`grep '^version' Cargo.toml`.

## Fix

Drop the sparse-checkout. `actions/checkout` defaults to
`clean: true`, so the second `Checkout release commit` step fully
replaces the workspace at the source SHA. The trade-off is one
full clone of the default branch before \`Resolve source request\`
runs; for this repo (~50 MB) that's negligible.

## Test plan

After merge:
- [ ] \`gh workflow run "Release Assets" -f tag=v0.5.0\` —
      \`Get release version from Cargo.toml\` now finds the file;
      run proceeds through asset upload (re-uploads the same
      artifacts already manually published, so customer-safe).
- [ ] Confirm the \`workflow_run\` auto-fire path (next merge to
      master that triggers Build Linux / Build Windows) still works
      — unchanged in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)