### PR TITLE
fix(codegen): drop ptr→aggregate bitcast on by-ref argument pass

### DIFF
--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_in_different_locations_with_debug_info.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_in_different_locations_with_debug_info.snap
@@ -9,41 +9,36 @@ target triple = "[filtered]"
 
 %mainProg = type {}
 
-@mainProg_instance = external global %mainProg, !dbg !0
+@mainProg_instance = external global %mainProg
 
-define i32 @main() !dbg !10 {
+define i32 @main() !dbg !4 {
 entry:
   %main = alloca i32, align [filtered]
-    #dbg_declare(ptr %main, !13, !DIExpression(), !15)
+    #dbg_declare(ptr %main, !8, !DIExpression(), !10)
   store i32 0, ptr %main, align [filtered]
-  call void @mainProg(ptr @mainProg_instance), !dbg !16
-  %main_ret = load i32, ptr %main, align [filtered], !dbg !17
-  ret i32 %main_ret, !dbg !17
+  call void @mainProg(ptr @mainProg_instance), !dbg !11
+  %main_ret = load i32, ptr %main, align [filtered], !dbg !12
+  ret i32 %main_ret, !dbg !12
 }
 
 declare void @mainProg(ptr)
 
-!llvm.module.flags = !{!5, !6}
-!llvm.dbg.cu = !{!7}
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
 
-!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
-!1 = distinct !DIGlobalVariable(name: "mainProg", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
-!2 = !DIFile(filename: "lib/file2.st", directory: "root")
-!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "mainProg", scope: !2, file: !2, line: 2, align [filtered], flags: DIFlagPublic, elements: !4, identifier: "mainProg")
-!4 = !{}
-!5 = !{i32 2, !"Dwarf Version", i32 5}
-!6 = !{i32 2, !"Debug Info Version", i32 3}
-!7 = distinct !DICompileUnit(language: DW_LANG_C, file: !8, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !9, splitDebugInlining: false)
-!8 = !DIFile(filename: "app/file1.st", directory: "root")
-!9 = !{!0}
-!10 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !8, file: !8, line: 2, type: !11, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !7, retainedNodes: !4)
-!11 = !DISubroutineType(flags: DIFlagPublic, types: !12)
-!12 = !{null}
-!13 = !DILocalVariable(name: "main", scope: !10, file: !8, line: 2, type: !14, align [filtered])
-!14 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-!15 = !DILocation(line: 2, column: 13, scope: !10)
-!16 = !DILocation(line: 10, column: 4, scope: !10)
-!17 = !DILocation(line: 11, column: 4, scope: !10)
+!0 = !{i32 2, !"Dwarf Version", i32 5}
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+!2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!3 = !DIFile(filename: "app/file1.st", directory: "root")
+!4 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !3, file: !3, line: 2, type: !5, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !7)
+!5 = !DISubroutineType(flags: DIFlagPublic, types: !6)
+!6 = !{null}
+!7 = !{}
+!8 = !DILocalVariable(name: "main", scope: !4, file: !3, line: 2, type: !9, align [filtered])
+!9 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+!10 = !DILocation(line: 2, column: 13, scope: !4)
+!11 = !DILocation(line: 10, column: 4, scope: !4)
+!12 = !DILocation(line: 11, column: 4, scope: !4)
 
 ; ModuleID = 'lib/file2.st'
 source_filename = "lib/file2.st"

--- a/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_with_debug_info.snap
+++ b/compiler/plc_driver/src/tests/snapshots/plc_driver__tests__multi_files__multiple_files_with_debug_info.snap
@@ -9,41 +9,36 @@ target triple = "[filtered]"
 
 %mainProg = type {}
 
-@mainProg_instance = external global %mainProg, !dbg !0
+@mainProg_instance = external global %mainProg
 
