### PR TITLE
fix(validation): reject FB-level VAR_TEMP referenced from a METHOD

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -236,6 +236,7 @@ lazy_static! {
         E132,   Ignore,    include_str!("./error_codes/E132.md"),  // Mixing implicit and explicit call parameters
         E133,   Error,      include_str!("./error_codes/E133.md"),  // AND_THEN/OR_ELSE with non-boolean operands
         E136,   Error,      include_str!("./error_codes/E136.md"),  // Incomplete hardware address in FUNCTION/METHOD
+        E137,   Error,      include_str!("./error_codes/E137.md"),  // FB-level VAR_TEMP referenced from a METHOD
     );
 }
 

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E137.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E137.md
@@ -1,0 +1,42 @@
+# FB-level VAR_TEMP referenced from a METHOD
+
+A `VAR_TEMP` declared in a `FUNCTION_BLOCK` belongs to the FB body's call frame.
+A `METHOD` has its own stack frame, so it cannot share that temporary.
+
+Erroneous code example:
+```iecst
+FUNCTION_BLOCK Bug
+VAR_TEMP
+    scratch : BOOL;
+END_VAR
+METHOD PUBLIC DoIt
+    scratch := TRUE; // ❌ scratch is not visible here
+END_METHOD
+END_FUNCTION_BLOCK
+```
+
+To fix, either declare the variable as a member of the `FUNCTION_BLOCK` (so it
+becomes part of the instance and is visible to the method), or declare a
+`VAR_TEMP` local to the method itself:
+
+```iecst
+FUNCTION_BLOCK Bug
+VAR
+    scratch : BOOL; // ✅ instance member, visible to methods
+END_VAR
+METHOD PUBLIC DoIt
+    scratch := TRUE;
+END_METHOD
+END_FUNCTION_BLOCK
+```
+
+```iecst
+FUNCTION_BLOCK Bug
+METHOD PUBLIC DoIt
+    VAR_TEMP
+        scratch : BOOL; // ✅ method-local temporary
+    END_VAR
+    scratch := TRUE;
+END_METHOD
+END_FUNCTION_BLOCK
+```

