### PR TITLE
refactor(cfc): adopt the bmx text declaration format

### DIFF
--- a/compiler/plc_cfc/fixtures/blocks/invalid/function_stale_output/function_stale_output.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/invalid/function_stale_output/function_stale_output.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_stale_output">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_stale_output
+            <bmx:TextDeclaration>PROGRAM function_stale_output
     VAR
         a, b, result: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/invalid/unknown_type/unknown_type.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/invalid/unknown_type/unknown_type.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="unknown_type">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM unknown_type
+            <bmx:TextDeclaration>PROGRAM unknown_type
     VAR
         countIn, countOut: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/reference/counter.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/counter.cfc
@@ -2,8 +2,7 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="counter">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM counter
+            <bmx:TextDeclaration>PROGRAM counter
     VAR
         localVar: DINT;
     END_VAR
@@ -18,8 +17,7 @@
 
     VAR_IN_OUT
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/reference/counter_fb.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/counter_fb.cfc
@@ -2,8 +2,7 @@
 <ppx:FunctionBlock xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="counter">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION_BLOCK counter
+            <bmx:TextDeclaration>FUNCTION_BLOCK counter
     VAR
         localVar: DINT;
     END_VAR
@@ -18,8 +17,7 @@
 
     VAR_IN_OUT
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/reference/fb_usage.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/fb_usage.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_negated">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_negated
+            <bmx:TextDeclaration>PROGRAM program_negated
 VAR
     counterInstanceA: counter;
     localIn, localOut: DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="feedbackLoop">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM feedbackLoop
+            <bmx:TextDeclaration>PROGRAM feedbackLoop
     VAR
 
     END_VAR
-                </content>
-            </textDeclaration>
+                </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop_chained.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/feedbackLoop_chained.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="feedbackLoop">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM feedbackLoop
+            <bmx:TextDeclaration>PROGRAM feedbackLoop
     VAR
 
     END_VAR
-                </content>
-            </textDeclaration>
+                </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/reference/mainCfc.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/mainCfc.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="mainCfc">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM mainCfc
+            <bmx:TextDeclaration>PROGRAM mainCfc
     VAR
         localCountInput, localCountOutput: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/reference/myAddCfc.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/reference/myAddCfc.cfc
@@ -2,8 +2,7 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="myAddCfc">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION myAddCfc : INT
+            <bmx:TextDeclaration>FUNCTION myAddCfc : INT
     VAR_INPUT
         in1, in2: DINT;
     END_VAR
@@ -11,8 +10,7 @@
     VAR_OUTPUT
         myAddDoubledCfc: DINT;
     END_VAR
-              </content>
-            </textDeclaration>
+              </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_bare/action_bare.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_bare/action_bare.cfc
@@ -2,12 +2,10 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_bare">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM action_bare
+            <bmx:TextDeclaration>PROGRAM action_bare
 VAR
     inst : counter;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_fb/action_fb.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_fb/action_fb.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_fb">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM action_fb
+            <bmx:TextDeclaration>PROGRAM action_fb
 VAR
     inst : counter;
     localIn : DINT;
     localOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/action_program/action_program.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/action_program/action_program.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_program">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM action_program
+            <bmx:TextDeclaration>PROGRAM action_program
 VAR
     localIn : DINT;
     localOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_call/fb_call.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_call/fb_call.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_call">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fb_call
+            <bmx:TextDeclaration>PROGRAM fb_call
 VAR
     inst : counter;
     localIn : DINT;
     localOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_feedback/fb_feedback.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_feedback/fb_feedback.cfc
@@ -2,12 +2,10 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_feedback">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fb_feedback
+            <bmx:TextDeclaration>PROGRAM fb_feedback
 VAR
     inst : counter;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_instances/fb_instances.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_instances/fb_instances.cfc
@@ -2,15 +2,13 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_instances">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fb_instances
+            <bmx:TextDeclaration>PROGRAM fb_instances
 VAR
     a : counter;
     b : counter;
     seed : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_straddle/fb_straddle.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_straddle/fb_straddle.cfc
@@ -2,15 +2,13 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_straddle">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fb_straddle
+            <bmx:TextDeclaration>PROGRAM fb_straddle
 VAR
     inst : counter;
     seed : DINT;
     before : DINT;
     after : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_bare/function_bare.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_bare/function_bare.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_bare">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_bare
