### PR TITLE
fix: reject VAR_IN_OUT access from outside the declaring POU

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E037.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E037.md
@@ -1,1 +1,63 @@
-# Invalid assignment
+# E037: Invalid assignment
+
+This error is reported for assignments or accesses that are not allowed, for example when the
+types of the left- and right-hand side are incompatible, when a `VOID` function result is
+assigned to a variable, or when a variable is written or read from a place where it must not be
+accessed.
+
+## Example - incompatible types
+
+```st
+FUNCTION main
+VAR
+    x : INT;
+    s : STRING;
+END_VAR
+    x := s; (* cannot assign 'STRING' to 'INT' *)
+END_FUNCTION
+```
+
+## Example - VAR_OUTPUT assigned outside of its scope
+
+`VAR_OUTPUT` variables of a function block may only be written by the function block itself.
+From the outside they can only be read.
+
+```st
+FUNCTION_BLOCK FB
+VAR_OUTPUT
+    out : BOOL;
+END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM main
+VAR
+    fb : FB;
+END_VAR
+    fb.out := TRUE; (* VAR_OUTPUT variables cannot be assigned outside of their scope *)
+END_PROGRAM
+```
+
+## Example - VAR_IN_OUT accessed outside of its scope
+
+`VAR_IN_OUT` variables of a function block or program may not be read or written from outside.
+They are references that are only bound to a target while the function block is being called, so
+any outside access - reading, writing or taking the address - would dereference an unbound
+reference. Pass the variable in the call instead.
+
+```st
+FUNCTION_BLOCK FB
+VAR_IN_OUT
+    inOut : LREAL;
+END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM main
+VAR
+    fb : FB;
+    value : LREAL;
+END_VAR
+    fb.inOut := value;  (* VAR_IN_OUT variables cannot be accessed outside of their scope *)
+    value := fb.inOut;  (* VAR_IN_OUT variables cannot be accessed outside of their scope *)
+    fb(inOut := value); (* correct: the variable is passed in the call *)
+END_PROGRAM
+```

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -70,6 +70,7 @@ pub fn visit_statement<T: AnnotationMap>(
             }
 
             validate_reference_expression(&data.access, validator, context, statement, &data.base);
