### PR TITLE
chore: pin serial_test to 3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "4.0.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -3002,13 +3002,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "4.0.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ project = { path = "./compiler/plc_project/", package = "plc_project", version =
 plc_xml = { path = "./compiler/plc_xml", version = "1.0.4" }
 test_utils = { path = "./tests/test_utils" }
 plc_lowering = { path = "./compiler/plc_lowering", version = "1.0.4" }
-serial_test = "*"
+serial_test = "3.5"
 tempfile.workspace = true
 encoding_rs.workspace = true
 encoding_rs_io.workspace = true


### PR DESCRIPTION
The wildcard requirement let lock-file refreshes jump `serial_test` across major versions unreviewed (3.5.0 → 4.0.1 during the v1.0.4 release). Pin it to `3.5` and downgrade the lock entries back to 3.5.0.

`serial_test` is a dev-dependency used only by `#[serial]` tests, so this has no impact on shipped artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)