+            <bmx:TextDeclaration>PROGRAM function_bare
 VAR
     a : DINT;
     b : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_call/function_call.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_call/function_call.cfc
@@ -2,15 +2,13 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_call">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION function_call : INT
+            <bmx:TextDeclaration>FUNCTION function_call : INT
 VAR_INPUT
     in1, in2 : DINT;
 END_VAR
 VAR_OUTPUT
     doubledOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_chain/function_chain.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_chain/function_chain.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_chain">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_chain
+            <bmx:TextDeclaration>PROGRAM function_chain
 VAR
     seed : DINT;
     k : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_fan_out/function_fan_out.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_fan_out/function_fan_out.cfc
@@ -2,15 +2,13 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_fan_out">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_fan_out
+            <bmx:TextDeclaration>PROGRAM function_fan_out
 VAR
     a : DINT;
     b : DINT;
     x : DINT;
     y : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_feedback/function_feedback.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_feedback/function_feedback.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_feedback">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_feedback
+            <bmx:TextDeclaration>PROGRAM function_feedback
 VAR
     seed : DINT;
     acc : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_inout/function_inout.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_inout/function_inout.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_inout">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_inout
+            <bmx:TextDeclaration>PROGRAM function_inout
 VAR
     total : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_inout_unwired/function_inout_unwired.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_inout_unwired/function_inout_unwired.cfc
@@ -2,12 +2,10 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_inout_unwired">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_inout_unwired
+            <bmx:TextDeclaration>PROGRAM function_inout_unwired
 VAR
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_negated/function_negated.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_negated/function_negated.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_negated">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_negated
+            <bmx:TextDeclaration>PROGRAM function_negated
 VAR
     a : DINT;
     b : DINT;
     r : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_return_only/function_return_only.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_return_only/function_return_only.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_return_only">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_return_only
+            <bmx:TextDeclaration>PROGRAM function_return_only
 VAR
     a : DINT;
     b : DINT;
     sum : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_scrambled/function_scrambled.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_scrambled/function_scrambled.cfc
@@ -2,15 +2,13 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_scrambled">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_scrambled
+            <bmx:TextDeclaration>PROGRAM function_scrambled
 VAR
     a : DINT;
     b : DINT;
     early : DINT;
     late : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_void/function_void.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_void/function_void.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_void">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_void
+            <bmx:TextDeclaration>PROGRAM function_void
     VAR
         localIn : DINT := 3;
         localOut : DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_call/program_call.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_call/program_call.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_call">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_call
+            <bmx:TextDeclaration>PROGRAM program_call
 VAR
     countIn : DINT;
     countOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_chain/program_chain.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_chain/program_chain.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_chain">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_chain
+            <bmx:TextDeclaration>PROGRAM program_chain
 VAR
     seed : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_chain_scrambled/program_chain_scrambled.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_chain_scrambled/program_chain_scrambled.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_chain_scrambled">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_chain_scrambled
+            <bmx:TextDeclaration>PROGRAM program_chain_scrambled
 VAR
     seed : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_cycle/program_cycle.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_cycle/program_cycle.cfc
@@ -2,9 +2,7 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_cycle">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_cycle</content>
-            </textDeclaration>
+            <bmx:TextDeclaration>PROGRAM program_cycle</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_fan_out/program_fan_out.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_fan_out/program_fan_out.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_fan_out">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_fan_out
+            <bmx:TextDeclaration>PROGRAM program_fan_out
 VAR
     seed : DINT;
     a : DINT;
     b : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_feedback/program_feedback.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_feedback/program_feedback.cfc
@@ -2,9 +2,7 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_feedback">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_feedback</content>
-            </textDeclaration>
+            <bmx:TextDeclaration>PROGRAM program_feedback</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_mixed/program_mixed.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_mixed/program_mixed.cfc
@@ -2,15 +2,13 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_mixed">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_mixed
+            <bmx:TextDeclaration>PROGRAM program_mixed
 VAR
     seed : DINT;
     p : DINT;
     q : DINT;
     r : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_negated/program_negated.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_negated/program_negated.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_negated">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_negated
