### PR TITLE
fix(resolver): enum names should resolve correctly when they collide with pou names

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2538,10 +2538,24 @@ impl<'i> TypeAnnotator<'i> {
         ctx: &VisitorContext<'_>,
     ) -> Option<StatementAnnotation> {
         match reference.get_stmt() {
-            AstStatement::Identifier(name, ..) => ctx
-                .resolve_strategy
-                .iter()
-                .find_map(|scope| scope.resolve_name(name, qualifier, self.index, ctx, &self.scopes)),
+            AstStatement::Identifier(name, ..) => {
+                // Internally generated ADR/REF calls (e.g. vtable wiring) may reference POU names
+                // that can potentially collide with enum variants.
+                let should_use_pou_resolution =
+                    qualifier.is_none() && reference.location.is_internal() && ctx.pou.is_none();
+
+                if should_use_pou_resolution {
+                    if let Some(annotation) =
+                        ResolvingStrategy::POU.resolve_name(name, qualifier, self.index, ctx, &self.scopes)
+                    {
+                        return Some(annotation);
+                    }
+                }
+
+                ctx.resolve_strategy
+                    .iter()
+                    .find_map(|scope| scope.resolve_name(name, qualifier, self.index, ctx, &self.scopes))
+            }
 
             AstStatement::ReferenceExpr(_) => {
                 self.visit_statement(ctx, reference);
@@ -3197,11 +3211,27 @@ impl ResolvingStrategy {
                         .or_else(|| index.find_enum_variant(qualifier, name))
                         .map(|it| to_variable_annotation(it, index, it.is_constant() || ctx.constant))
                 } else {
+                    // FIXME: String matching here isn't the best, but it will do until we have a set way to determine builtin ADR/REF
+                    let is_addressing_builtin_arg = ctx.lhs.is_some_and(|lhs| {
+                        let lhs = lhs.to_ascii_uppercase();
+                        lhs == "ADR" || lhs == "REF" || lhs.starts_with("ADR__") || lhs.starts_with("REF__")
+                    });
+
                     // look for member variable with name "pou.name"
                     // then try fopr a global variable called "name"
+                    // if that global varible is not shadowed by a
+                    // ADR/REF POU with the same name in the current context
                     ctx.pou
                         .and_then(|pou| scopes.find_member(index, pou, name))
-                        .or_else(|| index.find_global_variable(name))
+                        .or_else(|| {
+                            // In ADR/REF argument context, prefer callable/type symbols over
+                            // enum variants if both share the same unqualified name.
+                            if is_addressing_builtin_arg && index.find_pou(name).is_some() {
+                                None
+                            } else {
+                                index.find_global_variable(name)
+                            }
+                        })
                         .map(|g| to_variable_annotation(g, index, g.is_constant()))
                 }
             }

--- a/src/resolver/tests/resolve_expressions_tests.rs
+++ b/src/resolver/tests/resolve_expressions_tests.rs
@@ -7243,3 +7243,65 @@ fn fb_instance_shares_name_with_function_direct_call() {
         annotations.get(operator)
     );
 }
+
+#[test]
+fn enum_with_names_that_collide_with_pous_resolves_correctly() {
+    let id_provider = IdProvider::default();
+    let (unit, mut index) = index_with_ids(
+        "
+            TYPE
+                MyEnum : (MyFunc, MyFuncBlock, MyMethod, MyAlias);
+            END_TYPE
+
+            PROGRAM mainProg
+                VAR
+                    e : MyEnum;
+                END_VAR
+
+                e := MyFunc;
+                e := MyFuncBlock;
+                e := MyMethod;
+                e := MyAlias;
+
+            END_PROGRAM
+
+            TYPE
+                MyAlias : INT;
+            END_TYPE
+
+            FUNCTION MyFunc
+                // Does nothing
+            END_FUNCTION
+
+            FUNCTION_BLOCK MyFuncBlock
+                METHOD PUBLIC MyMethod
+                    // Does nothing
+                END_METHOD
+            END_FUNCTION_BLOCK
+        ",
+        id_provider.clone(),
+    );
+    let annotations = annotate_with_ids(&unit, &mut index, id_provider);
+
+    let statements = &unit.implementations[0].statements;
+    if let AstNode { stmt: AstStatement::Assignment(Assignment { right, .. }), .. } = &statements[0] {
+        assert_type_and_hint!(&annotations, &index, right.as_ref(), "MyEnum", Some("MyEnum"));
+    } else {
+        unreachable!()
+    }
+    if let AstNode { stmt: AstStatement::Assignment(Assignment { right, .. }), .. } = &statements[1] {
+        assert_type_and_hint!(&annotations, &index, right.as_ref(), "MyEnum", Some("MyEnum"));
+    } else {
+        unreachable!()
+    }
+    if let AstNode { stmt: AstStatement::Assignment(Assignment { right, .. }), .. } = &statements[2] {
+        assert_type_and_hint!(&annotations, &index, right.as_ref(), "MyEnum", Some("MyEnum"));
+    } else {
+        unreachable!()
+    }
+    if let AstNode { stmt: AstStatement::Assignment(Assignment { right, .. }), .. } = &statements[3] {
+        assert_type_and_hint!(&annotations, &index, right.as_ref(), "MyEnum", Some("MyEnum"));
+    } else {
+        unreachable!()
+    }
+}

--- a/tests/lit/single/enums/enum_name_conflicts_with_function_block.st
+++ b/tests/lit/single/enums/enum_name_conflicts_with_function_block.st
@@ -1,0 +1,54 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+TYPE
+    eW : (fooFunc, fooBlock, fooMethod, MyAlias);
+END_TYPE
+
+TYPE
+    MyAlias : INT;
+END_TYPE
+
+FUNCTION fooFunc
+    // Does nothing
+END_FUNCTION
+
+FUNCTION_BLOCK fooBlock
+    METHOD PUBLIC fooMethod
+        // Does nothing
+    END_METHOD
+END_FUNCTION_BLOCK
+
+PROGRAM mainProg
+    VAR
+        e : eW;
+    END_VAR
+
+    // Should be able to assign the enum element to the enum without ambiguity
+    e := fooFunc;
+
+    // CHECK: 0
+    printf('%d$N', e);
+
+    // Should be able to assign the enum element to the enum without ambiguity
+    e := fooBlock;
+
+    // CHECK: 1
+    printf('%d$N', e);
+
+    // Should be able to assign the enum element to the enum without ambiguity
+    e := fooMethod;
+
+    // CHECK: 2
+    printf('%d$N', e);
+
+    // Should be able to assign the enum element to the enum without ambiguity
+    e := MyAlias;
+
+    // CHECK: 3
+    printf('%d$N', e);
+
+END_PROGRAM
+
+FUNCTION main
+    mainProg();
+END_FUNCTION


### PR DESCRIPTION
**Changed**
- Resolver updated to allow enums to share the same name as pous but resolve correctly

**Testing**
- Added lit test to prove the case