-define i32 @main() !dbg !10 {
+define i32 @main() !dbg !4 {
 entry:
   %main = alloca i32, align [filtered]
-    #dbg_declare(ptr %main, !13, !DIExpression(), !15)
+    #dbg_declare(ptr %main, !8, !DIExpression(), !10)
   store i32 0, ptr %main, align [filtered]
-  call void @mainProg(ptr @mainProg_instance), !dbg !16
-  %main_ret = load i32, ptr %main, align [filtered], !dbg !17
-  ret i32 %main_ret, !dbg !17
+  call void @mainProg(ptr @mainProg_instance), !dbg !11
+  %main_ret = load i32, ptr %main, align [filtered], !dbg !12
+  ret i32 %main_ret, !dbg !12
 }
 
 declare void @mainProg(ptr)
 
-!llvm.module.flags = !{!5, !6}
-!llvm.dbg.cu = !{!7}
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
 
-!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
-!1 = distinct !DIGlobalVariable(name: "mainProg", scope: !2, file: !2, line: 2, type: !3, isLocal: false, isDefinition: true)
-!2 = !DIFile(filename: "file2.st", directory: "root")
-!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "mainProg", scope: !2, file: !2, line: 2, align [filtered], flags: DIFlagPublic, elements: !4, identifier: "mainProg")
-!4 = !{}
-!5 = !{i32 2, !"Dwarf Version", i32 5}
-!6 = !{i32 2, !"Debug Info Version", i32 3}
-!7 = distinct !DICompileUnit(language: DW_LANG_C, file: !8, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !9, splitDebugInlining: false)
-!8 = !DIFile(filename: "file1.st", directory: "root")
-!9 = !{!0}
-!10 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !8, file: !8, line: 2, type: !11, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !7, retainedNodes: !4)
-!11 = !DISubroutineType(flags: DIFlagPublic, types: !12)
-!12 = !{null}
-!13 = !DILocalVariable(name: "main", scope: !10, file: !8, line: 2, type: !14, align [filtered])
-!14 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
-!15 = !DILocation(line: 2, column: 13, scope: !10)
-!16 = !DILocation(line: 10, column: 4, scope: !10)
-!17 = !DILocation(line: 11, column: 4, scope: !10)
+!0 = !{i32 2, !"Dwarf Version", i32 5}
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+!2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!3 = !DIFile(filename: "file1.st", directory: "root")
+!4 = distinct !DISubprogram(name: "main", linkageName: "main", scope: !3, file: !3, line: 2, type: !5, scopeLine: 10, flags: DIFlagPublic, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !7)
+!5 = !DISubroutineType(flags: DIFlagPublic, types: !6)
+!6 = !{null}
+!7 = !{}
+!8 = !DILocalVariable(name: "main", scope: !4, file: !3, line: 2, type: !9, align [filtered])
+!9 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
+!10 = !DILocation(line: 2, column: 13, scope: !4)
+!11 = !DILocation(line: 10, column: 4, scope: !4)
+!12 = !DILocation(line: 11, column: 4, scope: !4)
 
 ; ModuleID = 'file2.st'
 source_filename = "file2.st"

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -1314,8 +1314,12 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
             };
 
             // From https://llvm.org/docs/LangRef.html#bitcast-to-instruction: The ‘bitcast’ instruction takes
