### PR TITLE
ci: fix release job container failure and workspace artifact leaks

### DIFF
--- a/.github/scripts/extract-workflow-steps.py
+++ b/.github/scripts/extract-workflow-steps.py
@@ -25,6 +25,7 @@ FIXED = {
     "github.repository": "${REPOSITORY}",
     "github.event_name": "${EVENT_NAME}",
     "inputs.tag": "${INPUT_TAG}",
+    "runner.temp": "${RUNNER_TEMP}",
 }
 
 

--- a/.github/scripts/test-release-flows.sh
+++ b/.github/scripts/test-release-flows.sh
@@ -72,6 +72,7 @@ merge_release_pr() { # arg1 = version
 # ---- release.yml end to end (sets VERSION TAG PREV DEV_VERSION DEV_BRANCH) ----
 release_yml() { # arg1 = base ref (the branch the release PR merged into)
   export PR_BASE_REF=$1 PR_MERGE_SHA=$(git rev-parse HEAD)
+  export RUNNER_TEMP=$(mktemp -d)
   run_step release__get-version-from-cargo-toml.sh
   VERSION=$(out version); TAG=$(out tag)
   export STEPS_VERSION_VERSION=$VERSION STEPS_VERSION_TAG=$TAG
@@ -80,9 +81,10 @@ release_yml() { # arg1 = base ref (the branch the release PR merged into)
   export STEPS_PREVIOUS_TAG_TAG=$PREV
   run_step release__prepare-release-notes-workspace.sh
   # git-cliff-action with args + OUTPUT env:
-  git-cliff --unreleased --tag "$TAG" --strip header -o .github/release/raw-notes.md 2>/dev/null
+  git-cliff --unreleased --tag "$TAG" --strip header -o "$RUNNER_TEMP/release/raw-notes.md" 2>/dev/null
   run_step release__compose-release-notes.sh
   COMPOSE_RC=$STEP_RC
+  NOTES_FILE=$RUNNER_TEMP/release/release-notes.md
   # softprops/action-gh-release with target_commitish: merge_commit_sha
   git tag "$TAG" "$PR_MERGE_SHA"
   run_step release__compute-dev-version.sh
@@ -91,6 +93,10 @@ release_yml() { # arg1 = base ref (the branch the release PR merged into)
   export STEPS_DEV_VERSION=$DEV_VERSION
   run_step release__bump-to-dev-version.sh
   cargo generate-lockfile --offline >/dev/null 2>&1
+  # create-pull-request commits every workspace change, so anything the job
+  # left in the workspace beyond the version bump ends up in the dev-bump
+  # PR. Fail if the workflow polluted the workspace.
+  POLLUTION=$(git status --porcelain | grep -vE 'Cargo\.(toml|lock)$' || true)
   git add -A >/dev/null
   git commit -qm "chore: bump version to $DEV_VERSION"
 }
@@ -136,7 +142,6 @@ edition = "2021"
 EOF
 touch src/lib.rs member/src/lib.rs
 cargo generate-lockfile --offline >/dev/null 2>&1
-echo '.github/release/' > .gitignore
 git add -A; git commit -qm "chore: init"
 git tag v0.5.0
 git commit -q --allow-empty -m "fix: some bugfix on master"
@@ -163,7 +168,8 @@ assert_rc "compose-release-notes" "$COMPOSE_RC" 0
 assert_eq "dev version" "$DEV_VERSION" "1.1.0-dev"
 assert_eq "dev branch"  "$DEV_BRANCH"  "post-release/dev-bump"
 assert_eq "tag points at release commit" "$(git rev-parse v1.0.0)" "$PR_MERGE_SHA"
-grep -q "feature on master" .github/release/release-notes.md \
+assert_eq "no workspace pollution in dev-bump commit" "$POLLUTION" ""
+grep -q "feature on master" "$NOTES_FILE" \
   && { echo "  PASS: release notes contain the feature"; pass=$((pass+1)); } \
   || { echo "  FAIL: release notes missing the feature"; fail=$((fail+1)); }
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -48,6 +48,12 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           args: --bumped-version
+        env:
+          # Keep the action's output file out of the workspace: anything left
+          # there is committed into the release PR by create-pull-request
+          # (this step's default output is git-cliff/CHANGELOG.md, which
+          # previously rode along in every release PR).
+          OUTPUT: ${{ runner.temp }}/bumped-version.txt
 
       - name: Derive branch names
         id: branches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,12 @@ jobs:
       github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.head.ref, 'release/next')
       && contains(github.event.pull_request.labels.*.name, 'release')
+    # Runs directly on the runner, NOT in the rust-llvm container: git-cliff
+    # uses libgit2, which rejects a bind-mounted workspace owned by a
+    # different user than the container process and fails with "could not
+    # find repository". On the plain runner the workspace is owned by the
+    # runner user, so the problem cannot occur.
     runs-on: ubuntu-latest
-    container: ghcr.io/plc-lang/rust-llvm:21-1.95
     permissions:
       contents: write
       pull-requests: write
@@ -41,14 +45,11 @@ jobs:
           # base branch has moved on since.
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
-      # Workaround: the rust-llvm container image is missing `jq`, which
-      # `orhun/git-cliff-action`'s install.sh needs to parse the GitHub API
-      # response. Tracked upstream at PLC-lang/rust-llvm-images#31; remove
-      # this step once a new image is published with jq baked in.
-      - name: Install jq (rust-llvm image workaround)
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends jq
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit --locked --version 0.13.9
 
       - name: Get version from Cargo.toml
         id: version
@@ -67,15 +68,18 @@ jobs:
           PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --merged HEAD --sort=-v:refname | grep -Fxv "$CURRENT_TAG" | head -n1 || true)
           echo "tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
 
+      # Release notes are assembled outside the workspace: the dev-bump
+      # create-pull-request step below commits every workspace change, so
+      # files left here would ride along in the dev-bump PR.
       - name: Prepare release notes workspace
-        run: mkdir -p .github/release
+        run: mkdir -p "${{ runner.temp }}/release"
 
       - name: Generate release notes
         uses: orhun/git-cliff-action@v4
         with:
           args: --unreleased --tag "${{ steps.version.outputs.tag }}" --strip header
         env:
-          OUTPUT: .github/release/raw-notes.md
+          OUTPUT: ${{ runner.temp }}/release/raw-notes.md
 
       - name: Compose release notes
         run: |
@@ -83,8 +87,8 @@ jobs:
             "${{ steps.version.outputs.version }}" \
             "${{ steps.version.outputs.tag }}" \
             "${{ steps.previous-tag.outputs.tag }}" \
-            .github/release/raw-notes.md \
-            .github/release/release-notes.md
+            "${{ runner.temp }}/release/raw-notes.md" \
+            "${{ runner.temp }}/release/release-notes.md"
 
       - name: Create tag and GitHub release
         uses: softprops/action-gh-release@v2
@@ -96,7 +100,7 @@ jobs:
           # branch — wrong for releases cut from a maintenance branch.
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           name: RuSTy PLC Compiler ${{ steps.version.outputs.version }}
-          body_path: .github/release/release-notes.md
+          body_path: ${{ runner.temp }}/release/release-notes.md
           draft: false
           prerelease: ${{ startsWith(steps.version.outputs.version, '0.') }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - master
       - "release/[0-9]*"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: >-
+          Preview only: run every release step but skip tagging, publishing,
+          and PR creation. Uncheck to publish a release from the dispatched
+          branch (manual fallback when the automated run failed).
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -15,9 +24,10 @@ jobs:
     # Release PR head branches are `release/next` (master) or
     # `release/next-<X.Y.x>` (maintenance branches), see release-pr.yml.
     if: >-
-      github.event.pull_request.merged == true
-      && startsWith(github.event.pull_request.head.ref, 'release/next')
-      && contains(github.event.pull_request.labels.*.name, 'release')
+      github.event_name == 'workflow_dispatch'
+      || (github.event.pull_request.merged == true
+          && startsWith(github.event.pull_request.head.ref, 'release/next')
+          && contains(github.event.pull_request.labels.*.name, 'release'))
     # Runs directly on the runner, NOT in the rust-llvm container: git-cliff
     # uses libgit2, which rejects a bind-mounted workspace owned by a
     # different user than the container process and fails with "could not
@@ -42,8 +52,9 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           # Pin to the release PR's merge commit so the version, release
           # notes, and tag all describe exactly what was merged, even if the
-          # base branch has moved on since.
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # base branch has moved on since. Manual dispatches release the
+          # tip of the dispatched branch.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.merge_commit_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -53,8 +64,16 @@ jobs:
 
       - name: Get version from Cargo.toml
         id: version
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          # A manual non-dry dispatch publishes for real: refuse dev versions,
+          # they mean the branch tip is not a release commit.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$DRY_RUN" != "true" ] && [ "${VERSION%-dev}" != "$VERSION" ]; then
+            echo "::error::refusing to publish dev version $VERSION; run as dry-run or dispatch on a release commit"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -91,6 +110,7 @@ jobs:
             "${{ runner.temp }}/release/release-notes.md"
 
       - name: Create tag and GitHub release
+        if: github.event_name != 'workflow_dispatch' || !inputs.dry-run
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -98,7 +118,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           # Without this the tag would be created on the repository default
           # branch — wrong for releases cut from a maintenance branch.
-          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          target_commitish: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.merge_commit_sha }}
           name: RuSTy PLC Compiler ${{ steps.version.outputs.version }}
           body_path: ${{ runner.temp }}/release/release-notes.md
           draft: false
