### PR TITLE
chore: bump version to 1.1.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "errorcode_book_generator"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "clap 4.6.1",
  "mdbook-preprocessor",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "iec61131std"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "cc",
  "chrono",
@@ -2232,7 +2232,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plc-compiler"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "plc_ast"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "plc_derive"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "plc_diagnostics"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "plc_driver"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "plc_header_generator"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "clap 3.2.25",
  "insta",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "plc_index"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "annotate-snippets",
  "encoding_rs",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "plc_llvm"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "cc",
  "inkwell",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "plc_lowering"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "insta",
  "itertools",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "plc_project"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "anyhow",
  "encoding_rs",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "plc_source"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "encoding_rs",
  "encoding_rs_io",
@@ -2432,11 +2432,11 @@ dependencies = [
 
 [[package]]
 name = "plc_util"
-version = "1.0.0"
+version = "1.1.0-dev"
 
 [[package]]
 name = "plc_xml"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "html-escape",
  "indexmap 2.14.0",
@@ -2857,7 +2857,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "section_mangler"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "nom",
 ]
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "plc-compiler",
  "plc_ast",
@@ -4293,7 +4293,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "1.0.0"
+version = "1.1.0-dev"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc-compiler"
-version = "1.0.0"
+version = "1.1.0-dev"
 authors = [
     "Ghaith Hachem <ghaith.hachem@gmail.com>",
     "Mathias Rieder <mathias.rieder@gmail.com>",
@@ -18,19 +18,19 @@ default = []
 verify = []
 
 [dependencies]
-plc_source = { path = "./compiler/plc_source", version = "1.0.0" }
-plc_ast = { path = "./compiler/plc_ast", version = "1.0.0" }
-plc_util = { path = "./compiler/plc_util", version = "1.0.0" }
-plc_diagnostics = { path = "./compiler/plc_diagnostics", version = "1.0.0" }
-plc_index = { path = "./compiler/plc_index", version = "1.0.0" }
-section_mangler = { path = "./compiler/section_mangler", version = "1.0.0" }
-plc_llvm = { path = "./compiler/plc_llvm", version = "1.0.0" }
+plc_source = { path = "./compiler/plc_source", version = "1.1.0-dev" }
+plc_ast = { path = "./compiler/plc_ast", version = "1.1.0-dev" }
+plc_util = { path = "./compiler/plc_util", version = "1.1.0-dev" }
+plc_diagnostics = { path = "./compiler/plc_diagnostics", version = "1.1.0-dev" }
+plc_index = { path = "./compiler/plc_index", version = "1.1.0-dev" }
+section_mangler = { path = "./compiler/section_mangler", version = "1.1.0-dev" }
+plc_llvm = { path = "./compiler/plc_llvm", version = "1.1.0-dev" }
 logos.workspace = true
 clap = { version = "3.0", features = ["derive"] }
 indexmap = { workspace = true, features = ["serde"] }
 generational-arena = { version = "0.2.8", features = ["serde"] }
 shell-words = "1.1.0"
-plc_derive = { path = "./compiler/plc_derive", version = "1.0.0" }
+plc_derive = { path = "./compiler/plc_derive", version = "1.1.0-dev" }
 which.workspace = true
 siphasher = "1"
 log.workspace = true
@@ -49,13 +49,13 @@ tempfile.workspace = true
 num = "0.4"
 insta.workspace = true
 pretty_assertions = "1.3.0"
-driver = { path = "./compiler/plc_driver/", package = "plc_driver", version = "1.0.0" }
-project = { path = "./compiler/plc_project/", package = "plc_project", version = "1.0.0", features = [
+driver = { path = "./compiler/plc_driver/", package = "plc_driver", version = "1.1.0-dev" }
+project = { path = "./compiler/plc_project/", package = "plc_project", version = "1.1.0-dev", features = [
     "integration",
 ] }
-plc_xml = { path = "./compiler/plc_xml", version = "1.0.0" }
+plc_xml = { path = "./compiler/plc_xml", version = "1.1.0-dev" }
 test_utils = { path = "./tests/test_utils" }
-plc_lowering = { path = "./compiler/plc_lowering", version = "1.0.0" }
+plc_lowering = { path = "./compiler/plc_lowering", version = "1.1.0-dev" }
 serial_test = "*"
 tempfile.workspace = true
 encoding_rs.workspace = true

--- a/compiler/plc_ast/Cargo.toml
+++ b/compiler/plc_ast/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "plc_ast"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "AST types for the PLC Structured Text compiler"
 
 [dependencies]
-plc_util = { path = "../plc_util", version = "1.0.0" }
-plc_source = { path = "../plc_source", version = "1.0.0" }
+plc_util = { path = "../plc_util", version = "1.1.0-dev" }
+plc_source = { path = "../plc_source", version = "1.1.0-dev" }
 chrono.workspace = true
 # Enabled the RC feature (for Arc<T>) see: https://serde.rs/feature-flags.html#-features-rc
 serde = { workspace = true, features = ["rc"] }

--- a/compiler/plc_derive/Cargo.toml
+++ b/compiler/plc_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_derive"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Derive macros for the PLC Structured Text compiler"

--- a/compiler/plc_diagnostics/Cargo.toml
+++ b/compiler/plc_diagnostics/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "plc_diagnostics"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Diagnostics and error reporting for the PLC Structured Text compiler"
 
 [dependencies]
 codespan-reporting = "0.12"
-plc_ast = { path = "../plc_ast", version = "1.0.0" }
-plc_source = { path = "../plc_source", version = "1.0.0" }
+plc_ast = { path = "../plc_ast", version = "1.1.0-dev" }
+plc_source = { path = "../plc_source", version = "1.1.0-dev" }
 serde_json.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_driver"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 build = "build.rs"
 license = "LGPL-3.0"
@@ -9,15 +9,15 @@ description = "IEC 61131-3 Structured Text compiler"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "1.0.0" }
-ast = { path = "../plc_ast/", package = "plc_ast", version = "1.0.0" }
-project = { path = "../plc_project/", package = "plc_project", version = "1.0.0" }
-source_code = { path = "../plc_source/", package = "plc_source", version = "1.0.0" }
-cfc = { path = "../plc_xml/", package = "plc_xml", version = "1.0.0" }
-plc_diagnostics = { path = "../plc_diagnostics/", version = "1.0.0" }
-plc_index = { path = "../plc_index", version = "1.0.0" }
-plc_lowering = { path = "../plc_lowering", version = "1.0.0" }
-plc_header_generator = { path = "../plc_header_generator", version = "1.0.0" }
+plc = { path = "../..", package = "plc-compiler", version = "1.1.0-dev" }
+ast = { path = "../plc_ast/", package = "plc_ast", version = "1.1.0-dev" }
+project = { path = "../plc_project/", package = "plc_project", version = "1.1.0-dev" }
+source_code = { path = "../plc_source/", package = "plc_source", version = "1.1.0-dev" }
+cfc = { path = "../plc_xml/", package = "plc_xml", version = "1.1.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics/", version = "1.1.0-dev" }
+plc_index = { path = "../plc_index", version = "1.1.0-dev" }
+plc_lowering = { path = "../plc_lowering", version = "1.1.0-dev" }
+plc_header_generator = { path = "../plc_header_generator", version = "1.1.0-dev" }
 
 serde.workspace = true
 serde_json.workspace = true
@@ -34,7 +34,7 @@ encoding_rs.workspace = true
 encoding_rs_io.workspace = true
 anyhow.workspace = true
 itertools.workspace = true
-plc_util = { path = "../plc_util", version = "1.0.0" }
+plc_util = { path = "../plc_util", version = "1.1.0-dev" }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/compiler/plc_header_generator/Cargo.toml
+++ b/compiler/plc_header_generator/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "plc_header_generator"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "C header file generator for the PLC Structured Text compiler"
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "1.0.0" }
-plc_diagnostics = { path = "../plc_diagnostics/", version = "1.0.0" }
-plc_ast = { path = "../plc_ast/", version = "1.0.0" }
-plc_source = { path = "../plc_source/", version = "1.0.0" }
+plc = { path = "../..", package = "plc-compiler", version = "1.1.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics/", version = "1.1.0-dev" }
+plc_ast = { path = "../plc_ast/", version = "1.1.0-dev" }
+plc_source = { path = "../plc_source/", version = "1.1.0-dev" }
 tera = "1"
 clap = { version = "3.0", features = ["derive"] }
 regex.workspace = true

--- a/compiler/plc_index/Cargo.toml
+++ b/compiler/plc_index/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "plc_index"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Symbol index and type system for the PLC Structured Text compiler"
 
 [dependencies]
-plc_ast = { path = "../plc_ast", version = "1.0.0" }
-plc_source = { path = "../plc_source", version = "1.0.0" }
-plc_diagnostics = { path = "../plc_diagnostics", version = "1.0.0" }
+plc_ast = { path = "../plc_ast", version = "1.1.0-dev" }
+plc_source = { path = "../plc_source", version = "1.1.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics", version = "1.1.0-dev" }
 #plc_project = { path = "../plc_project" } # TODO: This will create a circular dependency
 rustc-hash.workspace = true
 encoding_rs.workspace = true

--- a/compiler/plc_llvm/Cargo.toml
+++ b/compiler/plc_llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_llvm"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2024"
 license = "LGPL-3.0"
 description = "LLVM Wrapper for C++ functions not exposed by inkwell or in the C API"

--- a/compiler/plc_lowering/Cargo.toml
+++ b/compiler/plc_lowering/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "plc_lowering"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "AST lowering passes for the PLC Structured Text compiler"
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "1.0.0" }
-plc_ast = { path = "../plc_ast", version = "1.0.0" }
-plc_source = { path = "../plc_source", version = "1.0.0" }
-plc_diagnostics = { path = "../plc_diagnostics", version = "1.0.0" }
+plc = { path = "../..", package = "plc-compiler", version = "1.1.0-dev" }
+plc_ast = { path = "../plc_ast", version = "1.1.0-dev" }
+plc_source = { path = "../plc_source", version = "1.1.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics", version = "1.1.0-dev" }
 log.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