-            // a value to cast, which must be a **non-aggregate** first class value [...]
-            if !actual_type_info.is_aggregate() && actual_type_info != target_type_info {
+            // a value to cast, which must be a **non-aggregate** first class value, and a type to cast it to,
+            // which must also be a non-aggregate first class type.
+            if !actual_type_info.is_aggregate()
+                && !target_type_info.is_aggregate()
+                && actual_type_info != target_type_info
+            {
                 return Ok(self.llvm.builder.build_bit_cast(
                     value,
                     self.llvm_index.get_associated_type(hint.get_name())?,

--- a/src/codegen/generators/variable_generator.rs
+++ b/src/codegen/generators/variable_generator.rs
@@ -89,8 +89,13 @@ impl<'ctx, 'b> VariableGenerator<'ctx, 'b> {
             })?;
             index.associate_global(name, global_variable)?;
 
-            if !self.global_index.is_enum_variant(variable.get_qualified_name()) {
-                // generate debug info for non-enum-variant variables
+            if !self.global_index.is_enum_variant(variable.get_qualified_name())
+                && !linkage.is_external_or_included()
+            {
+                // Generate debug info for non-enum-variant variables defined in this unit.
+                // External/included declarations are owned by another module, and attaching
+                // !dbg metadata here keeps them as unresolved references in the final object
+                // at `-Onone` (default optimisation DCEs them, hiding the issue).
                 self.debug.create_global_variable(
                     variable.get_qualified_name(),
                     &variable.data_type_name,

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__external_impl_is_not_added_as_external_subroutine.snap
@@ -9,7 +9,7 @@ target triple = "[filtered]"
 
 %myPrg = type {}
 
-@myPrg_instance = external global %myPrg, !dbg !0
+@myPrg_instance = external global %myPrg
 
 declare i32 @myFunc()
 
@@ -17,15 +17,10 @@ declare void @myPrg(ptr)
 
 declare void @myFb(ptr)
 
-!llvm.module.flags = !{!5, !6}
-!llvm.dbg.cu = !{!7}
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
 
-!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
-!1 = distinct !DIGlobalVariable(name: "myPrg", scope: !2, file: !2, line: 4, type: !3, isLocal: false, isDefinition: true)
-!2 = !DIFile(filename: "<internal>", directory: "")
-!3 = !DICompositeType(tag: DW_TAG_structure_type, name: "myPrg", scope: !2, file: !2, line: 4, align [filtered], flags: DIFlagPublic, elements: !4, identifier: "myPrg")
-!4 = !{}
-!5 = !{i32 2, !"Dwarf Version", i32 5}
-!6 = !{i32 2, !"Debug Info Version", i32 3}
-!7 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !8, splitDebugInlining: false)
-!8 = !{!0}
+!0 = !{i32 2, !"Dwarf Version", i32 5}
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+!2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "RuSTy Structured text Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!3 = !DIFile(filename: "<internal>", directory: "")

--- a/tests/lit/ir_tests/var_input_aggregate_pass_by_ref.st
+++ b/tests/lit/ir_tests/var_input_aggregate_pass_by_ref.st
@@ -1,0 +1,20 @@
+// RUN: %COMPILE_IR %s | %CHECK_IR %s
+
+// Aggregate VAR_INPUT arguments must be passed by pointer; emitting
+// `bitcast ptr -> [N x T]` is invalid IR. See #1718.
+
+FUNCTION foo
+   VAR_INPUT
+       arr : ARRAY[1..3] OF DINT;
+   END_VAR
+END_FUNCTION
+
+FUNCTION main
+   foo([1, 2, 3]);
+END_FUNCTION
+
+// CHECK-LABEL: define {{.*}}@main
+// CHECK:       %{{[a-zA-Z0-9_.]+}} = alloca [3 x i32]
+// CHECK:       store [3 x i32]
+// CHECK:       call {{.*}}@foo(ptr {{.*}})
+// CHECK-NOT:   bitcast ptr {{.*}} to [

--- a/tests/lit/multi/pic_flags/run.test
+++ b/tests/lit/multi/pic_flags/run.test
@@ -1,7 +1,4 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: opt-none
-// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): builds
-// and runs under default optimization; runtime fails under `-Onone`.
 
 // === Part 1: Compile multi-file objects with PIC and no-PIC, link to executables ===
 

--- a/tests/lit/single/init/var_input_defaults_function_array_string.st
+++ b/tests/lit/single/init/var_input_defaults_function_array_string.st
@@ -1,7 +1,4 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// UNSUPPORTED: opt-none
-// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): segfaults
-// when compiled with `-Onone`; passes at the default optimization level.
 
 // Test VAR_INPUT defaults with STRING/ARRAY and mixed overrides
 

--- a/tests/lit/single/init/var_input_defaults_function_wstring.st
+++ b/tests/lit/single/init/var_input_defaults_function_wstring.st
@@ -1,8 +1,5 @@
 
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// UNSUPPORTED: opt-none
-// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): segfaults
-// when compiled with `-Onone`; passes at the default optimization level.
 // Test VAR_INPUT defaults with WSTRING and overrides
 
 TYPE ArrType : ARRAY[1..3] OF DINT;

--- a/tests/lit/single/var_input/var_input_arrays.st
+++ b/tests/lit/single/var_input/var_input_arrays.st
@@ -1,7 +1,4 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// UNSUPPORTED: opt-none
-// FIXME (tracked in the `-Onone` triage issue, follow-up to #1345): segfaults
-// when compiled with `-Onone`; passes at the default optimization level.
 
 FUNCTION foo
    VAR_INPUT


### PR DESCRIPTION
> _Drafted by Claude (Opus 4.7). Reviewer judgement applies as normal._

Fixes the four `-Onone` failures tracked in #1718. Two distinct codegen bugs, both masked at default optimisation by LLVM IR passes:

- **`ptr→aggregate` bitcast on by-ref argument pass.** The guard at the by-ref argument codegen site only checked the source of the bitcast; LLVM requires both source and target to be non-aggregate. With opaque pointers the source is always `ptr`, so an aggregate hint (ARRAY / STRUCT / STRING) produced invalid IR like `bitcast ptr to [N x i32]`. At default-opt the IR-pass pipeline rewrote it; under `-Onone` it survived to SelectionDAG and segfaulted in `DAGTypeLegalizer::PromoteIntOp_ANY_EXTEND`.
- **`!dbg` metadata on external global declarations.** Stdlib CONSTANTs pulled in via `-i <header>.st` had debug-info attached even though the definition lives in another module. The metadata kept the declaration alive as an undefined symbol in the emitted object; at default-opt DCE removed it, under `-Onone` it survived and broke link-time consumers of the produced shared libraries.

Drops `// UNSUPPORTED: opt-none` from four lit tests (`var_input_arrays.st`, the two `var_input_defaults_function_*.st`, and `pic_flags/run.test`). Adds an IR-level FILECHECK regression test for the bitcast. Three existing snapshots updated — each diff is a removal of an `!dbg` attachment on an external global plus the now-unused DI nodes.

plc does not run `LLVMVerifyModule` before handing the module to the backend; that is why an invalid `bitcast` reached SelectionDAG instead of being rejected with a clear diagnostic. Worth a separate follow-up.

Closes #1718.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo xtask lit --opt-levels default,none` — 364 / 378 pass, 14 XFAIL baseline, 0 fail, 0 unsupported
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace -- -Dwarnings`