+            <bmx:TextDeclaration>PROGRAM program_negated
 VAR
     localIn : DINT;
     localInOut : DINT;
     localOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_straddle/program_straddle.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_straddle/program_straddle.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_straddle">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_straddle
+            <bmx:TextDeclaration>PROGRAM program_straddle
 VAR
     seed : DINT;
     before : DINT;
     after : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/blocks/valid/program_unordered/program_unordered.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/program_unordered/program_unordered.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_unordered">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_unordered
+            <bmx:TextDeclaration>PROGRAM program_unordered
 VAR
     countIn : DINT;
     countOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/invalid/connector_cycle/connector_cycle.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/invalid/connector_cycle/connector_cycle.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="connector_cycle">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM connector_cycle
+            <bmx:TextDeclaration>PROGRAM connector_cycle
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/invalid/dangling_continuation/dangling_continuation.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/invalid/dangling_continuation/dangling_continuation.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="dangling_continuation">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM dangling_continuation
+            <bmx:TextDeclaration>PROGRAM dangling_continuation
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/invalid/duplicate_connector/duplicate_connector.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/invalid/duplicate_connector/duplicate_connector.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="duplicate_connector">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM duplicate_connector
+            <bmx:TextDeclaration>PROGRAM duplicate_connector
     VAR
         foo, bar, baz: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/invalid/without_source/without_source.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/invalid/without_source/without_source.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="without_source">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM without_source
+            <bmx:TextDeclaration>PROGRAM without_source
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/reference/assignment.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/reference/assignment.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/reference/duplicate_connector.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/reference/duplicate_connector.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
     VAR
         foo, bar, baz: DINT;
     END_VAR
-  </content>
-            </textDeclaration>
+  </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/reference/fan_out.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/reference/fan_out.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
     VAR
         foo, bar, baz: DINT;
     END_VAR
- </content>
-            </textDeclaration>
+ </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/reference/without_sink.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/reference/without_sink.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
     VAR
         foo, bar: DINT;
     END_VAR
- </content>
-            </textDeclaration>
+ </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/reference/without_source.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/reference/without_source.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/reference/without_source_and_sink.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/reference/without_source_and_sink.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
     VAR
         foo, bar: DINT;
     END_VAR
- </content>
-            </textDeclaration>
+ </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/valid/assignment/assignment.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/assignment/assignment.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="assignment">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM assignment
+            <bmx:TextDeclaration>PROGRAM assignment
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/valid/block_route/block_route.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/block_route/block_route.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="block_route">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM block_route
+            <bmx:TextDeclaration>PROGRAM block_route
     VAR
         seed, result: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/valid/chain/chain.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/chain/chain.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="chain">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM chain
+            <bmx:TextDeclaration>PROGRAM chain
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/valid/fan_out/fan_out.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/fan_out/fan_out.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fan_out">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fan_out
+            <bmx:TextDeclaration>PROGRAM fan_out
     VAR
         foo, bar, baz: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/connectors/valid/unused/unused.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/unused/unused.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="unused">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM unused
+            <bmx:TextDeclaration>PROGRAM unused
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/invalid/duplicate_label/duplicate_label.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/invalid/duplicate_label/duplicate_label.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="duplicate_label">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM duplicate_label
+            <bmx:TextDeclaration>PROGRAM duplicate_label
 VAR
     myCondition: BOOL;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/invalid/undefined_jump_target/undefined_jump_target.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/invalid/undefined_jump_target/undefined_jump_target.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="undefined_jump_target">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM undefined_jump_target
+            <bmx:TextDeclaration>PROGRAM undefined_jump_target
 VAR
     myCondition: BOOL;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/reference/conditional_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/reference/conditional_jump.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
 VAR
     x, y: DINT;
     myCondition: BOOL;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/reference/disconnected_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/reference/disconnected_jump.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_0
+            <bmx:TextDeclaration>PROGRAM program_0
 VAR
     x, y: DINT;
     myCondition: BOOL;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/valid/backward_jump/backward_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/backward_jump/backward_jump.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="backward_jump">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM backward_jump
