### PR TITLE
ci: release branch automation

### DIFF
--- a/.github/scripts/extract-workflow-steps.py
+++ b/.github/scripts/extract-workflow-steps.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Extract `run:` blocks from workflow YAMLs into executable step scripts.
+
+Used by test-release-flows.sh so the simulation executes the exact shell
+code the workflows run, instead of a hand-maintained copy that can drift.
+
+GitHub expression substitution:
+  ${{ steps.<id>.outputs.<key> }}  ->  ${STEPS_<ID>_<KEY>}   (env var, upper, - -> _)
+  selected github.* / inputs.*     ->  fixed env var names
+Anything unmapped becomes __UNMAPPED__<expr>__ so its use fails visibly.
+"""
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOWS = Path(sys.argv[1])
+OUT = Path(sys.argv[2])
+OUT.mkdir(parents=True, exist_ok=True)
+
+FIXED = {
+    "github.event.pull_request.base.ref": "${PR_BASE_REF}",
+    "github.event.pull_request.merge_commit_sha": "${PR_MERGE_SHA}",
+    "github.repository": "${REPOSITORY}",
+    "github.event_name": "${EVENT_NAME}",
+    "inputs.tag": "${INPUT_TAG}",
+}
+
+
+def subst(text):
+    def repl(m):
+        expr = m.group(1).strip()
+        sm = re.fullmatch(r"steps\.([\w-]+)\.outputs\.([\w-]+)", expr)
+        if sm:
+            sid = sm.group(1).replace("-", "_").upper()
+            key = sm.group(2).replace("-", "_").upper()
+            return "${STEPS_%s_%s}" % (sid, key)
+        if expr in FIXED:
+            return FIXED[expr]
+        return "__UNMAPPED__%s__" % re.sub(r"\W", "_", expr)
+
+    return re.sub(r"\$\{\{([^}]*)\}\}", repl, text)
+
+
+def slug(name):
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+for wf in sorted(WORKFLOWS.glob("*.yml")):
+    doc = yaml.safe_load(wf.read_text())
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if "run" not in step or "name" not in step:
+                continue
+            path = OUT / ("%s__%s.sh" % (wf.stem, slug(step["name"])))
+            path.write_text("#!/usr/bin/env bash\n" + subst(step["run"]))
+            path.chmod(0o755)

--- a/.github/scripts/test-release-flows.sh
+++ b/.github/scripts/test-release-flows.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Local simulation of the release automation: runs the workflows' actual
+# `run:` blocks (extracted by extract-workflow-steps.py) against a scratch
+# repo and asserts the version/branch/tag decisions for each release flow.
+#
+# Requires: git-cliff, cargo-edit (cargo set-version), python3 + pyyaml.
+#
+# Deliberately not `set -e`: assertion failures are counted and reported,
+# the script exits non-zero if any assertion failed.
+set -uo pipefail
+
+for tool in git-cliff python3; do
+  command -v "$tool" >/dev/null || { echo "missing tool: $tool" >&2; exit 1; }
+done
+cargo set-version --help >/dev/null 2>&1 || { echo "missing tool: cargo-edit (cargo set-version)" >&2; exit 1; }
+python3 -c "import yaml" 2>/dev/null || { echo "missing python module: yaml (pyyaml)" >&2; exit 1; }
+
+root_dir=$(git rev-parse --show-toplevel)
+work_dir=$(mktemp -d)
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+steps_dir=$work_dir/steps
+repo_dir=$work_dir/repo
+step_log=$work_dir/step.log
+pass=0 fail=0
+
+python3 "$root_dir/.github/scripts/extract-workflow-steps.py" \
+  "$root_dir/.github/workflows" "$steps_dir"
+
+note()  { printf '\n\033[1m=== %s ===\033[0m\n' "$*"; }
+assert_eq() { # label actual expected
+  if [ "$2" = "$3" ]; then echo "  PASS: $1 = '$2'"; pass=$((pass+1));
+  else echo "  FAIL: $1 = '$2' (expected '$3')"; fail=$((fail+1)); fi
+}
+assert_rc() { # label rc expected-rc
+  if [ "$2" -eq "$3" ]; then echo "  PASS: $1 rc=$2"; pass=$((pass+1));
+  else echo "  FAIL: $1 rc=$2 (expected $3)"; fail=$((fail+1)); fi
+}
+
+run_step() { # script-name (env must be pre-exported); outputs go to $GITHUB_OUTPUT
+  GITHUB_OUTPUT=$(mktemp); export GITHUB_OUTPUT
+  bash "$steps_dir/$1" >"$step_log" 2>&1
+  STEP_RC=$?
+}
+out() { grep "^$1=" "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-; }
+
+cliff_bumped() { git-cliff --bumped-version 2>/dev/null | tail -1; }
+
+# ---- release-pr.yml: derive + check (sets HEAD_BRANCH BASE_BRANCH CURRENT NEXT SKIP) ----
+release_pr_check() { # arg1 = GITHUB_REF_NAME
+  export GITHUB_REF_NAME=$1
+  run_step release-pr__derive-branch-names.sh
+  BASE_BRANCH=$(out base); HEAD_BRANCH=$(out head)
+  export STEPS_CLIFF_VERSION_CONTENT=$(cliff_bumped)
+  run_step release-pr__check-if-bump-needed.sh
+  CURRENT=$(out current); NEXT=$(out next); SKIP=$(out skip)
+  CLAMP_WARNING=$(grep -c '^::warning::' "$step_log" || true)
+}
+
+# ---- simulate merging the release PR (what create-pull-request + merge queue produce) ----
+merge_release_pr() { # arg1 = version
+  cargo set-version --workspace "$1" >/dev/null 2>&1
+  cargo generate-lockfile --offline >/dev/null 2>&1
+  git-cliff --tag "v$1" -o CHANGELOG.md 2>/dev/null
+  git add -A >/dev/null
+  git commit -qm "chore(release): v$1"
+}
+
+# ---- release.yml end to end (sets VERSION TAG PREV DEV_VERSION DEV_BRANCH) ----
+release_yml() { # arg1 = base ref (the branch the release PR merged into)
+  export PR_BASE_REF=$1 PR_MERGE_SHA=$(git rev-parse HEAD)
+  run_step release__get-version-from-cargo-toml.sh
+  VERSION=$(out version); TAG=$(out tag)
+  export STEPS_VERSION_VERSION=$VERSION STEPS_VERSION_TAG=$TAG
+  run_step release__determine-previous-release-tag.sh
+  PREV=$(out tag)
+  export STEPS_PREVIOUS_TAG_TAG=$PREV
+  run_step release__prepare-release-notes-workspace.sh
+  # git-cliff-action with args + OUTPUT env:
+  git-cliff --unreleased --tag "$TAG" --strip header -o .github/release/raw-notes.md 2>/dev/null
+  run_step release__compose-release-notes.sh
+  COMPOSE_RC=$STEP_RC
+  # softprops/action-gh-release with target_commitish: merge_commit_sha
+  git tag "$TAG" "$PR_MERGE_SHA"
+  run_step release__compute-dev-version.sh
+  DEV_VERSION=$(out version); DEV_BRANCH=$(out branch)
+  # dev-bump PR (created + merged)
+  export STEPS_DEV_VERSION=$DEV_VERSION
+  run_step release__bump-to-dev-version.sh
+  cargo generate-lockfile --offline >/dev/null 2>&1
+  git add -A >/dev/null
+  git commit -qm "chore: bump version to $DEV_VERSION"
+}
+
+# ---- release-branch-guard.yml on a fresh checkout (rc in GUARD_RC) ----
+guard() { # arg1 = base branch, arg2 = PR title, arg3 = PR body
+  local dir; dir=$(mktemp -d)
+  git clone -q "$repo_dir" "$dir" 2>/dev/null
+  ( cd "$dir"
+    git checkout -q "$1"
+    export GITHUB_BASE_REF=$1 PR_TITLE=$2 PR_BODY=$3
+    BASELINE=$(cliff_bumped)
+    bash "$steps_dir/release-branch-guard__simulate-the-squash-merge.sh" >/dev/null 2>&1
+    WITH_PR=$(cliff_bumped)
+    export BASELINE WITH_PR
+    bash "$steps_dir/release-branch-guard__reject-minor-major-bumps.sh"
+  )
+  GUARD_RC=$?
+  rm -rf "$dir"
+}
+
+# ================= scratch repo =================
+mkdir -p "$repo_dir"; cd "$repo_dir"
+git init -qb master
+git config user.name sim; git config user.email sim@sim
+cp "$root_dir/cliff.toml" .
+mkdir -p .github/scripts member/src src
+cp "$root_dir/.github/scripts/compose-release-notes.sh" .github/scripts/
+cat > Cargo.toml <<'EOF'
+[package]
+name = "sim"
+version = "0.5.0"
+edition = "2021"
+
+[workspace]
+members = ["member"]
+EOF
+cat > member/Cargo.toml <<'EOF'
+[package]
+name = "member"
+version = "0.5.0"
+edition = "2021"
+EOF
+touch src/lib.rs member/src/lib.rs
+cargo generate-lockfile --offline >/dev/null 2>&1
+echo '.github/release/' > .gitignore
+git add -A; git commit -qm "chore: init"
+git tag v0.5.0
+git commit -q --allow-empty -m "fix: some bugfix on master"
+git commit -q --allow-empty -m "feat: some feature on master"
+
+note "S0: fix + feat since the last tag offer a minor release PR on master"
+release_pr_check master
+assert_eq "head branch" "$HEAD_BRANCH" "release/next"
+assert_eq "base branch" "$BASE_BRANCH" "master"
+assert_eq "current"     "$CURRENT"     "0.5.0"
+assert_eq "next"        "$NEXT"        "0.6.0"
+assert_eq "skip"        "$SKIP"        "false"
+
+note "S1: release PR version manually overridden to 1.0.0 and merged"
+merge_release_pr 1.0.0
+assert_eq "Cargo.toml version" "$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')" "1.0.0"
+
+note "S2: release.yml tags v1.0.0 from master, dev-bumps to 1.1.0-dev"
+release_yml master
+assert_eq "version"     "$VERSION"     "1.0.0"
+assert_eq "tag"         "$TAG"         "v1.0.0"
+assert_eq "previous"    "$PREV"        "v0.5.0"
+assert_rc "compose-release-notes" "$COMPOSE_RC" 0
+assert_eq "dev version" "$DEV_VERSION" "1.1.0-dev"
+assert_eq "dev branch"  "$DEV_BRANCH"  "post-release/dev-bump"
+assert_eq "tag points at release commit" "$(git rev-parse v1.0.0)" "$PR_MERGE_SHA"
+grep -q "feature on master" .github/release/release-notes.md \
+  && { echo "  PASS: release notes contain the feature"; pass=$((pass+1)); } \
+  || { echo "  FAIL: release notes missing the feature"; fail=$((fail+1)); }
+
+note "S3: fix lands on master at 1.1.0-dev: no release PR, no patch collision"
+git commit -q --allow-empty -m "fix: patch after release"
+release_pr_check master
+assert_eq "cliff computed" "$NEXT" "1.0.1"
+assert_eq "skip"           "$SKIP" "true"
+
+note "S4: feat lands on master: 1.1.0 release PR (drop -dev)"
+git commit -q --allow-empty -m "feat: new feature"
+release_pr_check master
+assert_eq "next" "$NEXT" "1.1.0"
+assert_eq "skip" "$SKIP" "false"
+merge_release_pr 1.1.0
+release_yml master
+assert_eq "tag"         "$TAG"         "v1.1.0"
+assert_eq "previous"    "$PREV"        "v1.0.0"
+assert_eq "dev version" "$DEV_VERSION" "1.2.0-dev"
+
+note "S5: cut release/1.0.x at v1.0.0, backport a fix: 1.0.1 release PR"
+git checkout -qb release/1.0.x v1.0.0
+git commit -q --allow-empty -m "fix: backported fix"
+release_pr_check release/1.0.x
+assert_eq "head branch" "$HEAD_BRANCH" "release/next-1.0.x"
+assert_eq "current"     "$CURRENT"     "1.0.0"
+assert_eq "next"        "$NEXT"        "1.0.1"
+assert_eq "skip"        "$SKIP"        "false"
+assert_eq "no clamp warning" "$CLAMP_WARNING" "0"
+
+note "S6: release v1.0.1 from the maintenance branch"
+merge_release_pr 1.0.1
+release_yml release/1.0.x
+assert_eq "tag"         "$TAG"         "v1.0.1"
+assert_eq "previous (must not be master's v1.1.0)" "$PREV" "v1.0.0"
+assert_eq "dev version" "$DEV_VERSION" "1.0.2-dev"
+assert_eq "dev branch"  "$DEV_BRANCH"  "post-release/dev-bump-1.0.x"
+
+note "S7: guard on PRs targeting release/1.0.x"
+guard release/1.0.x "fix: good backport" "plain description"
+assert_rc "fix PR passes" "$GUARD_RC" 0
+guard release/1.0.x "feat: smuggled feature" ""
+assert_rc "feat PR fails" "$GUARD_RC" 1
+guard release/1.0.x "fix: sneaky" $'looks fine\n\nBREAKING CHANGE: breaks the ffi boundary'
+assert_rc "BREAKING CHANGE body fails" "$GUARD_RC" 1
+guard release/1.0.x "chore(release): v1.0.2" "release PR body"
+assert_rc "release PR passes" "$GUARD_RC" 0
+guard release/1.0.x "chore: bump version to 1.0.2-dev" "dev bump body"
+assert_rc "dev-bump PR passes" "$GUARD_RC" 0
+
+note "S8: feat merged onto the maintenance branch anyway: clamped to patch"
+git commit -q --allow-empty -m "feat: smuggled past the guard"
+release_pr_check release/1.0.x
+assert_eq "clamp warning emitted" "$CLAMP_WARNING" "1"
+assert_eq "next clamped" "$NEXT" "1.0.2"
+assert_eq "skip"         "$SKIP" "false"
+
+note "S9: release-assets head-branch validation"
+for case in "master:false" "release/1.0.x:false" "release/next:true" "feature/foo:true"; do
+  branch=${case%%:*}; expected=${case##*:}
+  export STEPS_SOURCE_MODE=workflow_run STEPS_SOURCE_SOURCE_WORKFLOW_NAME="Build Linux" \
+         STEPS_SOURCE_CONCLUSION=success STEPS_SOURCE_EVENT_NAME=push \
+         STEPS_SOURCE_HEAD_BRANCH=$branch
+  run_step release-assets__validate-source-request.sh
+  assert_eq "head_branch=$branch -> skip" "$(out skip)" "$expected"
+done
+
+note "S10: idle states produce no release PR"
+git checkout -q master
+release_pr_check master
+assert_eq "master idle at 1.2.0-dev: skip" "$SKIP" "true"
+git checkout -qb release/1.1.x v1.1.0
+release_pr_check release/1.1.x
+assert_eq "fresh-cut release/1.1.x: skip" "$SKIP" "true"
+
+printf '\n\033[1m%d passed, %d failed\033[0m\n' "$pass" "$fail"
+exit $((fail > 0))

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+    # Release branches get PR validation only; the gh-pages deploy below is
+    # additionally gated on master, so no deploys happen from release branches.
+    branches: [master, "release/[0-9]*"]
 
 env:
   IMAGE_NAME: rust-llvm

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,9 +2,9 @@ name: Build Linux
 
 on:
   push:
-    branches: [master]
+    branches: [master, "release/[0-9]*"]
   pull_request:
-    branches: [master]
+    branches: [master, "release/[0-9]*"]
   merge_group:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/lit.yml
+++ b/.github/workflows/lit.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [master]
+    branches: [master, "release/[0-9]*"]
   pull_request:
-    branches: [master]
+    branches: [master, "release/[0-9]*"]
   merge_group:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    # Release branches get PR validation only; the git reporter below only
+    # publishes on master.
+    branches: [ master, "release/[0-9]*" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -78,8 +78,9 @@ jobs:
               SKIP=true
             fi
 
-            if [[ "${{ steps.source.outputs.head_branch }}" != "master" ]]; then
-              echo "Skipping non-master run: ${{ steps.source.outputs.head_branch }}"
+            HEAD_BRANCH="${{ steps.source.outputs.head_branch }}"
+            if [[ "$HEAD_BRANCH" != "master" && "$HEAD_BRANCH" != release/[0-9]* ]]; then
+              echo "Skipping non-release-branch run: $HEAD_BRANCH"
               SKIP=true
             fi
           fi

--- a/.github/workflows/release-branch-guard.yml
+++ b/.github/workflows/release-branch-guard.yml
@@ -1,0 +1,79 @@
+---
+name: Release Branch Guard
+
+# Maintenance branches (release/X.Y.x) only ever publish patch releases.
+# This guard rejects pull requests whose squash-merge message would make
+# git-cliff compute a minor or major bump (feat commits, `!` markers, or
+# BREAKING CHANGE footers). release-pr.yml additionally clamps the computed
+# version to a patch bump as a backstop for anything that bypasses this
+# check, e.g. a manual non-squash merge.
+
+on:
+  pull_request:
+    # `edited` re-runs the check when the PR title or description is fixed.
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+    branches:
+      - "release/[0-9]*"
+
+jobs:
+  patch-only:
+    name: Patch-only check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Compute baseline bumped version
+        id: baseline
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --bumped-version
+
+      - name: Simulate the squash merge
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # The merge queue squash-merges with the PR title as subject and
+          # the PR description as body — that exact message is what
+          # git-cliff will parse on the branch after the merge. git-cliff
+          # only looks at commit messages, never at diffs, so an empty
+          # commit is enough to simulate the merge.
+          git config user.name "release-branch-guard"
+          git config user.email "release-branch-guard@users.noreply.github.com"
+          git commit --allow-empty -m "$PR_TITLE" -m "${PR_BODY:-}"
+
+      - name: Compute bumped version including this PR
+        id: with-pr
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --bumped-version
+
+      - name: Reject minor/major bumps
+        env:
+          BASELINE: ${{ steps.baseline.outputs.content }}
+          WITH_PR: ${{ steps.with-pr.outputs.content }}
+        run: |
+          BASELINE="${BASELINE#v}"
+          WITH_PR="${WITH_PR#v}"
+
+          # No bump-worthy commits at all: cliff may print nothing. Fall
+          # back to the latest reachable tag so the comparison still works.
+          FALLBACK=$(git tag --list 'v[0-9]*' --merged HEAD --sort=-v:refname | head -n1)
+          BASELINE="${BASELINE:-${FALLBACK#v}}"
+          WITH_PR="${WITH_PR:-${FALLBACK#v}}"
+
+          echo "next version without this PR: v$BASELINE"
+          echo "next version with this PR:    v$WITH_PR"
+
+          if [ "${WITH_PR%.*}" != "${BASELINE%.*}" ]; then
+            echo "::error::This PR's title/description escalates the next release on ${GITHUB_BASE_REF} from v$BASELINE to v$WITH_PR. Maintenance branches only take patch-level changes (no feat, no '!', no BREAKING CHANGE footer). Reword the PR title/description or retarget the PR at master."
+            exit 1
+          fi

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - master
+      # Maintenance branches for released versions, e.g. release/1.0.x. The
+      # character class keeps the automation's own `release/next*` head
+      # branches from matching.
+      - "release/[0-9]*"
   workflow_dispatch:
 
 jobs:
@@ -45,6 +49,20 @@ jobs:
         with:
           args: --bumped-version
 
+      - name: Derive branch names
+        id: branches
+        run: |
+          # Each base branch gets its own release-PR head branch so that a
+          # master release PR and a maintenance release PR can coexist.
+          BASE="${GITHUB_REF_NAME}"
+          if [ "$BASE" = "master" ]; then
+            HEAD="release/next"
+          else
+            HEAD="release/next-${BASE#release/}"
+          fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+
       - name: Check if bump needed
         id: version
         run: |
@@ -59,6 +77,22 @@ jobs:
           # agrees with the version we'd preemptively bumped to.
           CURRENT=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           NEXT=$(echo "${{ steps.cliff-version.outputs.content }}" | sed 's/^v//')
+
+          # Maintenance branches (release/X.Y.x) only ever publish patch
+          # releases; minting a minor/major there would collide with the tags
+          # master produces. The PR guard rejects feat/breaking backports up
+          # front — this clamp is the backstop for anything that slips
+          # through (e.g. a non-squash merge).
+          if [ "${GITHUB_REF_NAME}" != "master" ] && [ -n "$NEXT" ]; then
+            BASE_TAG=$(git tag --list 'v[0-9]*' --merged HEAD --sort=-v:refname | head -n1)
+            BASE_VERSION="${BASE_TAG#v}"
+            if [ -n "$BASE_VERSION" ] && [ "${NEXT%.*}" != "${BASE_VERSION%.*}" ]; then
+              CLAMPED="${BASE_VERSION%.*}.$(( ${BASE_VERSION##*.} + 1 ))"
+              echo "::warning::git-cliff computed v$NEXT on ${GITHUB_REF_NAME}; clamping to patch release v$CLAMPED"
+              NEXT="$CLAMPED"
+            fi
+          fi
+
           CURRENT_BASE="${CURRENT%-dev}"
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
@@ -101,7 +135,8 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore(release): prepare v${{ steps.version.outputs.next }}"
-          branch: release/next
+          branch: ${{ steps.branches.outputs.head }}
+          base: ${{ steps.branches.outputs.base }}
           delete-branch: true
           title: "chore(release): v${{ steps.version.outputs.next }}"
           body: |

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -9,13 +9,16 @@ on:
       - labeled
     branches:
       - master
+      - "release/[0-9]*"
 
 jobs:
   preview:
     name: Preview release notes
+    # Release PR head branches are `release/next` (master) or
+    # `release/next-<X.Y.x>` (maintenance branches), see release-pr.yml.
     if: >-
       github.event.pull_request.merged == false
-      && github.event.pull_request.head.ref == 'release/next'
+      && startsWith(github.event.pull_request.head.ref, 'release/next')
       && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     permissions:
@@ -38,7 +41,8 @@ jobs:
         id: previous-tag
         run: |
           CURRENT_TAG="${{ steps.version.outputs.tag }}"
-          PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -Fxv "$CURRENT_TAG" | head -n1 || true)
+          # Only consider tags reachable from this branch, mirroring release.yml.
+          PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --merged HEAD --sort=-v:refname | grep -Fxv "$CURRENT_TAG" | head -n1 || true)
           echo "tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release notes workspace
@@ -68,6 +72,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
           PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}
           RELEASE_NOTES_PATH: .github/release/release-notes.md
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         with:
           script: |
             const fs = require('fs');
@@ -112,7 +117,7 @@ jobs:
               '<details>',
               '<summary>Expected release assets</summary>',
               '',
-              'Assets are uploaded asynchronously from the post-merge `Build Linux` and `Build Windows` runs on `master`.',
+              `Assets are uploaded asynchronously from the post-merge \`Build Linux\` and \`Build Windows\` runs on \`${process.env.BASE_BRANCH}\`.`,
               '',
               ...assetNames.map(name => `- \`${name}\``),
               '',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,16 @@ on:
       - closed
     branches:
       - master
+      - "release/[0-9]*"
 
 jobs:
   release:
     name: Tag and create GitHub release
+    # Release PR head branches are `release/next` (master) or
+    # `release/next-<X.Y.x>` (maintenance branches), see release-pr.yml.
     if: >-
       github.event.pull_request.merged == true
-      && github.event.pull_request.head.ref == 'release/next'
+      && startsWith(github.event.pull_request.head.ref, 'release/next')
       && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     container: ghcr.io/plc-lang/rust-llvm:latest
@@ -33,6 +36,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          # Pin to the release PR's merge commit so the version, release
+          # notes, and tag all describe exactly what was merged, even if the
+          # base branch has moved on since.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       # Workaround: the rust-llvm container image is missing `jq`, which
       # `orhun/git-cliff-action`'s install.sh needs to parse the GitHub API
@@ -54,7 +61,10 @@ jobs:
         id: previous-tag
         run: |
           CURRENT_TAG="${{ steps.version.outputs.tag }}"
-          PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -Fxv "$CURRENT_TAG" | head -n1 || true)
+          # Only consider tags reachable from this branch: a maintenance
+          # release (e.g. v1.0.1) must not pick up a newer master tag
+          # (e.g. v1.1.0) as its predecessor.
+          PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --merged HEAD --sort=-v:refname | grep -Fxv "$CURRENT_TAG" | head -n1 || true)
           echo "tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release notes workspace
@@ -82,6 +92,9 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          # Without this the tag would be created on the repository default
+          # branch — wrong for releases cut from a maintenance branch.
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           name: RuSTy PLC Compiler ${{ steps.version.outputs.version }}
           body_path: .github/release/release-notes.md
           draft: false
@@ -90,12 +103,25 @@ jobs:
       - name: Compute dev version
         id: dev
         run: |
+          # Master mints minor (and major) releases; maintenance branches
+          # (release/X.Y.x) mint patch releases. Bumping master to the next
+          # *minor* -dev keeps the two version spaces disjoint: a fixes-only
+          # master can never offer a patch release that would collide with a
+          # tag minted from a maintenance branch.
           VERSION="${{ steps.version.outputs.version }}"
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
-          DEV_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-dev"
+          if [ "$BASE_BRANCH" = "master" ]; then
+            DEV_VERSION="${MAJOR}.$((MINOR + 1)).0-dev"
+            DEV_BRANCH="post-release/dev-bump"
+          else
+            DEV_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-dev"
+            DEV_BRANCH="post-release/dev-bump-${BASE_BRANCH#release/}"
+          fi
           echo "version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=$DEV_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Bump to dev version
         run: cargo set-version --workspace ${{ steps.dev.outputs.version }}
@@ -108,7 +134,8 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: bump version to ${{ steps.dev.outputs.version }}"
-          branch: post-release/dev-bump
+          branch: ${{ steps.dev.outputs.branch }}
+          base: ${{ github.event.pull_request.base.ref }}
           delete-branch: true
           title: "chore: bump version to ${{ steps.dev.outputs.version }}"
           body: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,9 +2,9 @@ name: Build Windows
 
 on:
   push:
-    branches: [master]
+    branches: [master, "release/[0-9]*"]
   pull_request:
-    branches: [master]
+    branches: [master, "release/[0-9]*"]
   merge_group:
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
In preparation for the release branches, this PR addes the release/x.y.z pattern tot he workflows so that PRs for the release still get built.
It also adjusts the -dev bump to a minor bump so that patch versions don't conflict with the release. 

A new test script is added tot he .github/scripts folder to test the workflows locally. 