### PR TITLE
feat(cfc): variable source/sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,6 +2277,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "plc_cfc"
+version = "1.1.0-dev"
+dependencies = [
+ "insta",
+ "plc-compiler",
+ "plc_ast",
+ "plc_diagnostics",
+ "plc_source",
+ "quick-xml",
+ "serde",
+]
+
+[[package]]
 name = "plc_derive"
 version = "1.1.0-dev"
 dependencies = [
@@ -2317,6 +2330,7 @@ dependencies = [
  "log",
  "plc-compiler",
  "plc_ast",
+ "plc_cfc",
  "plc_diagnostics",
  "plc_header_generator",
  "plc_index",
@@ -2558,6 +2572,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
     "compiler/plc_lowering",
     "compiler/plc_llvm",
     "compiler/plc_header_generator",
+    "compiler/plc_cfc",
     "tests/test_utils",
 ]
 default-members = [".", "compiler/plc_driver"]

--- a/compiler/plc_ast/src/ser.rs
+++ b/compiler/plc_ast/src/ser.rs
@@ -3,7 +3,7 @@ use crate::{
         Allocation, ArgumentProperty, Assignment, AstNode, AstStatement, AutoDerefType, BinaryExpression,
         CallStatement, CompilationUnit, ConfigVariable, DataType, DataTypeDeclaration, DefaultValue,
         DirectAccess, EmptyStatement, HardwareAccess, Implementation, Interface, JumpStatement,
-        LabelStatement, MultipliedStatement, Pou, PropertyBlock, RangeStatement, ReferenceAccess,
+        LabelStatement, MultipliedStatement, Pou, PouType, PropertyBlock, RangeStatement, ReferenceAccess,
         ReferenceExpr, UnaryExpression, UserTypeDeclaration, Variable, VariableBlock, VariableBlockType,
     },
     control_statements::{AstControlStatement, ReturnStatement},
@@ -29,6 +29,21 @@ impl AstSerializer<'_> {
             is_in_paren: false,
         };
         serializer.visit(node);
+
+        serializer.result
+    }
+
+    /// Serializes a whole compilation unit back to Structured Text, POU by POU
+    /// (header, variable blocks, body statements, closing keyword).
+    pub fn from_unit(unit: &CompilationUnit) -> String {
+        let mut serializer = AstSerializer {
+            result: String::new(),
+            indent: 0,
+            unit: Some(unit),
+            user_type_context: None,
+            is_in_paren: false,
+        };
+        serializer.visit_compilation_unit(unit);
 
         serializer.result
     }
@@ -100,17 +115,48 @@ impl AstSerializer<'_> {
     }
 }
 
+fn pou_keywords(kind: &PouType) -> (&'static str, &'static str) {
+    match kind {
+        PouType::Program => ("PROGRAM", "END_PROGRAM"),
+        PouType::FunctionBlock => ("FUNCTION_BLOCK", "END_FUNCTION_BLOCK"),
+        PouType::Class => ("CLASS", "END_CLASS"),
+        PouType::Action => ("ACTION", "END_ACTION"),
+        _ => ("FUNCTION", "END_FUNCTION"),
+    }
+}
+
 impl AstVisitor for AstSerializer<'_> {
     fn visit(&mut self, node: &AstNode) {
         node.walk(self)
     }
 