+            <bmx:TextDeclaration>PROGRAM backward_jump
 VAR
     cond: BOOL;
     i, x: DINT;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/valid/conditional_jump/conditional_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/conditional_jump/conditional_jump.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="conditional_jump">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM conditional_jump
+            <bmx:TextDeclaration>PROGRAM conditional_jump
 VAR
     x, y: DINT;
     myCondition: BOOL;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/valid/disconnected_jump/disconnected_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/disconnected_jump/disconnected_jump.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="disconnected_jump">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM disconnected_jump
+            <bmx:TextDeclaration>PROGRAM disconnected_jump
 VAR
     x, y: DINT;
     myCondition: BOOL;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/valid/negated_jump/negated_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/negated_jump/negated_jump.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_jump">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM negated_jump
+            <bmx:TextDeclaration>PROGRAM negated_jump
 VAR
     x, y: DINT;
     myCondition: BOOL;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/valid/scrambled/scrambled.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/scrambled/scrambled.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="scrambled">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM scrambled
+            <bmx:TextDeclaration>PROGRAM scrambled
 VAR
     g1, g2, g3: BOOL;
     x, a, b, c: DINT;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/jumps/valid/unused_label/unused_label.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/unused_label/unused_label.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="unused_label">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM unused_label
+            <bmx:TextDeclaration>PROGRAM unused_label
 VAR
     x, y: DINT;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/disconnected_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/disconnected_return.cfc
@@ -2,12 +2,10 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="disconnected_return">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION disconnected_return : INT&#13;
+            <bmx:TextDeclaration>FUNCTION disconnected_return : INT&#13;
 VAR&#13;
     myCondition: BOOL;&#13;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/returns/reference/conditional_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/reference/conditional_return.cfc
@@ -2,12 +2,10 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_0">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION function_0 : INT&#13;
+            <bmx:TextDeclaration>FUNCTION function_0 : INT&#13;
 VAR&#13;
     myCondition: BOOL;&#13;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/returns/valid/conditional_return/conditional_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/conditional_return/conditional_return.cfc
@@ -2,12 +2,10 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="conditional_return">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION conditional_return : INT&#13;
+            <bmx:TextDeclaration>FUNCTION conditional_return : INT&#13;
 VAR&#13;
     myCondition: BOOL;&#13;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return/negated_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return/negated_return.cfc
@@ -2,12 +2,10 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_return">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION negated_return : INT&#13;
+            <bmx:TextDeclaration>FUNCTION negated_return : INT&#13;
 VAR&#13;
     myCondition: BOOL;&#13;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/invalid/binary_expression/binary_expression.cfc
+++ b/compiler/plc_cfc/fixtures/variables/invalid/binary_expression/binary_expression.cfc
@@ -2,13 +2,11 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="binary_expression">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION binary_expression : INT
+            <bmx:TextDeclaration>FUNCTION binary_expression : INT
 VAR
     foo : DINT;
     bar : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/invalid/call_expression/call_expression.cfc
+++ b/compiler/plc_cfc/fixtures/variables/invalid/call_expression/call_expression.cfc
@@ -2,14 +2,12 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="call_expression">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION call_expression : INT
+            <bmx:TextDeclaration>FUNCTION call_expression : INT
 VAR
     foo : DINT;
     bar : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/reference/expression_identifier.cfc
+++ b/compiler/plc_cfc/fixtures/variables/reference/expression_identifier.cfc
@@ -2,12 +2,10 @@
 <ppx:FunctionBlock xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="two">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION_BLOCK two
+            <bmx:TextDeclaration>FUNCTION_BLOCK two
 VAR
 	a, b, c : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/reference/function_network.cfc
+++ b/compiler/plc_cfc/fixtures/variables/reference/function_network.cfc
@@ -2,13 +2,11 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="three">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION three : INT
+            <bmx:TextDeclaration>FUNCTION three : INT
 	VAR
 		foo, bar : DINT;
 	END_VAR
-                </content>
-            </textDeclaration>
+                </bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/reference/indexed_identifier.cfc
+++ b/compiler/plc_cfc/fixtures/variables/reference/indexed_identifier.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="one">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM one
+            <bmx:TextDeclaration>PROGRAM one
 VAR
 	in, out : ARRAY[0..3] OF DINT;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/valid/fan_out/fan_out.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/fan_out/fan_out.cfc
