### PR TITLE
ci: pin the rust-llvm container image to 21-1.90 on the release lane

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   IMAGE_NAME: rust-llvm
-  IMAGE_VERSION: latest
+  IMAGE_VERSION: 21-1.90
 
 jobs:
   cargo-docs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    container: ghcr.io/plc-lang/rust-llvm:21-1.95
+    container: ghcr.io/plc-lang/rust-llvm:21-1.90
     steps:
       - uses: actions/checkout@v6
 
@@ -56,7 +56,7 @@ jobs:
             --entrypoint /bin/bash \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/plc-lang/rust-llvm:21-1.95 \
+            ghcr.io/plc-lang/rust-llvm:21-1.90 \
             -c "df -h && ./scripts/build.sh --build --test"
 
   test-linux-release:
@@ -90,7 +90,7 @@ jobs:
             --entrypoint /bin/bash \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/plc-lang/rust-llvm:21-1.95 \
+            ghcr.io/plc-lang/rust-llvm:21-1.90 \
             -c "df -h && ./scripts/build.sh --build --test --release"
 
   package-linux:
@@ -101,7 +101,7 @@ jobs:
         config:
           - { os: "ubuntu-latest", arch: "x86_64" }
           - { os: "ubuntu-24.04-arm", arch: "aarch64" }
-    container: ghcr.io/plc-lang/rust-llvm:21-1.95
+    container: ghcr.io/plc-lang/rust-llvm:21-1.90
     steps:
       - uses: actions/checkout@v6
 
@@ -307,7 +307,7 @@ jobs:
   style:
     name: Check Style
     runs-on: ubuntu-latest
-    container: ghcr.io/plc-lang/rust-llvm:21-1.95
+    container: ghcr.io/plc-lang/rust-llvm:21-1.90
     steps:
       - uses: actions/checkout@v6
 
@@ -341,7 +341,7 @@ jobs:
             --entrypoint /bin/bash \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/plc-lang/rust-llvm:21-1.95 \
+            ghcr.io/plc-lang/rust-llvm:21-1.90 \
             -c "df -h && apt-get clean && rm -rf /var/lib/apt/lists/* && ./scripts/build.sh --coverage"
 
       - name: Upload to codecov.io

--- a/.github/workflows/lit.yml
+++ b/.github/workflows/lit.yml
@@ -19,7 +19,7 @@ jobs:
         config:
           - { os: "ubuntu-latest" }
           - { os: "ubuntu-24.04-arm" }
-    container: ghcr.io/plc-lang/rust-llvm:21-1.95
+    container: ghcr.io/plc-lang/rust-llvm:21-1.90
     steps:
       - uses: actions/checkout@v6
 
@@ -36,7 +36,7 @@ jobs:
         config:
           - { os: "ubuntu-latest" }
           - { os: "ubuntu-24.04-arm" }
-    container: ghcr.io/plc-lang/rust-llvm:21-1.95
+    container: ghcr.io/plc-lang/rust-llvm:21-1.90
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -13,13 +13,13 @@ on:
 
 env:
   IMAGE_NAME: rust-llvm
-  IMAGE_VERSION: latest
+  IMAGE_VERSION: 21-1.90
 
 jobs:
   metrics:
     name: Metrics
     runs-on: ubuntu-latest
-    container: ghcr.io/plc-lang/rust-llvm:21-1.95
+    container: ghcr.io/plc-lang/rust-llvm:21-1.90
 
     steps:
     - name: Install git


### PR DESCRIPTION
Pins all container jobs (`linux`, `lit`, `metrics`, `doc`) on the release lane to the immutable `rust-llvm:21-1.90` image instead of `:latest` / `21-1.95`:

- Rust 1.90 is the toolchain the 1.0.x line is actually built and tested against, so CI now validates against that target (including MSRV of any dependency updates).
- `doc.yml` and `metrics.yml` no longer float on `:latest`, which broke today when a rebuilt image republished the tag (PLC-lang/rust-llvm-images#41).
- Image updates on this lane are now explicit, reviewable diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)