### PR TITLE
fix: only error out on non existing files (not globs)

### DIFF
--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -451,12 +451,6 @@ fn get_project(compile_parameters: &CompileParameters) -> Result<Project<PathBuf
         })
         .map(|proj| proj.with_output_name(compile_parameters.output.clone()))?;
 
-    // Object-only inputs (e.g. `plc lib.o -ltest -L<dir>`) are a legitimate
-    // link-only invocation and must not trip the empty-set guard. Reject only
-    // when neither sources nor objects were resolved.
-    if project.get_sources().is_empty() && project.get_objects().is_empty() {
-        anyhow::bail!("no input files");
-    }
     Ok(project)
 }
 

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -409,6 +409,11 @@ impl<T: SourceContainer> Pipeline for BuildPipeline<T> {
             return Ok(());
         }
 
+        //If no input files are available in the project, stop the compilation
+        if self.project.get_sources().is_empty() && self.project.get_objects().is_empty() {
+            return Err(Diagnostic::new("no input files"));
+        }
+
         self.initialize_thread_pool();
 
         // 1. Parse

--- a/compiler/plc_project/src/project.rs
+++ b/compiler/plc_project/src/project.rs
@@ -361,54 +361,16 @@ fn resolve_file_paths(location: Option<&Path>, inputs: Vec<PathBuf>) -> Result<V
     Ok(sources)
 }
 
