### PR TITLE
ci: strip leading whitespace from commit subjects before conventional parsing

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -33,6 +33,13 @@ filter_commits = false
 tag_pattern = "v[0-9].*"
 sort_commits = "newest"
 
+# Strip leading whitespace so a squashed PR title with a stray leading space
+# still parses as a conventional commit; unparsed subjects are dropped from
+# both the changelog and the version-bump calculation.
+commit_preprocessors = [
+  { pattern = '^[ \t]+', replace = "" },
+]
+
 commit_parsers = [
   { message = "^feat", group = "<!-- 0 -->Added" },
   { message = "^fix", group = "<!-- 1 -->Fixed" },


### PR DESCRIPTION
## Problem

The release automation proposed **v1.1.0** (#1783) even though a breaking change (#1801, `feat!:`) landed on master since v1.0.0.

The squash commit subject of #1801 is literally ` feat!: changed time to unsigned 32-bit preserving ltime as 64-bit (#1801)` — the PR title carried a leading space. A subject that doesn't start with the type fails conventional-commit parsing, and with `filter_unconventional = true` git-cliff drops the commit entirely: it neither counts toward the version bump nor appears in the generated `CHANGELOG.md`. `protect_breaking_commits` can't help because the commit is never recognized as breaking in the first place.

## Fix

Add a `commit_preprocessors` entry that strips leading whitespace from the message before parsing.

## Verification

On current master with this change, `git-cliff --bumped-version` reports `v2.0.0` (previously `v1.1.0`), and `git-cliff --unreleased` again lists "Changed time to unsigned 32-bit preserving ltime as 64-bit (#1801)". Isolated behavior confirmed in a scratch repo: `fix:` only → v1.0.1; adding `" feat!:"` (leading space) → still v1.0.1; same subject without the space → v2.0.0.

Once this lands, the next master push regenerates the release PR as **v2.0.0** with the breaking change restored in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)