@@ -2,14 +2,12 @@
 <ppx:FunctionBlock xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fan_out">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION_BLOCK fan_out
+            <bmx:TextDeclaration>FUNCTION_BLOCK fan_out
 VAR
     foo : DINT;
     bar : DINT;
     baz : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/valid/indexed_assignment/indexed_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/indexed_assignment/indexed_assignment.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="indexed_assignment">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM indexed_assignment
+            <bmx:TextDeclaration>PROGRAM indexed_assignment
 VAR
     source : DINT;
     values : ARRAY[0..3] OF DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/valid/literal_assignment/literal_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/literal_assignment/literal_assignment.cfc
@@ -2,12 +2,10 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="literal_assignment">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION literal_assignment : INT
+            <bmx:TextDeclaration>FUNCTION literal_assignment : INT
 VAR
     foo : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/valid/reciprocal_assignment/reciprocal_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/reciprocal_assignment/reciprocal_assignment.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="reciprocal_assignment">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM reciprocal_assignment
+            <bmx:TextDeclaration>PROGRAM reciprocal_assignment
 VAR
     foo : DINT;
     bar : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/valid/simple_assignment/simple_assignment.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/simple_assignment/simple_assignment.cfc
@@ -2,13 +2,11 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="simple_assignment">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION simple_assignment : INT
+            <bmx:TextDeclaration>FUNCTION simple_assignment : INT
 VAR
     foo : DINT;
     bar : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/fixtures/variables/valid/unconnected_variables/unconnected_variables.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/unconnected_variables/unconnected_variables.cfc
@@ -2,13 +2,11 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="unconnected_variables">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION unconnected_variables : INT
+            <bmx:TextDeclaration>FUNCTION unconnected_variables : INT
 VAR
     foo : DINT;
     bar : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/compiler/plc_cfc/src/model.rs
