### PR TITLE
build: bump clap 3 -> 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,17 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,29 +432,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
- "clap_derive 4.6.1",
+ "clap_derive",
 ]
 
 [[package]]
@@ -476,21 +448,8 @@ checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 1.1.0",
- "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
- "syn 1.0.109",
+ "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -499,19 +458,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -802,7 +752,7 @@ dependencies = [
 name = "errorcode_book_generator"
 version = "0.5.0"
 dependencies = [
- "clap 4.6.1",
+ "clap",
  "mdbook-preprocessor",
  "semver",
  "serde_json",
@@ -1146,18 +1096,12 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1187,24 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1501,16 +1430,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1647,7 +1566,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "bytecount",
- "clap 4.6.1",
+ "clap",
  "fancy-regex",
  "fraction",
  "getrandom 0.2.17",
@@ -2082,12 +2001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "papergrid"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,11 +2213,11 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 3.2.25",
+ "clap",
  "encoding_rs",
  "encoding_rs_io",
  "generational-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "inkwell",
  "insta",
  "itertools",
@@ -2382,11 +2295,11 @@ dependencies = [
  "anstream",
  "anstyle",
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "encoding_rs",
  "encoding_rs_io",
  "env_logger",
- "indexmap 2.14.0",
+ "indexmap",
  "insta",
  "itertools",
  "log",
@@ -2412,7 +2325,7 @@ dependencies = [
 name = "plc_header_generator"
 version = "0.5.0"
 dependencies = [
- "clap 3.2.25",
+ "clap",
  "insta",
  "log",
  "once_cell",
@@ -2502,7 +2415,7 @@ name = "plc_xml"
 version = "0.5.0"
 dependencies = [
  "html-escape",
- "indexmap 2.14.0",
+ "indexmap",
  "insta",
  "itertools",
  "logos",
@@ -2586,30 +2499,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2 1.0.106",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2 1.0.106",
- "quote 1.0.45",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.45",
- "version_check",
 ]
 
 [[package]]
@@ -3252,7 +3141,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "native-tls",
@@ -3289,7 +3178,7 @@ dependencies = [
  "async-std",
  "dotenvy",
  "either",
- "heck 0.5.0",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2 1.0.106",
@@ -3427,12 +3316,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -3546,7 +3429,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro-error2",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -3621,12 +3504,6 @@ checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
  "unicode-width 0.2.2",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -3745,7 +3622,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4076,7 +3953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4089,7 +3966,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4425,7 +4302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -4436,8 +4313,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
+ "heck",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4468,7 +4345,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -4487,7 +4364,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -4524,7 +4401,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-std",
- "clap 4.6.1",
+ "clap",
  "plc-compiler",
  "plc_ast",
  "plc_source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ plc_index = { path = "./compiler/plc_index", version = "0.5.0" }
 section_mangler = { path = "./compiler/section_mangler", version = "0.5.0" }
 plc_llvm = { path = "./compiler/plc_llvm", version = "0.5.0" }
 logos = "0.12.0"
-clap = { version = "3.0", features = ["derive"] }
+clap.workspace = true
 indexmap = { version = "2.0", features = ["serde"] }
 generational-arena = { version = "0.2.8", features = ["serde"] }
 shell-words = "1.1.0"
@@ -105,3 +105,4 @@ rustc-hash = "1.1.0"
 tempfile = "3.17.0"
 anstream = "1"
 anstyle = "1"
+clap = { version = "4", features = ["derive"] }

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -22,7 +22,7 @@ plc_header_generator = { path = "../plc_header_generator", version = "0.5.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"
-clap = { version = "3.0", features = ["derive"] }
+clap.workspace = true
 rayon = "1.6.1"
 tempfile.workspace = true
 indexmap = "2.0"

--- a/compiler/plc_driver/src/cli.rs
+++ b/compiler/plc_driver/src/cli.rs
@@ -24,7 +24,7 @@ pub struct PrefixMapArg {
     pub new: PathBuf,
 }
 
-#[derive(clap::ArgEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LogLevel {
     Off,
     Error,
@@ -65,7 +65,7 @@ pub struct CompileParameters {
         global = true,
         help = "Set log verbosity (off, error, warn, info, debug, trace)",
         conflicts_with = "verbose",
-        arg_enum
+        value_enum
     )]
     pub log_level: Option<LogLevel>,
 
@@ -145,7 +145,13 @@ pub struct CompileParameters {
     #[clap(long = "fpic", global = true, help = "Generate position-independent code where applicable")]
     pub fpic: bool,
 
-    #[clap(long = "fno-pic", global = true, help = "Generate non-PIC code where applicable")]
+    // explicit id: referenced by the relocation-model group and conflicts_with
+    #[clap(
+        name = "fno-pic",
+        long = "fno-pic",
+        global = true,
+        help = "Generate non-PIC code where applicable"
+    )]
     pub fno_pic: bool,
 
     #[clap(
@@ -164,7 +170,7 @@ pub struct CompileParameters {
         name = "encoding",
         help = "The file encoding used to read the input-files, as defined by the Encoding Standard",
         global = true,
-        parse(try_from_str = parse_encoding),
+        value_parser = parse_encoding,
     )]
     pub encoding: Option<&'static Encoding>,
 
@@ -172,7 +178,7 @@ pub struct CompileParameters {
         name = "input-files",
         help = "Read input from <input-files>, may be a glob expression like 'src/**/*' or a sequence of files",
         // required = true,
-        min_values = 1
+        num_args = 1..
     )]
     // having a vec allows bash to resolve *.st itself
     pub input: Vec<String>,
@@ -230,7 +236,7 @@ pub struct CompileParameters {
         help = "[deprecated, use --hwmap-file] Generate Hardware configuration files to the given location.
     Format is detected by extension.
     Supported formats : json, toml",
-    parse(try_from_str = validate_config)
+    value_parser = validate_config
     ) ]
     pub hardware_config: Option<String>,
 
@@ -246,8 +252,7 @@ pub struct CompileParameters {
     <output>.hwmap.json. Format is detected by extension. Supported formats : json, toml.
     Note: when supplying a path, use `--hwmap-file=PATH` (the `=` is required);
     `--hwmap-file PATH` is rejected as a parse error.",
-        min_values = 0,
-        max_values = 1,
+        num_args = 0..=1,
         require_equals = true
     )]
     pub hwmap_file: Option<Option<String>>,