@@ -113,7 +133,10 @@ jobs:
           # master can never offer a patch release that would collide with a
           # tag minted from a maintenance branch.
           VERSION="${{ steps.version.outputs.version }}"
+          # Manual dispatches have no pull request; fall back to the
+          # dispatched branch.
           BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          BASE_BRANCH="${BASE_BRANCH:-$GITHUB_REF_NAME}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
@@ -134,12 +157,13 @@ jobs:
         run: cargo generate-lockfile
 
       - name: Create dev-bump pull request
+        if: github.event_name != 'workflow_dispatch' || !inputs.dry-run
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: bump version to ${{ steps.dev.outputs.version }}"
           branch: ${{ steps.dev.outputs.branch }}
-          base: ${{ github.event.pull_request.base.ref }}
+          base: ${{ github.event.pull_request.base.ref || github.ref_name }}
           delete-branch: true
           title: "chore: bump version to ${{ steps.dev.outputs.version }}"
           body: |
@@ -148,3 +172,18 @@ jobs:
             Sets the workspace version to `${{ steps.dev.outputs.version }}` so that
             development builds on `master` are distinguishable from the
             `${{ steps.version.outputs.tag }}` release.
+
+      - name: Dry-run summary
+        if: github.event_name == 'workflow_dispatch' && inputs.dry-run
+        run: |
+          {
+            echo "## Release dry run"
+            echo
+            echo "- Would tag: \`${{ steps.version.outputs.tag }}\` at \`${{ github.sha }}\`"
+            echo "- Previous tag: \`${{ steps.previous-tag.outputs.tag }}\`"
+            echo "- Post-release dev bump: \`${{ steps.dev.outputs.version }}\` via \`${{ steps.dev.outputs.branch }}\`"
+            echo
+            echo "### Release notes"
+            echo
+            cat "${{ runner.temp }}/release/release-notes.md"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The v1.0.0 release run failed before tagging (run 26892667305): `git-cliff`
uses libgit2, which rejects the bind-mounted workspace inside the rust-llvm
container because it is owned by a different user, failing with
`could not find repository at '/__w/rusty/rusty'`.

- Run the release job directly on the runner like the other release
  workflows (`release-pr.yml`, `release-preview.yml`), installing cargo-edit
  explicitly; this also removes the jq install workaround
- Write generated files (bumped-version output, release notes) to
  `runner.temp` instead of the workspace, where `create-pull-request` would
  otherwise commit them into the release PR (`git-cliff/CHANGELOG.md` rode
  along in every release PR so far) and the dev-bump PR (release notes)
- Harden `test-release-flows.sh`: assert the dev-bump commit contains only
  version files, map `runner.temp` in the step extractor

The libgit2 ownership failure was reproduced in a container with the exact
CI git-cliff binary (2.13.1). `safe.directory` workarounds are
environment-sensitive; running outside the container removes the failure
class entirely.

## Manual dry-run mode

`release.yml` gains `workflow_dispatch`:

- **Dry run (default)**: executes the full release pipeline but skips
  tagging, publishing, and PR creation; the would-be release (tag,
  previous tag, dev bump, full notes) is written to the step summary.
  Lets workflow changes be exercised on a real runner before a release
  depends on them.
- **Unchecked**: publishes a release from the dispatched branch tip — the
  manual fallback for a failed automated release run. Refuses `-dev`
  versions, so it can only fire on an actual release commit.

The `pull_request` merge path is behaviorally unchanged: all dispatch
conditionals collapse to the previous expressions for PR events.

## Verification

- `bash .github/scripts/test-release-flows.sh` — 45 passed, 0 failed
- actionlint clean
- First real exercise: dispatch a dry run from master once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)