### PR TITLE
fix: validate the generic natures before lowering (#1793)

### DIFF
--- a/compiler/plc_driver/src/pipelines/participant.rs
+++ b/compiler/plc_driver/src/pipelines/participant.rs
@@ -321,6 +321,10 @@ impl PipelineParticipantMut for AggregateTypeLowerer {
         project.diagnostics = diagnostics;
         project
     }
+
+    fn diagnostics(&mut self) -> Vec<Diagnostic> {
+        std::mem::take(&mut self.diagnostics)
+    }
 }
 
 impl PipelineParticipantMut for PolymorphismLowerer {

--- a/src/lowering/calls.rs
+++ b/src/lowering/calls.rs
@@ -58,6 +58,7 @@ use plc_ast::{
     provider::IdProvider,
     try_from_mut,
 };
+use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocation;
 
 use crate::{
@@ -65,6 +66,7 @@ use crate::{
     lowering::helper::create_member_reference_with_location,
     resolver::{AnnotationMap, StatementAnnotation},
     typesystem::{DataType, DataTypeInformation},
+    validation::statement::evaluate_generic_nature_violation,
 };
 
 // Performs lowering for aggregate types defined in functions
@@ -78,6 +80,11 @@ pub struct AggregateTypeLowerer {
     /// New statements to be added during visit, that should happen after the call. This should always be drained when read
     post_stmts: Vec<Vec<AstNode>>,
     counter: AtomicI32,
+    /// Diagnostics collected while visiting. Reported by the pipeline after lowering (see the
+    /// `PipelineParticipantMut::diagnostics` impl). We must emit generic type-nature errors here,
+    /// before lowering rewrites a generic call (e.g. `CONCAT`) into its concrete instantiation and
+    /// the subsequent re-annotation erases the generic nature the check relies on.
+    pub diagnostics: Vec<Diagnostic>,
 }
 
 impl AggregateTypeLowerer {
@@ -91,6 +98,62 @@ impl AggregateTypeLowerer {
 
     pub fn visit_unit(&mut self, unit: &mut CompilationUnit) {
         self.visit_compilation_unit(unit);
+    }
+
+    /// Collects `E062` diagnostics for call arguments whose actual type does not satisfy the nature
+    /// of the generic parameter they are bound to (e.g. a `DINT` passed to a `T: ANY_STRING`
+    /// variadic).
+    ///
+    /// This only fires for generic calls that this lowerer rewrites to their concrete instantiation
+    /// (e.g. `CONCAT` -> `CONCAT__STRING`): that rewrite plus the subsequent re-annotation erases
+    /// the generic nature, so the regular `validate_type_nature` pass can no longer see it. Every
+    /// other generic call keeps its nature and is reported by that pass, so we must skip them here
+    /// to avoid duplicate diagnostics. The rewrite happens iff the resolved function is a concrete
+    /// (non-generic) instantiation returning an aggregate type (see `visit_call_statement`).
+    fn collect_generic_nature_violations(&self, stmt: &CallStatement) -> Vec<Diagnostic> {
+        let Some((annotation, index)) = self.annotation.as_ref().zip(self.index.as_ref()) else {
+            return Vec::new();
+        };
+
+        let Some(StatementAnnotation::Function { qualified_name, generic_name, return_type, .. }) =
+            annotation.get(&stmt.operator).or_else(|| annotation.get_hint(&stmt.operator))
+        else {
+            return Vec::new();
+        };
+
+        let is_rewritten_generic = generic_name.is_some()
+            && index.find_pou(qualified_name).is_some_and(|it| !it.is_generic() && !it.is_builtin())
+            && index.get_effective_type_or_void_by_name(return_type).is_aggregate_type();
+        if !is_rewritten_generic {
+            return Vec::new();
+        }
+
+        let Some(parameters) = stmt.parameters.as_deref() else {
+            return Vec::new();
+        };
+
+        let mut diagnostics = Vec::new();
+        for argument in flatten_expression_list(parameters) {
+            // The nature is attached to the passed value; for `x := val` that is the right-hand side.
+            let value = match argument.get_stmt() {
+                AstStatement::Assignment(data) | AstStatement::OutputAssignment(data) => &data.right,
+                _ => argument,
+            };
+
+            let (Some(actual_type), Some(nature)) =
+                (annotation.get_type(value, index), annotation.get_generic_nature(value))
+            else {
+                continue;
+            };
+            let type_hint = annotation.get_type_hint(value, index).unwrap_or(actual_type);
+
+            if let Some(diagnostic) =
+                evaluate_generic_nature_violation(actual_type, type_hint, *nature, index, value)
+            {
+                diagnostics.push(diagnostic);
+            }
+        }
+        diagnostics
     }
 
     fn steal_and_walk_list(&mut self, list: &mut Vec<AstNode>) {
@@ -240,6 +303,14 @@ impl AstVisitorMut for AggregateTypeLowerer {
         let original_location = node.get_location();
         let stmt = try_from_mut!(node, CallStatement).expect("CallStatement");
         stmt.walk(self);
+
+        // Report generic type-nature violations (e.g. `CONCAT(aDint, aReal)`) now, while the call is
+        // still generic. The normal validator can only catch these before lowering; once we rewrite
+        // the call to its concrete instantiation the re-annotation drops the generic nature. Mirrors
+        // the diagnostics-during-lowering approach used by the property lowerer.
+        let nature_diagnostics = self.collect_generic_nature_violations(stmt);
+        self.diagnostics.extend(nature_diagnostics);
+
         let Some((annotation, index)) = self.annotation.as_ref().zip(self.index.as_ref()) else {
             //Early exit if not annotated or indexed
             return;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1198,6 +1198,7 @@ impl AnnotationMapImpl {
     pub fn import(&mut self, other: AnnotationMapImpl) {
         self.type_map.extend(other.type_map);
         self.type_hint_map.extend(other.type_hint_map);
+        self.generic_nature_map.extend(other.generic_nature_map);
         self.hidden_function_calls.extend(other.hidden_function_calls);
         self.new_index.import(other.new_index);
     }

--- a/src/resolver/generics.rs
+++ b/src/resolver/generics.rs
@@ -265,12 +265,6 @@ impl TypeAnnotator<'_> {
         function_name: &str,
         generic_map: &FxHashMap<String, GenericType>,
     ) {
-        /// An internal struct used to hold the type and nature of a generic parameter
-        struct TypeAndNature<'a> {
-            datatype: &'a typesystem::DataType,
-            nature: TypeNature,
-        }
-
         let declared_parameters = self.index.get_available_parameters(function_name);
         // separate variadic and non variadic parameters
         let mut passed_parameters = Vec::new();
@@ -321,25 +315,27 @@ impl TypeAnnotator<'_> {
 
         // Then handle the varargs
         // Get the variadic argument if any
-        if let Some(dt) = self.index.get_variadic_member(function_name).map(|it| {
-            // if the member is generic
-            if let Some(DataTypeInformation::Generic { generic_symbol, nature, .. }) =
-                self.index.find_effective_type_info(it.get_type_name())
+        if let Some(variadic_member) = self.index.get_variadic_member(function_name) {
+            // The variadic member may be declared `{ref}` (e.g. CONCAT's `args: {sized} T...`),
+            // in which case its type is a pointer wrapping the element type. Unwrap it the same
+            // way the non-variadic branch does above; otherwise a generic `{ref}` vararg is never
+            // recognised as generic and its arguments escape type-nature validation entirely.
+            if let Some(DataTypeInformation::Generic { generic_symbol, nature, .. }) = self
+                .index
+                .find_effective_type_info(variadic_member.get_type_name())
+                .map(|t| self.index.find_elementary_pointer_type(t))
             {
-                let real_type = generic_map
+                let concrete = generic_map
                     .get(generic_symbol)
-                    .and_then(|it| self.index.find_effective_type_by_name(it.derived_type.as_str()))
-                    .map(|datatype| TypeAndNature { datatype, nature: *nature });
-                real_type
-            } else {
-                None
-            }
-        }) {
-            for p in variadic_parameters {
-                if let Some(TypeAndNature { datatype, nature }) = dt {
-                    self.annotation_map.add_generic_nature(p, nature);
-                    self.annotation_map
-                        .annotate_type_hint(p, StatementAnnotation::value(datatype.get_name()));
+                    .and_then(|it| self.index.find_effective_type_by_name(it.derived_type.as_str()));
+                for p in variadic_parameters {
+                    // Attach the declared nature so the E062 nature check runs even when the
+                    // concrete type could not be derived from the passed arguments.
+                    self.annotation_map.add_generic_nature(p, *nature);
+                    if let Some(datatype) = concrete {
+                        self.annotation_map
+                            .annotate_type_hint(p, StatementAnnotation::value(datatype.get_name()));
+                    }
                 }
             }
         }

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -6,7 +6,7 @@ use plc_ast::control_statements::ForLoopStatement;
 use plc_ast::{
     ast::{
         flatten_expression_list, AstNode, AstStatement, BinaryExpression, CallStatement, DirectAccess,
-        DirectAccessType, JumpStatement, Operator, ReferenceAccess, UnaryExpression,
+        DirectAccessType, JumpStatement, Operator, ReferenceAccess, TypeNature, UnaryExpression,
     },
     control_statements::{AstControlStatement, ConditionalBlock},
     literals::{Array, AstLiteral, StringValue},
@@ -2220,6 +2220,33 @@ fn validate_for_loop<T: AnnotationMap>(
     //       by a VAR_INPUT {ref} function call.
 }
 
+/// Checks whether a generic call argument's `actual_type` satisfies the `generic_nature` it is
+/// bound to, returning the `E062` diagnostic (anchored at `location`) when it does not.
+///
+/// Shared with the aggregate-return lowerer, which must run this check before it rewrites a generic
+/// call to its concrete instantiation (which erases the generic nature this relies on).
+pub(crate) fn evaluate_generic_nature_violation(
+    actual_type: &DataType,
+    type_hint: &DataType,
+    generic_nature: TypeNature,
+    index: &Index,
+    location: &AstNode,
+) -> Option<Diagnostic> {
+    // An INT argument for a REAL generic is allowed, otherwise the nature must match.
+    if actual_type.has_nature(generic_nature, index) || (type_hint.is_real() && actual_type.is_numerical()) {
+        return None;
+    }
+
+    Some(
+        Diagnostic::new(format!(
+            "Invalid type nature for generic argument. {} is no {generic_nature}",
+            actual_type.get_name(),
+        ))
+        .with_error_code("E062")
+        .with_location(location),
+    )
+}
+
 /// Validates that the assigned type and type hint are compatible with the nature for this
 /// statement
 fn validate_type_nature<T: AnnotationMap>(
@@ -2251,19 +2278,14 @@ fn validate_type_nature<T: AnnotationMap>(
         {
             // check if type_hint and actual_type is compatible
             // should be handled by assignment validation
-            if !(actual_type.has_nature(*generic_nature, context.index)
-                // INT parameter for REAL is allowed
-                | (type_hint.is_real() & actual_type.is_numerical()))
-            {
-                validator.push_diagnostic(
-                    Diagnostic::new(format!(
-                        "Invalid type nature for generic argument. {} is no {}",
-                        actual_type.get_name(),
-                        generic_nature
-                    ))
-                    .with_error_code("E062")
-                    .with_location(statement),
-                );
+            if let Some(diagnostic) = evaluate_generic_nature_violation(
+                actual_type,
+                type_hint,
+                *generic_nature,
+                context.index,
+                statement,
+            ) {
+                validator.push_diagnostic(diagnostic);
             }
         }
     }

--- a/src/validation/tests/generic_validation_tests.rs
+++ b/src/validation/tests/generic_validation_tests.rs
@@ -1257,6 +1257,32 @@ fn any_string_does_not_allow_ints() {
 }
 
 #[test]
+fn any_string_variadic_flags_each_non_string_argument() {
+    // A generic variadic `{ref}` parameter (as used by the stdlib CONCAT/INSERT/... functions):
+    // every argument whose type is not ANY_STRING must be reported individually, while genuine
+    // string arguments are left alone. Regression test for variadic `{ref}` args escaping the
+    // generic type-nature check (they are pointers to the generic type, not the generic directly).
+    let src = r#"
+        FUNCTION CONCAT <T: ANY_STRING> : T
+        VAR_INPUT {ref}
+            args : {sized} T...;
+        END_VAR
+        END_FUNCTION
+
+        FUNCTION mainProg : DINT
+        VAR x : DINT; y : REAL; z : STRING; END_VAR
+            CONCAT(x, y);
+            CONCAT(x, y, z);
+            CONCAT(x, z);
+            CONCAT(1, 'hello');
+        END_FUNCTION
+    "#;
+
+    let diagnostics = parse_and_validate_buffered(src);
+    assert_snapshot!(&diagnostics);
+}
+
+#[test]
 fn any_string_does_not_allow_time() {
     let src = r"
         FUNCTION test<T : ANY_STRING> : INT VAR_INPUT x : T; END_VAR END_FUNCTION

--- a/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_variadic_flags_each_non_string_argument.snap
+++ b/src/validation/tests/snapshots/rusty__validation__tests__generic_validation_tests__any_string_variadic_flags_each_non_string_argument.snap
@@ -1,0 +1,81 @@
+---
+source: src/validation/tests/generic_validation_tests.rs
+expression: "&diagnostics"
+---
+error[E037]: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:10:20
+   │
+10 │             CONCAT(x, y);
+   │                    ^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error[E062]: Invalid type nature for generic argument. DINT is no ANY_STRING
+   ┌─ <internal>:10:20
+   │
+10 │             CONCAT(x, y);
+   │                    ^ Invalid type nature for generic argument. DINT is no ANY_STRING
+
+error[E037]: Invalid assignment: cannot assign 'REAL' to 'STRING'
+   ┌─ <internal>:10:23
+   │
+10 │             CONCAT(x, y);
+   │                       ^ Invalid assignment: cannot assign 'REAL' to 'STRING'
+
+error[E062]: Invalid type nature for generic argument. REAL is no ANY_STRING
+   ┌─ <internal>:10:23
+   │
+10 │             CONCAT(x, y);
+   │                       ^ Invalid type nature for generic argument. REAL is no ANY_STRING
+
+error[E037]: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:11:20
+   │
+11 │             CONCAT(x, y, z);
+   │                    ^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error[E062]: Invalid type nature for generic argument. DINT is no ANY_STRING
+   ┌─ <internal>:11:20
+   │
+11 │             CONCAT(x, y, z);
+   │                    ^ Invalid type nature for generic argument. DINT is no ANY_STRING
+
+error[E037]: Invalid assignment: cannot assign 'REAL' to 'STRING'
+   ┌─ <internal>:11:23
+   │
+11 │             CONCAT(x, y, z);
+   │                       ^ Invalid assignment: cannot assign 'REAL' to 'STRING'
+
+error[E062]: Invalid type nature for generic argument. REAL is no ANY_STRING
+   ┌─ <internal>:11:23
+   │
+11 │             CONCAT(x, y, z);
+   │                       ^ Invalid type nature for generic argument. REAL is no ANY_STRING
+
+error[E037]: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:12:20
+   │
+12 │             CONCAT(x, z);
+   │                    ^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error[E062]: Invalid type nature for generic argument. DINT is no ANY_STRING
+   ┌─ <internal>:12:20
+   │
+12 │             CONCAT(x, z);
+   │                    ^ Invalid type nature for generic argument. DINT is no ANY_STRING
+
+error[E031]: Expected a reference for parameter CONCAT__STRING because their type is InOut
+   ┌─ <internal>:13:20
+   │
+13 │             CONCAT(1, 'hello');
+   │                    ^ Expected a reference for parameter CONCAT__STRING because their type is InOut
+
+error[E037]: Invalid assignment: cannot assign 'DINT' to 'STRING'
+   ┌─ <internal>:13:20
+   │
+13 │             CONCAT(1, 'hello');
+   │                    ^ Invalid assignment: cannot assign 'DINT' to 'STRING'
+
+error[E062]: Invalid type nature for generic argument. DINT is no ANY_STRING
+   ┌─ <internal>:13:20
+   │
+13 │             CONCAT(1, 'hello');
+   │                    ^ Invalid type nature for generic argument. DINT is no ANY_STRING

--- a/tests/lit/single/string_functions/concat_scalar_generic_no_duplicate.st
+++ b/tests/lit/single/string_functions/concat_scalar_generic_no_duplicate.st
@@ -1,0 +1,17 @@
+// RUN: not %COMPILE %s --error-format clang 2>&1 | %CHECK %s
+// Regression: a nature violation on a generic function with a *scalar* return (here CONCAT_LTOD,
+// `<T: ANY_INT> : LTOD`) must be reported exactly once. Such calls are NOT rewritten by the
+// aggregate-return lowerer, so their generic nature survives to the regular validation pass. The
+// lowerer must therefore stay silent for them; otherwise the diagnostic is emitted twice (once by
+// the lowerer, once by validation). The CHECK-NEXT below pins the abort line directly after the
+// single E062, so a duplicate E062 would fail the test.
+
+FUNCTION mainProg : LTOD
+VAR
+    r : REAL;
+    i : INT;
+END_VAR
+    // CHECK: {{.*}}error[E062]: Invalid type nature for generic argument. REAL is no ANY_INT
+    // CHECK-NEXT: error: Compilation aborted due to critical errors
+    mainProg := CONCAT_LTOD(r, i, i, i);
+END_FUNCTION

--- a/tests/lit/single/string_functions/concat_type_mismatch.st
+++ b/tests/lit/single/string_functions/concat_type_mismatch.st
@@ -1,0 +1,22 @@
+// RUN: not %COMPILE %s --error-format clang 2>&1 | %CHECK %s
+// End-to-end guard for passing non-string arguments to the generic CONCAT stdlib function.
+// CONCAT is `FUNCTION CONCAT <T: ANY_STRING> : T` with a `{ref} {sized} T...` variadic. Passing a
+// non-ANY_STRING argument used to compile silently and then crash in codegen: the generic call is
+// lowered to the concrete `CONCAT__STRING` and the following re-annotation dropped the generic
+// nature before validation could see it. Every offending argument must now be reported, while
+// genuine string arguments are left alone.
+
+FUNCTION mainProg : DINT
+VAR
+    x : DINT;
+    y : REAL;
+    z : STRING;
+END_VAR
+    // Every non-string argument is flagged individually; `z` is a valid STRING and is not.
+    // CHECK-DAG: {{.*}}concat_type_mismatch.st:[[@LINE+1]]:{{[0-9]+}}:{{.*}}error[E062]: Invalid type nature for generic argument. DINT is no ANY_STRING
+    z := CONCAT(x, z);
+
+    // CHECK-DAG: {{.*}}concat_type_mismatch.st:[[@LINE+2]]:{{[0-9]+}}:{{.*}}error[E062]: Invalid type nature for generic argument. DINT is no ANY_STRING
+    // CHECK-DAG: {{.*}}concat_type_mismatch.st:[[@LINE+1]]:{{[0-9]+}}:{{.*}}error[E062]: Invalid type nature for generic argument. REAL is no ANY_STRING
+    z := CONCAT(x, y, z);
+END_FUNCTION


### PR DESCRIPTION
This is a backport from master into release.
Only merge once we test master and confirm the fix.