@@ -261,7 +266,7 @@ pub struct CompileParameters {
     Format is detected by extension.
     Supported formats : json, toml",
         default_value = DEFAULT_GOT_LAYOUT_FILE,
-        parse(try_from_str = validate_config),
+        value_parser = validate_config,
         requires = "online-change"
     ) ]
     pub got_layout_file: String,
@@ -271,7 +276,7 @@ pub struct CompileParameters {
         long,
         short = 'O',
         help = "Optimization level",
-        arg_enum,
+        value_enum,
         default_value = "default",
         global = true
     )]
@@ -281,7 +286,7 @@ pub struct CompileParameters {
         name = "error-format",
         long,
         help = "Set format for error reporting",
-        arg_enum,
+        value_enum,
         default_value = "rich",
         global = true
     )]
@@ -350,8 +355,8 @@ pub struct CompileParameters {
         global = true,
         group = "dbg",
         conflicts_with = "debug",
-        max_values = 1,
-        possible_values = &["2", "3", "4", "5"],
+        num_args = 1,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(2..=5),
     )]
     pub gdwarf_version: Option<usize>,
 
@@ -363,8 +368,8 @@ pub struct CompileParameters {
         global = true,
         group = "dbg",
         conflicts_with = "debug-variables",
-        max_values = 1,
-        possible_values = &["2", "3", "4", "5"],
+        num_args = 1,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(2..=5),
     )]
     pub gdwarf_varinfo_version: Option<usize>,
 
