### PR TITLE
build: bump rustc-hash 1 -> 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"
-rustc-hash = "1.1.0"
+rustc-hash = "2"
 tempfile = "3.17.0"
 anstream = "1"
 anstyle = "1"

--- a/compiler/plc_index/src/lib.rs
+++ b/compiler/plc_index/src/lib.rs
@@ -118,7 +118,10 @@ impl GlobalContext {
         let Some(code) = self.sources.get(path) else { return "" };
         let Some(span) = location.get_span().to_range() else { return "" };
 
-        &code.source[span]
+        // A location's span may not belong to the resolved source (e.g. a
+        // builtin type whose `<internal>` location is sliced against a user
+        // source), so index fallibly rather than panicking on out-of-bounds.
+        code.source.get(span).unwrap_or("")
     }
 
     // TODO: This is a proof-of-concept version how we could use the GlobalContext to handle

--- a/src/index.rs
+++ b/src/index.rs
@@ -672,7 +672,8 @@ impl InterfaceIndexEntry {
     /// Returns a list of ALL interfaces in this interface's hierarchy, **including `self`**,
     /// as well as all interfaces it extends directly or indirectly.
     pub fn get_interface_hierarchy<'i>(&self, index: &'i Index) -> Vec<&'i InterfaceIndexEntry> {
-        let mut seen: FxHashSet<&Identifier> = FxHashSet::default();
+        // Using FxIndexSet to preserve insertion order
+        let mut seen: FxIndexSet<&Identifier> = FxIndexSet::default();
         let mut queue: VecDeque<&InterfaceIndexEntry> = VecDeque::new();
 
         queue.push_back(self);

