### PR TITLE
feat(cfc): returns

### DIFF
--- a/compiler/plc_ast/src/ser.rs
+++ b/compiler/plc_ast/src/ser.rs
@@ -517,9 +517,15 @@ impl AstVisitor for AstSerializer<'_> {
     }
 
     fn visit_return_statement(&mut self, stmt: &ReturnStatement, _node: &AstNode) {
-        self.result.push_str("RETURN");
-        stmt.walk(self);
-        self.result.push(';');
+        // A CFC return carries a guard condition that has no bare ST syntax, so
+        // render it as the equivalent conditional block.
+        if stmt.condition.is_some() {
+            self.result.push_str("IF ");
+            stmt.walk(self);
+            self.result.push_str(" THEN RETURN; END_IF");
+        } else {
+            self.result.push_str("RETURN");
+        }
     }
 
     fn visit_jump_statement(&mut self, stmt: &JumpStatement, _node: &AstNode) {

--- a/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/README.md
+++ b/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/README.md
@@ -1,0 +1,6 @@
+What: a return with no wired condition can never fire and is rejected.
+
+Illustrated:
+
+    myCondition --> RETURN (0)
+                    RETURN (1)   [unconnected]

--- a/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/disconnected_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/disconnected_return.cfc
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="disconnected_return">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION disconnected_return : INT&#13;
+VAR&#13;
+    myCondition: BOOL;&#13;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="1">
+                    <ppx:RelPosition x="430" y="190"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <negated value="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="190"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <negated value="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/returns/reference/conditional_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/reference/conditional_return.cfc
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_0">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION function_0 : INT&#13;
+VAR&#13;
+    myCondition: BOOL;&#13;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="1">
+                    <ppx:RelPosition x="430" y="190"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <negated value="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="190"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <negated value="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/returns/valid/conditional_return/README.md
+++ b/compiler/plc_cfc/fixtures/returns/valid/conditional_return/README.md
@@ -1,0 +1,5 @@
+What: a return that fires when its wired condition evaluates to true.
+
+Illustrated:
+
+    myCondition --> RETURN (0)

--- a/compiler/plc_cfc/fixtures/returns/valid/conditional_return/conditional_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/conditional_return/conditional_return.cfc
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="conditional_return">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION conditional_return : INT&#13;
+VAR&#13;
+    myCondition: BOOL;&#13;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="1">
+                    <ppx:RelPosition x="430" y="190"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <negated value="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="190"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return/README.md
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return/README.md
@@ -1,0 +1,5 @@
+What: a negated return fires when its wired condition evaluates to false.
+
+Illustrated:
+
+    myCondition --o RETURN (0)

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return/negated_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return/negated_return.cfc
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_return">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION negated_return : INT&#13;
+VAR&#13;
+    myCondition: BOOL;&#13;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="1">
+                    <ppx:RelPosition x="430" y="190"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <negated value="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="190"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/src/model.rs
+++ b/compiler/plc_cfc/src/model.rs
@@ -57,6 +57,9 @@ pub struct Data {
 
     #[serde(rename = "EvaluationPriority")]
     pub evaluation_priority: Option<EvaluationPriority>,
+
+    #[serde(rename = "negated")]
+    pub negated: Option<Negated>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -70,6 +73,12 @@ pub struct TextDeclaration {
 pub struct EvaluationPriority {
     #[serde(rename = "@priorityInNetwork")]
     pub priority: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Negated {
+    #[serde(rename = "@value")]
+    pub value: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -179,5 +188,12 @@ impl FbdObject {
     pub fn priority(&self) -> Option<usize> {
         let add_data = self.add_data.as_ref()?;
         add_data.data.iter().find_map(|data| data.evaluation_priority.as_ref()).map(|it| it.priority)
+    }
+
+    pub fn negated(&self) -> bool {
+        self.add_data
+            .as_ref()
+            .and_then(|add_data| add_data.data.iter().find_map(|data| data.negated.as_ref()))
+            .is_some_and(|negated| negated.value)
     }
 }

--- a/compiler/plc_cfc/src/resolve.rs
+++ b/compiler/plc_cfc/src/resolve.rs
@@ -1,39 +1,63 @@
 //! Structural resolution of an FBD network: classify each element, link every
-//! sink to its single source, and order the sinks by evaluation priority.
+//! sink and return to its source, and order the statements by evaluation
+//! priority.
 
 use std::collections::HashMap;
 
 use crate::model::{FbdObject, Network};
 
 pub(crate) struct Resolved<'model> {
-    /// Sinks paired with their source, in evaluation-priority order.
-    pub assignments: Vec<Assignment<'model>>,
+    /// Network statements in evaluation-priority order.
+    pub statements: Vec<Statement<'model>>,
     pub unconnected: Vec<&'model FbdObject>,
 }
 
-pub(crate) struct Assignment<'model> {
-    pub sink: &'model FbdObject,
-    pub source: &'model FbdObject,
+pub(crate) enum Statement<'model> {
+    Assignment { sink: &'model FbdObject, source: &'model FbdObject },
+    Return { object: &'model FbdObject, condition: Option<&'model FbdObject> },
 }
 
 enum Role {
     Source,
     Sink,
+    Return,
     Unconnected,
     Other,
+}
+
+impl<'model> Statement<'model> {
+    /// The element carrying this statement's priority and diagram location.
+    fn anchor(&self) -> &'model FbdObject {
+        match self {
+            Statement::Assignment { sink, .. } => sink,
+            Statement::Return { object, .. } => object,
+        }
+    }
 }
 
 fn role(object: &FbdObject) -> Role {
     match object.kind.as_str() {
         "ppx:DataSource" => Role::Source,
         "ppx:DataSink" => Role::Sink,
+        "ppx:Return" => Role::Return,
         "ppx:Unconnected" => Role::Unconnected,
         _ => Role::Other,
     }
 }
 
+fn source_of<'model>(
+    object: &FbdObject,
+    source_by_pin: &HashMap<usize, &'model FbdObject>,
+) -> Option<&'model FbdObject> {
+    object
+        .connection_in
+        .as_ref()
+        .and_then(|it| it.connections.first())
+        .and_then(|connection| source_by_pin.get(&connection.ref_out_id).copied())
+}
+
 pub(crate) fn resolve(network: &Network) -> Resolved<'_> {