-/// Catches typos in project configurations by rejecting inputs that can never
-/// match anything: literal paths whose target is missing, and globs whose
-/// literal-prefix directory doesn't exist (e.g. `<typo>/include/*.st`).
-/// Globs whose directory exists but match nothing remain accepted (a
-/// templating pattern like `*.dt` is valid even when no .dt files are present),
-/// regardless of whether the wildcard sits in the leaf segment or mid-path.
-///
-/// The wildcard probe is intentionally lax — a stray `[` without a matching
-/// `]` (e.g. `[oddname.st`) classifies as a glob and routes through the
-/// parent-directory check rather than being rejected as a literal miss. The
-/// downstream `glob` crate would refuse the malformed pattern anyway; the
-/// worst case is a slightly fuzzier error message.
-///
-/// Existence is determined via `Path::exists()`, which follows symlinks and
-/// reports based on the target. A broken symlink rejects here; an unreadable
-/// path that the caller lacks permission to traverse is reported as missing
-/// only when the OS surfaces it that way (otherwise the failure resurfaces
-/// at compile / link time with the underlying I/O error).
+/// Validates that input files actually exist before the compilation starts.
+/// Ignores globs since they could point to a non existing (templating) directory.
 fn validate_input_exists(original: &Path, joined: &Path) -> Result<()> {
     let original_str = original.to_string_lossy();
     let has_wildcard = original_str.contains(['*', '?', '[']);
 
-    if has_wildcard {
-        let parent = glob_literal_parent(joined);
-        if !parent.exists() {
-            return Err(anyhow!("path '{original_str}' does not exist"));
-        }
-    } else if !joined.exists() {
+    if !has_wildcard && !joined.exists() {
         return Err(anyhow!("path '{original_str}' does not exist"));
     }
     Ok(())
-}
-
-/// Returns the deepest directory in `pattern` that contains no glob
-/// metacharacter. For `src/foo/*.st` this is `src/foo`; for `*.st` it is `.`.
-fn glob_literal_parent(pattern: &Path) -> PathBuf {
-    let mut parent = PathBuf::new();
-    for component in pattern.components() {
-        let s = component.as_os_str().to_string_lossy();
-        if s.contains(['*', '?', '[']) {
-            break;
-        }
-        parent.push(component);
-    }
-    if parent.as_os_str().is_empty() {
-        parent.push(".");
-    }
-    parent
 }
 
 impl From<LinkageInfo> for Linkage {
@@ -467,27 +429,16 @@ mod tests {
     }
 
     #[test]
-    fn glob_with_missing_parent_directory_errors() {
-        // The user's typical typo: `<typo>/include/*.st` where `<typo>` doesn't exist.
-        // We still want to reject these even though the path contains a wildcard.
+    fn glob_with_missing_parent_directory_resolves_empty() {
+        // Optional directories are routine in shared project templates
+        // (`conf/tasks/*.st` where `tasks/` doesn't exist in every project),
+        // so a glob whose parent directory is missing simply matches nothing.
+        // The driver still errors when the *entire* input set resolves empty.
         let dir = tempdir().unwrap();
 
-        let err =
-            resolve_file_paths(Some(dir.path()), vec![PathBuf::from("missing-subdir/*.st")]).unwrap_err();
-        assert!(err.to_string().contains("does not exist"), "got: {err}");
-        assert!(err.to_string().contains("missing-subdir/*.st"), "got: {err}");
-    }
-
-    #[test]
-    fn glob_literal_parent_strips_wildcard_components() {
-        assert_eq!(glob_literal_parent(Path::new("src/foo/*.st")), PathBuf::from("src/foo"));
-        assert_eq!(glob_literal_parent(Path::new("src/*/foo.st")), PathBuf::from("src"));
-        assert_eq!(glob_literal_parent(Path::new("*.st")), PathBuf::from("."));
-        // Defensive: production callers gate `glob_literal_parent` behind a
-        // wildcard check, so a literal path never reaches here today. The
-        // assertion documents the function's behaviour for that case in case
-        // a future caller drops the gate.
-        assert_eq!(glob_literal_parent(Path::new("src/file.st")), PathBuf::from("src/file.st"));
+        let result =
+            resolve_file_paths(Some(dir.path()), vec![PathBuf::from("missing-subdir/*.st")]).unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/tests/integration/command_line_compile.rs
+++ b/tests/integration/command_line_compile.rs
@@ -263,7 +263,7 @@ fn missing_include_path_errors_with_path_in_message() {
     let dir = tempfile::tempdir().unwrap();
     let main = dir.path().join("main.st");
     fs::write(&main, "FUNCTION main : DINT main := 0; END_FUNCTION").unwrap();
-    let bad_include = dir.path().join("no-such/*.st");
+    let bad_include = dir.path().join("no-such.st");
 
     let err = compile(&[
         "plc".to_string(),
@@ -273,7 +273,26 @@ fn missing_include_path_errors_with_path_in_message() {
     ])
     .unwrap_err();
     settings_with_tempdir_filter(dir.path())
-        .bind(|| insta::assert_snapshot!(err.to_string(), @"path '[tmp]/no-such/*.st' does not exist"));
+        .bind(|| insta::assert_snapshot!(err.to_string(), @"path '[tmp]/no-such.st' does not exist"));
+}
+
+#[test]
+fn glob_include_matching_nothing_is_accepted() {
+    // Globs may resolve to nothing (optional directories in shared project
+    // templates); only literal paths are validated for existence.
+    let dir = tempfile::tempdir().unwrap();
+    let main = dir.path().join("main.st");
+    fs::write(&main, "FUNCTION main : DINT main := 0; END_FUNCTION").unwrap();
+    let include_glob = dir.path().join("no-such/*.st");
+
+    compile(&[
+        "plc".to_string(),
+        main.to_string_lossy().into_owned(),
+        "-i".to_string(),
+        include_glob.to_string_lossy().into_owned(),
+        "--check".to_string(),
+    ])
+    .unwrap();
 }
 
 #[test]
@@ -282,7 +301,7 @@ fn missing_source_and_missing_include_surface_in_one_run() {
     // than surfaced one-per-run (see PR #1713 review feedback).
     let dir = tempfile::tempdir().unwrap();
     let bad_source = dir.path().join("missing.st");
-    let bad_include = dir.path().join("no-such/*.st");
+    let bad_include = dir.path().join("no-such.st");
 
     let err = compile(&[
         "plc".to_string(),
@@ -294,17 +313,57 @@ fn missing_source_and_missing_include_surface_in_one_run() {
     settings_with_tempdir_filter(dir.path()).bind(|| {
         insta::assert_snapshot!(err.to_string(), @r"
         path '[tmp]/missing.st' does not exist
-        path '[tmp]/no-such/*.st' does not exist
+        path '[tmp]/no-such.st' does not exist
         ")
     });
 }
 
-#[test]
-fn glob_with_missing_parent_directory_errors() {
-    let dir = tempfile::tempdir().unwrap();
-    let typo_glob = dir.path().join("typo-dir/*.st");
+// Informational modes must short-circuit before the "no input files" guard:
+// the guard lives in `Pipeline::run` *below* their early-returns, so these
+// invocations succeed without any inputs. Regression tests for the guard
+// previously sitting in `get_project`, which ran during pipeline construction
+// and broke every one of these.
 
-    let err = compile(&["plc".to_string(), typo_glob.to_string_lossy().into_owned()]).unwrap_err();
-    settings_with_tempdir_filter(dir.path())
-        .bind(|| insta::assert_snapshot!(err.to_string(), @"path '[tmp]/typo-dir/*.st' does not exist"));
+#[test]
+fn version_flag_succeeds_without_input_files() {
+    compile(&["plc", "--version"]).unwrap();
+}
+
+#[test]
+fn explain_subcommand_succeeds_without_input_files() {
+    compile(&["plc", "explain", "E001"]).unwrap();
+}
+
+#[test]
+fn config_schema_subcommand_succeeds_without_input_files() {
+    compile(&["plc", "config", "schema"]).unwrap();
+}
+
+#[test]
+fn config_diagnostics_subcommand_succeeds_without_input_files() {
+    compile(&["plc", "config", "diagnostics"]).unwrap();
+}
+
+#[test]
+fn no_input_files_errors() {
+    let err = compile(&["plc"]).unwrap_err();
+    assert!(err.to_string().contains("no input files"), "got: {err}");
+}
+
+#[test]
+fn check_without_input_files_errors() {
+    let err = compile(&["plc", "--check"]).unwrap_err();
+    assert!(err.to_string().contains("no input files"), "got: {err}");
+}
+
+#[test]
+fn globs_resolving_to_nothing_error_as_empty_input_set() {
+    // Globs are allowed to match nothing individually (missing optional
+    // directories are routine in shared project templates); the hard error
+    // only fires when the *entire* input set resolves empty.
+    let dir = tempfile::tempdir().unwrap();
+    let glob = dir.path().join("optional-dir/*.st");
+
+    let err = compile(&["plc".to_string(), glob.to_string_lossy().into_owned()]).unwrap_err();
+    assert!(err.to_string().contains("no input files"), "got: {err}");
 }


### PR DESCRIPTION
PR #1713 agressively errored out on globs to prevent typos. In practice this made legitemate cases like error out, for example a templated plc.json with non existing directories.

This commit soften the errors to only full files not being found. It also fixes an issue with the location of the error. Previously we errored out even if the flag being called did not actually compile (like --version).