### PR TITLE
fix: const-fold array initializers before lowering into constructors

### DIFF
--- a/compiler/plc_lowering/src/initializer.rs
+++ b/compiler/plc_lowering/src/initializer.rs
@@ -40,7 +40,7 @@
 use std::rc::Rc;
 
 use plc::{
-    index::{FxIndexMap, Index},
+    index::{const_expressions::ConstId, FxIndexMap, Index},
     lowering::helper::{
         create_assignment, create_assignment_with_index, create_assignments_from_initializer_with_index,
         create_call_statement, create_member_reference, create_ref_assignment,
@@ -50,9 +50,10 @@ use plc::{
 };
 use plc_ast::{
     ast::{
-        AstFactory, AstNode, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration, LinkageType,
-        PouType, Variable, VariableBlockType,
+        AstFactory, AstNode, AstStatement, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration,
+        LinkageType, PouType, Variable, VariableBlockType,
     },
+    literals::AstLiteral,
     provider::IdProvider,
     visitor::{AstVisitor, Walker},
 };
@@ -255,7 +256,13 @@ impl AstVisitor for Initializer {
         // Determine if we need to create an initializer
         // For alias/reference variables (AT x), if there's no explicit initializer, we use the AT target (address)
         // BUT only if the address is a simple identifier (not a hardware address like %I* or %QX1.2.1)
-        let initializer_to_use = if variable.initializer.is_some() {
+        let folded_initializer = variable
+            .initializer
+            .as_ref()
+            .and_then(|it| self.folded_array_initializer(it, self.initial_value_id(variable.get_name())));
+        let initializer_to_use = if folded_initializer.is_some() {
+            folded_initializer.as_ref()
+        } else if variable.initializer.is_some() {
             variable.initializer.as_ref()
         } else if is_alias_or_reference_variable(variable, index)
             && variable.address.as_ref().is_some_and(is_simple_identifier_address)
@@ -376,6 +383,10 @@ impl AstVisitor for Initializer {
         let mut stmts = vec![];
         // Explicitly add the initializer call here
         if let Some(initializer) = &user_type.initializer {
+            let const_id =
+                self.index.as_ref().and_then(|idx| idx.find_type(name)).and_then(|dt| dt.initial_value);
+            let folded_initializer = self.folded_array_initializer(initializer, const_id);
+            let initializer = folded_initializer.as_ref().unwrap_or(initializer);
             let assignment = create_assignment("self", None, initializer, self.id_provider.clone());
             stmts.push(assignment);
         }
@@ -399,7 +410,10 @@ impl AstVisitor for Initializer {
                     }
                 }
 
-                if let Some(initializer) = &variable.initializer {
+                let folded_initializer = variable.initializer.as_ref().and_then(|it| {
+                    self.folded_array_initializer(it, self.initial_value_id(variable.get_name()))
+                });
+                if let Some(initializer) = folded_initializer.as_ref().or(variable.initializer.as_ref()) {
                     let init_policy = InitLoweringPolicy::for_struct_field(variable, initializer, index);
                     match init_policy {
                         InitLoweringPolicy::RefAssign(ref_rhs) => {
@@ -768,6 +782,29 @@ impl Initializer {
         } else {
             log::debug!("Dropping {} init statement(s): no current POU/datatype in context", node.len());
         }
+    }
+
+    /// For array-literal initializers, prefer the const-evaluator's folded statement over the
+    /// raw AST — the raw tree may contain constant expressions (e.g. `UDINT#0 + UDINT#1`)
+    /// which codegen's literal generator cannot evaluate.
+    fn folded_array_initializer(&self, raw: &AstNode, const_id: Option<ConstId>) -> Option<AstNode> {
+        if !matches!(raw.get_stmt(), AstStatement::Literal(AstLiteral::Array(_))) {
+            return None;
+        }
+        let index = self.index.as_ref()?;
+        index.get_const_expressions().get_resolved_constant_statement(&const_id?).cloned()
+    }
+
+    /// Finds the const-expression id of a variable's initial value (POU/struct member or global).
+    fn initial_value_id(&self, variable_name: &str) -> Option<ConstId> {
+        let index = self.index.as_ref()?;
+        self.context
+            .current_pou
+            .as_deref()
+            .or(self.context.current_datatype.as_deref())
+            .and_then(|container| index.find_member(container, variable_name))
+            .or_else(|| index.find_global_variable(variable_name))?
+            .initial_value
     }
 
     /// Creates a call statement to the constructor of the given type: `<type_name>__ctor(<var_name>)`.

--- a/tests/lit/ir_tests/nested_array_const_expression_init.st
+++ b/tests/lit/ir_tests/nested_array_const_expression_init.st
@@ -1,0 +1,23 @@
+// RUN: %COMPILE_IR %s | %CHECK_IR %s
+//
+// Structural pin for the PRG-4521 fix: constant expressions inside nested
+// array initializers are const-folded, so the initializer lowers to a folded
+// constant global copied via memcpy. Previously the raw expression tree
+// reached codegen's literal generator and failed with "Cannot generate
+// Literal for BinaryExpression". Runtime coverage lives in
+// tests/lit/single/init/array_const_expression_init.st.
+
+PROGRAM mainProg
+VAR
+    mArr : ARRAY[0..1] OF ARRAY[0..1] OF UDINT := [[UDINT#0 + UDINT#1, UDINT#0], [UDINT#0, UDINT#2 - UDINT#1]];
+END_VAR
+    ;
+END_PROGRAM
+
+// The type's __init global is fully folded to [1, 0], [0, 1].
+// CHECK: @__mainProg.mArr__init = unnamed_addr constant [2 x [2 x i32]] {{\[}}[2 x i32] [i32 1, i32 0], [2 x i32] [i32 0, i32 1]]
+
+// The ctor assignment is folded as well and copied via memcpy.
+// CHECK: @.const_init = private unnamed_addr constant [2 x [2 x i32]] {{\[}}[2 x i32] [i32 1, i32 0], [2 x i32] [i32 0, i32 1]]
+// CHECK: define void @mainProg__ctor(ptr %0)
+// CHECK: call void @llvm.memcpy{{.*}}@.const_init

--- a/tests/lit/single/init/array_const_expression_init.st
+++ b/tests/lit/single/init/array_const_expression_init.st
@@ -1,0 +1,59 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+//
+// Regression test for PRG-4521: constant expressions (typed literals like
+// `UDINT#0 + UDINT#1`, plain arithmetic, and const references) inside array
+// initializers must be const-folded. Nested `ARRAY OF ARRAY` initializers
+// previously failed codegen with "Cannot generate Literal for BinaryExpression".
+
+TYPE nestedArr : ARRAY[0..1] OF ARRAY[0..1] OF UDINT := [[UDINT#0 + UDINT#1, UDINT#0], [UDINT#0, UDINT#2 - UDINT#1]]; END_TYPE
+
+TYPE withArr : STRUCT
+    m : ARRAY[0..1] OF ARRAY[0..1] OF UDINT := [[UDINT#1 + UDINT#1, UDINT#0], [UDINT#0, UDINT#3 - UDINT#1]];
+END_STRUCT END_TYPE
+
+VAR_GLOBAL CONSTANT
+    two : UDINT := 2;
+END_VAR
+
+VAR_GLOBAL
+    gNested : ARRAY[0..1] OF ARRAY[0..1] OF UDINT := [[two * UDINT#3, 1 + 2], [5 - 1, two]];
+END_VAR
+
+PROGRAM mainProg
+VAR
+    arr   : ARRAY[0..1] OF UDINT := [UDINT#0 + UDINT#1, UDINT#2 - UDINT#1];
+    mArr  : ARRAY[0..1] OF ARRAY[0..1] OF UDINT := [[UDINT#0 + UDINT#1, UDINT#0], [UDINT#0, UDINT#2 - UDINT#1]];
+    mArr2 : ARRAY[0..1, 0..1] OF UDINT := [UDINT#0, UDINT#0 + UDINT#1, UDINT#2 - UDINT#1, UDINT#0];
+    plain : ARRAY[0..1] OF ARRAY[0..1] OF DINT := [[0 + 1, 0], [0, 2 - 1]];
+    tArr  : nestedArr;
+    s     : withArr;
+END_VAR
+    ;
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+
+    // CHECK: arr=1,1
+    printf('arr=%d,%d$N', mainProg.arr[0], mainProg.arr[1]);
+
+    // CHECK: mArr=1,0,0,1
+    printf('mArr=%d,%d,%d,%d$N', mainProg.mArr[0][0], mainProg.mArr[0][1], mainProg.mArr[1][0], mainProg.mArr[1][1]);
+
+    // CHECK: mArr2=0,1,1,0
+    printf('mArr2=%d,%d,%d,%d$N', mainProg.mArr2[0,0], mainProg.mArr2[0,1], mainProg.mArr2[1,0], mainProg.mArr2[1,1]);
+
+    // CHECK: plain=1,0,0,1
+    printf('plain=%d,%d,%d,%d$N', mainProg.plain[0][0], mainProg.plain[0][1], mainProg.plain[1][0], mainProg.plain[1][1]);
+
+    // CHECK: tArr=1,0,0,1
+    printf('tArr=%d,%d,%d,%d$N', mainProg.tArr[0][0], mainProg.tArr[0][1], mainProg.tArr[1][0], mainProg.tArr[1][1]);
+
+    // CHECK: s.m=2,0,0,2
+    printf('s.m=%d,%d,%d,%d$N', mainProg.s.m[0][0], mainProg.s.m[0][1], mainProg.s.m[1][0], mainProg.s.m[1][1]);
+
+    // CHECK: gNested=6,3,4,2
+    printf('gNested=%d,%d,%d,%d$N', gNested[0][0], gNested[0][1], gNested[1][0], gNested[1][1]);
+
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Problem: An array initializer containing constant expressions, such as `mArr: ARRAY[0..1] OF ARRAY[0..1] OF UDINT := [[UDINT#0 + UDINT#1, ...]]`, failed to compile with "Cannot generate Literal for BinaryExpression". The initializer lowering cloned the raw initializer AST into the generated constructor body, discarding the folded statement the const evaluator had already produced. Flat arrays only worked by accident because the array lowering pass misclassifies expressions as non-constant and decomposes them into element-wise assignments; nested arrays were left as one literal assignment whose expression elements codegen's literal generator cannot evaluate.

Solution: When lowering an array-literal initializer into a constructor assignment, look up the const-evaluated statement in the index and prefer it over the raw AST — for POU variables, struct fields, and user-type declarations alike. Initializers the const evaluator cannot resolve (e.g. containing `ADR(x)`) fall through to the previous behavior. As a side effect, foldable flat arrays now initialize via a single memcpy from a constant global instead of element-wise runtime stores.