+++ b/compiler/plc_cfc/src/model.rs
@@ -49,7 +49,7 @@ pub struct Data {
     #[serde(rename = "@handleUnknown")]
     pub handle_unknown: Option<String>,
 
-    #[serde(rename = "textDeclaration")]
+    #[serde(rename = "TextDeclaration")]
     pub text_declaration: Option<TextDeclaration>,
 
     #[serde(rename = "EvaluationPriority")]
@@ -61,7 +61,7 @@ pub struct Data {
 
 #[derive(Debug, Deserialize)]
 pub struct TextDeclaration {
-    #[serde(rename = "content")]
+    #[serde(rename = "$text")]
     pub content: String,
 }
 

--- a/tests/lit/cfc/blocks/action_call/action_call.cfc
+++ b/tests/lit/cfc/blocks/action_call/action_call.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="action_call">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM action_call
+            <bmx:TextDeclaration>PROGRAM action_call
 VAR
     inst : counter;
     amount : DINT := 3;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/fb_call/fb_call.cfc
+++ b/tests/lit/cfc/blocks/fb_call/fb_call.cfc
@@ -2,8 +2,7 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_call">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fb_call
+            <bmx:TextDeclaration>PROGRAM fb_call
 VAR
     a : counter;
     b : counter;
@@ -11,8 +10,7 @@ VAR
     sb : DINT := 10;
     outA : DINT;
     outB : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/function_call/function_call.cfc
+++ b/tests/lit/cfc/blocks/function_call/function_call.cfc
@@ -2,15 +2,13 @@
 <ppx:Function xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_call">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>FUNCTION function_call : INT
+            <bmx:TextDeclaration>FUNCTION function_call : INT
 VAR_INPUT
     in1, in2 : DINT;
 END_VAR
 VAR_OUTPUT
     doubledOut : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/function_chain/function_chain.cfc
+++ b/tests/lit/cfc/blocks/function_chain/function_chain.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_chain">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_chain
+            <bmx:TextDeclaration>PROGRAM function_chain
 VAR
     seed : DINT;
     k : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/function_feedback/function_feedback.cfc
+++ b/tests/lit/cfc/blocks/function_feedback/function_feedback.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_feedback">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_feedback
+            <bmx:TextDeclaration>PROGRAM function_feedback
 VAR
     seed : DINT;
     acc : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/function_inout/function_inout.cfc
+++ b/tests/lit/cfc/blocks/function_inout/function_inout.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_inout">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_inout
+            <bmx:TextDeclaration>PROGRAM function_inout
 VAR
     total : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/function_inout_unwired/function_inout_unwired.cfc
+++ b/tests/lit/cfc/blocks/function_inout_unwired/function_inout_unwired.cfc
@@ -2,12 +2,10 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_inout_unwired">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_inout_unwired
+            <bmx:TextDeclaration>PROGRAM function_inout_unwired
 VAR
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/function_void/function_void.cfc
+++ b/tests/lit/cfc/blocks/function_void/function_void.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_void">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM function_void
+            <bmx:TextDeclaration>PROGRAM function_void
     VAR
         localIn : DINT := 3;
         localOut : DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/blocks/program_call/program_call.cfc
+++ b/tests/lit/cfc/blocks/program_call/program_call.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_call">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM program_call
+            <bmx:TextDeclaration>PROGRAM program_call
 VAR
     stepValue : DINT := 3;
     runningTotal : DINT;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/connectors/chain/chain.cfc
+++ b/tests/lit/cfc/connectors/chain/chain.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="chain">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM chain
+            <bmx:TextDeclaration>PROGRAM chain
     VAR
         foo, bar: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/connectors/fan_out/fan_out.cfc
+++ b/tests/lit/cfc/connectors/fan_out/fan_out.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fan_out">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fan_out
+            <bmx:TextDeclaration>PROGRAM fan_out
     VAR
         foo, bar, baz: DINT;
     END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/jumps/guarded_jump/guarded_jump.cfc
+++ b/tests/lit/cfc/jumps/guarded_jump/guarded_jump.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="guarded_jump">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM guarded_jump
+            <bmx:TextDeclaration>PROGRAM guarded_jump
 VAR
     cond: BOOL;
     x, y: DINT;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/jumps/scrambled/scrambled.cfc
+++ b/tests/lit/cfc/jumps/scrambled/scrambled.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="scrambled">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM scrambled
+            <bmx:TextDeclaration>PROGRAM scrambled
 VAR
     g1, g2, g3: BOOL;
     x, a, b, c: DINT;
 END_VAR
-</content>
-            </textDeclaration>
+</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/returns/guarded_return/guarded_return.cfc
+++ b/tests/lit/cfc/returns/guarded_return/guarded_return.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="guarded_return">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM guarded_return
+            <bmx:TextDeclaration>PROGRAM guarded_return
 VAR
     guard : BOOL;
     result : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/variables/evaluation_order/evaluation_order.cfc
+++ b/tests/lit/cfc/variables/evaluation_order/evaluation_order.cfc
@@ -2,13 +2,11 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="evaluation_order">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM evaluation_order
+            <bmx:TextDeclaration>PROGRAM evaluation_order
 VAR
     a : DINT;
     b : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/variables/fan_out/fan_out.cfc
+++ b/tests/lit/cfc/variables/fan_out/fan_out.cfc
@@ -2,14 +2,12 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fan_out">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM fan_out
+            <bmx:TextDeclaration>PROGRAM fan_out
 VAR
     src : DINT;
     x : DINT;
     y : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>

--- a/tests/lit/cfc/variables/literal_assignment/literal_assignment.cfc
+++ b/tests/lit/cfc/variables/literal_assignment/literal_assignment.cfc
@@ -2,12 +2,10 @@
 <ppx:Program xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="literal_assignment">
     <ppx:AddData>
         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-            <textDeclaration>
-                <content>PROGRAM literal_assignment
+            <bmx:TextDeclaration>PROGRAM literal_assignment
 VAR
     x : DINT;
-END_VAR</content>
-            </textDeclaration>
+END_VAR</bmx:TextDeclaration>
         </ppx:Data>
     </ppx:AddData>
     <ppx:MainBody>


### PR DESCRIPTION
Problem: Text declarations were read from a nested `<textDeclaration><content>...</content></textDeclaration>` element, which does not match the Bachmann-specific format.

Solution: Adapt the model to the Bachmann format, where the declaration is the direct text content of a single `<bmx:TextDeclaration>` element, and update all fixtures accordingly.