--- a/src/index.rs
+++ b/src/index.rs
@@ -1583,15 +1583,20 @@ impl Index {
         variable_name: &str,
         seen: &mut FxHashSet<String>,
     ) -> Option<&VariableIndexEntry> {
+        // METHODs have their own stack frame, so VAR_TEMP declared on the enclosing
+        // POU is not visible inside method bodies. ACTIONs share the parent's frame
+        // and may still see it.
+        let is_method = self.find_pou(container_name).is_some_and(|it| it.is_method());
+
         self.type_index
             .find_type(container_name)
             .and_then(|it| it.find_member(variable_name))
             .or(self.find_enum_variant_in_pou(container_name, variable_name))
             // underlying type of an `ACTION` or `METHOD`
-            .or(container_name
-                .rfind('.')
-                .map(|p| &container_name[..p])
-                .and_then(|qualifier| self.find_member_recursive(qualifier, variable_name, seen)))
+            .or(container_name.rfind('.').map(|p| &container_name[..p]).and_then(|qualifier| {
+                self.find_member_recursive(qualifier, variable_name, seen)
+                    .filter(|it| !(is_method && it.is_temp()))
+            }))
             // 'self' instance of a POUs init function
             .or(container_name
                 .rfind("__init_")

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -601,6 +601,12 @@ fn validate_reference<T: AnnotationMap>(
 
             _ => (),
         };
+
+        if let Some(diagnostic) = fb_temp_referenced_from_method(context, ref_name, location) {
+            validator.push_diagnostic(diagnostic);
+            return;
+        }
+
         validator.push_diagnostic(Diagnostic::unresolved_reference(ref_name, location));
 
         // was this meant as a direct access?
@@ -660,6 +666,35 @@ fn validate_reference<T: AnnotationMap>(
             }
         _ => (),
     }
+}
+
+/// Produces a focused diagnostic when a METHOD references a `VAR_TEMP` declared on its
+/// enclosing POU. Methods have their own stack frame, so the temp is not visible — the
+/// resolver therefore leaves the reference unannotated. Returning a dedicated diagnostic
+/// here yields a clearer message than the generic "unresolved reference".
+fn fb_temp_referenced_from_method<T: AnnotationMap>(
+    context: &ValidationContext<T>,
+    ref_name: &str,
+    location: &SourceLocation,
+) -> Option<Diagnostic> {
+    let pou = context.qualifier.and_then(|q| context.index.find_pou(q))?;
+    if !pou.is_method() {
+        return None;
+    }
+    let parent = pou.get_parent_pou_name()?;
+    let temp = context
+        .index
+        .get_pou_members(parent)
+        .iter()
+        .find(|m| m.is_temp() && m.get_name().eq_ignore_ascii_case(ref_name))?;
+    Some(
+        Diagnostic::new(format!(
+            "`{ref_name}` is a VAR_TEMP of `{parent}` and is not visible inside its METHODs"
+        ))
+        .with_error_code("E137")
+        .with_location(location)
+        .with_secondary_location(&temp.source_location),
+    )
 }
 
 fn visit_array_access<T: AnnotationMap>(

--- a/src/validation/tests/variable_validation_tests.rs
+++ b/src/validation/tests/variable_validation_tests.rs
@@ -1824,3 +1824,54 @@ fn function_and_method_parameters_do_not_trip_template_address_check() {
 
     assert!(diagnostics.is_empty(), "expected clean diagnostics, got:\n{diagnostics}");
 }
+
+#[test]
+fn fb_var_temp_is_not_visible_inside_method() {
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        FUNCTION_BLOCK Bug
+        VAR_TEMP
+            scratch : BOOL;
+        END_VAR
+        METHOD PUBLIC DoIt
+            scratch := TRUE;
+        END_METHOD
+        END_FUNCTION_BLOCK
+        "#,
+    );
+
+    assert_snapshot!(diagnostics, @r"
+    error[E137]: `scratch` is a VAR_TEMP of `Bug` and is not visible inside its METHODs
+      ┌─ <internal>:7:13
+      │
+    4 │             scratch : BOOL;
+      │             ------- see also
+      ·
+    7 │             scratch := TRUE;
+      │             ^^^^^^^ `scratch` is a VAR_TEMP of `Bug` and is not visible inside its METHODs
+    ");
+}
+
+#[test]
+fn fb_var_temp_visible_inside_fb_body_and_actions() {
+    // VAR_TEMP on a FUNCTION_BLOCK remains accessible from the FB body itself and
+    // from its ACTIONs (which share the FB's stack frame). Only METHODs are blocked.
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        FUNCTION_BLOCK Bug
+        VAR_TEMP
+            scratch : BOOL;
+        END_VAR
+        scratch := TRUE;
+        END_FUNCTION_BLOCK
+
+        ACTIONS Bug
+            ACTION DoIt
+                scratch := FALSE;
+            END_ACTION
+        END_ACTIONS
+        "#,
+    );
+
+    assert!(diagnostics.is_empty(), "expected clean diagnostics, got:\n{diagnostics}");
+}


### PR DESCRIPTION
<!-- Drafted by Claude on behalf of @ghaith -->

Fixes #1745.

## Summary

- A `VAR_TEMP` declared on a `FUNCTION_BLOCK` was silently miscompiled
  when read from one of that FB's `METHOD`s: the method allocated its
  own uninitialized stack slot for the temp, the load was `undef`,
  and any boolean expression depending on it folded to nonsense at
  optimization levels above `none`.
- CODESYS rejects the same source ("unresolved reference"), so this PR
  aligns behavior: the resolver no longer leaks a method's enclosing
  `VAR_TEMP` into the method body, and the validator emits a focused
  diagnostic (E137) instead of the generic "unresolved reference".
- `ACTION`s continue to see the FB's `VAR_TEMP` because they share the
  FB body's stack frame.

## Changes

- `src/index.rs` — `find_local_member_recursive` filters `is_temp()`
  when crossing from a METHOD into its enclosing POU.
- `src/validation/statement.rs` — `fb_temp_referenced_from_method`
  helper emits E137 with a secondary location at the TEMP declaration,
  shadowing the generic unresolved-reference diagnostic for this case.
- `compiler/plc_diagnostics/src/diagnostics/{diagnostics_registry.rs,error_codes/E137.md}`
  — register and document E137 with both fix options (promote to
  instance member, or move the TEMP into the method).

## Test plan

- [x] `cargo test --workspace` — all green, no regressions.
- [x] `cargo fmt --all` and `cargo clippy --workspace -- -Dwarnings`
      — clean.
- [x] New validator unit tests (inline snapshots):
  - method reading FB-level VAR_TEMP → E137 with secondary location.
  - FB body + ACTION reading the same TEMP → clean.
- [x] Manual: `plc --ir` on the reproducer from #1745 now aborts with
      E137 and emits no IR (previously it produced an `undef` load).