### PR TITLE
feat(cfc): stateful blocks

### DIFF
--- a/compiler/plc_cfc/fixtures/blocks/reference/counter.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/counter.cfc
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="counter">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM counter
+    VAR
+        localVar: DINT;
+    END_VAR
+
+    VAR_INPUT
+        in: DINT;
+    END_VAR
+
+    VAR_OUTPUT
+        out: DINT := 5; // Starts at 5
+    END_VAR
+
+    VAR_IN_OUT
+    END_VAR
+</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="in" globalId="1">
+                    <ppx:RelPosition x="340" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="myAdd" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="440" y="200"/>
+                    <ppx:Size x="90" y="60"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in1" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                        <ppx:InputVariable parameterName="in2" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="myAdd" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="5">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="1" globalId="6">
+                    <ppx:RelPosition x="340" y="240"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="out" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="560" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/reference/counter_fb.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/counter_fb.cfc
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:FunctionBlock xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="counter">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>FUNCTION_BLOCK counter
+    VAR
+        localVar: DINT;
+    END_VAR
+
+    VAR_INPUT
+        in: DINT;
+    END_VAR
+
+    VAR_OUTPUT
+        out: DINT := 5; // Starts at 5
+    END_VAR
+
+    VAR_IN_OUT
+    END_VAR
+</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="in" globalId="1">
+                    <ppx:RelPosition x="340" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="myAdd" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="440" y="200"/>
+                    <ppx:Size x="90" y="60"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in1" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                        <ppx:InputVariable parameterName="in2" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="myAdd" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="5">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="1" globalId="6">
+                    <ppx:RelPosition x="340" y="240"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="out" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="560" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:FunctionBlock>