-    fn visit_compilation_unit(&mut self, _: &CompilationUnit) {
-        unimplemented!("for now only interested in individual nodes located in a POU body")
+    fn visit_compilation_unit(&mut self, unit: &CompilationUnit) {
+        for (index, pou) in unit.pous.iter().enumerate() {
+            if index > 0 {
+                self.result.push_str("\n\n");
+            }
+            self.visit_pou(pou);
+            if let Some(implementation) = unit.implementations.iter().find(|it| it.name == pou.name) {
+                self.visit_implementation(implementation);
+            }
+            self.result.push('\n');
+            self.result.push_str(pou_keywords(&pou.kind).1);
+        }
     }
 
-    fn visit_implementation(&mut self, _: &Implementation) {
-        unimplemented!("for now only interested in individual nodes located in a POU body")
+    fn visit_implementation(&mut self, implementation: &Implementation) {
+        self.indent += 1;
+        for statement in &implementation.statements {
+            if statement.is_empty_statement() {
+                continue;
+            }
+            self.push_indent();
+            statement.walk(self);
+            if !statement.is_expression_list() {
+                self.result.push(';');
+            }
+        }
+        self.indent -= 1;
     }
 
     fn visit_variable_block(&mut self, variable_block: &VariableBlock) {
@@ -209,8 +255,18 @@ impl AstVisitor for AstSerializer<'_> {
         }
     }
 
-    fn visit_pou(&mut self, _: &Pou) {
-        unimplemented!("for now only interested in individual nodes located in a POU body")
+    fn visit_pou(&mut self, pou: &Pou) {
+        self.result.push_str(pou_keywords(&pou.kind).0);
+        self.result.push(' ');
+        self.result.push_str(&pou.name);
+        if let Some(return_type) = &pou.return_type {
+            self.result.push_str(" : ");
+            self.visit_data_type_declaration(return_type);
+        }
+        for variable_block in &pou.variable_blocks {
+            self.result.push('\n');
+            self.visit_variable_block(variable_block);
+        }
     }
 
     fn visit_empty_statement(&mut self, _stmt: &EmptyStatement, _node: &AstNode) {}

--- a/compiler/plc_cfc/Cargo.toml
+++ b/compiler/plc_cfc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "plc_cfc"
+version = "1.1.0-dev"
+edition = "2021"
+license = "LGPL-3.0"
+description = "CFC/FBD XML -> Structured Text AST transpiler for the PLC compiler"
+
+[dependencies]
+serde.workspace = true
+quick-xml = { version = "0.38", features = ["serialize"] }
+plc = { path = "../..", package = "plc-compiler", version = "1.1.0-dev" }
+plc_ast = { path = "../plc_ast/", version = "1.1.0-dev" }
+plc_diagnostics = { path = "../plc_diagnostics", version = "1.1.0-dev" }
+plc_source = { path = "../plc_source", version = "1.1.0-dev" }
+
+[dev-dependencies]
+insta.workspace = true

--- a/compiler/plc_cfc/README.md
+++ b/compiler/plc_cfc/README.md
@@ -1,0 +1,3 @@
+# plc_cfc
+
+Transpiles CFC files into AST, which the main compiler pipeline can then use to compile into binaries.

--- a/compiler/plc_cfc/fixtures/README.md
+++ b/compiler/plc_cfc/fixtures/README.md
@@ -1,0 +1,36 @@
+# Fixtures
+
+CFC example projects that double as transpiler/resolver test inputs. Every `.cfc`
+here is real, IDE-exported-shaped PLCopen XML (the `ppx` namespace,
+`www.iec.ch/public/TC65SC65BWG7TF10`) with valid `RelPosition`/`Size` values, so
+it can be **copy-pasted / imported into the IDE unchanged**. The authoritative
+schema is `src/model.rs` plus the verbatim exports under `reference/`.
+
+## Layout
+
+```
+fixtures/
+  valid/<name>/     compiles cleanly (warnings allowed)
+  invalid/<name>/   rejected with a diagnostic
+  reference/        verbatim IDE exports kept as schema ground-truth
+```
+
+Each fixture is a folder containing a `README.md` and the `.cfc` file(s) (plus
+companion `.st` files when a case needs them). Name the `.cfc` after the fixture.
+
+## Fixture README format
+
+Lean: a `What:` description, then an `Illustrated:` ASCII sketch of the network
+in a fenced block. Draw `source --> sink`, mark sink execution order with `(n)`,
+and skip element borders — the names, arrows and order carry the meaning.
+(Borders earn their place only later, for real multi-pin blocks.)
+
+```
+What: one or two sentences on what the network does and why it exists.
+
+Illustrated:
+​```
+foo --+--> bar (0)
+      +--> baz (1)
+​```
+```

--- a/compiler/plc_cfc/fixtures/variables/invalid/binary_expression/README.md
+++ b/compiler/plc_cfc/fixtures/variables/invalid/binary_expression/README.md
@@ -1,0 +1,8 @@
+What: A source whose identifier is an arithmetic expression, `foo + 1`. A source
+or sink may only carry a variable reference or a literal, not an expression, so
+this is rejected with an "unsupported CFC expression" error (E083).
+
+Illustrated:
+```
+foo + 1 --> bar (0)    (expression — rejected)
+```

--- a/compiler/plc_cfc/fixtures/variables/invalid/binary_expression/binary_expression.cfc
+++ b/compiler/plc_cfc/fixtures/variables/invalid/binary_expression/binary_expression.cfc
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="binary_expression">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION binary_expression : INT
+VAR
+    foo : DINT;
+    bar : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo + 1" globalId="1">
+                    <ppx:RelPosition x="240" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="370" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/variables/invalid/call_expression/README.md
+++ b/compiler/plc_cfc/fixtures/variables/invalid/call_expression/README.md
@@ -1,0 +1,8 @@
+What: A source whose identifier is a function call, `MAX(foo, bar)`. Sources and
+sinks may only carry a variable reference or a literal, so this is rejected with
+an "unsupported CFC expression" error (E083).
+
+Illustrated:
+```
+MAX(foo, bar) --> result (0)    (call — rejected)
+```

--- a/compiler/plc_cfc/fixtures/variables/invalid/call_expression/call_expression.cfc
+++ b/compiler/plc_cfc/fixtures/variables/invalid/call_expression/call_expression.cfc
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="call_expression">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION call_expression : INT
+VAR
+    foo : DINT;
+    bar : DINT;
+    result : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="MAX(foo, bar)" globalId="1">
+                    <ppx:RelPosition x="230" y="140"/>
+                    <ppx:Size x="120" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="120" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="390" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/variables/reference/README.md
+++ b/compiler/plc_cfc/fixtures/variables/reference/README.md
@@ -1,0 +1,10 @@
+# Reference exports
+
+Verbatim CFC files exported straight from the IDE, kept as the **ground truth**
+for the on-disk schema. They are not necessarily wired into tests; they exist so
+generated fixtures can be checked against a real export and so new element kinds
+(blocks, connectors, …) have an authoritative shape to derive from before we
+hand-author `valid/` and `invalid/` cases.
+
+Drop new IDE exports here unchanged (keep the original layout/positions). Prefix
+or subfolder by the feature they demonstrate, e.g. `reference/block_call/`.

--- a/compiler/plc_cfc/fixtures/variables/reference/expression_identifier.cfc
+++ b/compiler/plc_cfc/fixtures/variables/reference/expression_identifier.cfc
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:FunctionBlock xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="two">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION_BLOCK two
+VAR
+	a, b, c : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a + b" globalId="1">
+                    <ppx:RelPosition x="180" y="310"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="c" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="300" y="310"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:FunctionBlock>

--- a/compiler/plc_cfc/fixtures/variables/reference/function_network.cfc
+++ b/compiler/plc_cfc/fixtures/variables/reference/function_network.cfc
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="three">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION three : INT
+	VAR
+		foo, bar : DINT;
+	END_VAR
+                </content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:RelPosition x="230" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/variables/reference/indexed_identifier.cfc
+++ b/compiler/plc_cfc/fixtures/variables/reference/indexed_identifier.cfc
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="one">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM one
+VAR
+	in, out : ARRAY[0..3] OF DINT;
+END_VAR
+</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="in[0]" globalId="1">
+                    <ppx:RelPosition x="360" y="200"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="out[1]" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="500" y="200"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/variables/valid/fan_out/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/fan_out/README.md
@@ -1,0 +1,9 @@
+What: One source feeding two sinks — `bar := foo` (0) and `baz := foo` (1). A
+single `ConnectionPointOut` is referenced by multiple `Connection`s. Modeled as a
+`FUNCTION_BLOCK`.
+
+Illustrated:
+```
+foo --+--> bar (0)
+      +--> baz (1)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/fan_out/fan_out.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/fan_out/fan_out.cfc
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:FunctionBlock xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fan_out">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION_BLOCK fan_out
+VAR
+    foo : DINT;
+    bar : DINT;
+    baz : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:RelPosition x="250" y="150"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="baz" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="360" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:FunctionBlock>

--- a/compiler/plc_cfc/fixtures/variables/valid/indexed_assignment/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/indexed_assignment/README.md
@@ -1,0 +1,8 @@
+What: A sink whose target is an array element — `values[1] := source`. Exercises
+an indexed reference (not just a plain name) on the sink side. Modeled as a
+`PROGRAM`.
+
+Illustrated:
+```
+source --> values[1] (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/indexed_assignment/indexed_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/indexed_assignment/indexed_assignment.cfc
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="indexed_assignment">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM indexed_assignment
+VAR
+    source : DINT;
+    values : ARRAY[0..3] OF DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="source" globalId="1">
+                    <ppx:RelPosition x="240" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="values[1]" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/variables/valid/literal_assignment/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/literal_assignment/README.md
@@ -1,0 +1,7 @@
+What: A literal source assigned to a variable — `foo := 5`. The source's
+identifier is a numeric literal rather than a variable reference.
+
+Illustrated:
+```
+5 --> foo (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/literal_assignment/literal_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/literal_assignment/literal_assignment.cfc
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="literal_assignment">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION literal_assignment : INT
+VAR
+    foo : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="5" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="foo" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/variables/valid/reciprocal_assignment/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/reciprocal_assignment/README.md
@@ -1,0 +1,9 @@
+What: Two assignments whose evaluation order matters — `bar := foo` (0) then
+`foo := bar` (1). Confirms statements are emitted in `EvaluationPriority` order,
+not document order. Modeled as a `PROGRAM`.
+
+Illustrated:
+```
+foo --> bar (0)
+bar --> foo (1)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/reciprocal_assignment/reciprocal_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/reciprocal_assignment/reciprocal_assignment.cfc
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="reciprocal_assignment">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM reciprocal_assignment
+VAR
+    foo : DINT;
+    bar : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="bar" globalId="4">
+                    <ppx:RelPosition x="250" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="foo" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="360" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/variables/valid/simple_assignment/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/simple_assignment/README.md
@@ -1,0 +1,7 @@
+What: A single source-to-sink connection assigning one variable to another,
+`bar := foo`. The smallest non-empty network.
+
+Illustrated:
+```
+foo --> bar (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/simple_assignment/simple_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/simple_assignment/simple_assignment.cfc
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="simple_assignment">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION simple_assignment : INT
+VAR
+    foo : DINT;
+    bar : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/variables/valid/unconnected_variables/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/unconnected_variables/README.md
@@ -1,0 +1,10 @@
+What: Two placed-but-unwired variables (`foo`, `bar`) alongside one real
+assignment `bar := foo`. The unconnected boxes emit nothing and each raise a
+warning; compilation still succeeds and produces the single assignment.
+
+Illustrated:
+```
+foo          (unconnected — ignored, warns)
+bar          (unconnected — ignored, warns)
+foo --> bar (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/unconnected_variables/unconnected_variables.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/unconnected_variables/unconnected_variables.cfc
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="unconnected_variables">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION unconnected_variables : INT
+VAR
+    foo : DINT;
+    bar : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Unconnected" complexIdentifier="foo" globalId="1">
+                    <ppx:RelPosition x="270" y="120"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                    </ppx:ConnectionPointIn>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Unconnected" complexIdentifier="bar" globalId="4">
+                    <ppx:RelPosition x="400" y="120"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                    </ppx:ConnectionPointIn>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="6">
+                    <ppx:RelPosition x="270" y="150"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="7">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="8">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="150"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="7"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/src/lib.rs
+++ b/compiler/plc_cfc/src/lib.rs
@@ -1,0 +1,50 @@
+//! CFC/FBD XML -> Structured Text AST transpiler.
+//!
+//! [`parse_file`] is the driver entry point for `.cfc` sources: it deserializes
+//! the document, resolves the network into ordered assignments, validates them,
+//! and transpiles the result into a [`CompilationUnit`].
+
+pub mod model;
+mod resolve;
+mod transpile;
+mod validation;
+
+#[cfg(test)]
+mod test_utils;
+
+use plc_ast::ast::{CompilationUnit, LinkageType};
+use plc_ast::provider::IdProvider;
+use plc_diagnostics::diagnostician::Diagnostician;
+use plc_diagnostics::diagnostics::{Diagnostic, Severity};
+use plc_source::{SourceCode, SourceContainer};
+
+use crate::model::Pou;
+
+pub fn parse_file(
+    source: &SourceCode,
+    _: LinkageType,
+    id_provider: IdProvider,
+    diagnostician: &mut Diagnostician,
+) -> Result<CompilationUnit, Diagnostic> {
+    diagnostician.register_file(source.get_location_str().to_string(), source.source.clone());
+
+    let pou = match Pou::parse(&source.source) {
+        Ok(pou) => pou,
+        Err(err) => {
+            diagnostician.handle(&[Diagnostic::new(format!("Unable to parse CFC file: {err}"))]);
+            return Err(Diagnostic::new("Compilation aborted due to CFC parse errors"));
+        }
+    };
+
+    let resolved = resolve::resolve(pou.content().network());
+
+    let mut diagnostics = validation::validate(&resolved, source, id_provider.clone());
+    let (unit, transpile_diagnostics) = transpile::transpile(&pou, &resolved, source, id_provider);
+    diagnostics.extend(transpile_diagnostics);
+
+    if diagnostician.handle(&diagnostics) == Severity::Error {
+        Err(Diagnostic::new("Compilation aborted due to CFC parse errors"))
+    } else {
+        Ok(unit)
+    }
+}

--- a/compiler/plc_cfc/src/model.rs
+++ b/compiler/plc_cfc/src/model.rs
@@ -1,0 +1,183 @@
+//! Deserialization model for CFC (`.cfc`) files: a PLCopen-style XML document
+//! describing a single POU whose body is an FBD/CFC network.
+//!
+//! `quick-xml`'s serde support strips namespace prefixes and matches on the
+//! local name, so the `rename`s use bare names (`Function`, `type`) rather than
+//! their `ppx:` / `xsi:` prefixed forms, and attributes take a leading `@`.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub enum Pou {
+    #[serde(rename = "Function")]
+    Function(PouContent),
+
+    #[serde(rename = "FunctionBlock")]
+    FunctionBlock(PouContent),
+
+    #[serde(rename = "Program")]
+    Program(PouContent),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PouKind {
+    Function,
+    FunctionBlock,
+    Program,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PouContent {
+    #[serde(rename = "@name")]
+    pub name: String,
+
+    #[serde(rename = "AddData")]
+    pub add_data: AddData,
+
+    #[serde(rename = "MainBody")]
+    pub main_body: MainBody,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct AddData {
+    #[serde(rename = "Data", default)]
+    pub data: Vec<Data>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Data {
+    #[serde(rename = "@name")]
+    pub name: String,
+
+    #[serde(rename = "@handleUnknown")]
+    pub handle_unknown: Option<String>,
+
+    #[serde(rename = "textDeclaration")]
+    pub text_declaration: Option<TextDeclaration>,
+
+    #[serde(rename = "EvaluationPriority")]
+    pub evaluation_priority: Option<EvaluationPriority>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TextDeclaration {
+    /// The POU's header and variable blocks, carried verbatim as ST source.
+    #[serde(rename = "content")]
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EvaluationPriority {
+    #[serde(rename = "@priorityInNetwork")]
+    pub priority: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MainBody {
+    #[serde(rename = "BodyContent")]
+    pub body_content: BodyContent,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BodyContent {
+    #[serde(rename = "@type")]
+    pub kind: Option<String>,
+
+    #[serde(rename = "Network")]
+    pub network: Network,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Network {
+    #[serde(rename = "FbdObject", default)]
+    pub objects: Vec<FbdObject>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FbdObject {
+    /// The `xsi:type` discriminator, e.g. `"ppx:DataSource"` (prefix retained
+    /// because only names, not values, are stripped). Classified in `resolve`.
+    #[serde(rename = "@type")]
+    pub kind: String,
+
+    #[serde(rename = "@globalId")]
+    pub global_id: usize,
+
+    #[serde(rename = "@identifier")]
+    pub identifier: Option<String>,
+
+    #[serde(rename = "@complexIdentifier")]
+    pub complex_identifier: Option<String>,
+
+    #[serde(rename = "AddData")]
+    pub add_data: Option<AddData>,
+
+    #[serde(rename = "ConnectionPointIn")]
+    pub connection_in: Option<ConnectionPointIn>,
+
+    #[serde(rename = "ConnectionPointOut")]
+    pub connection_out: Option<ConnectionPointOut>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConnectionPointIn {
+    #[serde(rename = "Connection", default)]
+    pub connections: Vec<Connection>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConnectionPointOut {
+    #[serde(rename = "@connectionPointOutId")]
+    pub id: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Connection {
+    #[serde(rename = "@refConnectionPointOutId")]
+    pub ref_out_id: usize,
+}
+
+impl Pou {
+    pub fn parse(content: &str) -> Result<Self, quick_xml::DeError> {
+        quick_xml::de::from_str(content)
+    }
+
+    pub fn kind(&self) -> PouKind {
+        match self {
+            Pou::Function(_) => PouKind::Function,
+            Pou::FunctionBlock(_) => PouKind::FunctionBlock,
+            Pou::Program(_) => PouKind::Program,
+        }
+    }
+
+    pub fn content(&self) -> &PouContent {
+        match self {
+            Pou::Function(content) | Pou::FunctionBlock(content) | Pou::Program(content) => content,
+        }
+    }
+}
+
+impl PouContent {
+    pub fn network(&self) -> &Network {
+        &self.main_body.body_content.network
+    }
+
+    pub fn declaration(&self) -> Option<&str> {
+        self.add_data
+            .data
+            .iter()
+            .find_map(|data| data.text_declaration.as_ref())
+            .map(|it| it.content.as_str())
+    }
+}
+
+impl FbdObject {
+    pub fn identifier(&self) -> Option<&str> {
+        self.identifier.as_deref().or(self.complex_identifier.as_deref())
+    }
+
+    pub fn priority(&self) -> Option<usize> {
+        let add_data = self.add_data.as_ref()?;
+        add_data.data.iter().find_map(|data| data.evaluation_priority.as_ref()).map(|it| it.priority)
+    }
+}

--- a/compiler/plc_cfc/src/resolve.rs
+++ b/compiler/plc_cfc/src/resolve.rs
@@ -1,0 +1,150 @@
+//! Structural resolution of an FBD network: classify each element, link every
+//! sink to its single source, and order the sinks by evaluation priority.
+
+use std::collections::HashMap;
+
+use crate::model::{FbdObject, Network};
+
+pub(crate) struct Resolved<'model> {
+    /// Sinks paired with their source, in evaluation-priority order.
+    pub assignments: Vec<Assignment<'model>>,
+    pub unconnected: Vec<&'model FbdObject>,
+}
+
+pub(crate) struct Assignment<'model> {
+    pub sink: &'model FbdObject,
+    pub source: &'model FbdObject,
+}
+
+enum Role {
+    Source,
+    Sink,
+    Unconnected,
+    Other,
+}
+
+fn role(object: &FbdObject) -> Role {
+    match object.kind.as_str() {
+        "ppx:DataSource" => Role::Source,
+        "ppx:DataSink" => Role::Sink,
+        "ppx:Unconnected" => Role::Unconnected,
+        _ => Role::Other,
+    }
+}
+
+pub(crate) fn resolve(network: &Network) -> Resolved<'_> {
+    // Index every output pin so a sink can find its source in one hop.
+    let mut source_by_pin: HashMap<usize, &FbdObject> = HashMap::new();
+    for object in &network.objects {
+        if let Some(out) = &object.connection_out {
+            source_by_pin.insert(out.id, object);
+        }
+    }
+
+    let mut assignments = Vec::new();
+    let mut unconnected = Vec::new();
+
+    for object in &network.objects {
+        match role(object) {
+            Role::Sink => {
+                let source = object
+                    .connection_in
+                    .as_ref()
+                    .and_then(|it| it.connections.first())
+                    .and_then(|connection| source_by_pin.get(&connection.ref_out_id).copied());
+
+                if let Some(source) = source {
+                    assignments.push(Assignment { sink: object, source });
+                }
+            }
+            Role::Unconnected => unconnected.push(object),
+            Role::Source | Role::Other => {}
+        }
+    }
+
+    assignments.sort_by_key(|it| it.sink.priority().unwrap_or(usize::MAX));
+
+    Resolved { assignments, unconnected }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve, Resolved};
+    use crate::model::Pou;
+
+    fn resolve_project(fixture: &str) -> String {
+        let source = crate::test_utils::fixture_source(fixture);
+        let pou = Pou::parse(&source.source).unwrap();
+        render(&resolve(pou.content().network()))
+    }
+
+    fn render(resolved: &Resolved) -> String {
+        let mut out = String::new();
+        for it in &resolved.assignments {
+            let (sink, source) = (it.sink, it.source);
+            let line = format!(
+                "{} := {}   [sink {} <- source {}]\n",
+                sink.identifier().unwrap_or("?"),
+                source.identifier().unwrap_or("?"),
+                sink.global_id,
+                source.global_id,
+            );
+            out.push_str(&line);
+        }
+        let unconnected: Vec<_> =
+            resolved.unconnected.iter().map(|it| it.identifier().unwrap_or("?")).collect();
+        match unconnected.is_empty() {
+            true => out.push_str("unconnected: (none)"),
+            false => out.push_str(&format!("unconnected: {}", unconnected.join(", "))),
+        }
+        out
+    }
+
+    mod variables {
+        use super::resolve_project;
+
+        #[test]
+        fn simple_assignment() {
+            insta::assert_snapshot!(resolve_project("variables/valid/simple_assignment"), @r"
+        bar := foo   [sink 3 <- source 1]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn reciprocal_assignment() {
+            insta::assert_snapshot!(resolve_project("variables/valid/reciprocal_assignment"), @r"
+        bar := foo   [sink 3 <- source 1]
+        foo := bar   [sink 6 <- source 4]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn fan_out() {
+            insta::assert_snapshot!(resolve_project("variables/valid/fan_out"), @r"
+        bar := foo   [sink 3 <- source 1]
+        baz := foo   [sink 4 <- source 1]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn literal_assignment() {
+            insta::assert_snapshot!(resolve_project("variables/valid/literal_assignment"), @r"
+        foo := 5   [sink 3 <- source 1]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn indexed_assignment() {
+            insta::assert_snapshot!(resolve_project("variables/valid/indexed_assignment"), @r"
+        values[1] := source   [sink 3 <- source 1]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn unconnected_variables() {
+            insta::assert_snapshot!(resolve_project("variables/valid/unconnected_variables"), @r"
+        bar := foo   [sink 8 <- source 6]
+        unconnected: foo, bar");
+        }
+    }
+}

--- a/compiler/plc_cfc/src/test_utils.rs
+++ b/compiler/plc_cfc/src/test_utils.rs
@@ -1,0 +1,39 @@
+//! Shared helpers for the transpiler/resolver/validation tests.
+
+use plc_ast::ast::LinkageType;
+use plc_ast::provider::IdProvider;
+use plc_ast::ser::AstSerializer;
+use plc_diagnostics::diagnostician::Diagnostician;
+use plc_diagnostics::reporter::DiagnosticReporter;
+use plc_source::SourceCode;
+
+/// Load the `.cfc` of a fixture addressed relative to `fixtures/`, e.g.
+/// `"valid/simple_assignment"` or `"invalid/call_expression"`.
+pub(crate) fn fixture_source(fixture: &str) -> SourceCode {
+    let name = fixture.rsplit('/').next().unwrap();
+    let disk = format!("{}/fixtures/{fixture}/{name}.cfc", env!("CARGO_MANIFEST_DIR"));
+    // Label the source with a stable, machine-independent name so diagnostic
+    // snapshots don't embed an absolute path.
+    SourceCode { source: std::fs::read_to_string(&disk).unwrap(), path: Some(format!("{name}.cfc").into()) }
+}
+
+/// Run the CFC pipeline over a fixture. `Ok` is the transpiled POU serialized
+/// back to Structured Text; `Err` is the diagnostics rendered as the console
+/// shows them (returned when compilation aborts).
+pub(crate) fn transpile_project(fixture: &str) -> Result<String, String> {
+    let source = fixture_source(fixture);
+    let mut diagnostician = Diagnostician::buffered();
+    match crate::parse_file(&source, LinkageType::Internal, IdProvider::default(), &mut diagnostician) {
+        Ok(unit) => Ok(AstSerializer::from_unit(&unit)),
+        Err(_) => Err(diagnostician.buffer().unwrap_or_default()),
+    }
+}
+
+/// Render every diagnostic a fixture produces, whether or not it aborts
+/// compilation. Used to snapshot warnings on otherwise-valid fixtures.
+pub(crate) fn diagnostics(fixture: &str) -> String {
+    let source = fixture_source(fixture);
+    let mut diagnostician = Diagnostician::buffered();
+    let _ = crate::parse_file(&source, LinkageType::Internal, IdProvider::default(), &mut diagnostician);
+    diagnostician.buffer().unwrap_or_default()
+}

--- a/compiler/plc_cfc/src/transpile.rs
+++ b/compiler/plc_cfc/src/transpile.rs
@@ -1,0 +1,159 @@
+//! Lowering of a resolved CFC network into a Structured Text AST.
+//!
+//! The POU interface comes from the textual declaration, parsed by the ST
+//! parser; the body statements are built directly as AST nodes, each anchored
+//! to its element's `globalId` so diagnostics can point back into the diagram.
+
+use plc_ast::ast::{AstFactory, AstNode, CompilationUnit};
+use plc_ast::provider::IdProvider;
+use plc_diagnostics::diagnostics::Diagnostic;
+use plc_source::source_location::SourceLocationFactory;
+use plc_source::SourceCode;
+
+use crate::model::Pou;
+use crate::resolve::{Assignment, Resolved};
+
+pub(crate) fn transpile(
+    pou: &Pou,
+    resolved: &Resolved,
+    source: &SourceCode,
+    mut ids: IdProvider,
+) -> (CompilationUnit, Vec<Diagnostic>) {
+    let (mut unit, diagnostics) = helper::parse_interface(pou, source, ids.clone());
+
+    let factory = SourceLocationFactory::for_source(source);
+    let statements = resolved
+        .assignments
+        .iter()
+        .map(|assignment| transpile_assignment(assignment, &factory, &mut ids))
+        .collect();
+    if let Some(implementation) = unit.implementations.first_mut() {
+        implementation.statements = statements;
+    }
+
+    (unit, diagnostics)
+}
+
+fn transpile_assignment(
+    assignment: &Assignment,
+    factory: &SourceLocationFactory,
+    ids: &mut IdProvider,
+) -> AstNode {
+    let location = factory.create_block_location(assignment.sink.global_id);
+
+    let mut left = helper::parse_identifier(assignment.sink.identifier().unwrap_or_default(), ids.clone());
+    let mut right = helper::parse_identifier(assignment.source.identifier().unwrap_or_default(), ids.clone());
+    left.location = location.clone();
+    right.location = location;
+
+    AstFactory::create_assignment(left, right, ids.next_id())
+}
+
+pub(crate) mod helper {
+    use plc::lexer;
+    use plc::parser::{self, expressions_parser::parse_expression};
+    use plc_ast::ast::{AstNode, CompilationUnit, LinkageType};
+    use plc_ast::provider::IdProvider;
+    use plc_diagnostics::diagnostics::Diagnostic;
+    use plc_source::source_location::SourceLocationFactory;
+    use plc_source::{SourceCode, SourceContainer};
+
+    use crate::model::{Pou, PouKind};
+
+    /// Parse an identifier field into an expression. Its own text locations are
+    /// discarded by the caller in favour of a block location.
+    pub(crate) fn parse_identifier(text: &str, ids: IdProvider) -> AstNode {
+        let factory = SourceLocationFactory::internal(text);
+        let mut session = lexer::lex_with_ids(text, ids, factory);
+        parse_expression(&mut session)
+    }
+
+    pub(super) fn parse_interface(
+        pou: &Pou,
+        source: &SourceCode,
+        ids: IdProvider,
+    ) -> (CompilationUnit, Vec<Diagnostic>) {
+        // The declaration omits its closing keyword; re-attach it so the ST
+        // parser sees a complete POU with an empty body.
+        let end_keyword = match pou.kind() {
+            PouKind::Function => "END_FUNCTION",
+            PouKind::FunctionBlock => "END_FUNCTION_BLOCK",
+            PouKind::Program => "END_PROGRAM",
+        };
+        let declaration = format!("{}\n{end_keyword}", pou.content().declaration().unwrap_or_default());
+
+        let declaration = SourceCode { source: declaration, path: source.path.clone() };
+        let factory = SourceLocationFactory::for_source(&declaration);
+        let session = lexer::lex_with_ids(&declaration.source, ids, factory);
+        parser::parse(session, LinkageType::Internal, source.get_location_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod variables {
+        use crate::test_utils::transpile_project;
+
+        #[test]
+        fn simple_assignment() {
+            insta::assert_snapshot!(transpile_project("variables/valid/simple_assignment").unwrap(), @r"
+        FUNCTION simple_assignment : INT
+        VAR
+            foo : DINT;
+            bar : DINT;
+        END_VAR
+            bar := foo;
+        END_FUNCTION");
+        }
+
+        #[test]
+        fn reciprocal_assignment() {
+            insta::assert_snapshot!(transpile_project("variables/valid/reciprocal_assignment").unwrap(), @r"
+        PROGRAM reciprocal_assignment
+        VAR
+            foo : DINT;
+            bar : DINT;
+        END_VAR
+            bar := foo;
+            foo := bar;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn fan_out() {
+            insta::assert_snapshot!(transpile_project("variables/valid/fan_out").unwrap(), @r"
+        FUNCTION_BLOCK fan_out
+        VAR
+            foo : DINT;
+            bar : DINT;
+            baz : DINT;
+        END_VAR
+            bar := foo;
+            baz := foo;
+        END_FUNCTION_BLOCK");
+        }
+
+        #[test]
+        fn literal_assignment() {
+            insta::assert_snapshot!(transpile_project("variables/valid/literal_assignment").unwrap(), @r"
+        FUNCTION literal_assignment : INT
+        VAR
+            foo : DINT;
+        END_VAR
+            foo := 5;
+        END_FUNCTION");
+        }
+
+        #[test]
+        fn unconnected_variables() {
+            insta::assert_snapshot!(transpile_project("variables/valid/unconnected_variables").unwrap(), @r"
+        FUNCTION unconnected_variables : INT
+        VAR
+            foo : DINT;
+            bar : DINT;
+        END_VAR
+            bar := foo;
+        END_FUNCTION");
+        }
+    }
+}

--- a/compiler/plc_cfc/src/validation.rs
+++ b/compiler/plc_cfc/src/validation.rs
@@ -1,0 +1,96 @@
+//! Semantic validation of a resolved CFC network.
+
+use plc_ast::provider::IdProvider;
+use plc_diagnostics::diagnostics::Diagnostic;
+use plc_source::source_location::SourceLocationFactory;
+use plc_source::SourceCode;
+
+use crate::model::FbdObject;
+use crate::resolve::Resolved;
+use crate::transpile::helper::parse_identifier;
+
+pub(crate) fn validate(resolved: &Resolved, source: &SourceCode, ids: IdProvider) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    diagnostics.extend(validate_expressions(resolved, source, ids));
+    diagnostics.extend(validate_unconnected(resolved, source));
+    diagnostics
+}
+
+fn validate_expressions(resolved: &Resolved, source: &SourceCode, ids: IdProvider) -> Vec<Diagnostic> {
+    let factory = SourceLocationFactory::for_source(source);
+    let mut diagnostics = Vec::new();
+
+    let mut check = |object: &FbdObject| {
+        let Some(text) = object.identifier() else { return };
+        if !helper::is_supported(&parse_identifier(text, ids.clone()).stmt) {
+            let location = factory.create_block_location(object.global_id);
+            diagnostics.push(Diagnostic::unsupported_cfc_expression(text, location));
+        }
+    };
+
+    for assignment in &resolved.assignments {
+        check(assignment.sink);
+        check(assignment.source);
+    }
+
+    diagnostics
+}
+
+fn validate_unconnected(resolved: &Resolved, source: &SourceCode) -> Vec<Diagnostic> {
+    let factory = SourceLocationFactory::for_source(source);
+    resolved
+        .unconnected
+        .iter()
+        .map(|object| {
+            let location = factory.create_block_location(object.global_id);
+            Diagnostic::unconnected_element(object.identifier().unwrap_or("<unnamed>"), location)
+        })
+        .collect()
+}
+
+mod helper {
+    use plc_ast::ast::AstStatement;
+
+    pub(super) fn is_supported(statement: &AstStatement) -> bool {
+        match statement {
+            // See through parentheses, e.g. `(foo)` or `((5))`.
+            AstStatement::ParenExpression(inner) => is_supported(&inner.stmt),
+            AstStatement::Literal(_) | AstStatement::ReferenceExpr(_) => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod variables {
+        use crate::test_utils::{diagnostics, transpile_project};
+
+        #[test]
+        fn call_expression() {
+            insta::assert_snapshot!(transpile_project("variables/invalid/call_expression").unwrap_err(), @r"
+        error[E083]: Unsupported CFC expression: `MAX(foo, bar)`
+         = call_expression.cfc: Block 1
+        ");
+        }
+
+        #[test]
+        fn binary_expression() {
+            insta::assert_snapshot!(transpile_project("variables/invalid/binary_expression").unwrap_err(), @r"
+        error[E083]: Unsupported CFC expression: `foo + 1`
+         = binary_expression.cfc: Block 1
+        ");
+        }
+
+        #[test]
+        fn unconnected_variables() {
+            insta::assert_snapshot!(diagnostics("variables/valid/unconnected_variables"), @r"
+        warning[E084]: Element `foo` is unconnected and will be ignored
+         = unconnected_variables.cfc: Block 1
+
+        warning[E084]: Element `bar` is unconnected and will be ignored
+         = unconnected_variables.cfc: Block 4
+        ");
+        }
+    }
+}

--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -380,6 +380,24 @@ impl Diagnostic {
     {
         Diagnostic::new("Unnamed control").with_error_code("E087").with_location(location)
     }
+
+    pub fn unsupported_cfc_expression<T>(expression: &str, location: T) -> Diagnostic
+    where
+        T: Into<SourceLocation>,
+    {
+        Diagnostic::new(format!("Unsupported CFC expression: `{expression}`"))
+            .with_error_code("E083")
+            .with_location(location)
+    }
+
+    pub fn unconnected_element<T>(name: &str, location: T) -> Diagnostic
+    where
+        T: Into<SourceLocation>,
+    {
+        Diagnostic::new(format!("Element `{name}` is unconnected and will be ignored"))
+            .with_error_code("E084")
+            .with_location(location)
+    }
 }
 
 #[cfg(test)]

--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -182,12 +182,12 @@ lazy_static! {
         E078,   Error,      include_str!("./error_codes/E078.md"),
         E079,   Error,      include_str!("./error_codes/E079.md"),
         E080,   Error,      include_str!("./error_codes/E080.md"),
-        E081,   Error,      include_str!("./error_codes/E081.md"),
-        E082,   Error,      include_str!("./error_codes/E082.md"),
-        E083,   Error,      include_str!("./error_codes/E083.md"),
-        E084,   Error,      include_str!("./error_codes/E084.md"),
-        E085,   Error,      include_str!("./error_codes/E085.md"),
-        E086,   Error,      include_str!("./error_codes/E086.md"),
+        E081,   Error,      include_str!("./error_codes/E081.md"),   // TODO: Unclaimed, use me instead of creating a new diagnostic
+        E082,   Error,      include_str!("./error_codes/E082.md"),   // TODO: Unclaimed, use me instead of creating a new diagnostic
+        E083,   Error,      include_str!("./error_codes/E083.md"),   // Unsupported CFC expression
+        E084,   Warning,    include_str!("./error_codes/E084.md"),   // Unconnected CFC element
+        E085,   Error,      include_str!("./error_codes/E085.md"),   // TODO: Unclaimed, use me instead of creating a new diagnostic
+        E086,   Error,      include_str!("./error_codes/E086.md"),   // TODO: Unclaimed, use me instead of creating a new diagnostic
         E087,   Error,      include_str!("./error_codes/E087.md"),
         E088,   Error,      include_str!("./error_codes/E088.md"),
         E089,   Error,      include_str!("./error_codes/E089.md"),

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E083.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E083.md
@@ -1,1 +1,6 @@
-# Unexpected node
+# Unsupported CFC expression
+
+A variable, source or sink element in a CFC network carries an expression that
+is not supported. Only variable references (`foo`), qualified references
+(`foo.bar`), indexed references (`arr[i]`) and literals (`5`) are allowed;
+function calls and other expressions are not.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E084.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E084.md
@@ -1,1 +1,4 @@
-# Unconnected source
+# Unconnected CFC element
+
+A CFC network contains an element that is not wired to anything. It has no
+effect on the program and is ignored during transpilation.

--- a/compiler/plc_diagnostics/src/reporter/codespan.rs
+++ b/compiler/plc_diagnostics/src/reporter/codespan.rs
@@ -77,6 +77,11 @@ impl CodeSpanDiagnosticReporter {
     fn emit(&mut self, diag: Diagnostic<usize>) -> Result<(), codespan_reporting::files::Error> {
         codespan_reporting::term::emit(&mut self.writer, &self.config, &self.files, &diag)
     }
+
+    fn file_name(&self, handle: usize) -> String {
+        use codespan_reporting::files::Files;
+        self.files.name(handle).map(|name| name.to_string()).unwrap_or_default()
+    }
 }
 
 impl Default for CodeSpanDiagnosticReporter {
@@ -112,32 +117,33 @@ impl DiagnosticReporter for CodeSpanDiagnosticReporter {
             };
 
             let mut labels = vec![];
+            let mut notes = vec![];
 
-            if !matches!(d.main_location.span, CodeSpan::None) {
-                labels.push(
-                    Label::primary(
-                        d.main_location.file_handle,
-                        d.main_location.span.to_range().unwrap_or(0..0),
-                    )
-                    .with_message(d.message.as_str()),
-                );
+            // A text range renders a source snippet; a diagram (block) location
+            // has no text, so it is reported as a note pointing at the block.
+            match &d.main_location.span {
+                CodeSpan::None => {}
+                span => match span.to_range() {
+                    Some(range) => labels.push(
+                        Label::primary(d.main_location.file_handle, range).with_message(d.message.as_str()),
+                    ),
+                    None => notes.push(format!("{}: {}", self.file_name(d.main_location.file_handle), span)),
+                },
             }
 
             if let Some(additional_locations) = &d.additional_locations {
                 labels.extend(additional_locations.iter().filter_map(|it| {
-                    if !matches!(it.span, CodeSpan::None) {
-                        Some(
-                            Label::secondary(it.file_handle, it.span.to_range().unwrap_or(0..0))
-                                .with_message("see also"),
-                        )
-                    } else {
-                        None
-                    }
+                    it.span
+                        .to_range()
+                        .map(|range| Label::secondary(it.file_handle, range).with_message("see also"))
                 }));
             }
 
-            let diag =
-                diagnostic_factory.with_labels(labels).with_message(d.message.as_str()).with_code(&d.code);
+            let diag = diagnostic_factory
+                .with_labels(labels)
+                .with_notes(notes)
+                .with_message(d.message.as_str())
+                .with_code(&d.code);
 
             let result = self.emit(diag);
             if result.is_err() && d.main_location.is_internal() {

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -13,6 +13,7 @@ plc = { path = "../..", package = "plc-compiler", version = "1.1.0-dev" }
 ast = { path = "../plc_ast/", package = "plc_ast", version = "1.1.0-dev" }
 project = { path = "../plc_project/", package = "plc_project", version = "1.1.0-dev" }
 source_code = { path = "../plc_source/", package = "plc_source", version = "1.1.0-dev" }
+plc_cfc = { path = "../plc_cfc/", version = "1.1.0-dev" }
 plc_diagnostics = { path = "../plc_diagnostics/", version = "1.1.0-dev" }
 plc_index = { path = "../plc_index", version = "1.1.0-dev" }
 plc_lowering = { path = "../plc_lowering", version = "1.1.0-dev" }

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -680,15 +680,13 @@ impl ParsedProject {
             .map(|it| {
                 let source = ctxt.get(it.get_location_str()).expect("All sources should've been read");
 
-                match source.get_type() {
-                    source_code::SourceType::Text => {
-                        parse_file(source, LinkageType::Internal, ctxt.provider(), diagnostician)
-                    }
-                    source_code::SourceType::Xml => {
-                        Err(Diagnostic::new("XML/CFC source files are currently not supported"))
-                    }
+                let parse_func = match source.get_type() {
+                    source_code::SourceType::Text => parse_file,
+                    source_code::SourceType::Xml => plc_cfc::parse_file,
                     source_code::SourceType::Unknown => unreachable!(),
-                }
+                };
+
+                parse_func(source, LinkageType::Internal, ctxt.provider(), diagnostician)
             })
             .collect::<Vec<_>>();
 

--- a/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_combined.snap
+++ b/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_combined.snap
@@ -7,31 +7,15 @@ SourceLocation {
         [
             Block {
                 local_id: 1,
-                execution_order: Some(
-                    1,
-                ),
-                inner_range: None,
             },
             Block {
                 local_id: 2,
-                execution_order: Some(
-                    2,
-                ),
-                inner_range: None,
             },
             Block {
                 local_id: 3,
-                execution_order: Some(
-                    3,
-                ),
-                inner_range: None,
             },
             Block {
                 local_id: 4,
-                execution_order: Some(
-                    4,
-                ),
-                inner_range: None,
             },
         ],
     ),

--- a/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_id_and_range.snap
+++ b/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_id_and_range.snap
@@ -5,11 +5,5 @@ expression: loc1.span(&loc2)
 SourceLocation {
     span: Block {
         local_id: 1,
-        execution_order: Some(
-            1,
-        ),
-        inner_range: Some(
-            0..4,
-        ),
     },
 }

--- a/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_two_blocks.snap
+++ b/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_two_blocks.snap
@@ -7,17 +7,9 @@ SourceLocation {
         [
             Block {
                 local_id: 1,
-                execution_order: Some(
-                    1,
-                ),
-                inner_range: None,
             },
             Block {
                 local_id: 2,
-                execution_order: Some(
-                    1,
-                ),
-                inner_range: None,
             },
         ],
     ),

--- a/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_two_blocks_with_same_id.snap
+++ b/compiler/plc_source/src/snapshots/plc_source__source_location__tests__span_two_blocks_with_same_id.snap
@@ -5,9 +5,5 @@ expression: loc1.span(&loc2)
 SourceLocation {
     span: Block {
         local_id: 1,
-        execution_order: Some(
-            1,
-        ),
-        inner_range: None,
     },
 }

--- a/compiler/plc_source/src/source_location.rs
+++ b/compiler/plc_source/src/source_location.rs
@@ -35,11 +35,8 @@ impl SourceLocationFactory {
         SourceLocation { span: CodeSpan::Range(start..end), file: self.file.into() }
     }
 
-    pub fn create_block_location(&self, local_id: usize, execution_order: Option<usize>) -> SourceLocation {
-        SourceLocation {
-            span: CodeSpan::Block { local_id, execution_order, inner_range: None },
-            file: self.file.into(),
-        }
+    pub fn create_block_location(&self, local_id: usize) -> SourceLocation {
+        SourceLocation { span: CodeSpan::Block { local_id }, file: self.file.into() }
     }
 
     pub fn create_file_only_location(&self) -> SourceLocation {
@@ -81,7 +78,7 @@ impl TextLocation {
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CodeSpan {
     /// The location of a block in a diagram
-    Block { local_id: usize, execution_order: Option<usize>, inner_range: Option<Range<usize>> },
+    Block { local_id: usize },
     /// An element spanning multiple IDs
     Combined(Vec<CodeSpan>),
     /// A location inside a text
@@ -93,12 +90,7 @@ pub enum CodeSpan {
 impl std::fmt::Debug for CodeSpan {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Block { local_id, execution_order, inner_range } => f
-                .debug_struct("Block")
-                .field("local_id", local_id)
-                .field("execution_order", execution_order)
-                .field("inner_range", inner_range)
-                .finish(),
+            Self::Block { local_id } => f.debug_struct("Block").field("local_id", local_id).finish(),
             Self::Combined(arg0) => f.debug_tuple("Combined").field(arg0).finish(),
             Self::None => write!(f, "None"),
 
@@ -149,7 +141,7 @@ impl CodeSpan {
     pub fn get_line(&self) -> usize {
         match self {
             Self::Range(range) => range.start.line,
-            Self::Block { local_id, .. } => *local_id,
+            Self::Block { local_id } => *local_id,
             _ => 0,
         }
     }
@@ -166,7 +158,7 @@ impl CodeSpan {
     pub fn get_line_plus_one(&self) -> usize {
         match self {
             Self::Range(range) => range.start.line + 1,
-            Self::Block { local_id, .. } => *local_id,
+            Self::Block { local_id } => *local_id,
             _ => 0,
         }
     }
@@ -192,7 +184,6 @@ impl CodeSpan {
     pub fn to_range(&self) -> Option<Range<usize>> {
         match self {
             CodeSpan::Range(range) => Some(range.start.offset..range.end.offset),
-            CodeSpan::Block { inner_range, .. } => inner_range.clone(),
             _ => None,
         }
     }
@@ -332,36 +323,18 @@ impl SourceLocation {
     /// In other words this results in `self.start .. other.end`
     pub fn span(&self, other: &SourceLocation) -> SourceLocation {
         let span = match (&self.span, &other.span) {
-            //ID -> ID = Combile
-            (
-                CodeSpan::Block { local_id, execution_order, inner_range },
-                CodeSpan::Block { local_id: other, inner_range: other_range, .. },
-            ) if local_id == other => {
-                let inner_range = match (inner_range, other_range) {
-                    (None, None) => None,
-                    (Some(range), None) | (None, Some(range)) => Some(range.clone()),
-                    (Some(start), Some(end)) => Some(start.start..end.end),
-                };
-
-                CodeSpan::Block { local_id: *local_id, execution_order: *execution_order, inner_range }
+            //ID -> ID = Combine
+            (CodeSpan::Block { local_id }, CodeSpan::Block { local_id: other }) if local_id == other => {
+                CodeSpan::Block { local_id: *local_id }
             }
             (CodeSpan::Block { .. }, CodeSpan::Block { .. }) => {
                 CodeSpan::Combined(vec![self.span.clone(), other.span.clone()])
             }
             //Range -> Range = Range
             (CodeSpan::Range(start), CodeSpan::Range(end)) => CodeSpan::Range(start.start..end.end),
-            //ID -> Range = InnerRange
-            (CodeSpan::Block { local_id, execution_order, inner_range }, CodeSpan::Range(range))
-            | (CodeSpan::Range(range), CodeSpan::Block { local_id, execution_order, inner_range }) => {
-                CodeSpan::Block {
-                    local_id: *local_id,
-                    execution_order: *execution_order,
-                    inner_range: inner_range
-                        .as_ref()
-                        .map(|it| it.start..range.end.offset)
-                        .or(Some(range.start.offset..range.end.offset)),
-                }
-            }
+            //ID -> Range = keep the block identity
+            (CodeSpan::Block { local_id }, CodeSpan::Range(_))
+            | (CodeSpan::Range(_), CodeSpan::Block { local_id }) => CodeSpan::Block { local_id: *local_id },
             //None any -> None (unsupported)
             (CodeSpan::None, _) | (_, CodeSpan::None) => CodeSpan::None,
             (CodeSpan::Combined(inner), CodeSpan::Combined(other)) => {
@@ -549,36 +522,21 @@ mod tests {
 
     #[test]
     fn span_two_blocks() {
-        let loc1 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 1, execution_order: Some(1), inner_range: None },
-        };
-        let loc2 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 2, execution_order: Some(1), inner_range: None },
-        };
+        let loc1 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 1 } };
+        let loc2 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 2 } };
         assert_debug_snapshot!(loc1.span(&loc2));
     }
 
     #[test]
     fn span_two_blocks_with_same_id() {
-        let loc1 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 1, execution_order: Some(1), inner_range: None },
-        };
-        let loc2 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 1, execution_order: Some(1), inner_range: None },
-        };
+        let loc1 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 1 } };
+        let loc2 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 1 } };
         assert_debug_snapshot!(loc1.span(&loc2));
     }
 
     #[test]
     fn span_id_and_range() {
-        let loc1 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 1, execution_order: Some(1), inner_range: None },
-        };
+        let loc1 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 1 } };
         let loc2 = SourceLocation {
             file: None.into(),
             span: CodeSpan::from_text_info(TextLocation::new(1, 0, 0), TextLocation::new(2, 0, 4)),
@@ -601,31 +559,16 @@ mod tests {
 
     #[test]
     fn span_combined() {
-        let loc1 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 1, execution_order: Some(1), inner_range: None },
-        };
-        let loc2 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 2, execution_order: Some(2), inner_range: None },
-        };
-        let loc3 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 3, execution_order: Some(3), inner_range: None },
-        };
-        let loc4 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 4, execution_order: Some(4), inner_range: None },
-        };
+        let loc1 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 1 } };
+        let loc2 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 2 } };
+        let loc3 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 3 } };
+        let loc4 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 4 } };
         assert_debug_snapshot!(loc1.span(&loc2).span(&loc3.span(&loc4)));
     }
 
     #[test]
     fn span_none() {
-        let loc1 = SourceLocation {
-            file: None.into(),
-            span: CodeSpan::Block { local_id: 1, execution_order: Some(1), inner_range: None },
-        };
+        let loc1 = SourceLocation { file: None.into(), span: CodeSpan::Block { local_id: 1 } };
         let loc2 = SourceLocation { file: None.into(), span: CodeSpan::None };
         assert_debug_snapshot!(loc1.span(&loc2));
     }

--- a/tests/lit/cfc/lit.local.cfg
+++ b/tests/lit/cfc/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.test']

--- a/tests/lit/cfc/variables/evaluation_order/evaluation_order.cfc
+++ b/tests/lit/cfc/variables/evaluation_order/evaluation_order.cfc
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="evaluation_order">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM evaluation_order
+VAR
+    a : DINT;
+    b : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="1" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="a" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a" globalId="4">
+                    <ppx:RelPosition x="250" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="2" globalId="7">
+                    <ppx:RelPosition x="250" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="8">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="a" globalId="9">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="8"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/variables/evaluation_order/main.st
+++ b/tests/lit/cfc/variables/evaluation_order/main.st
@@ -1,0 +1,5 @@
+FUNCTION main : DINT
+    evaluation_order();
+    // CHECK: a = 2, b = 1
+    printf('a = %d, b = %d$N', evaluation_order.a, evaluation_order.b);
+END_FUNCTION

--- a/tests/lit/cfc/variables/evaluation_order/plc.json
+++ b/tests/lit/cfc/variables/evaluation_order/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_evaluation_order",
+	"files" : [
+		"evaluation_order.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/variables/evaluation_order/run.test
+++ b/tests/lit/cfc/variables/evaluation_order/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/variables/fan_out/fan_out.cfc
+++ b/tests/lit/cfc/variables/fan_out/fan_out.cfc
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fan_out">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM fan_out
+VAR
+    src : DINT;
+    x : DINT;
+    y : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="5" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="src" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="src" globalId="4">
+                    <ppx:RelPosition x="250" y="190"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="x" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="y" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/variables/fan_out/main.st
+++ b/tests/lit/cfc/variables/fan_out/main.st
@@ -1,0 +1,5 @@
+FUNCTION main : DINT
+    fan_out();
+    // CHECK: x = 5, y = 5
+    printf('x = %d, y = %d$N', fan_out.x, fan_out.y);
+END_FUNCTION

--- a/tests/lit/cfc/variables/fan_out/plc.json
+++ b/tests/lit/cfc/variables/fan_out/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_fan_out",
+	"files" : [
+		"fan_out.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/variables/fan_out/run.test
+++ b/tests/lit/cfc/variables/fan_out/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/variables/literal_assignment/literal_assignment.cfc
+++ b/tests/lit/cfc/variables/literal_assignment/literal_assignment.cfc
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="literal_assignment">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM literal_assignment
+VAR
+    x : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="42" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="x" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/variables/literal_assignment/main.st
+++ b/tests/lit/cfc/variables/literal_assignment/main.st
@@ -1,0 +1,5 @@
+FUNCTION main : DINT
+    literal_assignment();
+    // CHECK: x = 42
+    printf('x = %d$N', literal_assignment.x);
+END_FUNCTION

--- a/tests/lit/cfc/variables/literal_assignment/plc.json
+++ b/tests/lit/cfc/variables/literal_assignment/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_literal_assignment",
+	"files" : [
+		"literal_assignment.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/variables/literal_assignment/run.test
+++ b/tests/lit/cfc/variables/literal_assignment/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st


### PR DESCRIPTION
Problem: The rebuilt CFC crate can deserialize an empty POU but cannot yet
transpile a graphical network, so a .cfc with variables produces nothing.

Solution: Transpile variable source/sink assignments end to end — deserialize
the FBD network, resolve each sink to its source and order by evaluation
priority, validate the identifier expressions, and build the ST AST (interface
via the ST parser, body as block-located statements). Wire it into the driver's
XML dispatch. Supporting infra: reduce CodeSpan::Block to { local_id }, recycle
the orphaned E083/E084 diagnostics, add AstSerializer::from_unit, and render
diagram locations as a note instead of a bogus source snippet. Fixtures, unit
snapshots and lit tests are grouped by concept under variables/.

---

**Stacked PRs** — part of the CFC transpiler rewrite; merge bottom → top:

1. #1807 refactor(cfc): delete plc_xml crate
2. #1808 feat(cfc): variable source/sinks  👈 **this PR**
3. #1809 feat(cfc): returns
4. #1810 feat(cfc): connectors and continuations
5. #1811 feat(cfc): stateful blocks
6. #1812 feat(cfc): functions
7. #1813 chore(cfc): add CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
