### PR TITLE
fix(typesystem): wrong downcast warning when assigning numeric literal to SINT

### DIFF
--- a/src/typesystem.rs
+++ b/src/typesystem.rs
@@ -1597,7 +1597,9 @@ pub fn get_literal_actual_signed_type_name(lit: &AstLiteral, signed: bool) -> Op
 
     match lit {
         AstLiteral::Integer(value) => match signed {
-            _ if *value == 0_i128 || *value == 1_i128 => Some(BOOL_TYPE),
+            // BOOL types are not signed
+            false if *value == 0_i128 || *value == 1_i128 => Some(BOOL_TYPE),
+
             true if is_covered_by!(i8, *value) => Some(SINT_TYPE),
             true if is_covered_by!(i16, *value) => Some(INT_TYPE),
             true if is_covered_by!(i32, *value) => Some(DINT_TYPE),

--- a/src/validation/tests/literals_validation_tests.rs
+++ b/src/validation/tests/literals_validation_tests.rs
@@ -167,3 +167,37 @@ fn char_cast_validate() {
 
     assert_snapshot!(&diagnostics);
 }
+
+#[test]
+fn there_should_be_no_downcast_warning_for_literal_assignment_to_integer_types() {
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        PROGRAM prg
+        VAR
+            varSINT : SINT;
+            varINT : INT;
+            varDINT : DINT;
+            varLINT : LINT;
+
+            varUSINT : USINT;
+            varUINT : UINT;
+            varUDINT : UDINT;
+            varULINT : ULINT;
+        END_VAR
+
+        varSINT := 0;
+        varINT := 0;
+        varDINT := 0;
+        varLINT := 0;
+
+        varUSINT := 0;
+        varUINT := 0;
+        varUDINT := 0;
+        varULINT := 0;
+
+        END_PROGRAM
+       "#,
+    );
+
+    assert_snapshot!(&diagnostics, @r"");
+}

--- a/src/validation/tests/literals_validation_tests.rs
+++ b/src/validation/tests/literals_validation_tests.rs
@@ -183,6 +183,8 @@ fn there_should_be_no_downcast_warning_for_literal_assignment_to_integer_types()
             varUINT : UINT;
             varUDINT : UDINT;
             varULINT : ULINT;
+
+            varBOOL : BOOL;
         END_VAR
 
         varSINT := 0;
@@ -194,6 +196,9 @@ fn there_should_be_no_downcast_warning_for_literal_assignment_to_integer_types()
         varUINT := 0;
         varUDINT := 0;
         varULINT := 0;
+
+        // Prove the counter-case, this should still be valid
+        varBOOL := 0;
 
         END_PROGRAM
        "#,


### PR DESCRIPTION
Changed:
- Fixed incorrect downcast warning when assigning numeric literal to SINT

Testing:
- Added unit test to prove that no downcast warnings are surfaced when assigning literals to integer types