--- a/compiler/plc_cfc/fixtures/blocks/reference/fb_usage.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/fb_usage.cfc
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_negated">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_negated
+VAR
+    counterInstanceA: counter;
+    localIn, localOut: DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="counterInstanceA" globalId="8">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="490" y="120"/>
+                    <ppx:Size x="130" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="10"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="9">
+<ppx:RelPosition x="130" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="localIn" globalId="11">
+                    <ppx:RelPosition x="370" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="10">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="localOut" globalId="12">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="650" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="9"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop.cfc
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="feedbackLoop">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM feedbackLoop
+    VAR
+
+    END_VAR
+                </content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="660" y="160"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2">
+    <ppx:RelPosition x="630" y="190"/>
+    <ppx:RelPosition x="630" y="240"/>
+    <ppx:RelPosition x="770" y="240"/>
+    <ppx:RelPosition x="770" y="190"/>
+</ppx:Connection>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop_chained.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop_chained.cfc
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="feedbackLoop">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM feedbackLoop
+    VAR
+
+    END_VAR
+                </content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="680" y="160"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="3">
+    <ppx:RelPosition x="650" y="190"/>
+    <ppx:RelPosition x="650" y="250"/>
+    <ppx:RelPosition x="1050" y="250"/>
+    <ppx:RelPosition x="1050" y="190"/>
+</ppx:Connection>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="800" y="160"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="5">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="920" y="160"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="5"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="3">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/reference/mainCfc.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/mainCfc.cfc
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="mainCfc">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM mainCfc
+    VAR
+        localCountInput, localCountOutput: DINT;
+    END_VAR
+</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="660" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="3"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="localCountInput" globalId="4">
+                    <ppx:RelPosition x="490" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="3">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="localCountOutput" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="780" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/reference/myAdd.st
+++ b/compiler/plc_cfc/fixtures/blocks/reference/myAdd.st
@@ -1,0 +1,7 @@
+FUNCTION myAdd : INT
+VAR_INPUT
+    in1, in2: DINT;
+END_VAR
+
+myAdd := in1 + in2;
+END_FUNCTION

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_bare/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_bare/README.md
@@ -1,0 +1,9 @@
+What: A parameterless action call — `inst.reset()`. The block has no input,
+in_out, or output pins, so the call carries no arguments; it still emits (the
+action runs for its effect on the instance's state). Confirms a bare qualified
+call lowers cleanly.
+
+Illustrated:
+```
+[inst : counter.reset] (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_bare/action_bare.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_bare/action_bare.cfc
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_bare">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM action_bare
+VAR
+    inst : counter;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter.reset" instanceName="inst" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="490" y="120"/>
+                    <ppx:Size x="120" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables/>
+                    <ppx:OutputVariables/>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_fb/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_fb/README.md
@@ -1,0 +1,10 @@
+What: A call to a function-block **action**. The block's `typeName` is qualified
+(`counter.increment`) and `instanceName="inst"`, so the call dispatches to the
+action — `inst.increment(in := localIn)` — while its output is read off the
+instance itself, `localOut := inst.out` (outputs are the parent's members, not
+the action's). Owner/action come from `rsplit_once('.')` on `typeName`.
+
+Illustrated:
+```
+localIn --> in [inst : counter.increment] out (0) --> localOut (1)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_fb/action_fb.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_fb/action_fb.cfc
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_fb">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM action_fb
+VAR
+    inst : counter;
+    localIn : DINT;
+    localOut : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="localIn" globalId="1">
+                    <ppx:RelPosition x="370" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter.increment" instanceName="inst" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="490" y="120"/>
+                    <ppx:Size x="150" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="150" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="localOut" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="680" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_program/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_program/README.md
@@ -1,0 +1,10 @@
+What: A call to a **program-owned** action. `typeName="P.bump"` and there is no
+`instanceName` — a program is a singleton, so the owner `P` *is* the reference.
+The call is `P.bump(step := localIn)` and the output reads off the program,
+`localOut := P.out`. Same split as the function-block case; the instance simply
+falls back to the owner when no instance is declared.
+
+Illustrated:
+```
+localIn --> step [P.bump] out (0) --> localOut (1)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_program/action_program.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_program/action_program.cfc
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_program">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM action_program
+VAR
+    localIn : DINT;
+    localOut : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="localIn" globalId="1">
+                    <ppx:RelPosition x="370" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="P.bump" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="490" y="120"/>
+                    <ppx:Size x="120" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="step" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="120" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="localOut" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="650" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_call/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_call/README.md
@@ -1,0 +1,10 @@
+What: A function-block instance call. The block carries `instanceName="inst"`
+(the caller's `inst : counter;`), so the call and the output read run on the
+instance — `inst(in := localIn); localOut := inst.out;` — not on the type. This
+is the sole difference from a program call: the reference is the instance, not
+the singleton type name.
+
+Illustrated:
+```
+localIn --> in [inst : counter] out (0) --> localOut (1)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_call/fb_call.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_call/fb_call.cfc
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_call">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM fb_call
+VAR
+    inst : counter;
+    localIn : DINT;
+    localOut : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="localIn" globalId="1">
+                    <ppx:RelPosition x="370" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="inst" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="490" y="120"/>
+                    <ppx:Size x="130" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="130" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="localOut" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="650" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_feedback/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_feedback/README.md
@@ -1,0 +1,11 @@
+What: A function-block instance whose `out` pin feeds back into its own `in`
+pin (0) — `inst(in := inst.out)`. Same shape as `program_feedback`, but read
+through the instance rather than the type; the read resolves to the instance's
+persistent member, so no ordering fix-up or temporary is needed.
+
+Illustrated:
+```
+   +--> in [inst : counter] out (0) --+
+   |                                  |
+   +----------------------------------+
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_feedback/fb_feedback.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_feedback/fb_feedback.cfc
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_feedback">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM fb_feedback
+VAR
+    inst : counter;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="inst" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="490" y="130"/>
+                    <ppx:Size x="130" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2">
+    <ppx:RelPosition x="460" y="160"/>
+    <ppx:RelPosition x="460" y="210"/>
+    <ppx:RelPosition x="640" y="210"/>
+    <ppx:RelPosition x="640" y="160"/>
+</ppx:Connection>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="130" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_instances/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_instances/README.md
@@ -1,0 +1,9 @@
+What: Two distinct instances of the same function block, `a` (0) then `b` (1),
+chained `seed --> a --> b --> result` (2). Unlike a program (a shared singleton),
+each instance holds its own state, so `a.out` and `b.out` are separate — the
+degenerate case for programs becomes meaningful here.
+
+Illustrated:
+```
+seed --> in [a : counter] out (0) --> in [b : counter] out (1) --> result (2)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_instances/fb_instances.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_instances/fb_instances.cfc
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_instances">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM fb_instances
+VAR
+    a : counter;
+    b : counter;
+    seed : DINT;
+    result : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="seed" globalId="1">
+                    <ppx:RelPosition x="360" y="150"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="a" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="480" y="130"/>
+                    <ppx:Size x="110" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="110" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="b" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="640" y="130"/>
+                    <ppx:Size x="110" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="6">
+<ppx:RelPosition x="110" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="800" y="150"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="6"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_straddle/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_straddle/README.md
@@ -1,0 +1,11 @@
+What: `program_straddle` for a function-block instance — one instance `inst` (1)
+whose `out` feeds two sinks that straddle its priority, `before` (0) and `after`
+(2). Priority ordering is shared with programs, so this only re-confirms it holds
+when the reference is an instance: `before` sees last cycle's value, `after` this
+cycle's, both off the same persistent member; no reordering, no temporary.
+
+Illustrated:
+```
+seed --> in [inst : counter] out (1) --+--> before (0)
+                                       +--> after (2)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_straddle/fb_straddle.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_straddle/fb_straddle.cfc
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_straddle">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM fb_straddle
+VAR
+    inst : counter;
+    seed : DINT;
+    before : DINT;
+    after : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="seed" globalId="1">
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="inst" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="470" y="120"/>
+                    <ppx:Size x="110" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="110" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="before" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="620" y="120"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="after" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="620" y="170"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_call/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_call/README.md
@@ -1,0 +1,8 @@
+What: A program block `counter` called with input `in` from `countIn` (0); its
+`out` pin is read into `countOut` (1). The call carries only the input; the
+output is consumed as a member access on the program's global.
+
+Illustrated:
+```
+countIn --> in [counter] out (0) --> countOut (1)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_call/program_call.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_call/program_call.cfc
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_call">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_call
+VAR
+    countIn : DINT;
+    countOut : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="countIn" globalId="1">
+                    <ppx:RelPosition x="490" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="660" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="countOut" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="780" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_chain/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_chain/README.md
@@ -1,0 +1,9 @@
+What: Two distinct program blocks in series — `counter` (0) then `doubler` (1) —
+with `counter.out` wired into `doubler.in` and `doubler.out` read into `result`
+(2). A block input fed by another block's output lowers to a member access inside
+the call arguments.
+
+Illustrated:
+```
+seed --> in [counter] out (0) --> in [doubler] out (1) --> result (2)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_chain/program_chain.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_chain/program_chain.cfc
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_chain">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_chain
+VAR
+    seed : DINT;
+    result : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="seed" globalId="1">
+                    <ppx:RelPosition x="360" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="530" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="doubler" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="700" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="6">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="870" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="6"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_chain_scrambled/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_chain_scrambled/README.md
@@ -1,0 +1,10 @@
+What: The `program_chain` topology — `a` --> `b` --> `c` --> `result` — but with
+priorities scrambled against the data flow: `c` (0), `result` (1), `a` (2), `b`
+(3). Statements emit in raw priority order, so `c` is called before `a`/`b` even
+exist this cycle; every block-to-block read is just a persisted member access, so
+the scramble stays valid without reordering.
+
+Illustrated:
+```
+seed --> in [a] out (2) --> in [b] out (3) --> in [c] out (0) --> result (1)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_chain_scrambled/program_chain_scrambled.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_chain_scrambled/program_chain_scrambled.cfc
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_chain_scrambled">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_chain_scrambled
+VAR
+    seed : DINT;
+    result : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="seed" globalId="1">
+                    <ppx:RelPosition x="360" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="a" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="530" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="b" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="3"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="700" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="6">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="c" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="870" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="6"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="8">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="9">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1040" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="8"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_cycle/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_cycle/README.md
@@ -1,0 +1,12 @@
+What: Two distinct programs feeding each other in a cycle — `ping.out` --> `pong.in`
+and `pong.out` --> `ping.in` — with `pong` (0) evaluated before `ping` (1). Neither
+call can precede the other in data-flow terms; priority order breaks the tie and
+each reads the other's persisted member. Confirms wire-tracing terminates on a
+block output even across a cross-block loop.
+
+Illustrated:
+```
+   +--> in [ping] out (1) --+
+   |                        |
+   +-- out [pong] in <------+   (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_cycle/program_cycle.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_cycle/program_cycle.cfc
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_cycle">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_cycle</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="ping" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="530" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="pong" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="700" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_fan_out/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_fan_out/README.md
@@ -1,0 +1,9 @@
+What: One program block `counter` (0) whose single `out` pin feeds two sinks,
+`a` (1) and `b` (2). A persistent output can be read any number of times, so each
+sink is an independent member access — no temporary is introduced.
+
+Illustrated:
+```
+seed --> in [counter] out (0) --+--> a (1)
+                                +--> b (2)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_fan_out/program_fan_out.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_fan_out/program_fan_out.cfc
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_fan_out">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_fan_out
+VAR
+    seed : DINT;
+    a : DINT;
+    b : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="seed" globalId="1">
+                    <ppx:RelPosition x="490" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="660" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="a" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="780" y="150"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="780" y="200"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_feedback/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_feedback/README.md
@@ -1,0 +1,10 @@
+What: A single program block whose `out` pin feeds straight back into its own
+`in` pin (0). The read resolves to the program's persistent member, so the call
+lowers to `counter(in := counter.out)` with no ordering fix-up or temporary.
+
+Illustrated:
+```
+   +--> in [counter] out (0) --+
+   |                           |
+   +---------------------------+
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_feedback/program_feedback.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_feedback/program_feedback.cfc
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_feedback">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_feedback</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="660" y="160"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2">
+    <ppx:RelPosition x="630" y="190"/>
+    <ppx:RelPosition x="630" y="240"/>
+    <ppx:RelPosition x="770" y="240"/>
+    <ppx:RelPosition x="770" y="190"/>
+</ppx:Connection>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_mixed/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_mixed/README.md
@@ -1,0 +1,10 @@
+What: A block call interleaved with a plain variable wire, ordered purely by
+priority: `q := p` (0), `r := counter.out` (1), then the `counter` call (2). Both
+reads precede the call, so `r` observes last cycle's output. Confirms `Call` and
+`Assignment` statements sort into one priority-ordered list.
+
+Illustrated:
+```
+seed --> in [counter] out (2) --> r (1)
+p --> q (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_mixed/program_mixed.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_mixed/program_mixed.cfc
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_mixed">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_mixed
+VAR
+    seed : DINT;
+    p : DINT;
+    q : DINT;
+    r : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="seed" globalId="1">
+                    <ppx:RelPosition x="360" y="150"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="530" y="130"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="p" globalId="5">
+                    <ppx:RelPosition x="360" y="250"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="6">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="q" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="560" y="250"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="6"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="r" globalId="8">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="700" y="130"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_negated/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_negated/README.md
@@ -1,0 +1,11 @@
+What: A block `program_0` (0) with an inversion bubble on every pin. A negated
+input/in_out wraps its wired value in `NOT`; a negated output wraps each read.
+`NOT` on a numeric is bitwise, so `in`/`out` are valid — but a negated in_out
+yields `NOT localInOut`, which the main pipeline rejects (E031, an in_out
+argument must be a reference). This fixture is therefore transpile-only.
+
+Illustrated:
+```
+localIn    --> in    (¬) [program_0] out (¬) (0) --> localOut (1)
+localInOut --> inout (¬)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_negated/program_negated.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_negated/program_negated.cfc
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_negated">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_negated
+VAR
+    localIn : DINT;
+    localInOut : DINT;
+    localOut : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="program_0" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="130"/>
+                    <ppx:Size x="100" y="60"/>
+                    <ppx:InOutVariables>
+                        <ppx:InOutVariable parameterName="inout" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="10"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InOutVariable>
+                    </ppx:InOutVariables>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="9"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="true">
+                            <ppx:ConnectionPointOut connectionPointOutId="8">
+<ppx:RelPosition x="100" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="localIn" globalId="11">
+                    <ppx:RelPosition x="440" y="150"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="9">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="localInOut" globalId="12">
+                    <ppx:RelPosition x="420" y="170"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="10">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="localOut" globalId="13">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="710" y="150"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="8"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_straddle/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_straddle/README.md
@@ -1,0 +1,10 @@
+What: One block `counter` (1) whose single `out` pin feeds two sinks that straddle
+its own priority — `before` (0) and `after` (2). The output is read once before the
+call and once after, from the same persistent member: `before` sees last cycle's
+value, `after` sees this cycle's. No temporary, no reordering.
+
+Illustrated:
+```
+seed --> in [counter] out (1) --+--> before (0)
+                                +--> after (2)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_straddle/program_straddle.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_straddle/program_straddle.cfc
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_straddle">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_straddle
+VAR
+    seed : DINT;
+    before : DINT;
+    after : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="seed" globalId="1">
+                    <ppx:RelPosition x="490" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="660" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="before" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="780" y="150"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="after" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="780" y="200"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_unordered/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_unordered/README.md
@@ -1,0 +1,10 @@
+What: The same wiring as `program_call`, but the sink reading the output has a
+lower priority number than the block that produces it — sink `countOut` (0),
+block `counter` (1). Statements stay in raw priority order, so the read is
+emitted *before* the call and simply observes the member's previous-cycle value.
+This is exactly why stateful outputs need no reordering and no temporary.
+
+Illustrated:
+```
+countIn --> in [counter] out (1) --> countOut (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_unordered/program_unordered.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_unordered/program_unordered.cfc
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_unordered">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_unordered
+VAR
+    countIn : DINT;
+    countOut : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="countIn" globalId="1">
+                    <ppx:RelPosition x="490" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="660" y="150"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="countOut" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="780" y="170"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/src/model.rs
+++ b/compiler/plc_cfc/src/model.rs
@@ -130,8 +130,52 @@ pub struct FbdObject {
     #[serde(rename = "@label")]
     pub label: Option<String>,
 
+    /// The called POU's name; present on a `ppx:Block`.
+    #[serde(rename = "@typeName")]
+    pub type_name: Option<String>,
+
+    /// The caller-declared instance a function-block call runs on; absent for a
+    /// program call, which is a singleton reached by its bare type name.
+    #[serde(rename = "@instanceName")]
+    pub instance_name: Option<String>,
+
     #[serde(rename = "AddData")]
     pub add_data: Option<AddData>,
+
+    #[serde(rename = "ConnectionPointIn")]
+    pub connection_in: Option<ConnectionPointIn>,
+
+    #[serde(rename = "ConnectionPointOut")]
+    pub connection_out: Option<ConnectionPointOut>,
+
+    #[serde(rename = "InputVariables")]
+    pub input_variables: Option<PinGroup>,
+
+    #[serde(rename = "OutputVariables")]
+    pub output_variables: Option<PinGroup>,
+
+    #[serde(rename = "InOutVariables")]
+    pub inout_variables: Option<PinGroup>,
+}
+
+/// A block's parameter pins of one kind (input, output, or in_out). All three
+/// groups share a shape; only the child element name differs, and quick-xml
+/// matches `$value` on that local name.
+#[derive(Debug, Default, Deserialize)]
+pub struct PinGroup {
+    #[serde(rename = "$value", default)]
+    pub pins: Vec<Pin>,
+}
+
+/// One block parameter pin. An input/in_out pin carries an incoming wire; an
+/// output pin exposes a producer pin. `negated` is the pin's inversion bubble.
+#[derive(Debug, Deserialize)]
+pub struct Pin {
+    #[serde(rename = "@parameterName")]
+    pub parameter_name: String,
+
+    #[serde(rename = "@negated", default)]
+    pub negated: bool,
 
     #[serde(rename = "ConnectionPointIn")]
     pub connection_in: Option<ConnectionPointIn>,
@@ -213,6 +257,50 @@ impl FbdObject {
         self.label.as_deref()
     }
 
+    pub fn type_name(&self) -> Option<&str> {
+        self.type_name.as_deref()
+    }
+
+    /// The reference a block's outputs are *read* through: its declared instance
+    /// (function block), falling back to the owner POU (a program singleton, or
+    /// an action's owner — outputs live on the instance, not the action).
+    pub fn instance(&self) -> Option<&str> {
+        self.instance_name.as_deref().or_else(|| self.owner())
+    }
+
+    /// The reference a block is *called* through: the instance, suffixed with the
+    /// action when `typeName` is qualified (`inst.act`); otherwise the instance.
+    pub fn call_target(&self) -> Option<String> {
+        let instance = self.instance()?;
+        Some(match self.action() {
+            Some(action) => format!("{instance}.{action}"),
+            None => instance.to_string(),
+        })
+    }
+
+    /// The owner portion of `typeName`: everything before an action suffix
+    /// (`MyFb.act` → `MyFb`), or the whole name when unqualified.
+    fn owner(&self) -> Option<&str> {
+        self.type_name.as_deref().map(|name| name.rsplit_once('.').map_or(name, |(owner, _)| owner))
+    }
+
+    /// The action a qualified `typeName` (`owner.action`) dispatches to, if any.
+    fn action(&self) -> Option<&str> {
+        self.type_name.as_deref().and_then(|name| name.rsplit_once('.').map(|(_, action)| action))
+    }
+
+    pub fn input_pins(&self) -> &[Pin] {
+        self.input_variables.as_ref().map_or(&[], |group| &group.pins)
+    }
+
+    pub fn output_pins(&self) -> &[Pin] {
+        self.output_variables.as_ref().map_or(&[], |group| &group.pins)
+    }
+
+    pub fn inout_pins(&self) -> &[Pin] {
+        self.inout_variables.as_ref().map_or(&[], |group| &group.pins)
+    }
+
     pub fn priority(&self) -> Option<usize> {
         let add_data = self.add_data.as_ref()?;
         add_data.data.iter().find_map(|data| data.evaluation_priority.as_ref()).map(|it| it.priority)
@@ -223,5 +311,17 @@ impl FbdObject {
             .as_ref()
             .and_then(|add_data| add_data.data.iter().find_map(|data| data.negated.as_ref()))
             .is_some_and(|negated| negated.value)
+    }
+}
+
+impl Pin {
+    /// The producer pin feeding an input/in_out pin's incoming wire.
+    pub fn source_pin(&self) -> Option<usize> {
+        self.connection_in.as_ref()?.connections.first().map(|connection| connection.ref_out_id)
+    }
+
+    /// The producer pin an output pin exposes to downstream consumers.
+    pub fn output_pin(&self) -> Option<usize> {
+        self.connection_out.as_ref().map(|out| out.id)
     }
 }

--- a/compiler/plc_cfc/src/resolve.rs
+++ b/compiler/plc_cfc/src/resolve.rs
@@ -8,7 +8,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
-use crate::model::{FbdObject, Network};
+use crate::model::{FbdObject, Network, Pin};
 
 pub(crate) struct Resolved<'model> {
     /// Network statements in evaluation-priority order.
@@ -21,8 +21,22 @@ pub(crate) struct Resolved<'model> {
 }
 
 pub(crate) enum Statement<'model> {
-    Assignment { sink: &'model FbdObject, source: &'model FbdObject },
-    Return { object: &'model FbdObject, condition: Option<&'model FbdObject> },
+    Assignment { sink: &'model FbdObject, source: Source<'model> },
+    Return { object: &'model FbdObject, condition: Option<Source<'model>> },
+    Call { block: &'model FbdObject, arguments: Vec<Argument<'model>> },
+}
+
+/// A block input/in_out pin paired with the value that feeds it.
+pub(crate) struct Argument<'model> {
+    pub pin: &'model Pin,
+    pub source: Source<'model>,
+}
+
+/// The value a consumer reads: a plain variable/literal source, or one output
+/// pin of a block — a block output is read back as a member of its instance.
+pub(crate) enum Source<'model> {
+    Variable(&'model FbdObject),
+    Output { block: &'model FbdObject, pin: &'model Pin },
 }
 
 pub(crate) struct Broken<'model> {
@@ -39,6 +53,7 @@ enum Role {
     Source,
     Sink,
     Return,
+    Block,
     Connector,
     Continuation,
     Unconnected,
@@ -46,9 +61,20 @@ enum Role {
 }
 
 enum Trace<'model> {
-    Reached(&'model FbdObject),
+    Reached(Source<'model>),
     DeadEnd(Broken<'model>),
     Unwired,
+}
+
+/// The producers a consumer's wire can land on, indexed by output-pin id.
+struct Producers<'model> {
+    /// Every output pin (data source, continuation, or block) back to its owner,
+    /// used to walk a wire to its origin.
+    by_pin: HashMap<usize, &'model FbdObject>,
+    /// Block output pins only, so a landed wire recovers the exact pin (its
+    /// parameter name and inversion), not just the owning block.
+    block_output: HashMap<usize, &'model Pin>,
+    connector_by_label: HashMap<&'model str, &'model FbdObject>,
 }
 
 impl<'model> Statement<'model> {
@@ -57,20 +83,100 @@ impl<'model> Statement<'model> {
         match self {
             Statement::Assignment { sink, .. } => sink,
             Statement::Return { object, .. } => object,
+            Statement::Call { block, .. } => block,
+        }
+    }
+}
+
+impl<'model> Source<'model> {
+    /// The underlying data source, when this is a plain variable/literal rather
+    /// than a block output. Used by validation to vet free-text identifiers.
+    pub(crate) fn variable(&self) -> Option<&'model FbdObject> {
+        match self {
+            Source::Variable(object) => Some(object),
+            Source::Output { .. } => None,
         }
     }
 }
 
 pub(crate) fn resolve(network: &Network) -> Resolved<'_> {
-    // Index the network so the linking pass below is pure lookup.
-    let mut source_by_pin: HashMap<usize, &FbdObject> = HashMap::new();
-    let mut connector_by_label: HashMap<&str, &FbdObject> = HashMap::new();
-    let mut duplicate_connectors = Vec::new();
+    let (producers, duplicate_connectors) = index(network);
+
+    // Link each consumer to its source: a sink becomes an assignment, a return
+    // a (guarded) return, a block a call over its wired inputs. A chain that
+    // never reaches a source is set aside for validation; connectors and
+    // continuations are pure routing and emit nothing.
+    let mut statements = Vec::new();
+    let mut unconnected = Vec::new();
+    let mut broken = Vec::new();
     for object in network.elements() {
-        // A producer exposes an output pin; map that pin's id back to it so a
-        // consumer wired to the pin can find what drives it.
+        match role(object) {
+            Role::Sink => match trace(source_pin(object), &producers) {
+                Trace::Reached(source) => statements.push(Statement::Assignment { sink: object, source }),
+                Trace::DeadEnd(at) => broken.push(at),
+                Trace::Unwired => {} // an unwired sink assigns nothing; drop it
+            },
+
+            Role::Return => match trace(source_pin(object), &producers) {
+                Trace::Reached(source) => {
+                    statements.push(Statement::Return { object, condition: Some(source) })
+                }
+                Trace::DeadEnd(at) => broken.push(at),
+                // No wire means no guard; validation flags the bare return (E085).
+                Trace::Unwired => statements.push(Statement::Return { object, condition: None }),
+            },
+
+            // A block always emits its call so its state advances; only its wired
+            // inputs and in_outs become arguments (an unwired input keeps last
+            // cycle's value). Outputs are read back separately, as members.
+            Role::Block => {
+                let mut arguments = Vec::new();
+                for pin in object.input_pins().iter().chain(object.inout_pins()) {
+                    match trace(pin.source_pin(), &producers) {
+                        Trace::Reached(source) => arguments.push(Argument { pin, source }),
+                        Trace::DeadEnd(at) => broken.push(at),
+                        Trace::Unwired => {}
+                    }
+                }
+                statements.push(Statement::Call { block: object, arguments });
+            }
+
+            Role::Unconnected => unconnected.push(object),
+            Role::Source | Role::Connector | Role::Continuation | Role::Other => {}
+        }
+    }
+
+    // Statements run in evaluation-priority order; a break fanned out across
+    // several consumers points at one element, so report it just once.
+    statements.sort_by_key(|statement| statement.anchor().priority().unwrap_or(usize::MAX));
+    let mut seen = HashSet::new();
+    broken.retain(|at| seen.insert(at.element.global_id));
+
+    Resolved { statements, unconnected, duplicate_connectors, broken }
+}
+
+/// Index the network so the linking pass is pure lookup: map every output pin to
+/// its producer (and, for blocks, the exact pin), and claim connector labels.
+fn index(network: &Network) -> (Producers<'_>, Vec<&FbdObject>) {
+    let mut by_pin = HashMap::new();
+    let mut block_output = HashMap::new();
+    let mut connector_by_label = HashMap::new();
+    let mut duplicate_connectors = Vec::new();
+
+    for object in network.elements() {
+        // A data source or continuation exposes a single output pin; a block
+        // exposes one per output parameter. Map each back so a consumer wired to
+        // the pin can find what drives it.
         if let Some(out) = &object.connection_out {
-            source_by_pin.insert(out.id, object);
+            by_pin.insert(out.id, object);
+        }
+        if matches!(role(object), Role::Block) {
+            for pin in object.output_pins() {
+                if let Some(id) = pin.output_pin() {
+                    by_pin.insert(id, object);
+                    block_output.insert(id, pin);
+                }
+            }
         }
 
         // A connector names a source via its label; the first to claim a label
@@ -87,41 +193,7 @@ pub(crate) fn resolve(network: &Network) -> Resolved<'_> {
         }
     }
 
-    // Link each consumer to its source: a sink becomes an assignment, a return
-    // a (guarded) return. A chain that never reaches a source is set aside for
-    // validation; connectors/continuations are pure routing and emit nothing.
-    let mut statements = Vec::new();
-    let mut unconnected = Vec::new();
-    let mut broken = Vec::new();
-    for object in network.elements() {
-        match role(object) {
-            Role::Sink => match trace_source(object, &source_by_pin, &connector_by_label) {
-                Trace::Reached(source) => statements.push(Statement::Assignment { sink: object, source }),
-                Trace::DeadEnd(at) => broken.push(at),
-                Trace::Unwired => {} // an unwired sink assigns nothing; drop it
-            },
-
-            Role::Return => match trace_source(object, &source_by_pin, &connector_by_label) {
-                Trace::Reached(source) => {
-                    statements.push(Statement::Return { object, condition: Some(source) })
-                }
-                Trace::DeadEnd(at) => broken.push(at),
-                // No wire means no guard; validation flags the bare return (E085).
-                Trace::Unwired => statements.push(Statement::Return { object, condition: None }),
-            },
-
-            Role::Unconnected => unconnected.push(object),
-            Role::Source | Role::Connector | Role::Continuation | Role::Other => {}
-        }
-    }
-
-    // Statements run in evaluation-priority order; a break fanned out across
-    // several consumers points at one element, so report it just once.
-    statements.sort_by_key(|statement| statement.anchor().priority().unwrap_or(usize::MAX));
-    let mut seen = HashSet::new();
-    broken.retain(|at| seen.insert(at.element.global_id));
-
-    Resolved { statements, unconnected, duplicate_connectors, broken }
+    (Producers { by_pin, block_output, connector_by_label }, duplicate_connectors)
 }
 
 fn role(object: &FbdObject) -> Role {
@@ -129,6 +201,7 @@ fn role(object: &FbdObject) -> Role {
         "ppx:DataSource" => Role::Source,
         "ppx:DataSink" => Role::Sink,
         "ppx:Return" => Role::Return,
+        "ppx:Block" => Role::Block,
         "ppx:Connector" => Role::Connector,
         "ppx:Continuation" => Role::Continuation,
         "ppx:Unconnected" => Role::Unconnected,
@@ -136,28 +209,22 @@ fn role(object: &FbdObject) -> Role {
     }
 }
 
-/// The element on the far end of a consumer's single incoming wire.
-fn wired_source<'model>(
-    consumer: &FbdObject,
-    source_by_pin: &HashMap<usize, &'model FbdObject>,
-) -> Option<&'model FbdObject> {
+/// The producer pin a consumer's single incoming wire references.
+fn source_pin(consumer: &FbdObject) -> Option<usize> {
     consumer
         .connection_in
         .as_ref()
         .and_then(|it| it.connections.first())
-        .and_then(|connection| source_by_pin.get(&connection.ref_out_id).copied())
+        .map(|connection| connection.ref_out_id)
 }
 
-/// Follow a consumer's wire to the concrete source that feeds it, hopping
-/// transparently through any connector/continuation pairs on the way.
-fn trace_source<'model>(
-    consumer: &FbdObject,
-    source_by_pin: &HashMap<usize, &'model FbdObject>,
-    connector_by_label: &HashMap<&str, &'model FbdObject>,
-) -> Trace<'model> {
-    let Some(mut element) = wired_source(consumer, source_by_pin) else {
-        return Trace::Unwired;
-    };
+/// Follow a wire from a producer pin to the concrete source that feeds it,
+/// hopping transparently through any connector/continuation pairs on the way.
+/// Landing on a block output pin ends the walk — a block output is a real
+/// producer, so this is what stops a feedback loop from chasing itself.
+fn trace<'model>(start: Option<usize>, producers: &Producers<'model>) -> Trace<'model> {
+    let Some(mut pin) = start else { return Trace::Unwired };
+    let Some(mut element) = producers.by_pin.get(&pin).copied() else { return Trace::Unwired };
 
     // A continuation is a stand-in for its connector's input, so replace it with
     // that input and keep going until the wire lands on a real producer.
@@ -173,26 +240,30 @@ fn trace_source<'model>(
         if !visited.insert(label) {
             return dangling(element);
         }
-        let Some(connector) = connector_by_label.get(label).copied() else {
+        let Some(connector) = producers.connector_by_label.get(label).copied() else {
             return dangling(element);
         };
 
         // Step onto whatever feeds that connector; a connector with no input is
         // an open connector and produces no value.
-        match wired_source(connector, source_by_pin) {
-            Some(next) => element = next,
+        match source_pin(connector).and_then(|id| producers.by_pin.get(&id).copied().map(|next| (id, next))) {
+            Some((id, next)) => (pin, element) = (id, next),
             None => {
                 return Trace::DeadEnd(Broken { element: connector, reason: BrokenReason::OpenConnector })
             }
         }
     }
 
-    Trace::Reached(element)
+    // A landed wire is a block output pin (read as a member) or a plain source.
+    match producers.block_output.get(&pin).copied() {
+        Some(output) => Trace::Reached(Source::Output { block: element, pin: output }),
+        None => Trace::Reached(Source::Variable(element)),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve, Resolved, Statement};
+    use super::{resolve, Resolved, Source, Statement};
     use crate::model::Pou;
 
     fn resolve_project(fixture: &str) -> String {
@@ -201,26 +272,51 @@ mod tests {
         render(&resolve(pou.content().network()))
     }
 
+    /// A source rendered as its diagram text and the global id it originates at.
+    fn render_source(source: &Source) -> (String, usize) {
+        match source {
+            Source::Variable(object) => (object.identifier().unwrap_or("?").to_string(), object.global_id),
+            Source::Output { block, pin } => {
+                (format!("{}.{}", block.instance().unwrap_or("?"), pin.parameter_name), block.global_id)
+            }
+        }
+    }
+
     fn render(resolved: &Resolved) -> String {
         let mut out = String::new();
         for statement in &resolved.statements {
             let line = match statement {
-                Statement::Assignment { sink, source } => format!(
-                    "{} := {}   [sink {} <- source {}]\n",
-                    sink.identifier().unwrap_or("?"),
-                    source.identifier().unwrap_or("?"),
-                    sink.global_id,
-                    source.global_id,
-                ),
-                Statement::Return { object, condition: Some(source) } => format!(
-                    "RETURN {}{}   [return {} <- source {}]\n",
-                    if object.negated() { "NOT " } else { "" },
-                    source.identifier().unwrap_or("?"),
-                    object.global_id,
-                    source.global_id,
-                ),
+                Statement::Assignment { sink, source } => {
+                    let (text, id) = render_source(source);
+                    format!(
+                        "{} := {text}   [sink {} <- source {id}]\n",
+                        sink.identifier().unwrap_or("?"),
+                        sink.global_id
+                    )
+                }
+                Statement::Return { object, condition: Some(source) } => {
+                    let (text, id) = render_source(source);
+                    format!(
+                        "RETURN {}{text}   [return {} <- source {id}]\n",
+                        if object.negated() { "NOT " } else { "" },
+                        object.global_id,
+                    )
+                }
                 Statement::Return { object, condition: None } => {
                     format!("RETURN <disconnected>   [return {}]\n", object.global_id)
+                }
+                Statement::Call { block, arguments } => {
+                    let args = arguments
+                        .iter()
+                        .map(|arg| {
+                            let (text, _) = render_source(&arg.source);
+                            let negate = if arg.pin.negated { "NOT " } else { "" };
+                            format!("{} := {negate}{text}", arg.pin.parameter_name)
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let target = block.call_target().unwrap_or_default();
+                    format!("{target}({args})   [call {}]\n", block.global_id)
                 }
             };
             out.push_str(&line);
@@ -330,6 +426,75 @@ mod tests {
         fn chain() {
             insta::assert_snapshot!(resolve_project("connectors/valid/chain"), @r"
         bar := foo   [sink 12 <- source 1]
+        unconnected: (none)");
+        }
+    }
+
+    mod blocks {
+        use super::resolve_project;
+
+        #[test]
+        fn program_call() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/program_call"), @r"
+        counter(in := countIn)   [call 3]
+        countOut := counter.out   [sink 5 <- source 3]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn program_chain() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/program_chain"), @r"
+        counter(in := seed)   [call 3]
+        doubler(in := counter.out)   [call 5]
+        result := doubler.out   [sink 7 <- source 5]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn program_feedback() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/program_feedback"), @r"
+        counter(in := counter.out)   [call 1]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn program_negated() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/program_negated"), @r"
+        program_0(in := NOT localIn, inout := NOT localInOut)   [call 7]
+        localOut := program_0.out   [sink 13 <- source 7]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn fb_call() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/fb_call"), @r"
+        inst(in := localIn)   [call 3]
+        localOut := inst.out   [sink 5 <- source 3]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn fb_instances() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/fb_instances"), @r"
+        a(in := seed)   [call 3]
+        b(in := a.out)   [call 5]
+        result := b.out   [sink 7 <- source 5]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn action_fb() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/action_fb"), @r"
+        inst.increment(in := localIn)   [call 3]
+        localOut := inst.out   [sink 5 <- source 3]
+        unconnected: (none)");
+        }
+
+        #[test]
+        fn action_program() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/action_program"), @r"
+        P.bump(step := localIn)   [call 3]
+        localOut := P.out   [sink 5 <- source 3]
         unconnected: (none)");
         }
     }

--- a/compiler/plc_cfc/src/transpile.rs
+++ b/compiler/plc_cfc/src/transpile.rs
@@ -7,11 +7,11 @@
 use plc_ast::ast::{AstFactory, AstNode, CompilationUnit};
 use plc_ast::provider::IdProvider;
 use plc_diagnostics::diagnostics::Diagnostic;
-use plc_source::source_location::SourceLocationFactory;
+use plc_source::source_location::{SourceLocation, SourceLocationFactory};
 use plc_source::SourceCode;
 
 use crate::model::{FbdObject, Pou};
-use crate::resolve::{Resolved, Statement};
+use crate::resolve::{Argument, Resolved, Source, Statement};
 
 pub(crate) fn transpile(
     pou: &Pou,
@@ -33,7 +33,10 @@ pub(crate) fn transpile(
                 Some(transpile_assignment(sink, source, &factory, &mut ids))
             }
             Statement::Return { object, condition } => {
-                condition.map(|condition| transpile_return(object, condition, &factory, &mut ids))
+                condition.as_ref().map(|condition| transpile_return(object, condition, &factory, &mut ids))
+            }
+            Statement::Call { block, arguments } => {
+                Some(transpile_call(block, arguments, &factory, &mut ids))
             }
         })
         .collect();
@@ -47,39 +50,93 @@ pub(crate) fn transpile(
 
 fn transpile_assignment(
     sink: &FbdObject,
-    source: &FbdObject,
+    source: &Source,
     factory: &SourceLocationFactory,
     ids: &mut IdProvider,
 ) -> AstNode {
     let location = factory.create_block_location(sink.global_id);
 
-    // Parse both sides as expressions, then anchor them to the sink's diagram
-    // block so diagnostics point at the element, not the synthetic identifier text.
+    // Anchor both sides to the sink's diagram block so diagnostics point at the
+    // element, not the synthetic identifier text.
     let mut left = helper::parse_identifier(sink.identifier().unwrap_or_default(), ids.clone());
-    let mut right = helper::parse_identifier(source.identifier().unwrap_or_default(), ids.clone());
     left.location = location.clone();
-    right.location = location;
+    let right = render_source(source, &location, ids);
 
     AstFactory::create_assignment(left, right, ids.next_id())
 }
 
 fn transpile_return(
     object: &FbdObject,
-    condition: &FbdObject,
+    condition: &Source,
     factory: &SourceLocationFactory,
     ids: &mut IdProvider,
 ) -> AstNode {
     let location = factory.create_block_location(object.global_id);
 
-    // The wired input guards the return; a negated pin inverts it with a `NOT`.
-    let mut condition = helper::parse_identifier(condition.identifier().unwrap_or_default(), ids.clone());
-    condition.location = location.clone();
+    // The wired input guards the return; a negated return element inverts it.
+    let condition = render_source(condition, &location, ids);
     let condition = match object.negated() {
         true => AstFactory::create_not_expression(condition, location.clone(), ids.next_id()),
         false => condition,
     };
 
     AstFactory::create_return_statement(Some(condition), location, ids.next_id())
+}
+
+fn transpile_call(
+    block: &FbdObject,
+    arguments: &[Argument],
+    factory: &SourceLocationFactory,
+    ids: &mut IdProvider,
+) -> AstNode {
+    let location = factory.create_block_location(block.global_id);
+
+    let target = block.call_target().unwrap_or_default();
+    let mut operator = helper::parse_identifier(&target, ids.clone());
+    operator.location = location.clone();
+
+    // Each wired input becomes a `param := value` association; a negated input
+    // pin inverts its value with a `NOT`.
+    let parameters: Vec<AstNode> = arguments
+        .iter()
+        .map(|argument| {
+            let mut left = helper::parse_identifier(&argument.pin.parameter_name, ids.clone());
+            left.location = location.clone();
+            let mut right = render_source(&argument.source, &location, ids);
+            if argument.pin.negated {
+                right = AstFactory::create_not_expression(right, location.clone(), ids.next_id());
+            }
+            AstFactory::create_assignment(left, right, ids.next_id())
+        })
+        .collect();
+
+    let parameters = (!parameters.is_empty())
+        .then(|| AstFactory::create_expression_list(parameters, location.clone(), ids.next_id()));
+
+    AstFactory::create_call_statement(operator, parameters, ids.next_id(), location)
+}
+
+/// Build the expression a consumer reads: a plain source is its identifier; a
+/// block output is a member of the block's instance, inverted when the output
+/// pin is negated. The result is anchored to the consumer's diagram block.
+fn render_source(source: &Source, location: &SourceLocation, ids: &mut IdProvider) -> AstNode {
+    match source {
+        Source::Variable(object) => {
+            let mut expression =
+                helper::parse_identifier(object.identifier().unwrap_or_default(), ids.clone());
+            expression.location = location.clone();
+            expression
+        }
+        Source::Output { block, pin } => {
+            let member = format!("{}.{}", block.instance().unwrap_or_default(), pin.parameter_name);
+            let mut expression = helper::parse_identifier(&member, ids.clone());
+            expression.location = location.clone();
+            match pin.negated {
+                true => AstFactory::create_not_expression(expression, location.clone(), ids.next_id()),
+                false => expression,
+            }
+        }
+    }
 }
 
 pub(crate) mod helper {
@@ -265,6 +322,253 @@ mod tests {
             foo : DINT;
             bar : DINT;
         END_VAR
+        END_PROGRAM");
+        }
+    }
+
+    // Expected output for program-block calls, agreed before implementation
+    // exists. A block lowers to a call carrying only its inputs; every output is
+    // consumed as a member access on the program's persistent global, and
+    // statements stay in raw priority order (no reordering, no temporaries).
+    mod blocks {
+        use crate::test_utils::transpile_project;
+
+        #[test]
+        fn program_call() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_call").unwrap(), @r"
+        PROGRAM program_call
+        VAR
+            countIn : DINT;
+            countOut : DINT;
+        END_VAR
+            counter(in := countIn);
+            countOut := counter.out;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_feedback() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_feedback").unwrap(), @r"
+        PROGRAM program_feedback
+            counter(in := counter.out);
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_fan_out() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_fan_out").unwrap(), @r"
+        PROGRAM program_fan_out
+        VAR
+            seed : DINT;
+            a : DINT;
+            b : DINT;
+        END_VAR
+            counter(in := seed);
+            a := counter.out;
+            b := counter.out;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_chain() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_chain").unwrap(), @r"
+        PROGRAM program_chain
+        VAR
+            seed : DINT;
+            result : DINT;
+        END_VAR
+            counter(in := seed);
+            doubler(in := counter.out);
+            result := doubler.out;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_unordered() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_unordered").unwrap(), @r"
+        PROGRAM program_unordered
+        VAR
+            countIn : DINT;
+            countOut : DINT;
+        END_VAR
+            countOut := counter.out;
+            counter(in := countIn);
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_chain_scrambled() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_chain_scrambled").unwrap(), @r"
+        PROGRAM program_chain_scrambled
+        VAR
+            seed : DINT;
+            result : DINT;
+        END_VAR
+            c(in := b.out);
+            result := c.out;
+            a(in := seed);
+            b(in := a.out);
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_cycle() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_cycle").unwrap(), @r"
+        PROGRAM program_cycle
+            pong(in := ping.out);
+            ping(in := pong.out);
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_straddle() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_straddle").unwrap(), @r"
+        PROGRAM program_straddle
+        VAR
+            seed : DINT;
+            before : DINT;
+            after : DINT;
+        END_VAR
+            before := counter.out;
+            counter(in := seed);
+            after := counter.out;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn program_mixed() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_mixed").unwrap(), @r"
+        PROGRAM program_mixed
+        VAR
+            seed : DINT;
+            p : DINT;
+            q : DINT;
+            r : DINT;
+        END_VAR
+            q := p;
+            r := counter.out;
+            counter(in := seed);
+        END_PROGRAM");
+        }
+
+        // A negated input/in_out inverts its wired value; a negated output
+        // inverts each read. The in_out's `NOT` is invalid downstream (E031), so
+        // this fixture is transpile-only.
+        #[test]
+        fn program_negated() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/program_negated").unwrap(), @r"
+        PROGRAM program_negated
+        VAR
+            localIn : DINT;
+            localInOut : DINT;
+            localOut : DINT;
+        END_VAR
+            program_0(in := NOT localIn, inout := NOT localInOut);
+            localOut := NOT program_0.out;
+        END_PROGRAM");
+        }
+
+        // A function-block block carries `instanceName`, so the call and the
+        // output read run on the instance rather than the (program) type name.
+        #[test]
+        fn fb_call() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/fb_call").unwrap(), @r"
+        PROGRAM fb_call
+        VAR
+            inst : counter;
+            localIn : DINT;
+            localOut : DINT;
+        END_VAR
+            inst(in := localIn);
+            localOut := inst.out;
+        END_PROGRAM");
+        }
+
+        // Distinct instances of one function block keep separate state, so the
+        // chain that is degenerate for a program is meaningful here.
+        #[test]
+        fn fb_instances() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/fb_instances").unwrap(), @r"
+        PROGRAM fb_instances
+        VAR
+            a : counter;
+            b : counter;
+            seed : DINT;
+            result : DINT;
+        END_VAR
+            a(in := seed);
+            b(in := a.out);
+            result := b.out;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn fb_feedback() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/fb_feedback").unwrap(), @r"
+        PROGRAM fb_feedback
+        VAR
+            inst : counter;
+        END_VAR
+            inst(in := inst.out);
+        END_PROGRAM");
+        }
+
+        // Scrambled priority holds for an instance too: the output is read once
+        // before the call and once after, off the same persistent member.
+        #[test]
+        fn fb_straddle() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/fb_straddle").unwrap(), @r"
+        PROGRAM fb_straddle
+        VAR
+            inst : counter;
+            seed : DINT;
+            before : DINT;
+            after : DINT;
+        END_VAR
+            before := inst.out;
+            inst(in := seed);
+            after := inst.out;
+        END_PROGRAM");
+        }
+
+        // An action call: `typeName` is qualified (`owner.action`), so the call
+        // dispatches to `inst.action` while the output is read off the instance.
+        #[test]
+        fn action_fb() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/action_fb").unwrap(), @r"
+        PROGRAM action_fb
+        VAR
+            inst : counter;
+            localIn : DINT;
+            localOut : DINT;
+        END_VAR
+            inst.increment(in := localIn);
+            localOut := inst.out;
+        END_PROGRAM");
+        }
+
+        // A program-owned action has no instance; the owner is the singleton.
+        #[test]
+        fn action_program() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/action_program").unwrap(), @r"
+        PROGRAM action_program
+        VAR
+            localIn : DINT;
+            localOut : DINT;
+        END_VAR
+            P.bump(step := localIn);
+            localOut := P.out;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn action_bare() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/action_bare").unwrap(), @r"
+        PROGRAM action_bare
+        VAR
+            inst : counter;
+        END_VAR
+            inst.reset();
         END_PROGRAM");
         }
     }

--- a/compiler/plc_cfc/src/validation.rs
+++ b/compiler/plc_cfc/src/validation.rs
@@ -33,11 +33,24 @@ fn validate_expressions(resolved: &Resolved, source: &SourceCode, ids: IdProvide
     };
 
     // A return's condition is left to the main pipeline's validator, which sees
-    // the full interface; here we only have the untyped model.
+    // the full interface; here we only have the untyped model. Block outputs are
+    // synthesized member references, so only free-text data sources are vetted.
     for statement in &resolved.statements {
-        if let Statement::Assignment { sink, source } = statement {
-            check(sink);
-            check(source);
+        match statement {
+            Statement::Assignment { sink, source } => {
+                check(sink);
+                if let Some(object) = source.variable() {
+                    check(object);
+                }
+            }
+            Statement::Call { arguments, .. } => {
+                for argument in arguments {
+                    if let Some(object) = argument.source.variable() {
+                        check(object);
+                    }
+                }
+            }
+            Statement::Return { .. } => {}
         }
     }
 

--- a/tests/lit/cfc/blocks/action_call/action_call.cfc
+++ b/tests/lit/cfc/blocks/action_call/action_call.cfc
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_call">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM action_call
+VAR
+    inst : counter;
+    amount : DINT := 3;
+    result : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="amount" globalId="1">
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="90" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter.bump" instanceName="inst" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="470" y="120"/>
+                    <ppx:Size x="140" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="step" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="count" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="140" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="680" y="140"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/blocks/action_call/counter.st
+++ b/tests/lit/cfc/blocks/action_call/counter.st
@@ -1,0 +1,14 @@
+FUNCTION_BLOCK counter
+VAR_INPUT
+    step : DINT;
+END_VAR
+VAR_OUTPUT
+    count : DINT;
+END_VAR
+END_FUNCTION_BLOCK
+
+ACTIONS
+    ACTION bump
+        count := count + step;
+    END_ACTION
+END_ACTIONS

--- a/tests/lit/cfc/blocks/action_call/main.st
+++ b/tests/lit/cfc/blocks/action_call/main.st
@@ -1,0 +1,6 @@
+FUNCTION main : DINT
+    action_call();
+    action_call();
+    // CHECK: count = 6
+    printf('count = %d$N', action_call.result);
+END_FUNCTION

--- a/tests/lit/cfc/blocks/action_call/plc.json
+++ b/tests/lit/cfc/blocks/action_call/plc.json
@@ -1,0 +1,12 @@
+{
+	"name" : "cfc_action_call",
+	"files" : [
+		"action_call.cfc",
+		"counter.st",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/blocks/action_call/run.test
+++ b/tests/lit/cfc/blocks/action_call/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/blocks/fb_call/counter.st
+++ b/tests/lit/cfc/blocks/fb_call/counter.st
@@ -1,0 +1,9 @@
+FUNCTION_BLOCK counter
+VAR_INPUT
+    step : DINT;
+END_VAR
+VAR_OUTPUT
+    total : DINT;
+END_VAR
+    total := total + step;
+END_FUNCTION_BLOCK

--- a/tests/lit/cfc/blocks/fb_call/fb_call.cfc
+++ b/tests/lit/cfc/blocks/fb_call/fb_call.cfc
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_call">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM fb_call
+VAR
+    a : counter;
+    b : counter;
+    sa : DINT := 1;
+    sb : DINT := 10;
+    outA : DINT;
+    outB : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="sa" globalId="1">
+                    <ppx:RelPosition x="360" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="a" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="470" y="120"/>
+                    <ppx:Size x="110" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="step" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="total" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="4">
+<ppx:RelPosition x="110" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="outA" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="620" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="sb" globalId="6">
+                    <ppx:RelPosition x="360" y="240"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="7">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="b" globalId="8">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="470" y="220"/>
+                    <ppx:Size x="110" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="step" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="7"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="total" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="9">
+<ppx:RelPosition x="110" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="outB" globalId="10">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="3"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="620" y="240"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="9"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/blocks/fb_call/main.st
+++ b/tests/lit/cfc/blocks/fb_call/main.st
@@ -1,0 +1,6 @@
+FUNCTION main : DINT
+    fb_call();
+    fb_call();
+    // CHECK: a = 2, b = 20
+    printf('a = %d, b = %d$N', fb_call.outA, fb_call.outB);
+END_FUNCTION

--- a/tests/lit/cfc/blocks/fb_call/plc.json
+++ b/tests/lit/cfc/blocks/fb_call/plc.json
@@ -1,0 +1,12 @@
+{
+	"name" : "cfc_fb_call",
+	"files" : [
+		"fb_call.cfc",
+		"counter.st",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/blocks/fb_call/run.test
+++ b/tests/lit/cfc/blocks/fb_call/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/blocks/program_call/accumulator.st
+++ b/tests/lit/cfc/blocks/program_call/accumulator.st
@@ -1,0 +1,13 @@
+PROGRAM accumulator
+VAR_INPUT
+    step : DINT;
+END_VAR
+VAR_IN_OUT
+    total : DINT;
+END_VAR
+VAR_OUTPUT
+    doubled : DINT;
+END_VAR
+    total := total + step;
+    doubled := total * 2;
+END_PROGRAM

--- a/tests/lit/cfc/blocks/program_call/main.st
+++ b/tests/lit/cfc/blocks/program_call/main.st
@@ -1,0 +1,6 @@
+FUNCTION main : DINT
+    program_call();
+    program_call();
+    // CHECK: total = 6, result = 12
+    printf('total = %d, result = %d$N', program_call.runningTotal, program_call.result);
+END_FUNCTION

--- a/tests/lit/cfc/blocks/program_call/plc.json
+++ b/tests/lit/cfc/blocks/program_call/plc.json
@@ -1,0 +1,12 @@
+{
+	"name" : "cfc_program_call",
+	"files" : [
+		"program_call.cfc",
+		"accumulator.st",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/blocks/program_call/program_call.cfc
+++ b/tests/lit/cfc/blocks/program_call/program_call.cfc
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_call">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <textDeclaration>
+                <content>PROGRAM program_call
+VAR
+    stepValue : DINT := 3;
+    runningTotal : DINT;
+    result : DINT;
+END_VAR</content>
+            </textDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="stepValue" globalId="1">
+                    <ppx:RelPosition x="360" y="150"/>
+                    <ppx:Size x="120" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="120" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="runningTotal" globalId="3">
+                    <ppx:RelPosition x="340" y="180"/>
+                    <ppx:Size x="140" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="140" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="accumulator" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="520" y="130"/>
+                    <ppx:Size x="120" y="60"/>
+                    <ppx:InOutVariables>
+                        <ppx:InOutVariable parameterName="total" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InOutVariable>
+                    </ppx:InOutVariables>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="step" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="2"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="doubled" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="6">
+<ppx:RelPosition x="120" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="700" y="150"/>
+                    <ppx:Size x="90" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="6"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/blocks/program_call/run.test
+++ b/tests/lit/cfc/blocks/program_call/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st


### PR DESCRIPTION
Problem: A CFC block is a call to another POU, but the FBD `ppx:Block`
element was classified as `Other` and dropped, so no call was transpiled.

Solution: Lower a `ppx:Block` to a call statement for the stateful callees —
those whose outputs persist as readable instance members and so need no
temporaries: programs (a singleton reached by its type name), function blocks
(a caller-declared instance), and actions (a qualified `typeName`, dispatched
as `instance.action`). Inputs and in_outs become `param := value` arguments,
outputs are read back as members, and statements stay in evaluation-priority
order. Methods and plain functions are stateless-output callees whose
return/outputs are call-site values needing temporaries; they are left to a
follow-up.

---

**Stacked PRs** — part of the CFC transpiler rewrite; merge bottom → top:

1. #1807 refactor(cfc): delete plc_xml crate
2. #1808 feat(cfc): variable source/sinks
3. #1809 feat(cfc): returns
4. #1810 feat(cfc): connectors and continuations
5. #1811 feat(cfc): stateful blocks  👈 **this PR**
6. #1812 feat(cfc): functions
7. #1813 chore(cfc): add CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