-    // Index every output pin so a sink can find its source in one hop.
+    // Index every output pin so a consumer can find its source in one hop.
     let mut source_by_pin: HashMap<usize, &FbdObject> = HashMap::new();
     for object in &network.objects {
         if let Some(out) = &object.connection_out {
@@ -41,35 +65,32 @@ pub(crate) fn resolve(network: &Network) -> Resolved<'_> {
         }
     }
 
-    let mut assignments = Vec::new();
+    let mut statements = Vec::new();
     let mut unconnected = Vec::new();
 
     for object in &network.objects {
         match role(object) {
             Role::Sink => {
-                let source = object
-                    .connection_in
-                    .as_ref()
-                    .and_then(|it| it.connections.first())
-                    .and_then(|connection| source_by_pin.get(&connection.ref_out_id).copied());
-
-                if let Some(source) = source {
-                    assignments.push(Assignment { sink: object, source });
+                if let Some(source) = source_of(object, &source_by_pin) {
+                    statements.push(Statement::Assignment { sink: object, source });
                 }
+            }
+            Role::Return => {
+                statements.push(Statement::Return { object, condition: source_of(object, &source_by_pin) });
             }
             Role::Unconnected => unconnected.push(object),
             Role::Source | Role::Other => {}
         }
     }
 
-    assignments.sort_by_key(|it| it.sink.priority().unwrap_or(usize::MAX));
+    statements.sort_by_key(|statement| statement.anchor().priority().unwrap_or(usize::MAX));
 
-    Resolved { assignments, unconnected }
+    Resolved { statements, unconnected }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve, Resolved};
+    use super::{resolve, Resolved, Statement};
     use crate::model::Pou;
 
     fn resolve_project(fixture: &str) -> String {
@@ -80,15 +101,26 @@ mod tests {
 
     fn render(resolved: &Resolved) -> String {
         let mut out = String::new();
-        for it in &resolved.assignments {
-            let (sink, source) = (it.sink, it.source);
-            let line = format!(
-                "{} := {}   [sink {} <- source {}]\n",
-                sink.identifier().unwrap_or("?"),
-                source.identifier().unwrap_or("?"),
-                sink.global_id,
-                source.global_id,
-            );
+        for statement in &resolved.statements {
+            let line = match statement {
+                Statement::Assignment { sink, source } => format!(
+                    "{} := {}   [sink {} <- source {}]\n",
+                    sink.identifier().unwrap_or("?"),
+                    source.identifier().unwrap_or("?"),
+                    sink.global_id,
+                    source.global_id,
+                ),
+                Statement::Return { object, condition: Some(source) } => format!(
+                    "RETURN {}{}   [return {} <- source {}]\n",
+                    if object.negated() { "NOT " } else { "" },
+                    source.identifier().unwrap_or("?"),
+                    object.global_id,
+                    source.global_id,
+                ),
+                Statement::Return { object, condition: None } => {
+                    format!("RETURN <disconnected>   [return {}]\n", object.global_id)
+                }
+            };
             out.push_str(&line);
         }
         let unconnected: Vec<_> =
@@ -145,6 +177,32 @@ mod tests {
             insta::assert_snapshot!(resolve_project("variables/valid/unconnected_variables"), @r"
         bar := foo   [sink 8 <- source 6]
         unconnected: foo, bar");
+        }
+    }
+
+    mod returns {
+        use super::resolve_project;
+
+        #[test]
+        fn conditional_return() {
+            insta::assert_snapshot!(resolve_project("returns/valid/conditional_return"), @r"
+        RETURN myCondition   [return 3 <- source 1]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn negated_return() {
+            insta::assert_snapshot!(resolve_project("returns/valid/negated_return"), @r"
+        RETURN NOT myCondition   [return 3 <- source 1]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn disconnected_return() {
+            insta::assert_snapshot!(resolve_project("returns/invalid/disconnected_return"), @r"
+        RETURN myCondition   [return 3 <- source 1]
+        RETURN <disconnected>   [return 4]
+        unconnected: (none)");
         }
     }
 }

--- a/compiler/plc_cfc/src/transpile.rs
+++ b/compiler/plc_cfc/src/transpile.rs
@@ -10,8 +10,8 @@ use plc_diagnostics::diagnostics::Diagnostic;
 use plc_source::source_location::SourceLocationFactory;
 use plc_source::SourceCode;
 
-use crate::model::Pou;
-use crate::resolve::{Assignment, Resolved};
+use crate::model::{FbdObject, Pou};
+use crate::resolve::{Resolved, Statement};
 
 pub(crate) fn transpile(
     pou: &Pou,
@@ -23,9 +23,16 @@ pub(crate) fn transpile(
 
     let factory = SourceLocationFactory::for_source(source);
     let statements = resolved
-        .assignments
+        .statements
         .iter()
-        .map(|assignment| transpile_assignment(assignment, &factory, &mut ids))
+        .filter_map(|statement| match statement {
+            Statement::Assignment { sink, source } => {
+                Some(transpile_assignment(sink, source, &factory, &mut ids))
+            }
+            Statement::Return { object, condition } => {
+                condition.map(|condition| transpile_return(object, condition, &factory, &mut ids))
+            }
+        })
         .collect();
     if let Some(implementation) = unit.implementations.first_mut() {
         implementation.statements = statements;
@@ -35,18 +42,37 @@ pub(crate) fn transpile(
 }
 
 fn transpile_assignment(
-    assignment: &Assignment,
+    sink: &FbdObject,
+    source: &FbdObject,
     factory: &SourceLocationFactory,
     ids: &mut IdProvider,
 ) -> AstNode {
-    let location = factory.create_block_location(assignment.sink.global_id);
+    let location = factory.create_block_location(sink.global_id);
 
-    let mut left = helper::parse_identifier(assignment.sink.identifier().unwrap_or_default(), ids.clone());
-    let mut right = helper::parse_identifier(assignment.source.identifier().unwrap_or_default(), ids.clone());
+    let mut left = helper::parse_identifier(sink.identifier().unwrap_or_default(), ids.clone());
+    let mut right = helper::parse_identifier(source.identifier().unwrap_or_default(), ids.clone());
     left.location = location.clone();
     right.location = location;
 
     AstFactory::create_assignment(left, right, ids.next_id())
+}
+
+fn transpile_return(
+    object: &FbdObject,
+    condition: &FbdObject,
+    factory: &SourceLocationFactory,
+    ids: &mut IdProvider,
+) -> AstNode {
+    let location = factory.create_block_location(object.global_id);
+
+    let mut condition = helper::parse_identifier(condition.identifier().unwrap_or_default(), ids.clone());
+    condition.location = location.clone();
+    let condition = match object.negated() {
+        true => AstFactory::create_not_expression(condition, location.clone(), ids.next_id()),
+        false => condition,
+    };
+
+    AstFactory::create_return_statement(Some(condition), location, ids.next_id())
 }
 
 pub(crate) mod helper {
@@ -153,6 +179,32 @@ mod tests {
             bar : DINT;
         END_VAR
             bar := foo;
+        END_FUNCTION");
+        }
+    }
+
+    mod returns {
+        use crate::test_utils::transpile_project;
+
+        #[test]
+        fn conditional_return() {
+            insta::assert_snapshot!(transpile_project("returns/valid/conditional_return").unwrap(), @r"
+        FUNCTION conditional_return : INT
+        VAR
+            myCondition : BOOL;
+        END_VAR
+            IF myCondition THEN RETURN; END_IF;
+        END_FUNCTION");
+        }
+
+        #[test]
+        fn negated_return() {
+            insta::assert_snapshot!(transpile_project("returns/valid/negated_return").unwrap(), @r"
+        FUNCTION negated_return : INT
+        VAR
+            myCondition : BOOL;
+        END_VAR
+            IF NOT myCondition THEN RETURN; END_IF;
         END_FUNCTION");
         }
     }

--- a/compiler/plc_cfc/src/validation.rs
+++ b/compiler/plc_cfc/src/validation.rs
@@ -6,12 +6,13 @@ use plc_source::source_location::SourceLocationFactory;
 use plc_source::SourceCode;
 
 use crate::model::FbdObject;
-use crate::resolve::Resolved;
+use crate::resolve::{Resolved, Statement};
 use crate::transpile::helper::parse_identifier;
 
 pub(crate) fn validate(resolved: &Resolved, source: &SourceCode, ids: IdProvider) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     diagnostics.extend(validate_expressions(resolved, source, ids));
+    diagnostics.extend(validate_returns(resolved, source));
     diagnostics.extend(validate_unconnected(resolved, source));
     diagnostics
 }
@@ -28,12 +29,30 @@ fn validate_expressions(resolved: &Resolved, source: &SourceCode, ids: IdProvide
         }
     };
 
-    for assignment in &resolved.assignments {
-        check(assignment.sink);
-        check(assignment.source);
+    // A return's condition is left to the main pipeline's validator, which sees
+    // the full interface; here we only have the untyped model.
+    for statement in &resolved.statements {
+        if let Statement::Assignment { sink, source } = statement {
+            check(sink);
+            check(source);
+        }
     }
 
     diagnostics
+}
+
+fn validate_returns(resolved: &Resolved, source: &SourceCode) -> Vec<Diagnostic> {
+    let factory = SourceLocationFactory::for_source(source);
+    resolved
+        .statements
+        .iter()
+        .filter_map(|statement| match statement {
+            Statement::Return { object, condition: None } => {
+                Some(Diagnostic::disconnected_return(factory.create_block_location(object.global_id)))
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 fn validate_unconnected(resolved: &Resolved, source: &SourceCode) -> Vec<Diagnostic> {
@@ -90,6 +109,18 @@ mod tests {
 
         warning[E084]: Element `bar` is unconnected and will be ignored
          = unconnected_variables.cfc: Block 4
+        ");
+        }
+    }
+
+    mod returns {
+        use crate::test_utils::transpile_project;
+
+        #[test]
+        fn disconnected_return() {
+            insta::assert_snapshot!(transpile_project("returns/invalid/disconnected_return").unwrap_err(), @r"
+        error[E085]: Return element is not connected to a condition
+         = disconnected_return.cfc: Block 4
         ");
         }
     }

--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -398,6 +398,15 @@ impl Diagnostic {
             .with_error_code("E084")
             .with_location(location)
     }
+
+    pub fn disconnected_return<T>(location: T) -> Diagnostic
+    where
+        T: Into<SourceLocation>,
+    {
+        Diagnostic::new("Return element is not connected to a condition")
+            .with_error_code("E085")
+            .with_location(location)
+    }
 }
 
 #[cfg(test)]

--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -186,7 +186,7 @@ lazy_static! {
         E082,   Error,      include_str!("./error_codes/E082.md"),   // TODO: Unclaimed, use me instead of creating a new diagnostic
         E083,   Error,      include_str!("./error_codes/E083.md"),   // Unsupported CFC expression
         E084,   Warning,    include_str!("./error_codes/E084.md"),   // Unconnected CFC element
-        E085,   Error,      include_str!("./error_codes/E085.md"),   // TODO: Unclaimed, use me instead of creating a new diagnostic
+        E085,   Error,      include_str!("./error_codes/E085.md"),   // Disconnected CFC return
         E086,   Error,      include_str!("./error_codes/E086.md"),   // TODO: Unclaimed, use me instead of creating a new diagnostic
         E087,   Error,      include_str!("./error_codes/E087.md"),
         E088,   Error,      include_str!("./error_codes/E088.md"),

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E085.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E085.md
@@ -1,1 +1,5 @@
-# Cyclic connection
+# Disconnected CFC return
+
+A `RETURN` element in a CFC network is not wired to a condition. A conditional
+return only fires when its incoming value is true, so a return with nothing
+connected can never trigger and is almost certainly a mistake.

--- a/tests/lit/cfc/returns/guarded_return/guarded_return.cfc
+++ b/tests/lit/cfc/returns/guarded_return/guarded_return.cfc
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="guarded_return">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM guarded_return
+VAR
+    guard : BOOL;
+    result : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="guard" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <negated value="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="430" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="42" globalId="4">
+                    <ppx:RelPosition x="250" y="200"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="430" y="200"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/returns/guarded_return/main.st
+++ b/tests/lit/cfc/returns/guarded_return/main.st
@@ -1,0 +1,13 @@
+FUNCTION main : DINT
+    guarded_return.guard := FALSE;
+    guarded_return.result := 0;
+    guarded_return();
+    // CHECK: result = 42
+    printf('result = %d$N', guarded_return.result);
+
+    guarded_return.guard := TRUE;
+    guarded_return.result := 7;
+    guarded_return();
+    // CHECK: result = 7
+    printf('result = %d$N', guarded_return.result);
+END_FUNCTION

--- a/tests/lit/cfc/returns/guarded_return/plc.json
+++ b/tests/lit/cfc/returns/guarded_return/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_guarded_return",
+	"files" : [
+		"guarded_return.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/returns/guarded_return/run.test
+++ b/tests/lit/cfc/returns/guarded_return/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st


### PR DESCRIPTION
Problem: A CFC network can place a Return element that performs an early
return when its wired input evaluates to true, but the transpiler only
understood variable assignments and had no notion of returns.

Solution: Resolve Return elements alongside sinks into one
priority-ordered statement list, since the two interleave by evaluation
priority. Lower each return to the compiler's native conditional return
(create_return_statement with Some(condition)), which codegen turns into
a real conditional branch; a negated return wraps its condition in NOT.
A return with no wired condition can never fire and is rejected (E085).
Fix the AST serializer to render a conditional return as
`IF <cond> THEN RETURN; END_IF`.

---

**Stacked PRs** — part of the CFC transpiler rewrite; merge bottom → top:

1. #1807 refactor(cfc): delete plc_xml crate
2. #1808 feat(cfc): variable source/sinks
3. #1809 feat(cfc): returns  👈 **this PR**
4. #1810 feat(cfc): connectors and continuations
5. #1811 feat(cfc): stateful blocks
6. #1812 feat(cfc): functions
7. #1813 chore(cfc): add CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
