### PR TITLE
fix: construct array elements in generated array type constructors

### DIFF
--- a/compiler/plc_lowering/src/initializer.rs
+++ b/compiler/plc_lowering/src/initializer.rs
@@ -39,6 +39,7 @@
 
 use std::rc::Rc;
 
+use crate::loops::helper as loop_helper;
 use plc::{
     index::{const_expressions::ConstId, FxIndexMap, Index},
     lowering::helper::{
@@ -51,7 +52,7 @@ use plc::{
 use plc_ast::{
     ast::{
         AstFactory, AstNode, AstStatement, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration,
-        LinkageType, PouType, Variable, VariableBlockType,
+        LinkageType, Operator, PouType, RangeStatement, Variable, VariableBlockType,
     },
     literals::AstLiteral,
     provider::IdProvider,
@@ -396,7 +397,30 @@ impl AstVisitor for Initializer {
 
     /// Processes a struct data type's fields, generating constructor calls for fields whose
     /// types have constructors, and lowering field initializers into assignments.
+    /// For array types, generates a loop calling the element type's constructor on every
+    /// element so that defaults, vtable pointers, and `FB_INIT` reach each array element.
     fn visit_data_type(&mut self, data_type: &plc_ast::ast::DataType) {
+        if let plc_ast::ast::DataType::ArrayType {
+            bounds, referenced_type, is_variable_length: false, ..
+        } = data_type
+        {
+            let index = self.index.as_ref().expect("index is set at this stage");
+
+            // Only arrays of types with constructors need per-element construction.
+            let Some(element_type) = referenced_type.get_referenced_type() else { return };
+            let has_constructor = self.constructors.contains_key(element_type)
+                || index
+                    .find_type(element_type)
+                    .is_some_and(|dt| !dt.linkage.is_built_in() && !dt.is_interface());
+            if !has_constructor {
+                return;
+            }
+
+            let Some(array_type) = self.context.current_datatype.clone() else { return };
+            if let Some(ctor_loop) = self.create_element_ctor_loop(&array_type, element_type, bounds) {
+                self.add_to_current_constructor(ctor_loop);
+            }
+        }
         if let plc_ast::ast::DataType::StructType { variables, .. } = data_type {
             let index = self.index.as_ref().expect("index is set at this stage");
             let mut constructor = vec![];
@@ -805,6 +829,113 @@ impl Initializer {
             .and_then(|container| index.find_member(container, variable_name))
             .or_else(|| index.find_global_variable(variable_name))?
             .initial_value
+    }
+
+    /// Builds the per-element construction loop for an array type's constructor, one loop per
+    /// dimension with the element ctor call innermost:
+    /// ```st
+    /// __idx0 := <lo>;
+    /// WHILE TRUE DO
+    ///     IF __idx0 > <hi> THEN EXIT; END_IF
+    ///     <element_type>__ctor(self[__idx0, ...]);
+    ///     __idx0 := __idx0 + 1;
+    /// END_WHILE
+    /// ```
+    /// The loops are emitted in the canonical `WHILE TRUE` form directly because the
+    /// `LoopDesugarer` pass has already run by the time constructors are generated.
+    /// Returns `None` when the bounds are not ranges (invalid declarations are left
+    /// to validation).
+    fn create_element_ctor_loop(
+        &mut self,
+        array_type: &str,
+        element_type: &str,
+        bounds: &AstNode,
+    ) -> Option<Vec<AstNode>> {
+        // One range and one counter per dimension. The counter names carry the array type
+        // name: allocation scopes are resolved by name across implementations, so they must
+        // be unique per constructor.
+        let dimensions: Vec<&AstNode> = match bounds.get_stmt() {
+            AstStatement::ExpressionList(expressions) => expressions.iter().collect(),
+            _ => vec![bounds],
+        };
+        let counters: Vec<(AstNode, AstNode)> = (0..dimensions.len())
+            .map(|dim| {
+                loop_helper::create_alloca(&mut self.id_provider, "DINT", format!("{array_type}__idx{dim}"))
+            })
+            .collect();
+
+        // `<element_type>__ctor(self[__idx0, __idx1, ...])`
+        let counter_refs: Vec<AstNode> = counters.iter().map(|(_, reference)| reference.clone()).collect();
+        let subscript = if counter_refs.len() == 1 {
+            counter_refs.into_iter().next().expect("exactly one counter")
+        } else {
+            AstFactory::create_expression_list(
+                counter_refs,
+                SourceLocation::internal(),
+                self.id_provider.next_id(),
+            )
+        };
+        let element_access = AstFactory::create_index_reference(
+            subscript,
+            Some(create_member_reference("self", self.id_provider.clone(), None)),
+            self.id_provider.next_id(),
+            SourceLocation::internal(),
+        );
+        let operator =
+            create_member_reference(&format!("{element_type}__ctor"), self.id_provider.clone(), None);
+        let call = AstFactory::create_call_statement(
+            operator,
+            Some(element_access),
+            self.id_provider.next_id(),
+            SourceLocation::internal(),
+        );
+
+        // Wrap the call in one loop per dimension, innermost dimension first.
+        let mut statements = vec![call];
+        for ((alloca, counter), dimension) in counters.into_iter().zip(dimensions.iter()).rev() {
+            let AstStatement::RangeStatement(RangeStatement { start, end }) = dimension.get_stmt() else {
+                return None;
+            };
+
+            // IF __idx > <hi> THEN EXIT; END_IF
+            let bound_guard = loop_helper::create_if_then_exit(
+                self.id_provider.clone(),
+                loop_helper::create_internal_binary_expression(
+                    counter.clone(),
+                    Operator::Greater,
+                    end.as_ref().clone(),
+                    &mut self.id_provider,
+                ),
+            );
+
+            // __idx := __idx + 1
+            let increment = loop_helper::create_internal_assignment(
+                counter.clone(),
+                loop_helper::create_internal_binary_expression(
+                    counter.clone(),
+                    Operator::Plus,
+                    loop_helper::create_literal_integer(&mut self.id_provider, 1),
+                    &mut self.id_provider,
+                ),
+                &mut self.id_provider,
+            );
+
+            let mut body = vec![bound_guard];
+            body.append(&mut statements);
+            body.push(increment);
+
+            statements = vec![
+                alloca,
+                loop_helper::create_internal_assignment(
+                    counter,
+                    start.as_ref().clone(),
+                    &mut self.id_provider,
+                ),
+                loop_helper::create_while_true_loop(&mut self.id_provider, body),
+            ];
+        }
+
+        Some(statements)
     }
 
     /// Creates a call statement to the constructor of the given type: `<type_name>__ctor(<var_name>)`.
@@ -2160,5 +2291,174 @@ mod tests {
         ");
         // Global constructor should call NodeA's constructor
         insta::assert_snapshot!(print_to_string(&initializer.global_constructor), @"NodeA__ctor(myNode)");
+    }
+
+    #[test]
+    fn array_of_function_blocks_constructs_every_element() {
+        let src = r#"
+        FUNCTION_BLOCK MyFb
+        VAR
+            x : INT := 7;
+        END_VAR
+            METHOD FB_INIT
+            END_METHOD
+        END_FUNCTION_BLOCK
+
+        PROGRAM prog
+        VAR
+            arr : ARRAY[0..15] OF MyFb;
+        END_VAR
+        END_PROGRAM
+        "#;
+
+        let initializer = parse_and_init(src);
+        let body = print_body_to_string(initializer.constructors.get("__prog_arr").unwrap());
+        assert!(
+            body.contains("MyFb__ctor"),
+            "the array member ctor must construct its elements (vtable, defaults, FB_INIT); got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn array_of_structs_constructs_every_element() {
+        let src = r#"
+        TYPE Point : STRUCT
+            x : DINT := 11;
+            y : DINT := 22;
+        END_STRUCT
+        END_TYPE
+
+        PROGRAM prog
+        VAR
+            arr : ARRAY[0..3] OF Point;
+        END_VAR
+        END_PROGRAM
+        "#;
+
+        let initializer = parse_and_init(src);
+        let body = print_body_to_string(initializer.constructors.get("__prog_arr").unwrap());
+        assert!(
+            body.contains("Point__ctor"),
+            "the array member ctor must apply element defaults via the element ctor; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn named_array_type_of_function_blocks_constructs_every_element() {
+        let src = r#"
+        FUNCTION_BLOCK MyFb
+        VAR
+            x : INT := 7;
+        END_VAR
+        END_FUNCTION_BLOCK
+
+        TYPE FbArr : ARRAY[0..3] OF MyFb; END_TYPE
+
+        PROGRAM prog
+        VAR
+            arr : FbArr;
+        END_VAR
+        END_PROGRAM
+        "#;
+
+        let initializer = parse_and_init(src);
+        let body = print_body_to_string(initializer.constructors.get("FbArr").unwrap());
+        assert!(
+            body.contains("MyFb__ctor"),
+            "named array type ctors must construct their elements; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn nested_array_of_function_blocks_constructs_inner_arrays() {
+        let src = r#"
+        FUNCTION_BLOCK MyFb
+        VAR
+            x : INT := 7;
+        END_VAR
+        END_FUNCTION_BLOCK
+
+        PROGRAM prog
+        VAR
+            narr : ARRAY[0..1] OF ARRAY[0..2] OF MyFb;
+        END_VAR
+        END_PROGRAM
+        "#;
+
+        let initializer = parse_and_init(src);
+        let outer = print_body_to_string(initializer.constructors.get("__prog_narr").unwrap());
+        assert!(
+            outer.contains("__prog_narr___ctor"),
+            "the outer array ctor must construct each inner array; got:\n{outer}"
+        );
+        let inner = print_body_to_string(initializer.constructors.get("__prog_narr_").unwrap());
+        assert!(
+            inner.contains("MyFb__ctor"),
+            "the inner array ctor must construct its elements; got:\n{inner}"
+        );
+    }
+
+    #[test]
+    fn multi_dimensional_array_of_structs_constructs_every_element() {
+        let src = r#"
+        TYPE Point : STRUCT
+            x : DINT := 11;
+        END_STRUCT
+        END_TYPE
+
+        PROGRAM prog
+        VAR
+            marr : ARRAY[0..1, 0..2] OF Point;
+        END_VAR
+        END_PROGRAM
+        "#;
+
+        let initializer = parse_and_init(src);
+        let body = print_body_to_string(initializer.constructors.get("__prog_marr").unwrap());
+        assert!(
+            body.contains("Point__ctor"),
+            "multi-dimensional array ctors must construct every element; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn struct_with_array_of_function_blocks_field_constructs_elements() {
+        let src = r#"
+        FUNCTION_BLOCK MyFb
+        VAR
+            x : INT := 7;
+        END_VAR
+        END_FUNCTION_BLOCK
+
+        TYPE Holder : STRUCT
+            arr : ARRAY[0..2] OF MyFb;
+        END_STRUCT
+        END_TYPE
+        "#;
+
+        let initializer = parse_and_init(src);
+        let body = print_body_to_string(initializer.constructors.get("__Holder_arr").unwrap());
+        assert!(
+            body.contains("MyFb__ctor"),
+            "array-typed struct field ctors must construct their elements; got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn array_of_builtin_elements_needs_no_element_construction() {
+        let src = r#"
+        PROGRAM prog
+        VAR
+            arr : ARRAY[0..3] OF DINT;
+        END_VAR
+        END_PROGRAM
+        "#;
+
+        let initializer = parse_and_init(src);
+        let body = print_body_to_string(initializer.constructors.get("__prog_arr").unwrap());
+        assert!(
+            !body.contains("__ctor"),
+            "arrays of built-in elements must not emit element ctor calls; got:\n{body}"
+        );
     }
 }

--- a/compiler/plc_lowering/src/initializer.rs
+++ b/compiler/plc_lowering/src/initializer.rs
@@ -2312,11 +2312,19 @@ mod tests {
         "#;
 
         let initializer = parse_and_init(src);
-        let body = print_body_to_string(initializer.constructors.get("__prog_arr").unwrap());
-        assert!(
-            body.contains("MyFb__ctor"),
-            "the array member ctor must construct its elements (vtable, defaults, FB_INIT); got:\n{body}"
-        );
+        // The array member ctor must construct its elements (vtable, defaults, FB_INIT)
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("__prog_arr").unwrap()), @"
+        intern:
+        alloca __prog_arr__idx0: DINT
+        __prog_arr__idx0 := 0
+        WHILE TRUE DO
+            IF __prog_arr__idx0 > 15 THEN
+                EXIT;
+            END_IF
+            MyFb__ctor(self[__prog_arr__idx0])
+            __prog_arr__idx0 := __prog_arr__idx0 + 1
+        END_WHILE
+        ");
     }
 
     #[test]
@@ -2336,11 +2344,19 @@ mod tests {
         "#;
 
         let initializer = parse_and_init(src);
-        let body = print_body_to_string(initializer.constructors.get("__prog_arr").unwrap());
-        assert!(
-            body.contains("Point__ctor"),
-            "the array member ctor must apply element defaults via the element ctor; got:\n{body}"
-        );
+        // The array member ctor must apply element defaults via the element ctor
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("__prog_arr").unwrap()), @"
+        intern:
+        alloca __prog_arr__idx0: DINT
+        __prog_arr__idx0 := 0
+        WHILE TRUE DO
+            IF __prog_arr__idx0 > 3 THEN
+                EXIT;
+            END_IF
+            Point__ctor(self[__prog_arr__idx0])
+            __prog_arr__idx0 := __prog_arr__idx0 + 1
+        END_WHILE
+        ");
     }
 
     #[test]
@@ -2362,11 +2378,19 @@ mod tests {
         "#;
 
         let initializer = parse_and_init(src);
-        let body = print_body_to_string(initializer.constructors.get("FbArr").unwrap());
-        assert!(
-            body.contains("MyFb__ctor"),
-            "named array type ctors must construct their elements; got:\n{body}"
-        );
+        // Named array type ctors must construct their elements
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("FbArr").unwrap()), @"
+        intern:
+        alloca FbArr__idx0: DINT
+        FbArr__idx0 := 0
+        WHILE TRUE DO
+            IF FbArr__idx0 > 3 THEN
+                EXIT;
+            END_IF
+            MyFb__ctor(self[FbArr__idx0])
+            FbArr__idx0 := FbArr__idx0 + 1
+        END_WHILE
+        ");
     }
 
     #[test]
@@ -2386,16 +2410,32 @@ mod tests {
         "#;
 
         let initializer = parse_and_init(src);
-        let outer = print_body_to_string(initializer.constructors.get("__prog_narr").unwrap());
-        assert!(
-            outer.contains("__prog_narr___ctor"),
-            "the outer array ctor must construct each inner array; got:\n{outer}"
-        );
-        let inner = print_body_to_string(initializer.constructors.get("__prog_narr_").unwrap());
-        assert!(
-            inner.contains("MyFb__ctor"),
-            "the inner array ctor must construct its elements; got:\n{inner}"
-        );
+        // The outer array ctor must construct each inner array
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("__prog_narr").unwrap()), @"
+        intern:
+        alloca __prog_narr__idx0: DINT
+        __prog_narr__idx0 := 0
+        WHILE TRUE DO
+            IF __prog_narr__idx0 > 1 THEN
+                EXIT;
+            END_IF
+            __prog_narr___ctor(self[__prog_narr__idx0])
+            __prog_narr__idx0 := __prog_narr__idx0 + 1
+        END_WHILE
+        ");
+        // The inner array ctor must construct its elements
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("__prog_narr_").unwrap()), @"
+        intern:
+        alloca __prog_narr___idx0: DINT
+        __prog_narr___idx0 := 0
+        WHILE TRUE DO
+            IF __prog_narr___idx0 > 2 THEN
+                EXIT;
+            END_IF
+            MyFb__ctor(self[__prog_narr___idx0])
+            __prog_narr___idx0 := __prog_narr___idx0 + 1
+        END_WHILE
+        ");
     }
 
     #[test]
@@ -2414,11 +2454,27 @@ mod tests {
         "#;
 
         let initializer = parse_and_init(src);
-        let body = print_body_to_string(initializer.constructors.get("__prog_marr").unwrap());
-        assert!(
-            body.contains("Point__ctor"),
-            "multi-dimensional array ctors must construct every element; got:\n{body}"
-        );
+        // Multi-dimensional array ctors must construct every element (one loop per dimension)
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("__prog_marr").unwrap()), @"
+        intern:
+        alloca __prog_marr__idx0: DINT
+        __prog_marr__idx0 := 0
+        WHILE TRUE DO
+            IF __prog_marr__idx0 > 1 THEN
+                EXIT;
+            END_IF
+            alloca __prog_marr__idx1: DINT
+            __prog_marr__idx1 := 0
+            WHILE TRUE DO
+                IF __prog_marr__idx1 > 2 THEN
+                    EXIT;
+                END_IF
+                Point__ctor(self[__prog_marr__idx0, __prog_marr__idx1])
+                __prog_marr__idx1 := __prog_marr__idx1 + 1
+            END_WHILE
+            __prog_marr__idx0 := __prog_marr__idx0 + 1
+        END_WHILE
+        ");
     }
 
     #[test]
@@ -2437,11 +2493,19 @@ mod tests {
         "#;
 
         let initializer = parse_and_init(src);
-        let body = print_body_to_string(initializer.constructors.get("__Holder_arr").unwrap());
-        assert!(
-            body.contains("MyFb__ctor"),
-            "array-typed struct field ctors must construct their elements; got:\n{body}"
-        );
+        // Array-typed struct field ctors must construct their elements
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("__Holder_arr").unwrap()), @"
+        intern:
+        alloca __Holder_arr__idx0: DINT
+        __Holder_arr__idx0 := 0
+        WHILE TRUE DO
+            IF __Holder_arr__idx0 > 2 THEN
+                EXIT;
+            END_IF
+            MyFb__ctor(self[__Holder_arr__idx0])
+            __Holder_arr__idx0 := __Holder_arr__idx0 + 1
+        END_WHILE
+        ");
     }
 
     #[test]
@@ -2455,10 +2519,7 @@ mod tests {
         "#;
 
         let initializer = parse_and_init(src);
-        let body = print_body_to_string(initializer.constructors.get("__prog_arr").unwrap());
-        assert!(
-            !body.contains("__ctor"),
-            "arrays of built-in elements must not emit element ctor calls; got:\n{body}"
-        );
+        // Arrays of built-in elements must not emit element ctor calls; the body stays empty
+        insta::assert_snapshot!(print_body_to_string(initializer.constructors.get("__prog_arr").unwrap()), @"");
     }
 }

--- a/compiler/plc_lowering/src/loops.rs
+++ b/compiler/plc_lowering/src/loops.rs
@@ -389,7 +389,7 @@ impl AstVisitorMut for ForDesugarer {
     }
 }
 
-mod helper {
+pub(crate) mod helper {
     use plc_ast::{
         ast::{Allocation, AstFactory, AstNode, AstStatement, Operator},
         control_statements::{ConditionalBlock, IfStatement, LoopStatement},

--- a/compiler/plc_lowering/src/tests/array_lowering_tests.rs
+++ b/compiler/plc_lowering/src/tests/array_lowering_tests.rs
@@ -510,7 +510,8 @@ fn type_level_struct_array_ctor_is_lowered() {
     );
     let stmts = find_impl_stmts(&project, "tarr__ctor");
     assert!(!has_literal_array(stmts));
-    assert_eq!(count_assignments(stmts), 3);
+    // 3 indexed assignments + the element construction loop's counter initialization
+    assert_eq!(count_assignments(stmts), 4);
 }
 
 /// Verify that type-level struct array initializers are lowered in the constructor body.
@@ -529,7 +530,8 @@ fn type_level_struct_array_is_lowered_in_ctor() {
     );
     let stmts = find_impl_stmts(&project, "tarr__ctor");
     assert!(!has_literal_array(stmts), "Type-level struct array should be lowered");
-    assert_eq!(count_assignments(stmts), 3);
+    // 3 indexed assignments + the element construction loop's counter initialization
+    assert_eq!(count_assignments(stmts), 4);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/codegen/tests/debug_tests.rs
+++ b/src/codegen/tests/debug_tests.rs
@@ -1069,7 +1069,38 @@ END_FUNCTION
     entry:
       %self = alloca ptr, align [filtered], !dbg !58
       store ptr %0, ptr %self, align [filtered], !dbg !58
+      %__struct__inner_arr__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__struct__inner_arr__idx0, align [filtered], !dbg !58
+      store i32 0, ptr %__struct__inner_arr__idx0, align [filtered], !dbg !58
+      br label %while_body, !dbg !58
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___struct__inner_arr__idx0 = load i32, ptr %__struct__inner_arr__idx0, align [filtered], !dbg !58
+      %tmpVar = icmp sgt i32 %load___struct__inner_arr__idx0, 2, !dbg !58
+      %1 = zext i1 %tmpVar to i8, !dbg !58
+      %2 = icmp ne i8 %1, 0, !dbg !58
+      br i1 %2, label %condition_body, label %continue1, !dbg !58
+
+    continue:                                         ; preds = %condition_body
       ret void, !dbg !58
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue, !dbg !58
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1, !dbg !58
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered], !dbg !58
+      %load___struct__inner_arr__idx02 = load i32, ptr %__struct__inner_arr__idx0, align [filtered], !dbg !58
+      %tmpVar3 = mul i32 1, %load___struct__inner_arr__idx02, !dbg !58
+      %tmpVar4 = add i32 %tmpVar3, 0, !dbg !58
+      %tmpVar5 = getelementptr inbounds [3 x %inner], ptr %deref, i32 0, i32 %tmpVar4, !dbg !58
+      call void @inner__ctor(ptr %tmpVar5), !dbg !58
+      %load___struct__inner_arr__idx06 = load i32, ptr %__struct__inner_arr__idx0, align [filtered], !dbg !58
+      %tmpVar7 = add i32 %load___struct__inner_arr__idx06, 1, !dbg !58
+      store i32 %tmpVar7, ptr %__struct__inner_arr__idx0, align [filtered], !dbg !58
+      br label %while_body, !dbg !58
     }
 
     define void @__struct__arr__ctor(ptr %0) {

--- a/src/codegen/tests/oop_tests.rs
+++ b/src/codegen/tests/oop_tests.rs
@@ -739,7 +739,38 @@ fn array_in_parent_generated() {
     entry:
       %self = alloca ptr, align [filtered]
       store ptr %0, ptr %self, align [filtered]
+      %__main_arr__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__main_arr__idx0, align [filtered]
+      store i32 0, ptr %__main_arr__idx0, align [filtered]
+      br label %while_body
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___main_arr__idx0 = load i32, ptr %__main_arr__idx0, align [filtered]
+      %tmpVar = icmp sgt i32 %load___main_arr__idx0, 10
+      %1 = zext i1 %tmpVar to i8
+      %2 = icmp ne i8 %1, 0
+      br i1 %2, label %condition_body, label %continue1
+
+    continue:                                         ; preds = %condition_body
       ret void
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered]
+      %load___main_arr__idx02 = load i32, ptr %__main_arr__idx0, align [filtered]
+      %tmpVar3 = mul i32 1, %load___main_arr__idx02
+      %tmpVar4 = add i32 %tmpVar3, 0
+      %tmpVar5 = getelementptr inbounds [11 x %child], ptr %deref, i32 0, i32 %tmpVar4
+      call void @child__ctor(ptr %tmpVar5)
+      %load___main_arr__idx06 = load i32, ptr %__main_arr__idx0, align [filtered]
+      %tmpVar7 = add i32 %load___main_arr__idx06, 1
+      store i32 %tmpVar7, ptr %__main_arr__idx0, align [filtered]
+      br label %while_body
     }
 
     define void @__vtable_grandparent__ctor(ptr %0) {

--- a/src/codegen/tests/oop_tests/debug_tests.rs
+++ b/src/codegen/tests/oop_tests/debug_tests.rs
@@ -884,7 +884,38 @@ fn array_in_parent_generated() {
     entry:
       %self = alloca ptr, align [filtered], !dbg !56
       store ptr %0, ptr %self, align [filtered], !dbg !56
+      %__main_arr__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__main_arr__idx0, align [filtered], !dbg !56
+      store i32 0, ptr %__main_arr__idx0, align [filtered], !dbg !56
+      br label %while_body, !dbg !56
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___main_arr__idx0 = load i32, ptr %__main_arr__idx0, align [filtered], !dbg !56
+      %tmpVar = icmp sgt i32 %load___main_arr__idx0, 10, !dbg !56
+      %1 = zext i1 %tmpVar to i8, !dbg !56
+      %2 = icmp ne i8 %1, 0, !dbg !56
+      br i1 %2, label %condition_body, label %continue1, !dbg !56
+
+    continue:                                         ; preds = %condition_body
       ret void, !dbg !56
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue, !dbg !56
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1, !dbg !56
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered], !dbg !56
+      %load___main_arr__idx02 = load i32, ptr %__main_arr__idx0, align [filtered], !dbg !56
+      %tmpVar3 = mul i32 1, %load___main_arr__idx02, !dbg !56
+      %tmpVar4 = add i32 %tmpVar3, 0, !dbg !56
+      %tmpVar5 = getelementptr inbounds [11 x %child], ptr %deref, i32 0, i32 %tmpVar4, !dbg !56
+      call void @child__ctor(ptr %tmpVar5), !dbg !56
+      %load___main_arr__idx06 = load i32, ptr %__main_arr__idx0, align [filtered], !dbg !56
+      %tmpVar7 = add i32 %load___main_arr__idx06, 1, !dbg !56
+      store i32 %tmpVar7, ptr %__main_arr__idx0, align [filtered], !dbg !56
+      br label %while_body, !dbg !56
     }
 
     define void @__vtable_grandparent__ctor(ptr %0) {
@@ -1795,21 +1826,114 @@ END_FUNCTION
     entry:
       %self = alloca ptr, align [filtered], !dbg !83
       store ptr %0, ptr %self, align [filtered], !dbg !83
+      %__main_array_of_parent__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__main_array_of_parent__idx0, align [filtered], !dbg !83
+      store i32 0, ptr %__main_array_of_parent__idx0, align [filtered], !dbg !83
+      br label %while_body, !dbg !83
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___main_array_of_parent__idx0 = load i32, ptr %__main_array_of_parent__idx0, align [filtered], !dbg !83
+      %tmpVar = icmp sgt i32 %load___main_array_of_parent__idx0, 2, !dbg !83
+      %1 = zext i1 %tmpVar to i8, !dbg !83
+      %2 = icmp ne i8 %1, 0, !dbg !83
+      br i1 %2, label %condition_body, label %continue1, !dbg !83
+
+    continue:                                         ; preds = %condition_body
       ret void, !dbg !83
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue, !dbg !83
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1, !dbg !83
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered], !dbg !83
+      %load___main_array_of_parent__idx02 = load i32, ptr %__main_array_of_parent__idx0, align [filtered], !dbg !83
+      %tmpVar3 = mul i32 1, %load___main_array_of_parent__idx02, !dbg !83
+      %tmpVar4 = add i32 %tmpVar3, 0, !dbg !83
+      %tmpVar5 = getelementptr inbounds [3 x %parent], ptr %deref, i32 0, i32 %tmpVar4, !dbg !83
+      call void @parent__ctor(ptr %tmpVar5), !dbg !83
+      %load___main_array_of_parent__idx06 = load i32, ptr %__main_array_of_parent__idx0, align [filtered], !dbg !83
+      %tmpVar7 = add i32 %load___main_array_of_parent__idx06, 1, !dbg !83
+      store i32 %tmpVar7, ptr %__main_array_of_parent__idx0, align [filtered], !dbg !83
+      br label %while_body, !dbg !83
     }
 
     define void @__main_array_of_child__ctor(ptr %0) {
     entry:
       %self = alloca ptr, align [filtered], !dbg !83
       store ptr %0, ptr %self, align [filtered], !dbg !83
+      %__main_array_of_child__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__main_array_of_child__idx0, align [filtered], !dbg !83
+      store i32 0, ptr %__main_array_of_child__idx0, align [filtered], !dbg !83
+      br label %while_body, !dbg !83
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___main_array_of_child__idx0 = load i32, ptr %__main_array_of_child__idx0, align [filtered], !dbg !83
+      %tmpVar = icmp sgt i32 %load___main_array_of_child__idx0, 2, !dbg !83
+      %1 = zext i1 %tmpVar to i8, !dbg !83
+      %2 = icmp ne i8 %1, 0, !dbg !83
+      br i1 %2, label %condition_body, label %continue1, !dbg !83
+
+    continue:                                         ; preds = %condition_body
       ret void, !dbg !83
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue, !dbg !83
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1, !dbg !83
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered], !dbg !83
+      %load___main_array_of_child__idx02 = load i32, ptr %__main_array_of_child__idx0, align [filtered], !dbg !83
+      %tmpVar3 = mul i32 1, %load___main_array_of_child__idx02, !dbg !83
+      %tmpVar4 = add i32 %tmpVar3, 0, !dbg !83
+      %tmpVar5 = getelementptr inbounds [3 x %child], ptr %deref, i32 0, i32 %tmpVar4, !dbg !83
+      call void @child__ctor(ptr %tmpVar5), !dbg !83
+      %load___main_array_of_child__idx06 = load i32, ptr %__main_array_of_child__idx0, align [filtered], !dbg !83
+      %tmpVar7 = add i32 %load___main_array_of_child__idx06, 1, !dbg !83
+      store i32 %tmpVar7, ptr %__main_array_of_child__idx0, align [filtered], !dbg !83
+      br label %while_body, !dbg !83
     }
 
     define void @__main_array_of_grandchild__ctor(ptr %0) {
     entry:
       %self = alloca ptr, align [filtered], !dbg !83
       store ptr %0, ptr %self, align [filtered], !dbg !83
+      %__main_array_of_grandchild__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__main_array_of_grandchild__idx0, align [filtered], !dbg !83
+      store i32 0, ptr %__main_array_of_grandchild__idx0, align [filtered], !dbg !83
+      br label %while_body, !dbg !83
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___main_array_of_grandchild__idx0 = load i32, ptr %__main_array_of_grandchild__idx0, align [filtered], !dbg !83
+      %tmpVar = icmp sgt i32 %load___main_array_of_grandchild__idx0, 2, !dbg !83
+      %1 = zext i1 %tmpVar to i8, !dbg !83
+      %2 = icmp ne i8 %1, 0, !dbg !83
+      br i1 %2, label %condition_body, label %continue1, !dbg !83
+
+    continue:                                         ; preds = %condition_body
       ret void, !dbg !83
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue, !dbg !83
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1, !dbg !83
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered], !dbg !83
+      %load___main_array_of_grandchild__idx02 = load i32, ptr %__main_array_of_grandchild__idx0, align [filtered], !dbg !83
+      %tmpVar3 = mul i32 1, %load___main_array_of_grandchild__idx02, !dbg !83
+      %tmpVar4 = add i32 %tmpVar3, 0, !dbg !83
+      %tmpVar5 = getelementptr inbounds [3 x %grandchild], ptr %deref, i32 0, i32 %tmpVar4, !dbg !83
+      call void @grandchild__ctor(ptr %tmpVar5), !dbg !83
+      %load___main_array_of_grandchild__idx06 = load i32, ptr %__main_array_of_grandchild__idx0, align [filtered], !dbg !83
+      %tmpVar7 = add i32 %load___main_array_of_grandchild__idx06, 1, !dbg !83
+      store i32 %tmpVar7, ptr %__main_array_of_grandchild__idx0, align [filtered], !dbg !83
+      br label %while_body, !dbg !83
     }
 
     define void @__vtable_parent__ctor(ptr %0) {

--- a/src/codegen/tests/oop_tests/super_tests.rs
+++ b/src/codegen/tests/oop_tests/super_tests.rs
@@ -3020,7 +3020,38 @@ fn super_with_structured_types() {
     entry:
       %self = alloca ptr, align [filtered]
       store ptr %0, ptr %self, align [filtered]
+      %__parent_arr_data__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__parent_arr_data__idx0, align [filtered]
+      store i32 0, ptr %__parent_arr_data__idx0, align [filtered]
+      br label %while_body
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___parent_arr_data__idx0 = load i32, ptr %__parent_arr_data__idx0, align [filtered]
+      %tmpVar = icmp sgt i32 %load___parent_arr_data__idx0, 1
+      %1 = zext i1 %tmpVar to i8
+      %2 = icmp ne i8 %1, 0
+      br i1 %2, label %condition_body, label %continue1
+
+    continue:                                         ; preds = %condition_body
       ret void
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered]
+      %load___parent_arr_data__idx02 = load i32, ptr %__parent_arr_data__idx0, align [filtered]
+      %tmpVar3 = mul i32 1, %load___parent_arr_data__idx02
+      %tmpVar4 = add i32 %tmpVar3, 0
+      %tmpVar5 = getelementptr inbounds [2 x %Complex_Type], ptr %deref, i32 0, i32 %tmpVar4
+      call void @Complex_Type__ctor(ptr %tmpVar5)
+      %load___parent_arr_data__idx06 = load i32, ptr %__parent_arr_data__idx0, align [filtered]
+      %tmpVar7 = add i32 %load___parent_arr_data__idx06, 1
+      store i32 %tmpVar7, ptr %__parent_arr_data__idx0, align [filtered]
+      br label %while_body
     }
 
     define void @__vtable_parent__ctor(ptr %0) {

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_array_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_array_added_to_debug_info.snap
@@ -37,7 +37,38 @@ define void @__global_c__ctor(ptr %0) {
 entry:
   %self = alloca ptr, align [filtered]
   store ptr %0, ptr %self, align [filtered]
+  %__global_c__idx0 = alloca i32, align [filtered]
+  store i32 0, ptr %__global_c__idx0, align [filtered]
+  store i32 0, ptr %__global_c__idx0, align [filtered]
+  br label %while_body
+
+while_body:                                       ; preds = %continue1, %entry
+  %load___global_c__idx0 = load i32, ptr %__global_c__idx0, align [filtered]
+  %tmpVar = icmp sgt i32 %load___global_c__idx0, 10
+  %1 = zext i1 %tmpVar to i8
+  %2 = icmp ne i8 %1, 0
+  br i1 %2, label %condition_body, label %continue1
+
+continue:                                         ; preds = %condition_body
   ret void
+
+condition_body:                                   ; preds = %while_body
+  br label %continue
+
+buffer_block:                                     ; No predecessors!
+  br label %continue1
+
+continue1:                                        ; preds = %buffer_block, %while_body
+  %deref = load ptr, ptr %self, align [filtered]
+  %load___global_c__idx02 = load i32, ptr %__global_c__idx0, align [filtered]
+  %tmpVar3 = mul i32 1, %load___global_c__idx02
+  %tmpVar4 = add i32 %tmpVar3, 0
+  %tmpVar5 = getelementptr inbounds [11 x [10 x i32]], ptr %deref, i32 0, i32 %tmpVar4
+  call void @__global_c___ctor(ptr %tmpVar5)
+  %load___global_c__idx06 = load i32, ptr %__global_c__idx0, align [filtered]
+  %tmpVar7 = add i32 %load___global_c__idx06, 1
+  store i32 %tmpVar7, ptr %__global_c__idx0, align [filtered]
+  br label %while_body
 }
 
 define void @__unit___internal___[ctor-hash]__ctor() {

--- a/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
+++ b/src/codegen/tests/snapshots/rusty__codegen__tests__debug_tests__global_var_struct_added_to_debug_info.snap
@@ -27,7 +27,38 @@ define void @__global_b__ctor(ptr %0) {
 entry:
   %self = alloca ptr, align [filtered]
   store ptr %0, ptr %self, align [filtered]
+  %__global_b__idx0 = alloca i32, align [filtered]
+  store i32 0, ptr %__global_b__idx0, align [filtered]
+  store i32 0, ptr %__global_b__idx0, align [filtered]
+  br label %while_body
+
+while_body:                                       ; preds = %continue1, %entry
+  %load___global_b__idx0 = load i32, ptr %__global_b__idx0, align [filtered]
+  %tmpVar = icmp sgt i32 %load___global_b__idx0, 10
+  %1 = zext i1 %tmpVar to i8
+  %2 = icmp ne i8 %1, 0
+  br i1 %2, label %condition_body, label %continue1
+
+continue:                                         ; preds = %condition_body
   ret void
+
+condition_body:                                   ; preds = %while_body
+  br label %continue
+
+buffer_block:                                     ; No predecessors!
+  br label %continue1
+
+continue1:                                        ; preds = %buffer_block, %while_body
+  %deref = load ptr, ptr %self, align [filtered]
+  %load___global_b__idx02 = load i32, ptr %__global_b__idx0, align [filtered]
+  %tmpVar3 = mul i32 1, %load___global_b__idx02
+  %tmpVar4 = add i32 %tmpVar3, 0
+  %tmpVar5 = getelementptr inbounds [11 x %myStruct], ptr %deref, i32 0, i32 %tmpVar4
+  call void @myStruct__ctor(ptr %tmpVar5)
+  %load___global_b__idx06 = load i32, ptr %__global_b__idx0, align [filtered]
+  %tmpVar7 = add i32 %load___global_b__idx06, 1
+  store i32 %tmpVar7, ptr %__global_b__idx0, align [filtered]
+  br label %while_body
 }
 
 define void @__myStruct_c__ctor(ptr %0) {

--- a/tests/lit/single/init/array_member_defaults.st
+++ b/tests/lit/single/init/array_member_defaults.st
@@ -1,0 +1,25 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Struct defaults must be applied to every element of arrays of structs,
+// including nested and multi-dimensional arrays.
+TYPE Point : STRUCT
+    x : DINT := 11;
+    y : DINT := 22;
+END_STRUCT END_TYPE
+
+PROGRAM prog
+VAR
+    plain  : ARRAY[0..3] OF Point;
+    nested : ARRAY[0..1] OF ARRAY[0..2] OF Point;
+    multi  : ARRAY[0..1, 0..2] OF Point;
+END_VAR
+    printf('%d$N', plain[0].x);      // CHECK: 11
+    printf('%d$N', plain[3].y);      // CHECK: 22
+    printf('%d$N', nested[1][2].x);  // CHECK: 11
+    printf('%d$N', nested[0][1].y);  // CHECK: 22
+    printf('%d$N', multi[1, 2].x);   // CHECK: 11
+    printf('%d$N', multi[0, 1].y);   // CHECK: 22
+END_PROGRAM
+
+FUNCTION main : DINT
+    prog();
+END_FUNCTION

--- a/tests/lit/single/init/fb_array_global_and_stack_init.st
+++ b/tests/lit/single/init/fb_array_global_and_stack_init.st
@@ -1,0 +1,31 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Arrays of function blocks declared as globals and as locals of stateless
+// POUs (stack-constructed on each call) must construct every element.
+VAR_GLOBAL
+    init_calls : DINT;
+    g_arr : ARRAY[0..2] OF MyFb;
+END_VAR
+
+FUNCTION_BLOCK MyFb
+VAR
+    x : INT := 5;
+END_VAR
+    METHOD FB_INIT
+        init_calls := init_calls + 1;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION check_locals : DINT
+VAR
+    l_arr : ARRAY[0..1] OF MyFb;
+END_VAR
+    check_locals := l_arr[1].x;
+END_FUNCTION
+
+FUNCTION main : DINT
+    printf('%d$N', g_arr[2].x);     // CHECK: 5
+    printf('%d$N', init_calls);     // CHECK: 3
+    printf('%d$N', check_locals()); // CHECK: 5
+    // stack locals are constructed on each call: 3 at startup + 2 per call
+    printf('%d$N', init_calls);     // CHECK: 5
+END_FUNCTION

--- a/tests/lit/single/init/fb_array_init.st
+++ b/tests/lit/single/init/fb_array_init.st
@@ -1,0 +1,34 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Every element of an array of function blocks must be fully constructed:
+// declared defaults applied and FB_INIT invoked once per element.
+VAR_GLOBAL
+    init_calls : DINT;
+END_VAR
+
+FUNCTION_BLOCK MyFb
+VAR
+    x : INT := 7;
+    marker : DINT;
+END_VAR
+    METHOD FB_INIT
+        init_calls := init_calls + 1;
+        marker := 42;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+PROGRAM prog
+VAR
+    arr : ARRAY[0..15] OF MyFb;
+    single : MyFb;
+END_VAR
+    // one FB_INIT call per array element plus one for `single`
+    printf('%d$N', init_calls);     // CHECK: 17
+    printf('%d$N', arr[0].x);       // CHECK: 7
+    printf('%d$N', arr[1].marker);  // CHECK: 42
+    printf('%d$N', arr[15].x);      // CHECK: 7
+    printf('%d$N', single.marker);  // CHECK: 42
+END_PROGRAM
+
+FUNCTION main : DINT
+    prog();
+END_FUNCTION

--- a/tests/lit/single/init/fb_array_vtable_dispatch.st
+++ b/tests/lit/single/init/fb_array_vtable_dispatch.st
@@ -1,0 +1,25 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Array elements must have their vtable pointer set up: virtual dispatch
+// through a dereferenced pointer reads the element's __vtable field and
+// crashes if construction skipped it.
+FUNCTION_BLOCK Counter
+VAR
+    base : DINT := 30;
+END_VAR
+    METHOD Value : DINT
+        Value := base + 12;
+    END_METHOD
+END_FUNCTION_BLOCK
+
+PROGRAM prog
+VAR
+    arr : ARRAY[0..3] OF Counter;
+    r : REF_TO Counter;
+END_VAR
+    r := ADR(arr[2]);
+    printf('%d$N', r^.Value()); // CHECK: 42
+END_PROGRAM
+
+FUNCTION main : DINT
+    prog();
+END_FUNCTION


### PR DESCRIPTION
> [!NOTE]
> This PR was written with the help of Claude (posted from @ghaith's account).

Fixes #1830.

`visit_data_type` in the initializer lowering only handled `StructType`; array
type ctors (e.g. `__prog_arr__ctor`) were registered but their bodies stayed
empty, so array elements never received vtable pointers, `FB_INIT` calls, or
field defaults — segfaults at first use for arrays of `{external}` FBs, and
silently wrong defaults everywhere else.

### Changes
- `initializer.rs`: new `ArrayType` arm + `create_element_ctor_loop` — emits one
  canonical `WHILE TRUE` loop per dimension (the `LoopDesugarer` has already run
  by the time constructors are generated, so the desugared form is emitted
  directly), calling the element type's ctor on `self[i, j, ...]`. Counter names
  are prefixed with the array type name because allocation scopes are resolved
  by name across implementations (same reason the `ForDesugarer` uses a global
  counter for its temporaries).
- `loops.rs`: `helper` module is now `pub(crate)` for reuse.
- Element filter mirrors the struct-field logic: any non-builtin, non-interface
  element type with a ctor is constructed; scalars/VLAs are skipped.

### Tests
- 4 new lit tests (`tests/lit/single/init/`): FB arrays (FB_INIT count + defaults),
  struct arrays incl. nested + multi-dim, global + stack-local arrays, virtual
  dispatch through `REF_TO` deref on an array element (segfaulted before).
- 7 new lowering unit tests asserting element construction in array ctors.
- 7 IR snapshots updated: additions only — counter/loop scaffolding and
  `call void @<Element>__ctor`; no lines removed.
- 2 array-lowering count asserts updated (+1 top-level assignment from the
  counter init).

### Notes
- Arrays whose element ctor is empty (e.g. nested scalar arrays) now call an
  empty function per element at startup; optimized away at `-O2`, negligible at
  `-Onone`. A "trivial ctor" elision would apply to struct fields too and is
  left as a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