@@ -376,7 +381,7 @@ pub struct CompileParameters {
         help = "Remap debug/source paths: rewrites paths starting with OLD to start with NEW. \
                 NEW is taken as a literal replacement (no current-directory expansion). \
                 Repeat to add more mappings; later occurrences win on equal-length matches.",
-        parse(try_from_str = parse_prefix_map)
+        value_parser = parse_prefix_map
     )]
     pub prefix_maps: Vec<PrefixMapArg>,
 
@@ -385,7 +390,7 @@ pub struct CompileParameters {
         value_name = "dir",
         global = true,
         help = "Override the DWARF compilation directory",
-        parse(try_from_str = parse_debug_compilation_dir)
+        value_parser = parse_debug_compilation_dir
     )]
     pub debug_compilation_dir: Option<PathBuf>,
 
@@ -395,7 +400,7 @@ pub struct CompileParameters {
         short = 'j',
         help = "Set the number of threads to use for the compilation",
         global = true,
-        parse(try_from_str = get_parallel_threads)
+        value_parser = get_parallel_threads
     )]
     pub threads: Option<Threads>,
 
@@ -414,6 +419,7 @@ pub struct CompileParameters {
     pub check_only: bool,
 
     #[clap(
+        name = "online-change",
         long,
         help = "Emit a binary with specific compilation information, suitable for online changes when ran under a conforming runtime",
         global = true
@@ -456,7 +462,7 @@ pub enum SubCommands {
     ///
     Build {
         #[clap(
-            parse(try_from_str = validate_config)
+            value_parser = validate_config
         )]
         build_config: Option<String>,
 
@@ -471,7 +477,7 @@ pub enum SubCommands {
     /// Used to trigger a check, but not compile action.
     Check {
         #[clap(
-            parse(try_from_str = validate_config)
+            value_parser = validate_config
         )]
         build_config: Option<String>,
     },
@@ -491,7 +497,7 @@ pub enum SubCommands {
         option: ConfigOption,
 
         #[clap(
-            parse(try_from_str = validate_config)
+            value_parser = validate_config
         )]
         build_config: Option<String>,
     },
@@ -508,7 +514,7 @@ pub enum SubCommands {
     ///     Header : Generates the Header files
     Generate {
         #[clap(
-            parse(try_from_str = validate_config)
+            value_parser = validate_config
         )]
         build_config: Option<String>,
 
@@ -519,9 +525,9 @@ pub enum SubCommands {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Subcommand)]
 pub enum ConfigOption {
-    #[clap(help = "Prints the plc.json's schema used for validation")]
+    /// Prints the plc.json's schema used for validation
     Schema,
-    #[clap(help = "Prints the configuration for the project")]
+    /// Prints the configuration for the project
     Diagnostics,
 }
 
@@ -538,7 +544,7 @@ pub enum GenerateOption {
         #[clap(
             name = "header-language",
             long,
-            arg_enum,
+            value_enum,
             help = "The language used to generate the header file. Currently supported language(s) are: C",
             default_value = "c"
         )]
