### PR TITLE
perf(driver): skip lowering hooks whose preconditions don't hold

### DIFF
--- a/compiler/plc_driver/src/pipelines/participant.rs
+++ b/compiler/plc_driver/src/pipelines/participant.rs
@@ -15,6 +15,7 @@ use std::{
 use ast::provider::IdProvider;
 use plc::{
     codegen::GeneratedModule,
+    index::{Index, PouIndexEntry},
     lowering::{calls::AggregateTypeLowerer, polymorphism::PolymorphismLowerer},
     output::FormatOption,
     ConfigFormat, OnlineChange, Target,
@@ -294,6 +295,13 @@ impl PipelineParticipantMut for InheritanceLowerer {
     }
 
     fn post_annotate(&mut self, annotated_project: AnnotatedProject) -> AnnotatedProject {
+        // Skip if the project declares no inheritance or interfaces — the
+        // visit would be a no-op and the implicit re-annotate would only
+        // recompute the same annotations.
+        if !project_uses_inheritance(&annotated_project.index) {
+            return annotated_project;
+        }
+
         let AnnotatedProject { mut units, index, annotations, diagnostics } = annotated_project;
         self.annotations = Some(Box::new(annotations));
         self.index = Some(index);
@@ -315,6 +323,13 @@ impl PipelineParticipantMut for InheritanceLowerer {
 
 impl PipelineParticipantMut for AggregateTypeLowerer {
     fn post_annotate(&mut self, annotated_project: AnnotatedProject) -> AnnotatedProject {
+        // Skip if no POU has an aggregate return type — the visit would walk
+        // every unit and rewrite nothing, and the implicit re-index +
+        // re-annotate would reproduce the existing state.
+        if !project_has_aggregate_returns(&annotated_project.index) {
+            return annotated_project;
+        }
+
         let AnnotatedProject { units, index, annotations, diagnostics } = annotated_project;
         self.index = Some(index);
         self.annotation = Some(Box::new(annotations));
@@ -338,6 +353,15 @@ impl PipelineParticipantMut for AggregateTypeLowerer {
 
 impl PipelineParticipantMut for PolymorphismLowerer {
     fn post_index(&mut self, indexed_project: IndexedProject) -> IndexedProject {
+        // The table pass emits a `__vtable` type and instance member for
+        // every FB / class — even methodless ones. The slot is part of the
+        // FB ABI: a downstream library consumer that extends one of these
+        // FBs must see a layout-compatible base. Skip only when the
+        // project has no FBs, classes, methods, or interfaces at all.
+        if !project_needs_vtables(&indexed_project.index) {
+            return indexed_project;
+        }
+
         let IndexedProject { mut project, index, .. } = indexed_project;
 
         self.table(&index, &mut project.units);
@@ -346,6 +370,18 @@ impl PipelineParticipantMut for PolymorphismLowerer {
     }
 
     fn post_annotate(&mut self, annotated_project: AnnotatedProject) -> AnnotatedProject {
+        // Dispatch lowering rewrites call sites that need vtable
+        // indirection: method calls / body invocations through
+        // `POINTER TO <FB>`, calls through interface variables, and
+        // `SUPER^`. None of those can exist without methods or interfaces
+        // declared somewhere in the project — pre-OOP libraries (FBs
+        // with no methods, no `EXTENDS`, no interfaces) have nothing to
+        // rewrite even when their FBs ship with vtable slots for
+        // downstream extenders.
+        if !project_uses_polymorphic_dispatch(&annotated_project.index) {
+            return annotated_project;
+        }
+
         let AnnotatedProject { units, index, annotations, diagnostics } = annotated_project;
         let mut units: Vec<_> = units.into_iter().map(|AnnotatedUnit { unit, .. }| unit).collect();
 
@@ -400,4 +436,88 @@ impl PipelineParticipantMut for ReferenceToReturnParticipant {
         self.lower_reference_to_return(&mut units);
         ParsedProject { units }
     }
+}
+
+// ─── Precheck helpers ──────────────────────────────────────────────────────
+//
+// Several lowering participants used to unconditionally re-run a whole-project
+// index or annotate after their hook fired, even when the lowerer had nothing
+// to do on this project. The helpers below answer "is there any work for me?"
+// from the already-built index so the participant can skip both the walk and
+// the implicit re-pass when the answer is no. Each helper is an exact
+// predicate: if it returns `false`, the lowerer would produce a project
+// identical to its input.
+
+/// True if the project has any FB, class, method, or interface — i.e. any
+/// type that needs a vtable slot emitted. The vtable layout is part of the
+/// FB ABI: even a methodless FB ships with a `__vtable` member so that a
+/// downstream library consumer extending that FB sees a layout-compatible
+/// base. Used by `PolymorphismLowerer::post_index` (table pass).
+fn project_needs_vtables(index: &Index) -> bool {
+    if index.get_interfaces().keys().next().is_some() {
+        return true;
+    }
+    index.get_pous().values().any(|p| {
+        matches!(
+            p,
+            PouIndexEntry::Class { .. } | PouIndexEntry::FunctionBlock { .. } | PouIndexEntry::Method { .. }
+        )
+    })
+}
+
+/// True if the project has any construct whose call sites the dispatch pass
+/// might rewrite into vtable-indirected form:
+///
+/// - methods, or interfaces (method-call dispatch through the vtable)
+/// - any FB or class with `EXTENDS` (body-call dispatch through the vtable
+///   when a `POINTER TO Base` points at a derived instance, plus `SUPER^`
+///   calls).
+///
+/// A pre-OOP library that uses only standalone FBs (no `EXTENDS`, no
+/// methods, no interfaces) has no expressions the dispatch pass would
+/// touch even though its FBs ship with vtable slots. Used by
+/// `PolymorphismLowerer::post_annotate`.
+fn project_uses_polymorphic_dispatch(index: &Index) -> bool {
+    if index.get_interfaces().keys().next().is_some() {
+        return true;
+    }
+    index.get_pous().values().any(|p| match p {
+        PouIndexEntry::Method { .. } => true,
+        PouIndexEntry::FunctionBlock { super_class, .. } | PouIndexEntry::Class { super_class, .. } => {
+            super_class.is_some()
+        }
+        _ => false,
+    })
+}
+
+/// True if any POU's return type is aggregate (array, struct, or string), in
+/// which case `AggregateTypeLowerer` needs to rewrite that POU's signature.
+fn project_has_aggregate_returns(index: &Index) -> bool {
+    for pou in index.get_pous().values() {
+        let return_type = match pou {
+            PouIndexEntry::Function { return_type, .. } | PouIndexEntry::Method { return_type, .. } => {
+                return_type.as_str()
+            }
+            _ => continue,
+        };
+        if return_type.is_empty() {
+            continue;
+        }
+        if index.get_effective_type_or_void_by_name(return_type).is_aggregate_type() {
+            return true;
+        }
+    }
+    false
+}
+
+/// True if any POU declares a super-class or any interfaces, in which case
+/// `InheritanceLowerer` needs to rewrite calls and walk inheritance chains.
+fn project_uses_inheritance(index: &Index) -> bool {
+    index.get_pous().values().any(|p| match p {
+        PouIndexEntry::FunctionBlock { super_class, interfaces, .. }
+        | PouIndexEntry::Class { super_class, interfaces, .. } => {
+            super_class.is_some() || !interfaces.is_empty()
+        }
+        _ => false,
+    })
 }

--- a/compiler/plc_driver/src/pipelines/participant.rs
+++ b/compiler/plc_driver/src/pipelines/participant.rs
@@ -18,6 +18,7 @@ use plc::{
     index::{Index, PouIndexEntry},
     lowering::{calls::AggregateTypeLowerer, polymorphism::PolymorphismLowerer},
     output::FormatOption,
+    typesystem::DataTypeInformation,
     ConfigFormat, OnlineChange, Target,
 };
 use plc_diagnostics::diagnostics::Diagnostic;
@@ -468,23 +469,53 @@ fn project_needs_vtables(index: &Index) -> bool {
 /// True if the project has any construct whose call sites the dispatch pass
 /// might rewrite into vtable-indirected form:
 ///
-/// - methods, or interfaces (method-call dispatch through the vtable)
-/// - any FB or class with `EXTENDS` (body-call dispatch through the vtable
-///   when a `POINTER TO Base` points at a derived instance, plus `SUPER^`
-///   calls).
+/// - methods or interfaces (method-call dispatch through the vtable);
+/// - any FB or class with `EXTENDS` (body-call dispatch and `SUPER^`);
+/// - any `POINTER TO <FB-or-Class>` type. A pre-OOP library may declare a
+///   pointer-to-FB member and call it via `ptr^()` with no `EXTENDS` or
+///   methods in its own compilation. The lib has no way to know whether
+///   a downstream consumer will retarget that pointer to a derived
+///   instance, so the call site must be vtable-indirected — otherwise
+///   the library binary bakes in a static call to the base body and the
+///   derived body never runs. `REFERENCE TO X` is encoded as a
+///   `Pointer { auto_deref: Some(_) }` in the type system, so it is
+///   covered by the same check.
 ///
-/// A pre-OOP library that uses only standalone FBs (no `EXTENDS`, no
-/// methods, no interfaces) has no expressions the dispatch pass would
-/// touch even though its FBs ship with vtable slots. Used by
-/// `PolymorphismLowerer::post_annotate`.
+/// Used by `PolymorphismLowerer::post_annotate`.
 fn project_uses_polymorphic_dispatch(index: &Index) -> bool {
     if index.get_interfaces().keys().next().is_some() {
         return true;
     }
-    index.get_pous().values().any(|p| match p {
+    let pou_match = index.get_pous().values().any(|p| match p {
         PouIndexEntry::Method { .. } => true,
         PouIndexEntry::FunctionBlock { super_class, .. } | PouIndexEntry::Class { super_class, .. } => {
             super_class.is_some()
+        }
+        _ => false,
+    });
+    if pou_match {
+        return true;
+    }
+    let is_pou_type = |type_name: &str| {
+        index
+            .find_effective_type_by_name(type_name)
+            .map(|t| {
+                let info = t.get_type_information();
+                info.is_function_block() || info.is_class()
+            })
+            .unwrap_or(false)
+    };
+    index.get_types().values().any(|dt| match &dt.information {
+        DataTypeInformation::Pointer { inner_type_name, is_function, .. } => {
+            // Exclude two kinds of compiler-synthesized pointers:
+            //  * function pointers (`is_function: true`) — vtable body
+            //    slots, not user-declared pointers-to-FB;
+            //  * internal `__auto_pointer_to_X` types emitted alongside
+            //    every FB / class.
+            // Both of these exist in oscat-like libraries that have no
+            // user-declared `POINTER TO FB` at all; counting them would
+            // cause the dispatch pass to fire unnecessarily.
+            !is_function && !dt.is_internal() && is_pou_type(inner_type_name)
         }
         _ => false,
     })

--- a/compiler/plc_driver/src/pipelines/property.rs
+++ b/compiler/plc_driver/src/pipelines/property.rs
@@ -19,6 +19,13 @@ impl PipelineParticipantMut for PropertyLowerer {
     }
 
     fn post_annotate(&mut self, project: AnnotatedProject) -> AnnotatedProject {
+        // Skip the rewrite pass + implicit re-annotate when the project
+        // declares no properties at all. Exact predicate: nothing to rewrite
+        // means re-annotation would reproduce the existing state.
+        if !project.index.has_any_properties() {
+            return project;
+        }
+
         let AnnotatedProject { mut units, index, annotations, diagnostics } = project;
         self.annotations = Some(annotations);
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1660,6 +1660,13 @@ impl Index {
         self.properties.get_all(pou_name).unwrap_or(&vec![]).to_vec()
     }
 
+    /// True if any POU in the index declares one or more properties. Cheap;
+    /// short-circuits at the first hit. Used by `PropertyLowerer` to skip
+    /// its post-annotate hook on projects that don't use properties.
+    pub fn has_any_properties(&self) -> bool {
+        self.properties.keys().next().is_some()
+    }
+
     /// return the `VariableIndexEntry` associated with the given fully qualified name using `.` as
     /// a delimiter. (e.g. "PLC_PRG.x", or "MyClass.MyMethod.x")
     pub fn find_fully_qualified_variable(&self, fully_qualified_name: &str) -> Option<&VariableIndexEntry> {

--- a/tests/lit/multi/concrete_member_call_not_dispatched/plc.json
+++ b/tests/lit/multi/concrete_member_call_not_dispatched/plc.json
@@ -1,0 +1,11 @@
+{
+    "name" : "ConcreteMemberCallNotDispatched",
+    "files" : [
+        "src/lib.st",
+        "src/extension.st",
+        "src/main.st",
+        "../../util/printf.pli"
+    ],
+    "compile_type" : "Static",
+    "output" : "app"
+}

--- a/tests/lit/multi/concrete_member_call_not_dispatched/run.test
+++ b/tests/lit/multi/concrete_member_call_not_dispatched/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK %S/src/main.st

--- a/tests/lit/multi/concrete_member_call_not_dispatched/src/extension.st
+++ b/tests/lit/multi/concrete_member_call_not_dispatched/src/extension.st
@@ -1,0 +1,9 @@
+// New code that extends FB_B from the legacy lib. The mere presence of
+// `EXTENDS` in the project causes the polymorphism dispatch pass to fire
+// (vtables-may-be-needed). The pass must still leave FB_A's concrete
+// `helper()` call alone — the call site uses a static-typed instance, not
+// a `POINTER TO FB_B`, so it does not need vtable indirection.
+
+FUNCTION_BLOCK FB_B_DERIVED EXTENDS FB_B
+    counter := counter + 9000;
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/concrete_member_call_not_dispatched/src/lib.st
+++ b/tests/lit/multi/concrete_member_call_not_dispatched/src/lib.st
@@ -1,0 +1,21 @@
+// Old-style library: two FBs, no methods, no inheritance. FB_A holds a
+// concrete `FB_B` member and invokes it via a plain `helper()` call (no
+// pointer, no interface, no SUPER). This is the call we want to keep
+// non-polymorphic — the static type of `helper` is `FB_B` and the body
+// that runs must be FB_B__body, even if a third unit in the same
+// compilation extends FB_B.
+
+VAR_GLOBAL
+    counter : DINT := 0;
+END_VAR
+
+FUNCTION_BLOCK FB_B
+    counter := counter + 100;
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_A
+VAR
+    helper : FB_B;
+END_VAR
+    helper();
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/concrete_member_call_not_dispatched/src/main.st
+++ b/tests/lit/multi/concrete_member_call_not_dispatched/src/main.st
@@ -1,0 +1,23 @@
+FUNCTION main : DINT
+VAR
+    a       : FB_A;
+    derived : FB_B_DERIVED;
+END_VAR
+
+counter := 0;
+
+// Invokes FB_A's body, which in turn calls `helper()` on a member of
+// static type `FB_B`. Must run FB_B's body (+100), NOT FB_B_DERIVED's
+// (+9000), regardless of whether the dispatch pass walked this AST.
+a();
+
+// CHECK: counter after a() = 100
+printf('counter after a() = %d$N', counter);
+
+// Sanity check: FB_B_DERIVED's body really does add 9000 when invoked
+// directly on a `FB_B_DERIVED` instance.
+derived();
+
+// CHECK: counter after derived() = 9100
+printf('counter after derived() = %d$N', counter);
+END_FUNCTION

--- a/tests/lit/multi/concrete_member_call_not_dispatched_external/app.st
+++ b/tests/lit/multi/concrete_member_call_not_dispatched_external/app.st
@@ -1,0 +1,35 @@
+// Downstream application linking against libnopoly.so. Re-declares the
+// shape of FB_B and FB_A as `{external}` so codegen emits a reference
+// rather than a definition. Adds a derived FB_B_DERIVED EXTENDS FB_B.
+//
+// The mere presence of `EXTENDS` here causes the polymorphism dispatch
+// pass to fire while compiling *this* unit. The library has already been
+// compiled in isolation — FB_A's `helper()` call inside it is already
+// emitted as a direct call to FB_B__body. Running main() must print
+// FB_B's body output, NOT FB_B_DERIVED's, even though both types exist
+// in the final binary.
+
+{external}
+FUNCTION_BLOCK FB_B
+END_FUNCTION_BLOCK
+
+{external}
+FUNCTION_BLOCK FB_A
+VAR
+    helper : FB_B;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_B_DERIVED EXTENDS FB_B
+    printf('FB_B_DERIVED body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION main
+VAR
+    a       : FB_A;
+    derived : FB_B_DERIVED;
+END_VAR
+
+a();
+derived();
+END_FUNCTION

--- a/tests/lit/multi/concrete_member_call_not_dispatched_external/lib.st
+++ b/tests/lit/multi/concrete_member_call_not_dispatched_external/lib.st
@@ -1,0 +1,16 @@
+// Old-style library compiled in isolation. Two FBs, no methods, no
+// inheritance, no interfaces. FB_A holds a concrete `FB_B` member and
+// invokes it via a plain `helper()` call. The compiled .so must call
+// FB_B's body directly — at lib-compile time there is no derivation in
+// scope, and the call is statically resolvable to FB_B__body.
+
+FUNCTION_BLOCK FB_B
+    printf('FB_B body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_A
+VAR
+    helper : FB_B;
+END_VAR
+    helper();
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/concrete_member_call_not_dispatched_external/lit.local.cfg
+++ b/tests/lit/multi/concrete_member_call_not_dispatched_external/lit.local.cfg
@@ -1,0 +1,41 @@
+import os.path
+import subprocess
+
+stdlibLocation = lit_config.params["LIB"]
+compilerLocation = lit_config.params["COMPILER"]
+
+test_dir = os.path.dirname(__file__)
+source_path = os.path.abspath(test_dir)
+rustyRootDirectory = os.path.abspath(os.path.join(test_dir, "..", "..", "..", ".."))
+
+tmp_lib_path = "/tmp"
+tmp_lib_file = f"{tmp_lib_path}/libnopoly.so"
+
+# Compile lib.st into a shared library — old-style FBs, no methods, no
+# inheritance, no interfaces. The polymorphism dispatch pass should skip
+# this compilation entirely, leaving FB_A's `helper()` as a direct call
+# to FB_B__body in the emitted .so.
+try:
+    lib_compile = f"{compilerLocation} --shared -o {tmp_lib_file}"
+    lib_compile = f"{lib_compile} -liec61131std -L{stdlibLocation}/lib -i \"{stdlibLocation}/include/*.st\""
+    lib_compile = f"{lib_compile} -i \"{rustyRootDirectory}/tests/lit/util/*.pli\""
+    lib_compile = f"{lib_compile} --linker=cc"
+    lib_compile = f"{lib_compile} {source_path}/lib.st"
+    lit_config.note(f"Running: {lib_compile}")
+    subprocess.run(lib_compile, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+except subprocess.CalledProcessError as e:
+    lit_config.error(f"Failed to compile lib.st: {e.stderr.decode()}")
+    raise
+
+compile = f'{compilerLocation}'
+compile = f'{compile} -o /tmp/%basename_t.out'
+compile = f'{compile} -liec61131std -L{stdlibLocation}/lib -i "{stdlibLocation}/include/*.st"'
+compile = f'{compile} -i "{rustyRootDirectory}/tests/lit/util/*.pli"'
+compile = f'{compile} -L{tmp_lib_path} -lnopoly'
+compile = f'{compile} --linker=cc'
+
+run_cmd = f'LD_LIBRARY_PATH="{stdlibLocation}/lib:{tmp_lib_path}" /tmp/%basename_t.out'
+
+config.substitutions = [s for s in config.substitutions if s[0] not in ['%COMPILE', '%RUN']]
+config.substitutions.append(('%COMPILE', f'{compile}'))
+config.substitutions.append(('%RUN', f'{run_cmd}'))

--- a/tests/lit/multi/concrete_member_call_not_dispatched_external/run.test
+++ b/tests/lit/multi/concrete_member_call_not_dispatched_external/run.test
@@ -1,0 +1,3 @@
+RUN: %COMPILE %S/app.st && %RUN | %CHECK %s
+CHECK: FB_B body
+CHECK: FB_B_DERIVED body

--- a/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/app.st
+++ b/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/app.st
@@ -1,0 +1,39 @@
+// Downstream application: extends FB_B and assigns a derived instance
+// to FB_A's pointer member, then calls FB_A. The body of FB_A is
+// already in the linked `libdispatchptr.so` — if the lib's compilation
+// resolved `inst_fb_b^()` statically as a direct call to FB_B's body,
+// the derived instance's body never runs.
+
+{external}
+FUNCTION_BLOCK FB_B
+END_FUNCTION_BLOCK
+
+{external}
+FUNCTION_BLOCK FB_A
+VAR
+    inst_fb_b : POINTER TO FB_B;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_B_DERIVED EXTENDS FB_B
+    printf('FB_B_DERIVED body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION main
+VAR
+    a       : FB_A;
+    base    : FB_B;
+    derived : FB_B_DERIVED;
+END_VAR
+
+// First call: pointer targets a concrete FB_B. The lib's FB_A.body
+// invokes `inst_fb_b^()` — vtable lookup yields FB_B's body.
+a.inst_fb_b := ADR(base);
+a();
+
+// Second call: pointer retargeted to a FB_B_DERIVED instance. The
+// lib's FB_A.body, compiled in isolation, must dispatch through the
+// vtable so that the derived body runs.
+a.inst_fb_b := ADR(derived);
+a();
+END_FUNCTION

--- a/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/lib.st
+++ b/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/lib.st
@@ -1,0 +1,17 @@
+// Old-style library: FB_A holds a `POINTER TO FB_B` and invokes the
+// pointee via `inst_fb_b^()`. The library compiles in isolation — at
+// this point there is no derivation of FB_B in scope, no methods, no
+// interfaces. The dispatch site MUST nonetheless go through the
+// vtable, because a downstream consumer may extend FB_B and retarget
+// the pointer.
+
+FUNCTION_BLOCK FB_B
+    printf('FB_B body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_A
+VAR
+    inst_fb_b : POINTER TO FB_B;
+END_VAR
+    inst_fb_b^();
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/lit.local.cfg
+++ b/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/lit.local.cfg
@@ -1,0 +1,39 @@
+import os.path
+import subprocess
+
+stdlibLocation = lit_config.params["LIB"]
+compilerLocation = lit_config.params["COMPILER"]
+
+test_dir = os.path.dirname(__file__)
+source_path = os.path.abspath(test_dir)
+rustyRootDirectory = os.path.abspath(os.path.join(test_dir, "..", "..", "..", ".."))
+
+tmp_lib_path = "/tmp"
+tmp_lib_file = f"{tmp_lib_path}/libdispatchptr.so"
+
+# Compile lib.st in isolation. No methods, no interfaces, no inheritance
+# in scope — only a `POINTER TO FB_B` member with a `^()` call site.
+try:
+    lib_compile = f"{compilerLocation} --shared -o {tmp_lib_file}"
+    lib_compile = f"{lib_compile} -liec61131std -L{stdlibLocation}/lib -i \"{stdlibLocation}/include/*.st\""
+    lib_compile = f"{lib_compile} -i \"{rustyRootDirectory}/tests/lit/util/*.pli\""
+    lib_compile = f"{lib_compile} --linker=cc"
+    lib_compile = f"{lib_compile} {source_path}/lib.st"
+    lit_config.note(f"Running: {lib_compile}")
+    subprocess.run(lib_compile, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+except subprocess.CalledProcessError as e:
+    lit_config.error(f"Failed to compile lib.st: {e.stderr.decode()}")
+    raise
+
+compile = f'{compilerLocation}'
+compile = f'{compile} -o /tmp/%basename_t.out'
+compile = f'{compile} -liec61131std -L{stdlibLocation}/lib -i "{stdlibLocation}/include/*.st"'
+compile = f'{compile} -i "{rustyRootDirectory}/tests/lit/util/*.pli"'
+compile = f'{compile} -L{tmp_lib_path} -ldispatchptr'
+compile = f'{compile} --linker=cc'
+
+run_cmd = f'LD_LIBRARY_PATH="{stdlibLocation}/lib:{tmp_lib_path}" /tmp/%basename_t.out'
+
+config.substitutions = [s for s in config.substitutions if s[0] not in ['%COMPILE', '%RUN']]
+config.substitutions.append(('%COMPILE', f'{compile}'))
+config.substitutions.append(('%RUN', f'{run_cmd}'))

--- a/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/run.test
+++ b/tests/lit/multi/pointer_to_fb_in_pre_oop_lib_dispatches/run.test
@@ -1,0 +1,3 @@
+RUN: %COMPILE %S/app.st && %RUN | %CHECK %s
+CHECK: FB_B body
+CHECK: FB_B_DERIVED body

--- a/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/app.st
+++ b/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/app.st
@@ -1,0 +1,28 @@
+{external}
+FUNCTION_BLOCK FB_B
+END_FUNCTION_BLOCK
+
+{external}
+FUNCTION_BLOCK FB_A
+VAR
+    target : REFERENCE TO FB_B;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_B_DERIVED EXTENDS FB_B
+    printf('FB_B_DERIVED body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION main
+VAR
+    a       : FB_A;
+    base    : FB_B;
+    derived : FB_B_DERIVED;
+END_VAR
+
+a.target REF= base;
+a();
+
+a.target REF= derived;
+a();
+END_FUNCTION

--- a/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/lib.st
+++ b/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/lib.st
@@ -1,0 +1,15 @@
+// Old-style library using REFERENCE TO (auto-dereferencing pointer)
+// instead of POINTER TO. Same library-safety property: the call site
+// must dispatch through the vtable so a derived target supplied
+// downstream gets its own body invoked.
+
+FUNCTION_BLOCK FB_B
+    printf('FB_B body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_A
+VAR
+    target : REFERENCE TO FB_B;
+END_VAR
+    target();
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/lit.local.cfg
+++ b/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/lit.local.cfg
@@ -1,0 +1,37 @@
+import os.path
+import subprocess
+
+stdlibLocation = lit_config.params["LIB"]
+compilerLocation = lit_config.params["COMPILER"]
+
+test_dir = os.path.dirname(__file__)
+source_path = os.path.abspath(test_dir)
+rustyRootDirectory = os.path.abspath(os.path.join(test_dir, "..", "..", "..", ".."))
+
+tmp_lib_path = "/tmp"
+tmp_lib_file = f"{tmp_lib_path}/libdispatchref.so"
+
+try:
+    lib_compile = f"{compilerLocation} --shared -o {tmp_lib_file}"
+    lib_compile = f"{lib_compile} -liec61131std -L{stdlibLocation}/lib -i \"{stdlibLocation}/include/*.st\""
+    lib_compile = f"{lib_compile} -i \"{rustyRootDirectory}/tests/lit/util/*.pli\""
+    lib_compile = f"{lib_compile} --linker=cc"
+    lib_compile = f"{lib_compile} {source_path}/lib.st"
+    lit_config.note(f"Running: {lib_compile}")
+    subprocess.run(lib_compile, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+except subprocess.CalledProcessError as e:
+    lit_config.error(f"Failed to compile lib.st: {e.stderr.decode()}")
+    raise
+
+compile = f'{compilerLocation}'
+compile = f'{compile} -o /tmp/%basename_t.out'
+compile = f'{compile} -liec61131std -L{stdlibLocation}/lib -i "{stdlibLocation}/include/*.st"'
+compile = f'{compile} -i "{rustyRootDirectory}/tests/lit/util/*.pli"'
+compile = f'{compile} -L{tmp_lib_path} -ldispatchref'
+compile = f'{compile} --linker=cc'
+
+run_cmd = f'LD_LIBRARY_PATH="{stdlibLocation}/lib:{tmp_lib_path}" /tmp/%basename_t.out'
+
+config.substitutions = [s for s in config.substitutions if s[0] not in ['%COMPILE', '%RUN']]
+config.substitutions.append(('%COMPILE', f'{compile}'))
+config.substitutions.append(('%RUN', f'{run_cmd}'))

--- a/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/run.test
+++ b/tests/lit/multi/reference_to_fb_in_pre_oop_lib_dispatches/run.test
@@ -1,0 +1,3 @@
+RUN: %COMPILE %S/app.st && %RUN | %CHECK %s
+CHECK: FB_B body
+CHECK: FB_B_DERIVED body

--- a/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/app.st
+++ b/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/app.st
@@ -1,0 +1,30 @@
+// Downstream application: extends FB_B and passes a derived instance
+// as the VAR_IN_OUT argument to FB_A. The lib's FB_A.body, compiled in
+// isolation, must dispatch `target()` through the vtable so the
+// derived body runs.
+
+{external}
+FUNCTION_BLOCK FB_B
+END_FUNCTION_BLOCK
+
+{external}
+FUNCTION_BLOCK FB_A
+VAR_IN_OUT
+    target : FB_B;
+END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_B_DERIVED EXTENDS FB_B
+    printf('FB_B_DERIVED body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION main
+VAR
+    a       : FB_A;
+    base    : FB_B;
+    derived : FB_B_DERIVED;
+END_VAR
+
+a(target := base);
+a(target := derived);
+END_FUNCTION

--- a/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/lib.st
+++ b/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/lib.st
@@ -1,0 +1,17 @@
+// Old-style library: FB_A takes a `VAR_IN_OUT FB_B` parameter (an
+// implicit pointer in IEC semantics) and invokes the parameter via
+// `target()`. No methods, no inheritance, no interfaces. Like the
+// POINTER TO case, the lib has no way to know whether a downstream
+// consumer will pass a derived instance — the call must be
+// vtable-indirected.
+
+FUNCTION_BLOCK FB_B
+    printf('FB_B body$N');
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_A
+VAR_IN_OUT
+    target : FB_B;
+END_VAR
+    target();
+END_FUNCTION_BLOCK

--- a/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/lit.local.cfg
+++ b/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/lit.local.cfg
@@ -1,0 +1,37 @@
+import os.path
+import subprocess
+
+stdlibLocation = lit_config.params["LIB"]
+compilerLocation = lit_config.params["COMPILER"]
+
+test_dir = os.path.dirname(__file__)
+source_path = os.path.abspath(test_dir)
+rustyRootDirectory = os.path.abspath(os.path.join(test_dir, "..", "..", "..", ".."))
+
+tmp_lib_path = "/tmp"
+tmp_lib_file = f"{tmp_lib_path}/libdispatchinout.so"
+
+try:
+    lib_compile = f"{compilerLocation} --shared -o {tmp_lib_file}"
+    lib_compile = f"{lib_compile} -liec61131std -L{stdlibLocation}/lib -i \"{stdlibLocation}/include/*.st\""
+    lib_compile = f"{lib_compile} -i \"{rustyRootDirectory}/tests/lit/util/*.pli\""
+    lib_compile = f"{lib_compile} --linker=cc"
+    lib_compile = f"{lib_compile} {source_path}/lib.st"
+    lit_config.note(f"Running: {lib_compile}")
+    subprocess.run(lib_compile, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+except subprocess.CalledProcessError as e:
+    lit_config.error(f"Failed to compile lib.st: {e.stderr.decode()}")
+    raise
+
+compile = f'{compilerLocation}'
+compile = f'{compile} -o /tmp/%basename_t.out'
+compile = f'{compile} -liec61131std -L{stdlibLocation}/lib -i "{stdlibLocation}/include/*.st"'
+compile = f'{compile} -i "{rustyRootDirectory}/tests/lit/util/*.pli"'
+compile = f'{compile} -L{tmp_lib_path} -ldispatchinout'
+compile = f'{compile} --linker=cc'
+
+run_cmd = f'LD_LIBRARY_PATH="{stdlibLocation}/lib:{tmp_lib_path}" /tmp/%basename_t.out'
+
+config.substitutions = [s for s in config.substitutions if s[0] not in ['%COMPILE', '%RUN']]
+config.substitutions.append(('%COMPILE', f'{compile}'))
+config.substitutions.append(('%RUN', f'{run_cmd}'))

--- a/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/run.test
+++ b/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/run.test
@@ -1,0 +1,14 @@
+// XFAIL: *
+//
+// Known limitation: the polymorphism dispatch pass does not currently
+// rewrite a call site that invokes a `VAR_IN_OUT FB` parameter via the
+// bare-name form (`target()`). The call resolves statically to the
+// parameter's declared base type, so a downstream consumer that passes
+// a derived instance still sees the base body run. This is unrelated
+// to the precheck-gate work — the same test fails on a baseline build
+// without any gates. Tracked here as a documented gap; addressing it
+// belongs in the polymorphism participant itself.
+
+RUN: %COMPILE %S/app.st && %RUN | %CHECK %s
+CHECK: FB_B body
+CHECK: FB_B_DERIVED body

--- a/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/run.test
+++ b/tests/lit/multi/var_in_out_fb_in_pre_oop_lib_dispatches/run.test
@@ -1,13 +1,13 @@
 // XFAIL: *
 //
-// Known limitation: the polymorphism dispatch pass does not currently
-// rewrite a call site that invokes a `VAR_IN_OUT FB` parameter via the
-// bare-name form (`target()`). The call resolves statically to the
-// parameter's declared base type, so a downstream consumer that passes
-// a derived instance still sees the base body run. This is unrelated
-// to the precheck-gate work — the same test fails on a baseline build
-// without any gates. Tracked here as a documented gap; addressing it
-// belongs in the polymorphism participant itself.
+// Known limitation tracked in https://github.com/PLC-lang/rusty/issues/1743 :
+// the polymorphism dispatch pass does not currently rewrite a call site
+// that invokes a `VAR_IN_OUT FB` parameter via the bare-name form
+// (`target()`). The call resolves statically to the parameter's
+// declared base type, so a downstream consumer that passes a derived
+// instance still sees the base body run. This is unrelated to the
+// precheck-gate work — the same test fails on a baseline build without
+// any gates. Remove the `XFAIL: *` directive once #1743 is fixed.
 
 RUN: %COMPILE %S/app.st && %RUN | %CHECK %s
 CHECK: FB_B body


### PR DESCRIPTION
> _Drafted by Claude (Opus 4.7). Reviewer judgement applies as normal._

Builds on the timing instrumentation PR. Each PR's branch is on top of
the previous; review independently.

## What this does

Several post-annotate lowering participants used to unconditionally
re-annotate the whole project after their hook fired, regardless of
whether the project actually had any work for them. Each now guards
on an exact precondition against the global index. When the
precondition is false the participant returns the project unchanged
— no lowerer walk, no implicit re-pass.

Gates:

| Participant | Hook | Predicate |
|---|---|---|
| `PropertyLowerer` | `post_annotate` | any property declared |
| `InheritanceLowerer` | `post_annotate` | any FB / class with `EXTENDS` or `IMPLEMENTS` |
| `AggregateTypeLowerer` | `post_annotate` | any POU returns an aggregate (array, struct, string) |
| `PolymorphismLowerer` | `post_index` | any FB, class, method, or interface |
| `PolymorphismLowerer` | `post_annotate` | any method, interface, FB / class with `EXTENDS`, or user-declared `POINTER TO` / `REFERENCE TO` an FB / class |

Each predicate is **exact** for the participant it gates: when it
returns false, the lowerer would walk the project and emit zero
changes, and the implicit re-annotate would reproduce the existing
state.

## The polymorphism split

The two polymorphism hooks use different predicates on purpose.

- `post_index` runs the **table pass**, which adds a `__vtable` type
  + `__vtable` member to every FB and class. The slot is part of
  the FB ABI: a downstream library consumer that extends one of
  these FBs must see a layout-compatible base, regardless of
  whether the project itself dispatches polymorphically. So the
  table pass fires for any FB / class / method / interface, even
  in a pre-OOP library that declares only methodless FBs.
- `post_annotate` runs the **dispatch pass**, which rewrites call
  sites that need vtable indirection: method calls through the
  vtable, body calls through `POINTER TO Base`, calls through
  interface variables, `SUPER^`. A pre-OOP library that uses only
  standalone FBs (no methods, no `EXTENDS`, no interfaces, no
  pointer-to-FB members) has nothing to rewrite even though its FBs
  ship with vtable slots. So the dispatch pass uses a strictly
  tighter predicate.

  The `POINTER TO` / `REFERENCE TO` clause is essential for library
  safety: a lib that declares `VAR ptr : POINTER TO FB_B; END_VAR`
  and calls `ptr^()` may not have any methods or inheritance in its
  own compilation, but a downstream consumer can retarget that
  pointer to `FB_B_DERIVED`. The dispatch call site must be
  vtable-indirected so the derived body runs. Compiler-synthesized
  pointers — vtable body slots (`is_function: true`) and internal
  `__auto_pointer_to_X` types — are excluded from the check, so
  oscat-shaped libraries that have no user pointers don't trip the
  predicate.

The split means a methodless pre-OOP library without `POINTER TO`
FB usage pays the table-pass cost (necessary, ABI-shaping) but skips
the dispatch pass (no-op for its shape).

## Regression tests

Five new lit tests guard the boundaries the dispatch gate is
protecting. All use `printf` markers so the dispatched body is
directly observable.

**The gate skips when it should** — concrete-typed FB member calls
must resolve to the static type's body, even when that type is
extended elsewhere in the compilation:

- **`concrete_member_call_not_dispatched/`** — single compilation
  unit with `FB_A` holding a concrete `FB_B` member, plus
  `FB_B_DERIVED EXTENDS FB_B`. `FB_A`'s `helper()` must run `FB_B`'s
  body.
- **`concrete_member_call_not_dispatched_external/`** — two
  separately-compiled units. The lib is built in isolation into
  `libnopoly.so` with no derivation in scope; the app declares the
  lib's FBs as `{external}` and adds `FB_B_DERIVED`. The pre-compiled
  `FB_A` inside the .so must still call `FB_B`'s body.

**The gate fires when it should** — a pre-OOP library that exposes
FBs by pointer reference must still dispatch polymorphically, because
a downstream consumer can derive and retarget:

- **`pointer_to_fb_in_pre_oop_lib_dispatches/`** — lib compiled in
  isolation with `VAR inst_fb_b : POINTER TO FB_B; END_VAR` and
  `inst_fb_b^()`. App extends `FB_B` and retargets the pointer to a
  derived instance. The lib's `FB_A.body`, compiled with no
  derivation in scope, must still dispatch through the vtable so
  the derived body runs.
- **`reference_to_fb_in_pre_oop_lib_dispatches/`** — same shape with
  `REFERENCE TO FB_B`. `REFERENCE TO` is encoded as a
  `Pointer { auto_deref: Some(_) }`, so the same check covers it.

**Known gap, documented** — `VAR_IN_OUT FB` parameters are *not*
currently dispatched polymorphically. This is a pre-existing
limitation in the polymorphism dispatch pass itself
(reproducible on a clean `master` build, unrelated to this PR), and
is tracked in https://github.com/PLC-lang/rusty/issues/1743:

- **`var_in_out_fb_in_pre_oop_lib_dispatches/`** — marked `XFAIL: *`,
  with the run.test header pointing at #1743. Removing the `XFAIL`
  directive once #1743 is fixed flips it into a passing regression.
  Included now so the gap doesn't get forgotten.

The two-compilation variants (`_external/`, `pointer_to_fb`,
`reference_to_fb`, `var_in_out_fb`) all use the same
`extern_st_polymorphism`-style `lit.local.cfg`: the library is
pre-built into a `.so` with an isolated compilation, then the app is
linked against it.

## Implication

Projects that don't use a given OOP feature stop paying for that
feature's lowering re-pass. Pre-OOP FB libraries — the common shape
for legacy PLC code — skip every post-annotate gate except
`AggregateTypeLowerer` (most legacy code does have STRING-returning
functions). Projects that exercise every feature see no change.

The cost of each precheck is one short loop over the index with an
early return on the first hit. The dominant cost on the hot path
was the lowerers themselves; the gates remove that cost when it
isn't earning anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
