### PR TITLE
fix(codegen): ptrtoint pointer operands in int binary arithmetic

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -2190,8 +2190,8 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
         right_value: BasicValueEnum<'ink>,
         is_signed: Option<bool>,
     ) -> Result<BasicValueEnum<'ink>, CodegenError> {
-        let int_lvalue = left_value.into_int_value();
-        let int_rvalue = right_value.into_int_value();
+        let int_lvalue = self.convert_to_int_value_if_pointer(left_value)?;
+        let int_rvalue = self.convert_to_int_value_if_pointer(right_value)?;
 
         let value = match operator {
             Operator::Plus => self.llvm.builder.build_int_add(int_lvalue, int_rvalue, "tmpVar")?,

--- a/tests/lit/ir_tests/adr_ptr_arith.st
+++ b/tests/lit/ir_tests/adr_ptr_arith.st
@@ -1,0 +1,22 @@
+// RUN: %COMPILE_IR %s | %CHECK_IR %s
+//
+// Structural pin for the #1749 fix: `ADR(x) + N` must lower to
+// `ptrtoint` + `add` (byte-stride integer arithmetic), not panic. ADR is
+// declared `: LWORD` so the binary `+` flows through the integer path; the
+// codegen entry now routes pointer operands through
+// `convert_to_int_value_if_pointer` (matching the existing comparison-op
+// path) instead of an unconditional `into_int_value()` that crashed inkwell.
+
+FUNCTION main
+VAR
+    arr : ARRAY[0..3] OF BYTE;
+    pt  : REF_TO BYTE;
+END_VAR
+
+pt := ADR(arr) + 2;
+pt^ := BYTE#16#FF;
+END_FUNCTION
+
+// CHECK: ptrtoint ptr %{{.*}} to i64
+// CHECK-NEXT: add i64 %{{.*}}, 2
+// CHECK-NEXT: inttoptr i64 %{{.*}} to ptr

--- a/tests/lit/single/builtin/adr_ptr_arith_runtime.st
+++ b/tests/lit/single/builtin/adr_ptr_arith_runtime.st
@@ -1,0 +1,33 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+//
+// `ADR(x) + N` is byte-stride pointer arithmetic — `ADR` is declared to
+// return LWORD, so the `+` flows through the integer-arithmetic path; the
+// receiver pointer ends up `N` bytes past the operand. Regression for #1749
+// (previously panicked in `create_llvm_int_binary_expression`).
+
+FUNCTION main
+VAR
+    arr : ARRAY[0..7] OF BYTE := [0, 0, 0, 0, 0, 0, 0, 0];
+    pt  : REF_TO BYTE;
+END_VAR
+
+pt := ADR(arr) + 4;
+pt^ := BYTE#16#AB;
+
+// CHECK: arr[4]=171
+printf('arr[4]=%d$N', arr[4]);
+
+pt := ADR(arr) + 7;
+pt^ := BYTE#16#5C;
+
+// CHECK: arr[7]=92
+printf('arr[7]=%d$N', arr[7]);
+
+// Subtraction flows through the same path: take a pointer past the end
+// and walk back. Writing to arr[2] via `ADR(arr[6]) - 4`.
+pt := ADR(arr[6]) - 4;
+pt^ := BYTE#16#11;
+
+// CHECK: arr[2]=17
+printf('arr[2]=%d$N', arr[2]);
+END_FUNCTION


### PR DESCRIPTION
`ADR(x) + N` panicked during codegen with "Found PointerValue but expected the IntValue variant". `ADR` is declared
`FUNCTION ADR<U: ANY> : LWORD`, so the binary `+` flows through `create_llvm_int_binary_expression` — but the codegen for `ADR` returns the operand's `PointerValue` directly (no `ptrtoint`), and the arithmetic entry called `into_int_value()` unconditionally, crashing inkwell.

Route both operands through `convert_to_int_value_if_pointer` at the entry of `create_llvm_int_binary_expression`. For `IntValue` inputs this is a no-op (the helper returns the value unchanged); for `PointerValue` inputs it emits `ptrtoint <ptr> to i64`, matching `ADR`'s declared `LWORD` return type, after which the integer add proceeds normally. The comparison operators in the same file already took this path; the arithmetic site was just never updated.

Closes #1749.