+            validate_in_out_variable_access(validator, statement, data.base.as_deref(), context);
         }
         AstStatement::BinaryExpression(data) => {
             visit_all_statements!(validator, context, &data.left, &data.right);
@@ -1550,6 +1551,51 @@ fn is_ref_or_adr_call<T: AnnotationMap>(node: &AstNode, context: &ValidationCont
             .index
             .get_builtin_function(call_name)
             .is_some_and(|builtin| std::ptr::eq(builtin, ref_builtin))
+}
+
+/// Validates that a `VAR_IN_OUT` variable is not read or written outside of the POU it is
+/// declared in (e.g. `fbInstance.inOutVariable := 1;`). In the instance an in-out variable is a
+/// pointer that is only bound to a target for the duration of a call, so any outside access
+/// dereferences an unbound pointer.
+fn validate_in_out_variable_access<T: AnnotationMap>(
+    validator: &mut Validator,
+    statement: &AstNode,
+    base: Option<&AstNode>,
+    context: &ValidationContext<T>,
+) {
+    let location = statement.get_location();
+    if location.is_internal() {
+        return;
+    }
+
+    // a named argument in a call (`fbInstance(inOutVariable := x)`) is how the variable gets
+    // bound in the first place
+    if context.is_call() && base.is_none() {
+        return;
+    }
+
+    let Some(StatementAnnotation::Variable { qualified_name, argument_type, .. }) =
+        context.annotations.get(statement)
+    else {
+        return;
+    };
+
+    if !matches!(argument_type.get_inner(), VariableType::InOut) {
+        return;
+    }
+
+    if !variable_is_in_inherited_or_self_scope(
+        context.qualifier.and_then(|qualifier| context.index.find_pou(qualifier)),
+        context,
+        qualified_name,
+        &location,
+    ) {
+        validator.push_diagnostic(
+            Diagnostic::new("VAR_IN_OUT variables cannot be accessed outside of their scope.")
+                .with_error_code("E037")
+                .with_location(&location),
+        );
+    }
 }
 
 fn variable_is_in_inherited_or_self_scope<T: AnnotationMap>(

--- a/src/validation/tests/variable_validation_tests.rs
+++ b/src/validation/tests/variable_validation_tests.rs
@@ -1621,6 +1621,142 @@ fn output_variables_must_be_assignable_within_the_scope_of_inheritance() {
 }
 
 #[test]
+fn in_out_variables_must_not_be_accessible_outside_of_their_scope() {
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        FUNCTION_BLOCK FB_Sample
+            VAR_IN_OUT
+                Velocity : LREAL;
+            END_VAR
+        END_FUNCTION_BLOCK
+
+        FUNCTION takeIt : DINT
+            VAR_INPUT
+                value : LREAL;
+            END_VAR
+        END_FUNCTION
+
+        PROGRAM prog
+            VAR_IN_OUT
+                progInOut : LREAL;
+            END_VAR
+        END_PROGRAM
+
+        PROGRAM mainProg
+            VAR
+                myVel : LREAL;
+                fbSample : FB_Sample;
+                pVel : POINTER TO LREAL;
+            END_VAR
+
+            fbSample.Velocity := myVel;
+            myVel := fbSample.Velocity;
+            myVel := fbSample.Velocity + 1.0;
+            takeIt(fbSample.Velocity);
+            takeIt(value := fbSample.Velocity);
+            pVel := ADR(fbSample.Velocity);
+            prog.progInOut := myVel;
+        END_PROGRAM
+        "#,
+    );
+
+    assert_snapshot!(&diagnostics, @r"
+    error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+       ┌─ <internal>:27:13
+       │
+    27 │             fbSample.Velocity := myVel;
+       │             ^^^^^^^^^^^^^^^^^ VAR_IN_OUT variables cannot be accessed outside of their scope.
+
+    error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+       ┌─ <internal>:28:22
+       │
+    28 │             myVel := fbSample.Velocity;
+       │                      ^^^^^^^^^^^^^^^^^ VAR_IN_OUT variables cannot be accessed outside of their scope.
+
+    error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+       ┌─ <internal>:29:22
+       │
+    29 │             myVel := fbSample.Velocity + 1.0;
+       │                      ^^^^^^^^^^^^^^^^^ VAR_IN_OUT variables cannot be accessed outside of their scope.
+
+    error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+       ┌─ <internal>:30:20
+       │
+    30 │             takeIt(fbSample.Velocity);
+       │                    ^^^^^^^^^^^^^^^^^ VAR_IN_OUT variables cannot be accessed outside of their scope.
+
+    error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+       ┌─ <internal>:31:29
+       │
+    31 │             takeIt(value := fbSample.Velocity);
+       │                             ^^^^^^^^^^^^^^^^^ VAR_IN_OUT variables cannot be accessed outside of their scope.
+
+    error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+       ┌─ <internal>:32:25
+       │
+    32 │             pVel := ADR(fbSample.Velocity);
+       │                         ^^^^^^^^^^^^^^^^^ VAR_IN_OUT variables cannot be accessed outside of their scope.
+
+    error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+       ┌─ <internal>:33:13
+       │
+    33 │             prog.progInOut := myVel;
+       │             ^^^^^^^^^^^^^^ VAR_IN_OUT variables cannot be accessed outside of their scope.
+    ");
+}
+
+#[test]
+fn in_out_variables_are_accessible_within_their_scope() {
+    let diagnostics = parse_and_validate_buffered(
+        r#"
+        FUNCTION_BLOCK FB_Other
+            VAR_IN_OUT
+                otherInOut : LREAL;
+            END_VAR
+        END_FUNCTION_BLOCK
+
+        FUNCTION_BLOCK FB_Sample
+            VAR_IN_OUT
+                Velocity : LREAL;
+            END_VAR
+            VAR
+                innerFb : FB_Other;
+            END_VAR
+
+            METHOD someMethod
+                Velocity := 3.0;
+            END_METHOD
+
+            Velocity := Velocity + 1.0;
+            THIS^.Velocity := 2.0;
+            innerFb(otherInOut := Velocity);
+        END_FUNCTION_BLOCK
+
+        ACTIONS FB_Sample
+            ACTION someAction
+                Velocity := 4.0;
+            END_ACTION
+        END_ACTIONS
+
+        FUNCTION_BLOCK FB_Child EXTENDS FB_Sample
+            Velocity := 5.0;
+        END_FUNCTION_BLOCK
+
+        PROGRAM mainProg
+            VAR
+                myVel : LREAL;
+                fbSample : FB_Sample;
+            END_VAR
+
+            fbSample(Velocity := myVel);
+        END_PROGRAM
+        "#,
+    );
+
+    assert_snapshot!(&diagnostics, @"");
+}
+
+#[test]
 fn enum_and_fb_output_must_not_generate_duplicate_symbol_error() {
     let diagnostics = parse_and_validate_buffered(
         "

--- a/tests/lit/single/function_blocks/var_in_out_access_outside_scope.st
+++ b/tests/lit/single/function_blocks/var_in_out_access_outside_scope.st
@@ -1,0 +1,33 @@
+// RUN: rm -f %T/%basename_t.out
+// RUN: not %COMPILE --error-format clang %s 2>&1 | %CHECK %s
+// RUN: test ! -e %T/%basename_t.out
+
+// In the instance struct a VAR_IN_OUT member is a pointer that is only bound to a
+// target while the POU is being called. Reading or writing it from outside used to
+// pass validation and dereference a null pointer at runtime.
+
+// CHECK-NOT: {{.*}}error[E037]{{.*}}
+// CHECK: {{.*}}var_in_out_access_outside_scope.st:31:{{.*}}error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+// CHECK: {{.*}}var_in_out_access_outside_scope.st:32:{{.*}}error[E037]: VAR_IN_OUT variables cannot be accessed outside of their scope.
+// CHECK: error: Compilation aborted due to critical errors
+
+FUNCTION_BLOCK FB_Sample
+VAR_IN_OUT
+    Velocity : LREAL;
+END_VAR
+    Velocity := Velocity + 1.0;
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FB_Child EXTENDS FB_Sample
+    Velocity := 2.0;
+END_FUNCTION_BLOCK
+
+PROGRAM mainProg
+VAR
+    myVel : LREAL;
+    fbSample : FB_Sample;
+END_VAR
+    fbSample(Velocity := myVel);
+    fbSample.Velocity := myVel;
+    myVel := fbSample.Velocity;
+END_PROGRAM


### PR DESCRIPTION
Reading or writing a VAR_IN_OUT member of a function block or program instance (e.g. `fbInstance.inOut := 1;`) passed validation and dereferenced an unbound pointer at runtime. Such accesses are now reported as E037, mirroring the existing VAR_OUTPUT scope rule. Binding the variable in a call (`fbInstance(inOut := x)`) remains valid.