-plc_driver = { path = "../plc_driver", version = "1.0.0" }
+plc_driver = { path = "../plc_driver", version = "1.1.0-dev" }
 insta.workspace = true

--- a/compiler/plc_project/Cargo.toml
+++ b/compiler/plc_project/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "plc_project"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Project configuration and file resolution for the PLC Structured Text compiler"
 
 [dependencies]
-plc = { path = "../..", package = "plc-compiler", version = "1.0.0" }
-plc_diagnostics = { path = "../plc_diagnostics/", version = "1.0.0" }
-source_code = { path = "../plc_source/", package = "plc_source", version = "1.0.0" }
+plc = { path = "../..", package = "plc-compiler", version = "1.1.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics/", version = "1.1.0-dev" }
+source_code = { path = "../plc_source/", package = "plc_source", version = "1.1.0-dev" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true

--- a/compiler/plc_source/Cargo.toml
+++ b/compiler/plc_source/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_source"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Source file handling for the PLC Structured Text compiler"

--- a/compiler/plc_util/Cargo.toml
+++ b/compiler/plc_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_util"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "Shared utilities for the PLC Structured Text compiler"

--- a/compiler/plc_xml/Cargo.toml
+++ b/compiler/plc_xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plc_xml"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "CFC/FBD XML format support for the PLC Structured Text compiler"
@@ -11,10 +11,10 @@ quick-xml = { version = "0.30", features = ["serialize"] }
 insta.workspace = true
 indexmap.workspace = true
 html-escape = "0.2"
-plc = { path = "../..", package = "plc-compiler", version = "1.0.0" }
-ast = { path = "../plc_ast/", package = "plc_ast", version = "1.0.0" }
-plc_diagnostics = { path = "../plc_diagnostics", version = "1.0.0" }
-plc_source = { path = "../plc_source", version = "1.0.0" }
+plc = { path = "../..", package = "plc-compiler", version = "1.1.0-dev" }
+ast = { path = "../plc_ast/", package = "plc_ast", version = "1.1.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics", version = "1.1.0-dev" }
+plc_source = { path = "../plc_source", version = "1.1.0-dev" }
 itertools.workspace = true
 rustc-hash.workspace = true
 

--- a/compiler/section_mangler/Cargo.toml
+++ b/compiler/section_mangler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "section_mangler"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "ELF section name mangling for the PLC Structured Text compiler"

--- a/errorcode_book_generator/Cargo.toml
+++ b/errorcode_book_generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "errorcode_book_generator"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 publish = false
 

--- a/libs/stdlib/Cargo.toml
+++ b/libs/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iec61131std"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 license = "LGPL-3.0"
 description = "IEC 61131-3 standard library implementation"
@@ -10,21 +10,21 @@ glob.workspace = true
 
 [build-dependencies.plc_driver]
 path = "../../compiler/plc_driver"
-version = "1.0.0"
+version = "1.1.0-dev"
 
 
 [dev-dependencies.plc_driver]
 path = "../../compiler/plc_driver"
-version = "1.0.0"
+version = "1.1.0-dev"
 
 [dev-dependencies.plc_source]
 path = "../../compiler/plc_source"
-version = "1.0.0"
+version = "1.1.0-dev"
 
 [dev-dependencies.plc]
 package = "plc-compiler"
 path = "../.."
-version = "1.0.0"
+version = "1.1.0-dev"
 
 
 [dependencies]

--- a/tests/test_utils/Cargo.toml
+++ b/tests/test_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_utils"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 publish = false
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "1.0.0"
+version = "1.1.0-dev"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Routine post-release version
  bump.

  Sets the workspace version to `1.1.0-dev` so that
  development builds on `master` are distinguishable from the
  `v1.0.0` release.