### PR TITLE
build: bump logos 0.12 -> 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,12 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,7 +1102,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1793,25 +1787,34 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.12.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
-name = "logos-derive"
-version = "0.12.1"
+name = "logos-codegen"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
 dependencies = [
- "beef",
  "fnv",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
- "regex-syntax 0.6.29",
- "syn 1.0.109",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -2505,7 +2508,6 @@ dependencies = [
  "indexmap 2.14.0",
  "insta",
  "itertools",
- "logos",
  "plc-compiler",
  "plc_ast",
  "plc_diagnostics",
@@ -2769,7 +2771,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2780,7 +2782,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2788,12 +2790,6 @@ name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ plc_diagnostics = { path = "./compiler/plc_diagnostics", version = "0.5.0" }
 plc_index = { path = "./compiler/plc_index", version = "0.5.0" }
 section_mangler = { path = "./compiler/section_mangler", version = "0.5.0" }
 plc_llvm = { path = "./compiler/plc_llvm", version = "0.5.0" }
-logos = "0.12.0"
+logos = "0.16"
 clap = { version = "3.0", features = ["derive"] }
 indexmap = { version = "2.0", features = ["serde"] }
 generational-arena = { version = "0.2.8", features = ["serde"] }

--- a/compiler/plc_xml/Cargo.toml
+++ b/compiler/plc_xml/Cargo.toml
@@ -6,7 +6,6 @@ license = "LGPL-3.0"
 description = "CFC/FBD XML format support for the PLC Structured Text compiler"
 
 [dependencies]
-logos = "0.12"
 quick-xml = { version = "0.30", features = ["serialize"] }
 insta = "1.20"
 indexmap = "2.0"

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -84,7 +84,11 @@ impl<'a> ParseSession<'a> {
     /// current token.
     pub fn peek(&self) -> Token {
         let mut peeked = self.lexer.clone();
-        peeked.next().unwrap_or(Token::End)
+        match peeked.next() {
+            Some(Ok(token)) => token,
+            Some(Err(())) => Token::Error,
+            None => Token::End,
+        }
     }
 
     pub fn try_consume_or_report(&mut self, token: Token) {
@@ -109,7 +113,12 @@ impl<'a> ParseSession<'a> {
 
     pub fn advance(&mut self) {
         self.last_range = self.range();
-        self.last_token = std::mem::replace(&mut self.token, self.lexer.next().unwrap_or(Token::End));
+        let next = match self.lexer.next() {
+            Some(Ok(token)) => token,
+            Some(Err(())) => Token::Error,
+            None => Token::End,
+        };
+        self.last_token = std::mem::replace(&mut self.token, next);
         self.parse_progress += 1;
 
         match self.token {

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -3,13 +3,12 @@ use logos::Logos;
 use plc_ast::ast::{DirectAccessType, HardwareAccessType};
 
 #[derive(Debug, PartialEq, Eq, Logos, Clone, Copy)]
+#[logos(skip(r"//.*", allow_greedy = true))]
+#[logos(skip r"(?m)\r")]
 pub enum Token {
-    #[error]
     #[regex(r"\(\*", |lex| super::parse_comments(lex))]
     #[regex(r"/\*", |lex| super::parse_comments(lex))]
     #[regex(r"\{", |lex| super::parse_pragma(lex))]
-    #[regex(r"//.*", logos::skip)]
-    #[regex(r"(?m)\r", logos::skip)]
     Error,
 
     #[token("@EXTERNAL")]


### PR DESCRIPTION
Migrate the token enum and lexer to logos' Result-based API: drop #[error], move skip patterns to enum-level attributes, and handle the next() Result at the two consumption sites. Opt the line-comment skip into allow_greedy for 0.16's greedy-repetition lint. Drop the unused logos dependency from plc_xml.