--- a/src/resolver/tests/resolve_declarations.rs
+++ b/src/resolver/tests/resolve_declarations.rs
@@ -224,20 +224,20 @@ fn all_available_methods_of_container_are_annotated() {
     Some(
         MethodDeclarations {
             declarations: {
-                "bar": [
-                    Concrete(
-                        "derived.bar",
-                    ),
-                    Abstract(
-                        "base2.bar",
-                    ),
-                ],
                 "foo": [
                     Concrete(
                         "derived.foo",
                     ),
                     Abstract(
                         "base2.foo",
+                    ),
+                ],
+                "bar": [
+                    Concrete(
+                        "derived.bar",
+                    ),
+                    Abstract(
+                        "base2.bar",
                     ),
                 ],
             },
@@ -294,19 +294,14 @@ fn all_available_methods_of_interface_are_annotated() {
     Some(
         MethodDeclarations {
             declarations: {
-                "fred": [
-                    Abstract(
-                        "quxar.fred",
-                    ),
-                ],
                 "garply": [
                     Abstract(
                         "quuz.garply",
                     ),
                 ],
-                "corge": [
+                "bar": [
                     Abstract(
-                        "quux.corge",
+                        "foo.bar",
                     ),
                 ],
                 "waldo": [
@@ -314,14 +309,19 @@ fn all_available_methods_of_interface_are_annotated() {
                         "quxat.waldo",
                     ),
                 ],
+                "fred": [
+                    Abstract(
+                        "quxar.fred",
+                    ),
+                ],
                 "grault": [
                     Abstract(
                         "quuz.grault",
                     ),
                 ],
-                "bar": [
+                "corge": [
                     Abstract(
-                        "foo.bar",
+                        "quux.corge",
                     ),
                 ],
                 "qux": [
@@ -502,14 +502,6 @@ fn function_block_has_both_abstract_and_concrete_annotation_from_extended_intf()
     Some(
         MethodDeclarations {
             declarations: {
-                "corge": [
-                    Concrete(
-                        "fb.corge",
-                    ),
-                    Abstract(
-                        "quux.corge",
-                    ),
-                ],
                 "garply": [
                     Concrete(
                         "fb.garply",
@@ -534,6 +526,14 @@ fn function_block_has_both_abstract_and_concrete_annotation_from_extended_intf()
                         "quxar.fred",
                     ),
                 ],
+                "qux": [
+                    Concrete(
+                        "fb.qux",
+                    ),
+                    Abstract(
+                        "baz.qux",
+                    ),
+                ],
                 "grault": [
                     Concrete(
                         "fb.grault",
@@ -550,12 +550,12 @@ fn function_block_has_both_abstract_and_concrete_annotation_from_extended_intf()
                         "foo.bar",
                     ),
                 ],
-                "qux": [
+                "corge": [
                     Concrete(
-                        "fb.qux",
+                        "fb.corge",
                     ),
                     Abstract(
-                        "baz.qux",
+                        "quux.corge",
                     ),
                 ],
             },

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -140,7 +140,14 @@ impl<'a> Validator<'a> {
             return dt.get_type_information().get_inner_name().to_string();
         }
 
-        self.context.slice(&dt.location)
+        // Fall back to the type name when the location can't be sliced (e.g. a
+        // builtin type whose location doesn't resolve within the user source).
+        let slice = self.context.slice(&dt.location);
+        if slice.is_empty() {
+            return dt.get_name().to_string();
+        }
+
+        slice
     }
 
     pub fn diagnostics(&mut self) -> Vec<Diagnostic> {

--- a/src/validation/tests/interface_validation_tests.rs
+++ b/src/validation/tests/interface_validation_tests.rs
@@ -758,26 +758,7 @@ fn interface_with_aggregate_return_type_array_dimension_mismatch() {
         ";
 
     let diagnostics = parse_and_validate_buffered(source);
-    insta::assert_snapshot!(diagnostics, @r"
-    error[E112]: Derived methods with conflicting signatures, return types do not match:
-      ┌─ <internal>:9:24
-      │
-    9 │         FUNCTION_BLOCK fb IMPLEMENTS foo
-      │                        ^^ Derived methods with conflicting signatures, return types do not match:
-
-    note[E118]: Array declared with `1` dimension but implemented with `2`
-       ┌─ <internal>:3:20
-       │
-     3 │             METHOD bar : ARRAY[1..5, 1..5] OF STRING
-       │                    ---   --------------------------- see also
-       │                    │      
-       │                    see also
-       ·
-    10 │             METHOD bar : ARRAY[1..5] OF STRING
-       │                    ---   --------------------- see also
-       │                    │      
-       │                    see also
-
+    insta::assert_snapshot!(diagnostics, @"
     error[E112]: Derived methods with conflicting signatures, return types do not match:
       ┌─ <internal>:9:24
       │
@@ -794,6 +775,25 @@ fn interface_with_aggregate_return_type_array_dimension_mismatch() {
        ·
     12 │             METHOD baz : ARRAY[1..5, 1..5] OF STRING
        │                    ---   --------------------------- see also
+       │                    │      
+       │                    see also
+
+    error[E112]: Derived methods with conflicting signatures, return types do not match:
+      ┌─ <internal>:9:24
+      │
+    9 │         FUNCTION_BLOCK fb IMPLEMENTS foo
+      │                        ^^ Derived methods with conflicting signatures, return types do not match:
+
+    note[E118]: Array declared with `1` dimension but implemented with `2`
+       ┌─ <internal>:3:20
+       │
+     3 │             METHOD bar : ARRAY[1..5, 1..5] OF STRING
+       │                    ---   --------------------------- see also
+       │                    │      
+       │                    see also
+       ·
+    10 │             METHOD bar : ARRAY[1..5] OF STRING
+       │                    ---   --------------------- see also
        │                    │      
        │                    see also
     ");
@@ -1094,37 +1094,7 @@ fn interface_with_aggregate_return_type_non_aggregate_impl_parameter_count_misma
         ";
 
     let diagnostics = parse_and_validate_buffered(source);
-    insta::assert_snapshot!(diagnostics, @r"
-    error[E112]: Derived methods with conflicting signatures, return types do not match:
-       ┌─ <internal>:17:24
-       │
-    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
-       │                        ^^ Derived methods with conflicting signatures, return types do not match:
-
-    note[E118]: Type `STRING` declared in `foo.bar` but `fb.bar` declared type `DINT`
-       ┌─ <internal>:3:20
-       │
-     3 │             METHOD bar : STRING
-       │                    --- see also
-       ·
-    18 │             METHOD bar : DINT
-       │                    --- see also
-
-    error[E112]: Derived methods with conflicting signatures, parameters do not match:
-       ┌─ <internal>:17:24
-       │
-    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
-       │                        ^^ Derived methods with conflicting signatures, parameters do not match:
-
-    note[E118]: Parameter `b : DINT` missing in method `bar`
-       ┌─ <internal>:6:17
-       │
-     6 │                 b : DINT;
-       │                 - see also
-       ·
-    18 │             METHOD bar : DINT
-       │                    --- see also
-
+    insta::assert_snapshot!(diagnostics, @"
     error[E112]: Derived methods with conflicting signatures, return types do not match:
        ┌─ <internal>:17:24
        │
@@ -1154,6 +1124,36 @@ fn interface_with_aggregate_return_type_non_aggregate_impl_parameter_count_misma
        ·
     27 │                 b : DINT;
        │                 - see also
+
+    error[E112]: Derived methods with conflicting signatures, return types do not match:
+       ┌─ <internal>:17:24
+       │
+    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
+       │                        ^^ Derived methods with conflicting signatures, return types do not match:
+
+    note[E118]: Type `STRING` declared in `foo.bar` but `fb.bar` declared type `DINT`
+       ┌─ <internal>:3:20
+       │
+     3 │             METHOD bar : STRING
+       │                    --- see also
+       ·
+    18 │             METHOD bar : DINT
+       │                    --- see also
+
+    error[E112]: Derived methods with conflicting signatures, parameters do not match:
+       ┌─ <internal>:17:24
+       │
+    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
+       │                        ^^ Derived methods with conflicting signatures, parameters do not match:
+
+    note[E118]: Parameter `b : DINT` missing in method `bar`
+       ┌─ <internal>:6:17
+       │
+     6 │                 b : DINT;
+       │                 - see also
+       ·
+    18 │             METHOD bar : DINT
+       │                    --- see also
     ");
 }
 
@@ -1192,37 +1192,7 @@ fn interface_with_non_aggregate_return_type_aggregate_impl_parameter_count_misma
         ";
 
     let diagnostics = parse_and_validate_buffered(source);
-    insta::assert_snapshot!(diagnostics, @r"
-    error[E112]: Derived methods with conflicting signatures, return types do not match:
-       ┌─ <internal>:17:24
-       │
-    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
-       │                        ^^ Derived methods with conflicting signatures, return types do not match:
-
-    note[E118]: Type `DINT` declared in `foo.bar` but `fb.bar` declared type `STRING`
-       ┌─ <internal>:3:20
-       │
-     3 │             METHOD bar : DINT
-       │                    --- see also
-       ·
-    18 │             METHOD bar : STRING
-       │                    --- see also
-
-    error[E112]: Derived methods with conflicting signatures, parameters do not match:
-       ┌─ <internal>:17:24
-       │
-    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
-       │                        ^^ Derived methods with conflicting signatures, parameters do not match:
-
-    note[E118]: Parameter `b : DINT` missing in method `bar`
-       ┌─ <internal>:6:17
-       │
-     6 │                 b : DINT;
-       │                 - see also
-       ·
-    18 │             METHOD bar : STRING
-       │                    --- see also
-
+    insta::assert_snapshot!(diagnostics, @"
     error[E112]: Derived methods with conflicting signatures, return types do not match:
        ┌─ <internal>:17:24
        │
@@ -1252,6 +1222,36 @@ fn interface_with_non_aggregate_return_type_aggregate_impl_parameter_count_misma
        ·
     27 │                 b : DINT;
        │                 - see also
+
+    error[E112]: Derived methods with conflicting signatures, return types do not match:
+       ┌─ <internal>:17:24
+       │
+    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
+       │                        ^^ Derived methods with conflicting signatures, return types do not match:
+
+    note[E118]: Type `DINT` declared in `foo.bar` but `fb.bar` declared type `STRING`
+       ┌─ <internal>:3:20
+       │
+     3 │             METHOD bar : DINT
+       │                    --- see also
+       ·
+    18 │             METHOD bar : STRING
+       │                    --- see also
+
+    error[E112]: Derived methods with conflicting signatures, parameters do not match:
+       ┌─ <internal>:17:24
+       │
+    17 │         FUNCTION_BLOCK fb IMPLEMENTS foo
+       │                        ^^ Derived methods with conflicting signatures, parameters do not match:
+
+    note[E118]: Parameter `b : DINT` missing in method `bar`
+       ┌─ <internal>:6:17
+       │
+     6 │                 b : DINT;
+       │                 - see also
+       ·
+    18 │             METHOD bar : STRING
+       │                    --- see also
     ");
 }
 
@@ -1780,16 +1780,7 @@ fn pou_missing_methods_of_extended_interface() {
         ";
 
     let diagnostics = parse_and_validate_buffered(source);
-    insta::assert_snapshot!(diagnostics, @r"
-    error[E112]: Method `bar` defined in interface `foo` is missing in POU `fb`
-       ┌─ <internal>:12:24
-       │
-     3 │             METHOD bar
-       │                    --- see also
-       ·
-    12 │         FUNCTION_BLOCK fb IMPLEMENTS baz
-       │                        ^^ Method `bar` defined in interface `foo` is missing in POU `fb`
-
+    insta::assert_snapshot!(diagnostics, @"
     error[E112]: Method `qux` defined in interface `baz` is missing in POU `fb`
        ┌─ <internal>:12:24
        │
@@ -1798,6 +1789,15 @@ fn pou_missing_methods_of_extended_interface() {
        ·
     12 │         FUNCTION_BLOCK fb IMPLEMENTS baz
        │                        ^^ Method `qux` defined in interface `baz` is missing in POU `fb`
+
+    error[E112]: Method `bar` defined in interface `foo` is missing in POU `fb`
+       ┌─ <internal>:12:24
+       │
+     3 │             METHOD bar
+       │                    --- see also
+       ·
+    12 │         FUNCTION_BLOCK fb IMPLEMENTS baz
+       │                        ^^ Method `bar` defined in interface `foo` is missing in POU `fb`
     ");
 }
 
@@ -1824,7 +1824,16 @@ fn pou_missing_methods_of_nested_extended_interface() {
         ";
 
     let diagnostics = parse_and_validate_buffered(source);
-    insta::assert_snapshot!(diagnostics, @r"
+    insta::assert_snapshot!(diagnostics, @"
+    error[E112]: Method `qux` defined in interface `baz` is missing in POU `fb`
+       ┌─ <internal>:17:24
+       │
+     8 │             METHOD qux
+       │                    --- see also
+       ·
+    17 │         FUNCTION_BLOCK fb IMPLEMENTS quux
+       │                        ^^ Method `qux` defined in interface `baz` is missing in POU `fb`
+
     error[E112]: Method `corge` defined in interface `quux` is missing in POU `fb`
        ┌─ <internal>:17:24
        │
@@ -1842,15 +1851,6 @@ fn pou_missing_methods_of_nested_extended_interface() {
        ·
     17 │         FUNCTION_BLOCK fb IMPLEMENTS quux
        │                        ^^ Method `bar` defined in interface `foo` is missing in POU `fb`
-
-    error[E112]: Method `qux` defined in interface `baz` is missing in POU `fb`
-       ┌─ <internal>:17:24
-       │
-     8 │             METHOD qux
-       │                    --- see also
-       ·
-    17 │         FUNCTION_BLOCK fb IMPLEMENTS quux
-       │                        ^^ Method `qux` defined in interface `baz` is missing in POU `fb`
     ");
 }
 
@@ -1895,16 +1895,7 @@ fn pou_missing_methods_of_multiple_nested_interfaces() {
         ";
 
     let diagnostics = parse_and_validate_buffered(source);
-    insta::assert_snapshot!(diagnostics, @r"
-    error[E112]: Method `fred` defined in interface `quxar` is missing in POU `fb`
-       ┌─ <internal>:35:24
-       │
-    31 │             METHOD fred
-       │                    ---- see also
-       ·
-    35 │         FUNCTION_BLOCK fb IMPLEMENTS quxar
-       │                        ^^ Method `fred` defined in interface `quxar` is missing in POU `fb`
-
+    insta::assert_snapshot!(diagnostics, @"
     error[E112]: Method `garply` defined in interface `quuz` is missing in POU `fb`
        ┌─ <internal>:35:24
        │
@@ -1914,14 +1905,14 @@ fn pou_missing_methods_of_multiple_nested_interfaces() {
     35 │         FUNCTION_BLOCK fb IMPLEMENTS quxar
        │                        ^^ Method `garply` defined in interface `quuz` is missing in POU `fb`
 
-    error[E112]: Method `corge` defined in interface `quux` is missing in POU `fb`
+    error[E112]: Method `bar` defined in interface `foo` is missing in POU `fb`
        ┌─ <internal>:35:24
        │
-    13 │             METHOD corge
-       │                    ----- see also
+     3 │             METHOD bar
+       │                    --- see also
        ·
     35 │         FUNCTION_BLOCK fb IMPLEMENTS quxar
-       │                        ^^ Method `corge` defined in interface `quux` is missing in POU `fb`
+       │                        ^^ Method `bar` defined in interface `foo` is missing in POU `fb`
 
     error[E112]: Method `waldo` defined in interface `quxat` is missing in POU `fb`
        ┌─ <internal>:35:24
@@ -1932,6 +1923,15 @@ fn pou_missing_methods_of_multiple_nested_interfaces() {
     35 │         FUNCTION_BLOCK fb IMPLEMENTS quxar
        │                        ^^ Method `waldo` defined in interface `quxat` is missing in POU `fb`
 
+    error[E112]: Method `fred` defined in interface `quxar` is missing in POU `fb`
+       ┌─ <internal>:35:24
+       │
+    31 │             METHOD fred
+       │                    ---- see also
+       ·
+    35 │         FUNCTION_BLOCK fb IMPLEMENTS quxar
+       │                        ^^ Method `fred` defined in interface `quxar` is missing in POU `fb`
+
     error[E112]: Method `grault` defined in interface `quuz` is missing in POU `fb`
        ┌─ <internal>:35:24
        │
@@ -1941,14 +1941,14 @@ fn pou_missing_methods_of_multiple_nested_interfaces() {
     35 │         FUNCTION_BLOCK fb IMPLEMENTS quxar
        │                        ^^ Method `grault` defined in interface `quuz` is missing in POU `fb`
 
-    error[E112]: Method `bar` defined in interface `foo` is missing in POU `fb`
+    error[E112]: Method `corge` defined in interface `quux` is missing in POU `fb`
        ┌─ <internal>:35:24
        │
-     3 │             METHOD bar
-       │                    --- see also
+    13 │             METHOD corge
+       │                    ----- see also
        ·
     35 │         FUNCTION_BLOCK fb IMPLEMENTS quxar
-       │                        ^^ Method `bar` defined in interface `foo` is missing in POU `fb`
+       │                        ^^ Method `corge` defined in interface `quux` is missing in POU `fb`
 
     error[E112]: Method `qux` defined in interface `baz` is missing in POU `fb`
        ┌─ <internal>:35:24
@@ -2273,8 +2273,8 @@ fn property_with_conflicting_signatures() {
     END_INTERFACE
     ";
 
-    insta::assert_snapshot!(parse_and_validate_buffered(source), @r"
-    error[E112]: Property `prop` defined in interface `intf2` and `intf1` have different datatypes
+    insta::assert_snapshot!(parse_and_validate_buffered(source), @"
+    error[E112]: Property `prop` defined in interface `intf1` and `intf2` have different datatypes
        ┌─ <internal>:10:15
        │
      3 │         PROPERTY_GET prop: DINT END_PROPERTY
@@ -2284,7 +2284,7 @@ fn property_with_conflicting_signatures() {
        │                            ------ see also
        ·
     10 │     INTERFACE intf3 EXTENDS intf1, intf2
-       │               ^^^^^ Property `prop` defined in interface `intf2` and `intf1` have different datatypes
+       │               ^^^^^ Property `prop` defined in interface `intf1` and `intf2` have different datatypes
     ");
 }
 

--- a/src/validation/tests/property_validation_tests.rs
+++ b/src/validation/tests/property_validation_tests.rs
@@ -527,15 +527,15 @@ fn overriding_property_in_interface_with_different_datatype_is_not_ok() {
     END_INTERFACE
     ";
 
-    insta::assert_snapshot!(test_utils::parse_and_validate_buffered(source), @r"
-    error[E112]: Property `prop` defined in interface `intf1` and `intf2` have different datatypes
+    insta::assert_snapshot!(test_utils::parse_and_validate_buffered(source), @"
+    error[E112]: Property `prop` defined in interface `intf2` and `intf1` have different datatypes
       ┌─ <internal>:7:15
       │
     3 │         PROPERTY_GET prop: DINT END_PROPERTY
       │                            ---- see also
       ·
     7 │     INTERFACE intf2 EXTENDS intf1
-      │               ^^^^^ Property `prop` defined in interface `intf1` and `intf2` have different datatypes
+      │               ^^^^^ Property `prop` defined in interface `intf2` and `intf1` have different datatypes
     8 │         PROPERTY_SET prop: STRING END_PROPERTY
       │                            ------ see also
     ");
@@ -715,7 +715,7 @@ fn extending_interface_with_interfaces_with_conflicting_signatures_is_not_ok() {
     END_INTERFACE
     ";
 
-    insta::assert_snapshot!(test_utils::parse_and_validate_buffered(source), @r"
+    insta::assert_snapshot!(test_utils::parse_and_validate_buffered(source), @"
     error[E112]: Property `prop` defined in interface `A` and `B` have different datatypes
        ┌─ <internal>:10:15
        │
@@ -774,30 +774,7 @@ fn multiple_levels() {
     END_INTERFACE
     ";
 
-    insta::assert_snapshot!(test_utils::parse_and_validate_buffered(source), @r"
-    error[E112]: Property `propA` defined in interface `E` and `A` have different datatypes
-       ┌─ <internal>:19:15
-       │
-     3 │         PROPERTY_GET propA: DINT END_PROPERTY
-       │                             ---- see also
-       ·
-    19 │     INTERFACE E EXTENDS B, C, A
-       │               ^ Property `propA` defined in interface `E` and `A` have different datatypes
-    20 │         PROPERTY_GET propA: REAL END_PROPERTY
-       │                             ---- see also
-
-    error[E112]: Property `propA` defined in interface `A` and `E` have different datatypes
-       ┌─ <internal>:19:15
-       │
-     3 │         PROPERTY_GET propA: DINT END_PROPERTY
-       │                             ---- see also
-       ·
-    19 │     INTERFACE E EXTENDS B, C, A
-       │               ^ Property `propA` defined in interface `A` and `E` have different datatypes
-       ·
-    26 │         PROPERTY_GET propC: INT END_PROPERTY
-       │                             --- see also
-
+    insta::assert_snapshot!(test_utils::parse_and_validate_buffered(source), @"
     error[E112]: Property `propC` defined in interface `E` and `C` have different datatypes
        ┌─ <internal>:19:15
        │
@@ -818,6 +795,28 @@ fn multiple_levels() {
        ·
     19 │     INTERFACE E EXTENDS B, C, A
        │               ^ Property `propC` defined in interface `C` and `E` have different datatypes
+    20 │         PROPERTY_GET propA: REAL END_PROPERTY
+       │                             ---- see also
+
+    error[E112]: Property `propA` defined in interface `E` and `A` have different datatypes
+       ┌─ <internal>:19:15
+       │
+     3 │         PROPERTY_GET propA: DINT END_PROPERTY
+       │                             ---- see also
+       ·
+    19 │     INTERFACE E EXTENDS B, C, A
+       │               ^ Property `propA` defined in interface `E` and `A` have different datatypes
+    20 │         PROPERTY_GET propA: REAL END_PROPERTY
+       │                             ---- see also
+
+    error[E112]: Property `propA` defined in interface `A` and `E` have different datatypes
+       ┌─ <internal>:19:15
+       │
+     3 │         PROPERTY_GET propA: DINT END_PROPERTY
+       │                             ---- see also
+       ·
+    19 │     INTERFACE E EXTENDS B, C, A
+       │               ^ Property `propA` defined in interface `A` and `E` have different datatypes
        ·
     23 │         PROPERTY_GET propB: STRING END_PROPERTY
        │                             ------ see also

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -1085,7 +1085,7 @@ fn builtin_functions_named_arguments_invalid_parameter_names() {
     ",
     );
 
-    assert_snapshot!(diagnostics, @r"
+    assert_snapshot!(diagnostics, @"
     error[E089]: Invalid call parameters
        ┌─ <internal>:10:22
        │
@@ -1122,11 +1122,11 @@ fn builtin_functions_named_arguments_invalid_parameter_names() {
     14 │             arr2 := MOVE(SOURCE := arr);
        │                          ^^^^^^ Could not resolve reference to SOURCE
 
-    error[E037]: Invalid assignment: cannot assign 'SEL with wrong parameter names a := SEL(WRONG := sel, IN0 := a, IN1 := b); a := SEL(G := sel, INVALID := a,' to 'ARRAY[0..5] OF INT'
+    error[E037]: Invalid assignment: cannot assign '__MOVE__U' to 'ARRAY[0..5] OF INT'
        ┌─ <internal>:14:13
        │
     14 │             arr2 := MOVE(SOURCE := arr);
-       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign 'SEL with wrong parameter names a := SEL(WRONG := sel, IN0 := a, IN1 := b); a := SEL(G := sel, INVALID := a,' to 'ARRAY[0..5] OF INT'
+       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid assignment: cannot assign '__MOVE__U' to 'ARRAY[0..5] OF INT'
 
     error[E089]: Invalid call parameters
        ┌─ <internal>:17:25


### PR DESCRIPTION
Guard slice_raw against out-of-range spans and fall back to the type name in get_type_name_or_slice. Use FxIndexSet in get_interface_hierarchy so it keeps breadth-first order. Refresh the reordered snapshots.