@@ -845,7 +851,7 @@ mod cli_tests {
     use crate::cli::{ConfigOption, GenerateLanguage, GenerateOption};
 
     use super::{CompileParameters, SubCommands};
-    use clap::ErrorKind;
+    use clap::error::ErrorKind;
     use plc::{
         output::{FormatOption, RelocationPreference},
         ConfigFormat, ErrorFormat, OptimizationLevel,
@@ -1486,29 +1492,26 @@ mod cli_tests {
     #[test]
     fn invalid_dwarf_version() {
         let error = CompileParameters::parse(vec_of_strings!("input.st", "--gdwarf", "1")).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::InvalidValue);
-        let inner = &error.info;
-        assert_eq!(inner[1], "1");
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+        assert!(error.to_string().contains('1'));
 
         let error =
             CompileParameters::parse(vec_of_strings!("input.st", "--gdwarf-variables", "99")).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::InvalidValue);
-        let inner = &error.info;
-        assert_eq!(inner[1], "99");
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+        assert!(error.to_string().contains("99"));
 
         let error = CompileParameters::parse(vec_of_strings!("input.st", "--gdwarf", "abc")).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::InvalidValue);
-        let inner = &error.info;
-        assert_eq!(inner[1], "abc");
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+        assert!(error.to_string().contains("abc"));
     }
 
     #[test]
     fn dwarf_version_override_arg_requries_value() {
         let error = CompileParameters::parse(vec_of_strings!("input.st", "--gdwarf")).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::EmptyValue);
+        assert_eq!(error.kind(), ErrorKind::InvalidValue);
 
         let error = CompileParameters::parse(vec_of_strings!("input.st", "--gdwarf-variables")).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::EmptyValue);
+        assert_eq!(error.kind(), ErrorKind::InvalidValue);
     }
 
     #[test]

--- a/compiler/plc_header_generator/Cargo.toml
+++ b/compiler/plc_header_generator/Cargo.toml
@@ -11,7 +11,7 @@ plc_diagnostics = { path = "../plc_diagnostics/", version = "0.5.0" }
 plc_ast = { path = "../plc_ast/", version = "0.5.0" }
 plc_source = { path = "../plc_source/", version = "0.5.0" }
 tera = "1"
-clap = { version = "3.0", features = ["derive"] }
+clap.workspace = true
 regex = "1"
 once_cell = "1.21.3"
 log.workspace = true

--- a/compiler/plc_header_generator/src/lib.rs
+++ b/compiler/plc_header_generator/src/lib.rs
@@ -1,9 +1,9 @@
-use clap::ArgEnum;
+use clap::ValueEnum;
 use std::path::PathBuf;
 
 pub mod header_generator;
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy, ArgEnum, Default)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, ValueEnum, Default)]
 pub enum GenerateLanguage {
     #[default]
     C,

--- a/errorcode_book_generator/Cargo.toml
+++ b/errorcode_book_generator/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-clap = "4.5.4"
+clap.workspace = true
 mdbook-preprocessor = "0.5"
 semver = "1.0.22"
 serde_json.workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 use std::convert::Infallible;
 use std::str::FromStr;
 
-use clap::clap_derive::ArgEnum;
+use clap::ValueEnum;
 use plc_index::ErrorFormat as IndexErrorFormat;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -131,7 +131,7 @@ impl FromStr for Target {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Copy, ArgEnum)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, ValueEnum)]
 pub enum ConfigFormat {
     JSON,
     TOML,
@@ -149,7 +149,7 @@ impl FromStr for ConfigFormat {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, ArgEnum, Serialize, Deserialize, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum, Serialize, Deserialize, Default)]
 pub enum ErrorFormat {
     #[default]
     Rich,
@@ -175,7 +175,7 @@ pub enum Threads {
     None,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum, Serialize, Deserialize, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Serialize, Deserialize, Default)]
 pub enum OptimizationLevel {
     None,
     Less,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,7 +22,7 @@ sqlx = { version = "0.8", features = [
 
 async-std = "1.12.0"
 tempfile = "3"
-clap = { version = "4.3.10", features = ["derive"] }
+clap.workspace = true
 plc = { path = "../", package = "plc-compiler" }
 plc_ast = { path = "../compiler/plc_ast" }
 plc_source = { path = "../compiler/plc_source" }


### PR DESCRIPTION
Unify all crates on a single clap 4 workspace dependency and migrate the derive: ValueEnum, value_parser, num_args, doc-comment subcommand help, and explicit ids for the group/conflicts/requires references. Update the cli tests for clap 4's error kinds.