### PR TITLE
chore: standardize error code

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E001.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E001.md
@@ -1,4 +1,16 @@
 # General Error
 
-This error is a catch all error. It is usually thrown when no other error better matches the case.
+A catch-all, reported when no specific error code matches the problem. It is also the default
+code for diagnostics created without an explicit one, so the message text varies.
 
+Erroneous code example:
+
+```iecst
+FUNCTION foo : DINT
+    PROPERTY_GET prop : DINT // error: Properties cannot be declared in a Function
+        prop := 5;
+    END_PROPERTY
+END_FUNCTION
+```
+
+There is no single solution; refer to the message text of the reported diagnostic.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E002.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E002.md
@@ -1,4 +1,14 @@
 # General IO Error
 
-This error describes a problem during an IO operation such as reading or writing a file.
-It is usually accompanied by an internal error with further details.
+A problem during an IO operation such as reading or writing a file. It is caused by the
+environment, not the source code, e.g. a missing file or insufficient permissions.
+
+Erroneous invocation:
+
+```sh
+plc missing.st
+# error[E002]: Cannot read file 'missing.st': No such file or directory
+```
+
+The message contains the underlying operating system error; check that the path exists and is
+accessible.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E003.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E003.md
@@ -1,3 +1,5 @@
 # Parameter Error
 
-This error describes a problem with the command parameters, such as a file required for the compilation not being found.:
+A problem with the parameters passed to the compiler, such as an invalid combination of
+command line options. Most parameter problems are caught by the command line interface itself
+and reported as plain usage errors instead.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E004.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E004.md
@@ -1,3 +1,17 @@
 # Duplicate Symbol
 
-The marked symbol has been defined multiple times.
+A name was defined more than once within the same namespace, making references to it
+ambiguous. This covers POUs, data types, global variables, enum variants, names clashing with
+a built-in datatype, and properties with more than one `PROPERTY_GET` or `PROPERTY_SET` block.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : INT
+END_FUNCTION
+
+PROGRAM foo // error: foo: Duplicate symbol.
+END_PROGRAM
+```
+
+Rename one of the conflicting definitions.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E005.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E005.md
@@ -1,5 +1,5 @@
 # Generic LLVM Error
 
-An unexpected error occurred during the LLVM generation phase.
-This is usually a follow up problem from a different diagnostics.
-If it occurrs without a previous diagnostics please file a bug report.
+An unexpected error inside LLVM during code generation, usually a follow-up problem of an
+earlier diagnostic rather than caused by the source code itself. If it occurs without any previous
+diagnostic, file a bug report at <https://github.com/PLC-lang/rusty/issues>.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E006.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E006.md
@@ -1,19 +1,16 @@
 # Missing Token
 
-During the parsing phase, an additional _Token_ (Element) was required to correctly interpret the code.
-The error message usually indicates what Token was missing.
+The parser required a specific token (element) at this position but it was absent from the
+source. The message names the missing token, e.g. a keyword, an identifier or a hardware
+access address.
 
-## Example
-In the following example the name (Identifier) of the program is missing.
+Erroneous code example:
+
 ```iecst
-PROGRAM (*name*)
-END_PROGRAM
+VAR_CONFIG
+    instance1; // error: Missing expected Token AT
+END_VAR
 ```
 
-```
-error: Unexpected token: expected Identifier but found END_PROGRAM
-  ┌─ example.st:2:1
-  │
-2 │ END_PROGRAM
-  │ ^^^^^^^^^^^ Unexpected token: expected Identifier but found END_PROGRAM
-```
+Insert the missing token named in the message, here a complete entry such as
+`instance1.x AT %IX3.1 : BOOL;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E007.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E007.md
@@ -1,3 +1,32 @@
 # Unexpected Token
 
-During parsing, a _Token_ (Element) was encountered in the wrong location. This could be an indication of a missused or misspelled keyword
+A token (element) appeared where the parser expected something else, often caused by a
+misspelled or misplaced keyword, a stray character or a missing operand. The message states
+what was expected and what was found.
+
+Erroneous code example:
+
+```iecst
+PROGRAM p
+    x := &; // error: Unexpected token: expected expression but found &
+END_PROGRAM
+```
+
+## Property called like a function
+
+The same code is reported by validation when a property is accessed with call parentheses.
+
+```iecst
+FUNCTION_BLOCK fb
+    PROPERTY_GET foo : DINT END_PROPERTY
+END_FUNCTION_BLOCK
+
+FUNCTION main
+    VAR
+        fb_instance : fb;
+    END_VAR
+    fb_instance.foo(); // error: Properties cannot be called like functions. Remove `()`
+END_FUNCTION
+```
+
+Properties are accessed like variables; remove the `()`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E008.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E008.md
@@ -1,70 +1,32 @@
-# E008: Invalid Range
+# Invalid Range
 
-This error is emitted when an array range declaration is malformed. There are two
-cases that trigger it.
+An array dimension is not a valid range. Every dimension must be written as `start..end`
+(or `*` for variable-length arrays), and both bounds must be of an integer type.
 
-## 1. Missing or malformed range
+## Dimension is not a range
 
-An array dimension must be written as `start .. end`. A bare literal or any
-other expression in a dimension slot is rejected, including in multi-dimensional
-arrays where any single dimension is not a range.
+Erroneous code example:
 
-Invalid:
-
-```st
-VAR
-    arr1 : ARRAY[5] OF DINT;           // bare literal, no range
-    arr2 : ARRAY[0..5, 5] OF DINT;     // second dimension is not a range
-END_VAR
+```iecst
+PROGRAM p
+    VAR
+        arr : ARRAY[5] OF DINT; // error: Expected a range statement, got LiteralInteger { value: 5 } instead
+    END_VAR
+END_PROGRAM
 ```
 
-## How to fix
+Write the dimension as a range, e.g. `ARRAY[0..5] OF DINT`.
 
-Use `start .. end` for every dimension:
+## Non-integer bounds
 
-```st
-VAR
-    arr1 : ARRAY[0..5] OF DINT;
-    arr2 : ARRAY[0..5, 0..5] OF DINT;
-END_VAR
+Erroneous code example:
+
+```iecst
+PROGRAM p
+    VAR
+        arr : ARRAY[1.5 .. 3.5] OF INT; // error: Invalid type 'REAL' for array bounds. Only integer types are allowed
+    END_VAR
+END_PROGRAM
 ```
 
-## 2. Non-integer range bounds
-
-Array range bounds must be of an integer type. `BOOL`, `REAL` / `LREAL`,
-`STRING` / `WSTRING`, time/date types, and other non-integer types are
-rejected. This matches the IEC 61131-3 requirement that array dimensions are
-integer-indexable.
-
-Invalid:
-
-```st
-VAR
-    a : ARRAY[FALSE .. TRUE] OF BOOL;       // BOOL bounds
-    b : ARRAY[1.5 .. 3.5] OF INT;           // REAL bounds
-    c : ARRAY['a' .. 'z'] OF INT;           // STRING bounds
-    d : ARRAY[T#0s .. T#1s] OF INT;         // TIME bounds
-END_VAR
-```
-
-## How to fix
-
-Use integer literals, integer constants, or integer-typed expressions:
-
-```st
-VAR_GLOBAL CONSTANT
-    LO : DINT := 0;
-    HI : DINT := 10;
-END_VAR
-
-VAR
-    a : ARRAY[0..1] OF BOOL;
-    b : ARRAY[LO..HI] OF INT;
-END_VAR
-```
-
-## Valid integer types
-
-The valid integer types for array bounds are the same as for enum base types
-(see [`E122`](./E122.md)): `SINT`, `USINT`, `INT`, `UINT`, `DINT`, `UDINT`,
-`LINT`, `ULINT`, `BYTE`, `WORD`, `DWORD`, `LWORD`.
+Use integer literals or integer constants for both bounds.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E009.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E009.md
@@ -1,1 +1,12 @@
-# Mismatched Parantheses
+# Mismatched Parentheses
+
+The size expression of a `STRING` or `WSTRING` type was opened with one kind of parenthesis
+and closed with the other, e.g. opened with `[` but closed with `)`.
+
+Erroneous code example:
+
+```iecst
+TYPE MyString : STRING[254); END_TYPE // error: Mismatched types of parentheses around string size expression
+```
+
+Use the same kind on both sides, preferably square parentheses: `STRING[254]`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E010.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E010.md
@@ -1,1 +1,20 @@
-# Invalid time literal
+# Invalid Time Literal
+
+A `TIME` literal such as `T#1d2h3m` is malformed. Each segment is a number followed by one of
+the units `d`, `h`, `m`, `s`, `ms`, `us`, `ns`; segments must appear in descending unit order
+and each unit may occur only once. A missing or unknown unit is reported as well.
+
+Erroneous code example:
+
+```iecst
+PROGRAM p
+    VAR
+        t : TIME;
+    END_VAR
+    t := T#1d4d; // error: Invalid TIME Literal: segments must be unique
+    t := T#1s2h; // error: Invalid TIME Literal: segments out of order, use d-h-m-s-ms
+END_PROGRAM
+```
+
+Order the segments from largest to smallest unit and use each unit at most once, e.g.
+`T#2h1s`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E011.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E011.md
@@ -1,1 +1,16 @@
 # Invalid Number
+
+A numeric literal could not be parsed into a value of the required type, e.g. the repetition
+count in a multiplied initializer must fit into a 32-bit unsigned integer.
+
+Erroneous code example:
+
+```iecst
+PROGRAM p
+    VAR
+        arr : ARRAY[0..10] OF INT := [4294967296(0)]; // error: Failed to parse number 4294967296
+    END_VAR
+END_PROGRAM
+```
+
+Use a number within the valid range for the given context.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E012.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E012.md
@@ -1,1 +1,20 @@
-# Missing Case Contition
+# Missing Case Condition
+
+A statement inside a `CASE` block appears before any case condition, so the parser cannot
+associate it with a branch. Every statement in a `CASE` body must follow a condition label
+such as `1:` or `2..5:`.
+
+Erroneous code example:
+
+```iecst
+PROGRAM p
+    VAR
+        x : INT;
+    END_VAR
+    CASE x OF
+        x := 1; // error: Missing Case-Condition
+    END_CASE
+END_PROGRAM
+```
+
+Add a condition label before the statement, e.g. `1: x := 1;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E013.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E013.md
@@ -1,1 +1,13 @@
-# Keywords should contain Underscores
+# Keywords Should Contain Underscores
+
+A multi-word keyword such as `END_PROGRAM`, `END_IF` or `VAR_INPUT` was written without the
+underscore. The lexer accepts both spellings but warns about the variant without `_`.
+
+Erroneous code example:
+
+```iecst
+PROGRAM p
+ENDPROGRAM // warning: the words in ENDPROGRAM should be separated by a `_`
+```
+
+Write the keyword with an underscore, e.g. `END_PROGRAM`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E014.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E014.md
@@ -1,1 +1,12 @@
-# Wrong paranthese for String delimiter
+# Wrong Parentheses Around String Size
+
+The size expression of a `STRING` or `WSTRING` type was written with round parentheses.
+While accepted, square parentheses are the preferred notation.
+
+Erroneous code example:
+
+```iecst
+TYPE MyString : STRING(255); END_TYPE // warning: Unusual type of parentheses around string size expression, consider using square parentheses '[]'
+```
+
+Write the size as `STRING[255]`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E015.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E015.md
@@ -1,19 +1,20 @@
-# POINTER TO is type-unsafe
+# POINTER TO Is Type-Unsafe
 
-Variables defined as a `POINTER TO` data-type are considered type-unsafe in the sense that
-assigning between incompatible types will not be caught. For example the following
-code, while incorrect, will not return any diagnostics when compiling:
+A variable was declared as `POINTER TO`, which is type-unsafe: assignments between pointers
+to incompatible types are not caught. The message reads "`POINTER TO` is type-unsafe,
+consider using `REF_TO` instead".
+
+```iecst
+PROGRAM p
+    VAR
+        stringVar  : STRING;
+        unsafePtrA : POINTER TO DINT := ADR(stringVar); // no diagnostic despite the type mismatch
+        unsafePtrB : POINTER TO DINT := REF(stringVar); // no diagnostic despite the type mismatch
+    END_VAR
+END_PROGRAM
 ```
-VAR
-    stringVar : STRING;
-    unsafePtrA : POINTER TO DINT := ADR(stringVar);
-    unsafePtrB : POINTER TO DINT := REF(stringVar);
-END_VAR
-```
 
-Note that for class and function block hierarchies, `POINTER TO` assignments **are** validated —
-the compiler checks that the pointee types are related via `EXTENDS` (see [E125](E125.md)).
-`POINTER TO` is the recommended mechanism for polymorphism per IEC 61131-3.
-
-For other types, consider using `REF_TO` instead of `POINTER TO`, which is a type-safe
-alternative and _should_ catch type-mismatches early on.
+For class and function block hierarchies, `POINTER TO` assignments are validated: the compiler
+checks that the pointee types are related via `EXTENDS`, and `POINTER TO`
+is the recommended mechanism for polymorphism per IEC 61131-3. For other types, prefer the
+type-safe `REF_TO`, which catches such mismatches early.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E016.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E016.md
@@ -1,1 +1,13 @@
- # Return types cannot have a default value
+# Return Types Cannot Have a Default Value
+
+The return type of a function was declared with an initializer. Return values cannot be
+given a default, so the value is ignored.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : INT := 3 // warning: Return types cannot have a default value, the value will be ignored
+END_FUNCTION
+```
+
+Remove the initializer and assign the return value in the body instead, e.g. `foo := 3;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E017.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E017.md
@@ -1,1 +1,17 @@
-# Classes cannot contain implementation
+# Classes Cannot Contain Implementations
+
+A `CLASS` body contains executable statements. Unlike function blocks, classes only declare
+variables, methods and properties; code must live inside a `METHOD`.
+
+Erroneous code example:
+
+```iecst
+CLASS MyClass
+    VAR
+        light : BOOL;
+    END_VAR
+    light := TRUE; // error: A class cannot have an implementation
+END_CLASS
+```
+
+Move the statements into a method of the class.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E018.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E018.md
@@ -1,1 +1,17 @@
 # Duplicate Label
+
+A jump label was defined more than once within the same POU body, making jumps to it
+ambiguous. The message is `<name>: Duplicate label.` and points at all conflicting
+definitions. Labels are created by label elements in graphical (CFC) source files; textual
+Structured Text has no label syntax, so this error cannot be produced from an `.st` file.
+
+Erroneous network example:
+
+```text
+myCondition --> JMP loop (0)
+
+LABEL loop (1)
+LABEL loop (2)   // error: loop: Duplicate label.
+```
+
+Rename or remove one of the conflicting labels in the CFC POU.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E019.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E019.md
@@ -1,1 +1,17 @@
-# Classes cannot contain IN_OUT variables
+# Class With Input, Output, or In-Out Variables
+
+A `CLASS` declared a `VAR_INPUT`, `VAR_IN_OUT`, or `VAR_OUTPUT` block. Classes have no callable
+body that could receive or return parameters, so these block types are only allowed in methods,
+not in the class itself.
+
+Erroneous code example:
+
+```iecst
+CLASS cls // error: A class cannot contain `VAR_INPUT`, `VAR_IN_OUT`, or `VAR_OUTPUT` blocks
+    VAR_INPUT
+        x : INT;
+    END_VAR
+END_CLASS
+```
+
+Use a plain `VAR` block for class state, or move the parameters into a `METHOD` of the class.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E020.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E020.md
@@ -1,1 +1,3 @@
-# Classes cannot contain a return type
+# Class With Return Type
+
+A `CLASS` was declared with a return type. This code is currently not emitted by the compiler.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E021.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E021.md
@@ -1,19 +1,38 @@
-# Variable re-declatation in Subclasses is not allowed
+# Re-Declaration of Variable
 
-A variable already declared in a parent class cannot be re-declared in a subclass.
+A name in a derived POU clashes with a name inherited from a parent POU. This fires when a
+variable declared in a parent is re-declared in a child (temporary variables are exempt), or
+when a property and a variable with the same name meet across the inheritance chain.
 
-Example:
+## Variable shadows a parent variable
 
 ```iecst
-FUNCTION_BLOCK FB
-VAR
-    a : INT;
-END_VAR
+FUNCTION_BLOCK fb
+    VAR
+        var1 : BOOL;
+    END_VAR
 END_FUNCTION_BLOCK
 
-FUNCTION_BLOCK FB2 EXTENDS FB
-VAR
-    a : INT; // Error: Variable 'a' is already declared in the parent class
-END_VAR
+FUNCTION_BLOCK fb2 EXTENDS fb
+    VAR
+        var1 : BOOL; // error: Variable `var1` is already declared in parent POU `fb`
+    END_VAR
 END_FUNCTION_BLOCK
 ```
+
+## Property conflicts with an inherited variable
+
+```iecst
+FUNCTION_BLOCK fb1
+    VAR
+        foo : DINT;
+    END_VAR
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK fb2 EXTENDS fb1
+    // error: Name conflict between property and variable `foo` defined in POU `fb1` and `fb2`
+    PROPERTY_GET foo : DINT END_PROPERTY
+END_FUNCTION_BLOCK
+```
+
+Rename the member in the child POU, or reuse the inherited one instead of re-declaring it.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E022.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E022.md
@@ -1,1 +1,17 @@
-# Missing container name for action
+# Missing Action Container Name
+
+An `ACTIONS` block was declared without naming the program or function block its actions belong
+to, and no POU precedes it in the file. An unnamed `ACTIONS` block normally attaches to the
+last POU declared before it; without one there is no container to associate the actions with.
+
+Erroneous code example:
+
+```iecst
+ACTIONS // warning: Missing Actions Container Name
+    ACTION myAction
+    END_ACTION
+END_ACTIONS
+```
+
+Write the container name after the keyword, e.g. `ACTIONS prg`, or declare the containing POU
+before the `ACTIONS` block.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E023.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E023.md
@@ -1,1 +1,17 @@
-# Statement has no effect
+# Statement With No Effect
+
+A standalone `=` comparison is used as a statement. Its boolean result is discarded, so the
+line does nothing; this is almost always a typo for the assignment operator `:=`.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        w1, w2 : WORD;
+    END_VAR
+    w1 = w2; // warning: This equal statement has no effect, did you mean `w1 := w2`?
+END_PROGRAM
+```
+
+Use `:=` to assign, or use the comparison result in a condition or expression.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E024.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E024.md
@@ -1,1 +1,16 @@
 # Invalid Pragma Location
+
+The `{ref}` property, which passes parameters by reference, was placed on a variable block
+other than `VAR_INPUT`. The property is ignored for other block types.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : INT
+    VAR_OUTPUT {ref} // warning: Invalid pragma location: Only VAR_INPUT support by ref properties
+        x : INT;
+    END_VAR
+END_FUNCTION
+```
+
+Move `{ref}` to a `VAR_INPUT` block, or use `VAR_IN_OUT` which already passes by reference.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E025.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E025.md
@@ -1,1 +1,4 @@
-# Missing return type
+# Missing Return Type
+
+A construct that requires a return type was declared without one. This code is currently not
+emitted by the compiler; functions without a return type are accepted as void functions.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E026.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E026.md
@@ -1,1 +1,13 @@
-# Unexpected return type
+# Unexpected Return Type
+
+A POU that is not a `FUNCTION` or `METHOD` was declared with a return type. Programs, function
+blocks, classes, and actions do not return a value, so a `: <type>` after the name is invalid.
+
+Erroneous code example:
+
+```iecst
+PROGRAM prg : INT // error: POU Type Program does not support a return type
+END_PROGRAM
+```
+
+Remove the return type, or declare the POU as a `FUNCTION` if it should return a value.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E027.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E027.md
@@ -1,1 +1,20 @@
-# Unsupported return type
+# Unsupported Return Type
+
+A function return type was declared as an inline enum or struct definition. Return types must
+refer to a named type; anonymous type definitions are not supported in this position.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : (green, yellow, red) // error: Data Type (green, yellow, red) not supported as a function return type!
+END_FUNCTION
+```
+
+Declare the type in a `TYPE` block and use its name as the return type:
+
+```iecst
+TYPE Color : (green, yellow, red); END_TYPE
+
+FUNCTION foo : Color
+END_FUNCTION
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E028.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E028.md
@@ -1,1 +1,15 @@
-# Empty variable block
+# Empty Variable Block
+
+A `STRUCT` was declared with no members, or an enum with no elements. Such types have no
+representable values and are rejected.
+
+Erroneous code example:
+
+```iecst
+TYPE the_struct:  // error: Variable block is empty
+    STRUCT 
+    END_STRUCT
+END_TYPE
+```
+
+Add at least one member to the struct or one element to the enum, or remove the declaration.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E029.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E029.md
@@ -1,76 +1,24 @@
-# E029: Recursive data structure
+# Recursive Data Structure
 
-This error occurs when data structures contain themselves directly or indirectly, creating infinite recursion during type resolution.
+A data type contains itself, directly or through a chain of other types, so its size would be
+infinite. This applies to structs whose members embed the struct itself, arrays whose element
+type leads back to the array type, and function blocks that extend themselves through
+inheritance. The message spells out the detected cycle, e.g. `A -> B -> A`.
 
-## Example
+Erroneous code example:
 
-```st
+```iecst
 TYPE MyStruct : STRUCT
-    value : INT;
-    nested : MyStruct;  (* This creates infinite recursion *)
-END_STRUCT; END_TYPE
+    value  : INT;
+    nested : MyStruct; // error: Recursive data structure `MyStruct -> MyStruct` has infinite size
+END_STRUCT END_TYPE
 ```
 
-In this example, `MyStruct` contains a field of type `MyStruct`, which would require infinite memory to represent.
+Break the cycle with a pointer, which has a fixed size:
 
-## Another example - indirect recursion
-
-```st
-TYPE StructA : STRUCT
-    data : INT;
-    ref_b : StructB;
-END_STRUCT; END_TYPE
-
-TYPE StructB : STRUCT
-    info : STRING;
-    ref_a : StructA;  (* Creates a cycle: StructA -> StructB -> StructA *)
-END_STRUCT; END_TYPE
-```
-
-This shows two structures that reference each other, creating a circular dependency.
-
-## Valid self-referential structures with pointers
-
-Self-referential data structures are allowed when using references or pointers, as these have fixed size:
-
-```st
-(* Tree node structure *)
-TYPE TreeNode : STRUCT
-    value : INT;
-    left : REF_TO TreeNode;   (* Pointer to left child *)
-    right : REF_TO TreeNode;  (* Pointer to right child *)
-END_STRUCT; END_TYPE
-
-(* Linked list node *)
-TYPE ListNode : STRUCT
-    data : STRING;
-    next : REF_TO ListNode;   (* Pointer to next node *)
-END_STRUCT; END_TYPE
-```
-
-## How to fix
-
-**Use references or pointers for self-referential structures**
-
-Break the infinite recursion by using `REF_TO` for recursive references:
-
-```st
-TYPE Node : STRUCT
-    value : INT;
-    child : REF_TO Node;  (* Use REF_TO instead of direct inclusion *)
-END_STRUCT; END_TYPE
-```
-
-**Restructure circular dependencies**
-
-For mutually recursive structures, consider using references or redesigning the data structure:
-
-```st
-TYPE PersonID : DINT; END_TYPE
-
-TYPE Person : STRUCT
-    name : STRING;
-    manager_id : PersonID;    (* Reference by ID instead of direct inclusion *)
-    reports : ARRAY[0..9] OF PersonID;
-END_STRUCT; END_TYPE
+```iecst
+TYPE MyStruct : STRUCT
+    value  : INT;
+    nested : REF_TO MyStruct;
+END_STRUCT END_TYPE
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E030.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E030.md
@@ -1,1 +1,24 @@
-# Missing IN_OUT parameters
+# Missing IN_OUT Argument
+
+A call to a stateful POU (`PROGRAM`, `FUNCTION_BLOCK`) or a method omits an argument for a
+declared `VAR_IN_OUT` parameter. While input and output arguments are optional for stateful
+POUs, IN_OUT parameters are references and must be bound on every call.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    VAR_IN_OUT
+        value : BOOL;
+    END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM main
+    VAR
+        instance : fb;
+    END_VAR
+    instance(); // error: Argument `value` is missing
+END_PROGRAM
+```
+
+Pass a variable for every IN_OUT parameter, e.g. `instance(value := someVariable)`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E031.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E031.md
@@ -1,1 +1,41 @@
-# Invalid parameter type
+# Incompatible Types
+
+Two operands with incompatible types are combined in one expression, or a call passes a
+non-assignable value (e.g. a literal) where the parameter requires a reference.
+
+## Incompatible types in an expression
+
+Erroneous code example:
+
+```iecst
+FUNCTION main
+    VAR
+        var_int    : INT;
+        var_string : STRING;
+    END_VAR
+    var_int + var_string; // error: Invalid expression, types INT and STRING are incompatible in the given context
+END_FUNCTION
+```
+
+## Missing reference for an output parameter
+
+`VAR_OUTPUT` and `VAR_IN_OUT` parameters write back to the caller, so the argument must be an
+assignable variable. Output arguments may alternatively be left empty, e.g. `foo(out1 => )`.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo
+    VAR_OUTPUT
+        out1 : INT;
+    END_VAR
+END_FUNCTION
+
+FUNCTION main
+    VAR
+        x : INT;
+    END_VAR
+    foo(1); // error: Expected a reference for parameter out1 because their type is Output
+    foo(x); // correct
+END_FUNCTION
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E032.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E032.md
@@ -1,18 +1,19 @@
-# Invalid number of arguments
+# Invalid Number of Arguments
 
-An invalid number of arguments was passed to a POU. For example
+The number of arguments in a call does not match the POU's parameter list. For `FUNCTION`s the
+count must match exactly, or may exceed it when the function is variadic. For stateful POUs
+input and output arguments may be omitted, but never exceeded.
+
+Erroneous code example:
 
 ```iecst
-FUNCTION foo
-    (* ... *)
+FUNCTION foo : INT
+    VAR_INPUT
+        a : INT;
+    END_VAR
 END_FUNCTION
 
 FUNCTION main : DINT
-    foo('bar'); // Error, foo isn't expecting any arguments
+    foo(1, 2); // error: this POU takes 1 argument but 2 arguments were supplied
 END_FUNCTION
 ```
-
-Note that for `FUNCTION`s the argument count must match with the parameter list and can be bigger if a variadic
-parameter is present. For stateful POUs variadic parameters are not supported, thus the argument count must be equal 
-or less than the parameter list depending on whether optional arguments such as `VAR_INPUT` or `VAR_OUTPUT` were 
-passed or not.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E033.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E033.md
@@ -1,31 +1,34 @@
-# Unresolved constant
+# Unresolved Constant
 
-A `CONSTANT` declaration could not be resolved to a compile-time value.
+A `CONSTANT` variable could not be resolved to a compile-time value, because its initializer
+references non-constant symbols or calls, or because it has no initializer and no default value
+can be derived from its type.
 
-This error is reported when the compiler cannot determine a valid constant initializer, for example when:
+## Non-constant initializer
 
-- the initializer references non-constant values,
-- the initializer contains non-constant operations/calls,
-- a referenced constant is itself unresolved,
-- a `CONSTANT` has no explicit initializer and no usable default can be derived from its type.
+Erroneous code example:
 
-## Example
-
-```st
-TYPE MyInt : INT; END_TYPE
+```iecst
+FUNCTION F : INT
+    F := 1;
+END_FUNCTION
 
 VAR_GLOBAL CONSTANT
-    // No explicit initializer, and no type default available
-    a : MyInt;
-
-    // Not a constant expression
-    b : INT := someVar + 1;
+    value : INT := F(); // error: Unresolved constant `value` variable: Call-statement 'F' in initializer is not constant.
 END_VAR
 ```
 
-## Possible fixes
+## Missing initializer without type default
 
-- Provide an explicit compile-time initializer, e.g. `a : MyInt := 0;`.
-- Ensure all referenced symbols in the initializer are themselves constants.
-- Replace non-constant calls/operations with compile-time expressions.
-- If relying on implicit defaults, define a default on the declared type.
+Erroneous code example:
+
+```iecst
+TYPE SintArray : ARRAY[1..3] OF SINT; END_TYPE
+
+VAR_GLOBAL CONSTANT
+    gArray : SintArray; // error: Unresolved constant `gArray` variable: no explicit initializer and no default value could be resolved
+END_VAR
+```
+
+Initialize the constant with a compile-time expression that only references other constants, or
+declare a default value on the type.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E034.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E034.md
@@ -1,1 +1,17 @@
-# Invalid constant block
+# Invalid CONSTANT Block
+
+The `CONSTANT` modifier is only supported on `VAR`, `VAR_GLOBAL` and `VAR_EXTERNAL` blocks.
+Interface variable blocks such as `VAR_INPUT`, `VAR_OUTPUT`, `VAR_IN_OUT` and `VAR_TEMP` cannot
+be declared constant.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    VAR_INPUT CONSTANT // error: This variable block does not support the CONSTANT modifier
+        x : INT := 1;
+    END_VAR
+END_FUNCTION_BLOCK
+```
+
+Remove the `CONSTANT` modifier or move the variable into a supported block.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E035.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E035.md
@@ -1,1 +1,19 @@
-# Invalid Constant
+# Constant Function Block Instance
+
+A `FUNCTION_BLOCK` or `CLASS` instance was declared in a `CONSTANT` variable block. Instances
+carry mutable state that is written on every call, so they cannot be constant.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+END_FUNCTION_BLOCK
+
+PROGRAM main
+    VAR CONSTANT
+        instance : fb; // error: Invalid constant instance, FUNCTION_BLOCK- and CLASS-instances cannot be declared constant
+    END_VAR
+END_PROGRAM
+```
+
+Declare the instance in a regular `VAR` block.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E036.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E036.md
@@ -1,1 +1,17 @@
-# Cannot assign to constant
+# Assignment to CONSTANT
+
+A variable declared in a `CONSTANT` block is the target of an assignment. Constants are
+read-only after their initialization.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR CONSTANT
+        ci : INT := 1;
+    END_VAR
+    ci := 4; // error: Cannot assign to CONSTANT 'main.ci'
+END_PROGRAM
+```
+
+Remove the assignment or declare the variable in a non-constant block.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E037.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E037.md
@@ -1,63 +1,66 @@
-# E037: Invalid assignment
+# Invalid Assignment
 
-This error is reported for assignments or accesses that are not allowed, for example when the
-types of the left- and right-hand side are incompatible, when a `VOID` function result is
-assigned to a variable, or when a variable is written or read from a place where it must not be
-accessed.
+An assignment or access that is not allowed, for example assigning between incompatible types,
+assigning the result of a `VOID` call, assigning an `ADR(...)` result to a `REFERENCE TO`
+variable instead of using `REF=`, or accessing a variable outside of its permitted scope.
 
-## Example - incompatible types
+## Incompatible types
 
-```st
+Erroneous code example:
+
+```iecst
 FUNCTION main
-VAR
-    x : INT;
-    s : STRING;
-END_VAR
-    x := s; (* cannot assign 'STRING' to 'INT' *)
+    VAR
+        x : INT;
+        s : STRING;
+    END_VAR
+    x := s; // error: Invalid assignment: cannot assign 'STRING' to 'INT'
 END_FUNCTION
 ```
 
-## Example - VAR_OUTPUT assigned outside of its scope
+## VAR_OUTPUT assigned outside of its scope
 
-`VAR_OUTPUT` variables of a function block may only be written by the function block itself.
-From the outside they can only be read.
+`VAR_OUTPUT` variables may only be written by their POU itself. From the outside they can only
+be read.
 
-```st
-FUNCTION_BLOCK FB
-VAR_OUTPUT
-    out : BOOL;
-END_VAR
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    VAR_OUTPUT
+        out : BOOL;
+    END_VAR
 END_FUNCTION_BLOCK
 
 PROGRAM main
-VAR
-    fb : FB;
-END_VAR
-    fb.out := TRUE; (* VAR_OUTPUT variables cannot be assigned outside of their scope *)
+    VAR
+        instance : fb;
+    END_VAR
+    instance.out := TRUE; // error: VAR_OUTPUT variables cannot be assigned outside of their scope.
 END_PROGRAM
 ```
 
-## Example - VAR_IN_OUT accessed outside of its scope
+## VAR_IN_OUT accessed outside of its scope
 
-`VAR_IN_OUT` variables of a function block or program may not be read or written from outside.
-They are references that are only bound to a target while the function block is being called, so
-any outside access - reading, writing or taking the address - would dereference an unbound
-reference. Pass the variable in the call instead.
+`VAR_IN_OUT` variables are references that are only bound to a target while their POU is being
+called, so any outside access would dereference an unbound reference. Pass the variable in the
+call instead.
 
-```st
-FUNCTION_BLOCK FB
-VAR_IN_OUT
-    inOut : LREAL;
-END_VAR
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    VAR_IN_OUT
+        inOut : LREAL;
+    END_VAR
 END_FUNCTION_BLOCK
 
 PROGRAM main
-VAR
-    fb : FB;
-    value : LREAL;
-END_VAR
-    fb.inOut := value;  (* VAR_IN_OUT variables cannot be accessed outside of their scope *)
-    value := fb.inOut;  (* VAR_IN_OUT variables cannot be accessed outside of their scope *)
-    fb(inOut := value); (* correct: the variable is passed in the call *)
+    VAR
+        instance : fb;
+        value : LREAL;
+    END_VAR
+    instance.inOut := value;  // error: VAR_IN_OUT variables cannot be accessed outside of their scope.
+    instance(inOut := value); // correct: the variable is passed in the call
 END_PROGRAM
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E038.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E038.md
@@ -1,1 +1,16 @@
-# Missing type
+# Missing Datatype for Sized Variadic
+
+A sized variadic parameter was declared without a datatype. The `{sized}` attribute passes the
+argument count to the callee, which requires all variadic arguments to share one known type.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : INT
+    VAR_INPUT
+        args : {sized} ...; // error: Missing datatype: Sized Variadics require a known datatype.
+    END_VAR
+END_FUNCTION
+```
+
+Declare the variadic with a concrete type, e.g. `args : {sized} INT...;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E039.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E039.md
@@ -1,1 +1,16 @@
-# Variable Overflow
+# Constant Expression Overflow
+
+A constant expression evaluates to a value outside the range of its declared type, so the value
+would overflow at runtime.
+
+Erroneous code example:
+
+```iecst
+FUNCTION main : DINT
+    VAR
+        x : SINT := 128; // warning: This will overflow for type SINT
+    END_VAR
+END_FUNCTION
+```
+
+Use a value within the type's range (`SINT` holds -128 to 127) or a wider type such as `INT`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E040.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E040.md
@@ -1,5 +1,18 @@
-# Non-Standard Enum Variant
+# Non-Standard Enum Value
 
-This warning indicates the right-hand side in an enum assignment does not match a defined variant.
-For example an enum such as `TYPE Color : (red := 0, green := 1, blue := 2); END_TYPE` is expected to take values
-which (internally) yield a literal integer 0, 1 or 2.
+A value assigned to an enum variable does not match any of the enum's declared variants, for
+example a variant of a different enum or an integer literal that no variant maps to. The
+assignment is accepted but the variable then holds a value outside its declared set.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        color : (red, yellow, green);
+    END_VAR
+    color := 7; // warning: Non-standard enum value `7` for `(red, yellow, green)`
+END_PROGRAM
+```
+
+Assign one of the declared variants instead.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E041.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E041.md
@@ -1,1 +1,9 @@
-# Invalid variable initializer
+# Cannot Generate Initializer
+
+Code generation failed to compute a constant literal initializer for a variable, e.g. because
+the initializer contains an unresolvable value or an invalid reference. It is reported with the
+message `Cannot generate literal initializer for '<name>': Value cannot be derived`, or wraps
+an underlying diagnostic for global variables.
+
+This error originates in the code generation stage; the underlying problem is normally already
+reported during validation before code generation is reached.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E042.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E042.md
@@ -1,1 +1,17 @@
 # Assignment to Reference
+
+A `VAR_INPUT {ref}` variable was assigned to. Such variables are passed by reference, so the
+assignment also modifies the variable at the call site, which is easy to overlook for an input.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : DINT
+    VAR_INPUT {ref}
+        x : DINT;
+    END_VAR
+    x := 1; // warning: VAR_INPUT {ref} variables are mutable and changes to them will also affect the referenced variable. For increased clarity use VAR_IN_OUT instead.
+END_FUNCTION
+```
+
+Declare the variable in a `VAR_IN_OUT` block instead to make the by-reference mutation explicit.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E043.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E043.md
@@ -1,1 +1,34 @@
-# Invalid array assignment
+# Invalid Array Assignment
+
+An array was initialized or assigned with a malformed value list. Array values must be
+surrounded with `[]`, and the number of initial values must not exceed the array length.
+
+## Missing brackets
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        arr : ARRAY[1..3] OF DINT;
+    END_VAR
+    arr := 1, 2, 3; // error: Array assignments must be surrounded with `[]`
+END_PROGRAM
+```
+
+Write `arr := [1, 2, 3];` instead.
+
+## Too many initial values
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        arr : ARRAY[1..2] OF DINT := [1, 2, 3]; // error: Too many initial values for array `arr`. Expected 2, found 3.
+    END_VAR
+END_PROGRAM
+```
+
+The same code also reports struct initializers inside array literals that are not wrapped in
+parentheses, e.g. `[idx := 0, idx := 1]` instead of `[(idx := 0), (idx := 1)]`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E044.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E044.md
@@ -1,1 +1,19 @@
-# Invalid POU for VLA
+# Invalid Location for Variable Length Array
+
+A variable length array (`ARRAY[*] OF ...`) was declared in an unsupported place. VLAs are only
+allowed as `VAR_INPUT {ref}`, `VAR_OUTPUT` and `VAR_IN_OUT` of functions and methods, and as
+`VAR_IN_OUT` of function blocks. They cannot be global variables, cannot appear in a program,
+and cannot be declared in any other variable block.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : DINT
+    VAR
+        arr : ARRAY[*] OF DINT; // error: Variable Length Arrays are not allowed to be defined as Local variables inside a Function
+    END_VAR
+END_FUNCTION
+```
+
+Either declare the variable in one of the permitted parameter blocks or use an array with fixed
+bounds.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E045.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E045.md
@@ -1,1 +1,17 @@
-# Invalid VLA array access
+# Wrong Number of Array Access Dimensions
+
+An array was accessed with a different number of index expressions than its declared number of
+dimensions. This applies to both fixed-size arrays and variable length arrays.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : DINT
+    VAR_IN_OUT
+        arr : ARRAY[*, *] OF DINT;
+    END_VAR
+    foo := arr[1]; // error: Expected array access with 2 dimensions, found 1
+END_FUNCTION
+```
+
+Provide exactly one index per dimension, e.g. `arr[1, 1]`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E046.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E046.md
@@ -1,1 +1,16 @@
-# VLA Dimension out of bounds
+# VLA Dimension Index out of Bounds
+
+The dimension argument passed to `LOWER_BOUND` or `UPPER_BOUND` does not exist on the given
+variable length array. Dimensions are numbered starting at 1, so the argument must be between 1
+and the number of dimensions of the array.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : DINT
+    VAR_IN_OUT
+        arr : ARRAY[*] OF DINT;
+    END_VAR
+    foo := LOWER_BOUND(arr, 2); // error: Index out of bound
+END_FUNCTION
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E047.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E047.md
@@ -1,1 +1,18 @@
-# VLAs are always By Reference
+# VLAs Are Always by Reference
+
+A variable length array was declared in a by-value `VAR_INPUT` block of a function or method.
+VLAs are always passed by reference regardless of the block kind, so changes to the array
+inside the POU affect the array at the call site.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : DINT
+    VAR_INPUT
+        arr : ARRAY[*] OF DINT; // warning: Variable Length Arrays are always by-ref, even when declared in a by-value block
+    END_VAR
+END_FUNCTION
+```
+
+Declare the parameter as `VAR_INPUT {ref}` or `VAR_IN_OUT` to make the by-reference semantics
+explicit.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E048.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E048.md
@@ -1,1 +1,34 @@
 # Unresolved Reference
+
+A name could not be resolved to any known variable, POU, base class, interface or property
+accessor in the current scope.
+
+## Unresolved variable or POU
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    x := 1; // error: Could not resolve reference to x
+END_PROGRAM
+```
+
+Declare the referenced name or fix its spelling.
+
+## Unknown base class or interface
+
+`EXTENDS` and `IMPLEMENTS` clauses referring to undeclared names report
+"Base `...` does not exist" or "Interface `...` does not exist".
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb EXTENDS unknown_base // error: Base `unknown_base` does not exist
+END_FUNCTION_BLOCK
+```
+
+## Missing property accessor
+
+Reading a property without a `GET` block or writing one without a `SET` block reports
+"PROPERTY_GET for property `...` is not defined" or "PROPERTY_SET for property `...` is not
+defined". Add the missing accessor to the property declaration.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E049.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E049.md
@@ -1,1 +1,24 @@
-# Illegal reference access
+# Illegal Access to Private Member
+
+A variable declared in a `VAR` block of a function block, class or program was accessed from
+outside that POU (or its subclasses). Such members are considered private to their container.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    VAR
+        x : DINT;
+    END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM main
+    VAR
+        instance : fb;
+    END_VAR
+    instance.x := 1; // warning: Illegal access to private member fb.x
+END_PROGRAM
+```
+
+Expose the value through a `VAR_OUTPUT`, `VAR_IN_OUT` or property instead of accessing the
+internal variable directly.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E050.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E050.md
@@ -1,1 +1,16 @@
-# Expression is not assignable
+# Expression Is Not Assignable
+
+The left-hand side of an assignment is not a location that can be written to, for example a
+literal, a call result, or keywords such as `THIS` and `SUPER`. The same code is reported
+during code generation when the left side of a named argument in a call is not a plain
+parameter name.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    1 := 5; // error: Expression 1 is not assignable.
+END_PROGRAM
+```
+
+Assign to a variable or another writable location instead.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E051.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E051.md
@@ -1,1 +1,7 @@
-# Typecast error
+# Cannot Cast to Integer Type
+
+Reported during code generation when the index expression of a direct bit/byte/word access
+(e.g. `x.%Xi`) does not produce an integer value and therefore cannot be cast to one. The
+message is "Cannot cast from `<type>` to Integer Type". Validation normally rejects non-integer
+index types earlier, so this error acts as a code generation safeguard and is not
+expected to be reachable from source code.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E052.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E052.md
@@ -1,3 +1,17 @@
-# Unknown type
+# Unknown Type
 
-Use of undeclared type-identifier.
+A declaration references a type name that is not declared anywhere. If the name itself is
+declared but is an alias whose chain ends in an unknown type, the alias is reported with
+"Type '...' references an unknown type" instead.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        x : undefined; // error: Unknown type: undefined
+    END_VAR
+END_PROGRAM
+```
+
+Declare the type or fix its spelling.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E053.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E053.md
@@ -1,1 +1,18 @@
-# Literal out of range
+# Literal out of Range
+
+A type-prefixed literal (e.g. `SINT#300`) does not fit the value range of the cast type. This
+fires when an integer literal is larger than the prefixed integer type can hold, or when a
+string literal cast to a character type (e.g. `CHAR#"ab"`) contains more than one character.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        x : SINT;
+    END_VAR
+    x := SINT#300; // error: Literal 300 out of range (SINT)
+END_PROGRAM
+```
+
+Use a larger type prefix or a value within the range of the target type.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E054.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E054.md
@@ -1,1 +1,15 @@
-# Literal not compatible with type
+# Literal Not Compatible With Type
+
+A typed literal cast (`TYPE#value`) combines a type prefix and a literal of an incompatible
+type class, for example casting a boolean or a number into a string type, or mixing date/time
+types with anything else. Casting an integer literal into a float type (`REAL#100`) is allowed.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    STRING#TRUE; // error: Literal true is not compatible to STRING
+END_PROGRAM
+```
+
+Use a literal that matches the prefix type, or remove the cast.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E055.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E055.md
@@ -1,1 +1,18 @@
-# Incompatible direct access
+# Incompatible Direct Access
+
+A direct access (`%X`, `%B`, `%W`, `%D`) was applied to a variable whose type is not an
+integer strictly larger than the accessed width. For example `%D` reads 32 bits, so the base
+variable must be an integer type larger than 32 bits, such as `LWORD` or `LINT`.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    x : DWORD;
+END_VAR
+    x.%D1; // error: DWord-Wise access requires a Numerical type larger than 32 bits
+END_PROGRAM
+```
+
+Use a larger base type or a smaller access width, e.g. `x.%W1` on a `DWORD`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E056.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E056.md
@@ -1,1 +1,19 @@
-# Incompatible variable for direct access
+# Incompatible Variable For Direct Access
+
+The index of a direct access (`%X`, `%B`, `%W`, `%D`) was given as a variable, but that
+variable is not of an integer type. Only integer variables can select the bit, byte, word or
+dword position.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    x : DWORD;
+    f : REAL;
+END_VAR
+    x.%Xf; // error: Invalid type REAL for direct variable access. Only variables of Integer types are allowed
+END_PROGRAM
+```
+
+Use an integer variable, e.g. `i : INT`, as the access index.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E057.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E057.md
@@ -1,1 +1,18 @@
-# Invalid range for direct access
+# Invalid Range For Direct Access
+
+A direct access with a constant index addresses a bit, byte, word or dword position outside
+the base type. The valid range depends on the base type's size and the access width, e.g. bit
+access on a `BYTE` allows indices 0 to 7, on a `WORD` 0 to 15.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    b : BYTE;
+END_VAR
+    b.%X8; // error: Bit-Wise access for type BYTE must be in range 0..7
+END_PROGRAM
+```
+
+Use an index within the reported range, or a larger base type.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E058.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E058.md
@@ -1,1 +1,17 @@
-# Invalid range for array access
+# Invalid Range For Array Access
+
+An array was indexed with a constant that lies outside the declared dimension bounds. The
+check applies to literal indices only; variable indices are not range-checked at compile time.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    arr : ARRAY[0..1] OF INT;
+END_VAR
+    arr[3]; // error: Array access must be in the range 0..1
+END_PROGRAM
+```
+
+Use an index within the declared bounds, or widen the array's dimension.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E059.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E059.md
@@ -1,1 +1,31 @@
-# Invalid variable for array access
+# Invalid Variable For Array Access
+
+An array access uses an incompatible type, either the index expression is not an integer, or
+the accessed variable is not an array at all.
+
+## Non-integer index
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    arr : ARRAY[0..1] OF INT;
+    s : STRING;
+END_VAR
+    arr[s]; // error: Invalid type STRING for array access. Only variables of Integer types are allowed to access an array
+END_PROGRAM
+```
+
+## Indexing a non-array
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    x : INT;
+END_VAR
+    x[0]; // error: Invalid type INT for array access. Only variables of Array types are allowed
+END_PROGRAM
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E060.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E060.md
@@ -1,1 +1,19 @@
-# Direct access to variable with %
+# Direct Access To Variable With %
+
+A note attached to an unresolved reference error. It is emitted when a member
+access like `x.name` cannot be resolved, but `name` matches a numerical or enum variable in
+scope, suggesting that a direct access such as `x.%Xname` was intended.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    dw : DWORD;
+    n1 : INT;
+END_VAR
+    dw.n1; // note: If you meant to directly access a bit/byte/word/..., use %X/%B/%Wn1 instead.
+END_PROGRAM
+```
+
+Prefix the member with the intended access width, e.g. `dw.%Xn1` for bit access.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E061.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E061.md
@@ -1,1 +1,17 @@
-# Expected literal
+# Expected Literal
+
+A cast prefix (`TYPE#...`) was applied to a value that cannot be cast this way, such as an
+array literal. Cast prefixes only work on elementary values like numbers, booleans, strings
+and time literals.
+
+Erroneous code example:
+
+```iecst
+VAR_GLOBAL
+    x : INT;
+END_VAR
+
+PROGRAM main
+    INT#[x]; // error: Cannot cast into [x], only elementary types are allowed
+END_PROGRAM
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E062.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E062.md
@@ -1,1 +1,26 @@
-# Invalid Nature
+# Invalid Type Nature For Generic Argument
+
+An argument passed to a generic function does not satisfy the declared type nature of the
+generic parameter, e.g. passing a `REAL` where `T : ANY_UNSIGNED` requires an unsigned
+integer. The same code is used when the dimension argument of the `LOWER_BOUND`/`UPPER_BOUND`
+built-ins is not an integer.
+
+Erroneous code example:
+
+```iecst
+FUNCTION func<T : ANY_UNSIGNED> : INT
+VAR_INPUT
+    in : T;
+END_VAR
+END_FUNCTION
+
+FUNCTION main : INT
+VAR
+    x : REAL;
+END_VAR
+    func(x); // error: Invalid type nature for generic argument. REAL is no ANY_UNSIGNED
+END_FUNCTION
+```
+
+Pass an argument whose type matches the nature, or widen the nature in the generic
+declaration.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E063.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E063.md
@@ -1,1 +1,15 @@
-# Unknown Nature
+# Unknown Type Nature
+
+The bound of a generic type parameter is not a known type nature. Valid natures are `ANY`,
+`ANY_DERIVED`, `ANY_ELEMENTARY`, `ANY_MAGNITUDE`, `ANY_NUM`, `ANY_REAL`, `ANY_INT`,
+`ANY_SIGNED`, `ANY_UNSIGNED`, `ANY_DURATION`, `ANY_BIT`, `ANY_CHARS`, `ANY_STRING`,
+`ANY_CHAR` and `ANY_DATE`.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo<T : ANY_FOO> : INT // error: Unkown type nature `ANY_FOO`
+END_FUNCTION
+```
+
+Use one of the natures listed above as the generic bound.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E064.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E064.md
@@ -1,1 +1,18 @@
 # Unresolved Generic
+
+A call to a generic function does not provide enough information to infer a concrete type for
+a generic parameter, typically because no argument uses that parameter, so the generic type
+cannot be resolved.
+
+Erroneous code example:
+
+```iecst
+FUNCTION test<T : ANY_STRING> : T
+END_FUNCTION
+
+FUNCTION main : INT
+    test(); // error: Could not resolve generic type T with ANY_STRING
+END_FUNCTION
+```
+
+Pass an argument that binds the generic parameter to a concrete type.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E065.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E065.md
@@ -1,1 +1,38 @@
-# Incompatible size
+# Incompatible Size
+
+The sizes of the two sides of an assignment do not fit, either a string literal longer than
+one character is assigned to a `CHAR`/`WCHAR`, or a pointer is stored in (or filled from) a
+type smaller than the 64-bit pointer size.
+
+## String literal too long for a character
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    c : CHAR;
+END_VAR
+    c := 'AB'; // error: Value: 'AB' exceeds length for type: CHAR
+END_PROGRAM
+```
+
+## Type too small to hold a pointer
+
+Assigning a pointer to a non-pointer type requires at least 64 bits; the reverse direction,
+storing a value smaller than 64 bits into a pointer, is rejected the same way.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    x : DWORD;
+    p : REF_TO DINT;
+END_VAR
+    x := p; // error: The type DWORD 32 is too small to hold a Pointer
+END_PROGRAM
+```
+
+Use `LWORD` to hold a pointer value, or dereference the pointer with `^` to assign the
+pointed-to value.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E066.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E066.md
@@ -1,1 +1,9 @@
-# Invalid operation
+# Invalid address-of operation
+
+The operand of an address-of expression must be a variable or an array element; taking the
+address of anything else, such as a literal or the temporary result of an expression, is
+rejected with "Invalid address-of operation".
+
+This check operates on address-of AST nodes, which the current grammar no longer produces
+(the `&` operator is not accepted as an address operator), so no Structured Text example
+triggers it. Use `REF(...)` or `ADR(...)` to obtain addresses instead.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E067.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E067.md
@@ -1,1 +1,20 @@
-# Implicit typecast
+# Implicit downcast
+
+An assignment, or an implicit assignment such as passing a call argument, converts a value to
+a smaller type and may truncate it. Reported when the right-hand type is larger than the
+left-hand type, or equally sized but unsigned-to-signed or float-to-integer.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    a : INT;
+    b : DINT;
+END_VAR
+    a := b; // warning: Implicit downcast from 'DINT' to 'INT'.
+END_PROGRAM
+```
+
+Make the conversion explicit with a conversion function such as `DINT_TO_INT(b)`, or widen the
+target variable's type.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E068.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E068.md
@@ -1,1 +1,18 @@
-# Pointer derefernce to non pointer
+# Dereference of a non-pointer value
+
+The dereference operator `^` can only be applied to values of a pointer type such as
+`REF_TO` or `POINTER TO`. It also fires when a pointer is dereferenced more often than its
+indirection allows, e.g. `p^^` on a single-level pointer.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    a : DINT;
+END_VAR
+    a^; // error: Dereferencing requires a pointer-value.
+END_PROGRAM
+```
+
+Remove the `^`, or declare the variable as a pointer type.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E069.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E069.md
@@ -1,1 +1,8 @@
-# Array access to non array value
+# Index access without an array value
+
+An index access `[...]` was found without a base expression to index into, so there is no
+array value the subscript could apply to.
+
+This only occurs for programmatically constructed ASTs; the parser always attaches a base to
+an index access (a bare `[0]` parses as an array literal instead), and indexing a non-array
+variable is reported as a separate error. No Structured Text example triggers it.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E070.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E070.md
@@ -1,1 +1,8 @@
-# Address-of requires a value
+# Address-of without a value
+
+An address-of expression was found without an operand, so there is no value whose address
+could be taken.
+
+This only occurs for programmatically constructed ASTs; the current grammar does not produce
+address-of nodes (the `&` operator is not accepted as an address operator), so no Structured
+Text example triggers it.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E071.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E071.md
@@ -1,1 +1,16 @@
 # General codegen error
+
+A catch-all for problems detected while generating LLVM IR, after parsing and validation have
+passed. The message text varies with the cause, e.g. control-flow statements outside their
+required context, invalid signatures for built-in functions like `MUX` or `REF`, or failures
+while emitting debug information.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    EXIT; // error: Cannot break out of loop when not inside a loop
+END_PROGRAM
+```
+
+There is no single solution; refer to the message text of the reported diagnostic.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E072.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E072.md
@@ -1,1 +1,9 @@
-# Missing function
+# Missing function context
+
+An internal code-generation error reported as "Cannot generate code outside of function
+context." It occurs when the code generator has to emit a statement or expression without an
+enclosing POU. When this happens while initializing a global variable, it is wrapped in a
+"Cannot generate literal initializer" diagnostic instead.
+
+It is not triggered by ordinary source code; if it appears, it usually indicates a compiler
+bug worth reporting.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E073.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E073.md
@@ -1,1 +1,34 @@
 # Missing compare function
+
+Comparison operators like `=`, `<` or `>=` on non-numerical types such as structs or arrays
+require a user-defined compare function, because the compiler cannot compare them directly.
+The expected function is named `<Type>_EQUAL`, `<Type>_LESS` or `<Type>_GREATER` depending on
+the operator, takes two `VAR_INPUT` parameters of the type and returns `BOOL`.
+
+Erroneous code example:
+
+```iecst
+TYPE Point : STRUCT
+    x : DINT;
+END_STRUCT END_TYPE
+
+PROGRAM main
+VAR
+    a, b : Point;
+    eq : BOOL;
+END_VAR
+    // error: Missing compare function 'FUNCTION Point_EQUAL : BOOL VAR_INPUT a,b : Point; END_VAR ...'.
+    eq := a = b;
+END_PROGRAM
+```
+
+Define the compare function named in the message:
+
+```iecst
+FUNCTION Point_EQUAL : BOOL
+VAR_INPUT
+    a, b : Point;
+END_VAR
+    Point_EQUAL := a.x = b.x;
+END_FUNCTION
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E074.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E074.md
@@ -1,1 +1,6 @@
 # Cannot generate string literal
+
+The code generator had to materialize a string literal for a type that is neither a string
+nor a character type, reported as "Cannot generate String-Literal for type <name>". Such
+mismatches are normally rejected earlier by validation, so no Structured Text
+example triggers it; if it appears, it usually indicates a compiler bug worth reporting.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E075.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E075.md
@@ -1,1 +1,10 @@
-# Initial values were not generated
+# Initial values could not be generated
+
+During code generation the initial values of one or more data types could not be computed,
+even after repeatedly retrying types whose initializers depend on other types. The message
+"Could not generate initial value(s) for: <names>" lists the affected types, with a
+sub-diagnostic per type carrying the underlying cause.
+
+Unresolvable initializers are normally rejected earlier by constant evaluation, so no
+Structured Text example triggers it; refer to the attached sub-diagnostics for the actual
+cause.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E076.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E076.md
@@ -1,1 +1,5 @@
 # General debug error
+
+Formerly reported as "Cannot find debug information for type <name>" when the debug-info
+generator could not look up the metadata for a data type. This code is no longer emitted by
+the compiler.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E077.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E077.md
@@ -1,1 +1,16 @@
-# Generic linker error
+# Linker error
+
+The final linking step failed. It is caused by the environment or the invocation rather than
+the source code, e.g. an undefined symbol, a library that cannot be found, a target platform
+without an available linker, or a path containing invalid UTF-8.
+
+Erroneous invocation:
+
+```sh
+plc input.st -o out -lnonexistent
+# ld.lld: error: unable to find library -lnonexistent
+# error: An error occurred during linking: An error occured during linking.
+```
+
+The underlying linker output precedes the diagnostic; check library paths (`-L`), library
+names (`-l`) and that all referenced symbols are provided.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E078.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E078.md
@@ -1,1 +1,23 @@
 # Duplicate case condition
+
+Two conditions of a `CASE` statement evaluate to the same constant value, so the later block
+can never be reached. Conditions are constant-folded before the comparison, so literals,
+constant expressions and enum variants that resolve to the same integer collide.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    input, res : DINT;
+END_VAR
+    CASE input OF
+        4:
+            res := 1;
+        2 + 2: // error: Duplicate condition value: 4. Occurred more than once!
+            res := 2;
+    END_CASE
+END_PROGRAM
+```
+
+Remove or change one of the conditions so that every case covers a distinct value.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E079.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E079.md
@@ -1,1 +1,40 @@
-# Case condition outside of a case statement
+# Invalid case condition
+
+## Assignment or call used as a condition
+
+A `CASE` condition must be a constant expression; an assignment or a call statement is not a
+valid condition.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo : DINT
+END_FUNCTION
+
+PROGRAM main
+VAR
+    input, res : DINT;
+END_VAR
+    CASE input OF
+        foo(): // error: Invalid case condition!
+            res := 1;
+    END_CASE
+END_PROGRAM
+```
+
+## Case condition outside of a case statement
+
+A statement of the form `<value>:` outside a `CASE` block is parsed as a case condition,
+usually because `:` was typed instead of `;`.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    x : DINT;
+END_VAR
+    x := 1;
+    23: // error: Case condition used outside of case statement! Did you mean to use ';'?
+END_PROGRAM
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E080.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E080.md
@@ -1,1 +1,22 @@
-# Invalid case condition
+# Non-constant case condition
+
+A `CASE` condition could not be evaluated to a constant value at compile time, for example
+because it references a non-constant variable. The message starts with the reason the constant
+evaluation failed.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+VAR
+    input, res, x : DINT;
+END_VAR
+    CASE input OF
+        x: // error: `x` is no const reference. Non constant variables are not supported in case conditions
+            res := 1;
+    END_CASE
+END_PROGRAM
+```
+
+Use a literal or a `CONSTANT` variable as the condition, or rewrite the statement as an `IF`
+chain if the values are only known at runtime.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E081.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E081.md
@@ -1,5 +1,16 @@
 # Duplicate CFC connector
 
-Two connectors in a CFC network share the same label. A connector is the single
-named source for its label, so continuations reading it would be ambiguous. Give
-each connector a distinct label.
+Two connectors in a CFC network share the same label. A connector is the single named source
+for its label, so continuations reading that label would be ambiguous. Raised while compiling
+graphical CFC source files.
+
+Erroneous network example:
+
+```text
+foo --> x>        (connector `x` captures foo)
+>x --> bar (0)    (continuation re-emits it)
+
+baz --> x>   // error: Connector `x` is already defined
+```
+
+Give each connector a distinct label.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E082.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E082.md
@@ -1,5 +1,16 @@
 # Dangling CFC continuation
 
-A continuation refers to a label that no connector defines. It re-emits a named
-signal that was never captured, so whatever reads it receives no value. Add the
-matching connector or remove the continuation.
+A continuation in a CFC network refers to a label that no connector defines. It re-emits a
+named signal that was never captured, so whatever reads it receives no value. Also raised when
+connectors and continuations form a cycle, since the chain never reaches a real source. Raised
+while compiling graphical CFC source files.
+
+Erroneous network example:
+
+```text
+>x --> bar (0)   // error: Continuation `x` has no matching connector
+
+(no connector `x` exists in the network)
+```
+
+Add the matching connector or remove the continuation.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E083.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E083.md
@@ -1,6 +1,15 @@
 # Unsupported CFC expression
 
-A variable, source or sink element in a CFC network carries an expression that
-is not supported. Only variable references (`foo`), qualified references
-(`foo.bar`), indexed references (`arr[i]`) and literals (`5`) are allowed;
-function calls and other expressions are not.
+A variable, source or sink element in a CFC network carries an expression that is not
+supported. Only variable references (`foo`), qualified references (`foo.bar`), indexed
+references (`arr[i]`) and literals (`5`) are allowed in these elements. Raised while compiling
+graphical CFC source files.
+
+Erroneous network example:
+
+```text
+foo + 1 --> bar (0)   // error: Unsupported CFC expression: `foo + 1`
+```
+
+Calls and arithmetic must be modeled with block elements instead of being written into a
+variable element.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E084.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E084.md
@@ -1,4 +1,15 @@
 # Unconnected CFC element
 
-A CFC network contains an element that is not wired to anything. It has no
-effect on the program and is ignored during transpilation.
+A CFC network contains an element that is not wired to anything. It has no effect on the
+program and is dropped during transpilation. Raised while compiling graphical CFC source
+files.
+
+Erroneous network example:
+
+```text
+foo --> bar (0)   (wired pair, transpiles to bar := foo)
+
+qux   // warning: Element `qux` is unconnected and will be ignored
+```
+
+Wire the element into the network or delete it.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E085.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E085.md
@@ -1,5 +1,15 @@
 # Disconnected CFC return
 
-A `RETURN` element in a CFC network is not wired to a condition. A conditional
-return only fires when its incoming value is true, so a return with nothing
-connected can never trigger and is almost certainly a mistake.
+A return element in a CFC network is not wired to a condition. A conditional return only fires
+when its incoming value is true, so a return with nothing connected can never trigger and is
+almost certainly a mistake. Raised while compiling graphical CFC source files.
+
+Erroneous network example:
+
+```text
+myCondition --> RETURN (0)
+
+                RETURN (1)   // error: Return element is not connected to a condition
+```
+
+Wire a boolean condition into the return element.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E086.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E086.md
@@ -1,5 +1,14 @@
 # Open CFC connector
 
-A connector has no incoming connection, yet something reads its label through a
-continuation. The named signal is never produced, so the consumer would be left
-without a value. Wire a source into the connector.
+A connector in a CFC network has no incoming connection, yet something reads its label through
+a continuation. The named signal is never produced, so the consumer would be left without a
+value. Raised while compiling graphical CFC source files.
+
+Erroneous network example:
+
+```text
+x>               // error: Connector `x` has no incoming connection
+>x --> bar (0)
+```
+
+Wire a source into the connector.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E087.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E087.md
@@ -1,1 +1,4 @@
 # Unnamed control
+
+A control element in a CFC network is missing a name. The compiler currently defines this
+diagnostic but never emits it, so it cannot be triggered by any source input.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E088.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E088.md
@@ -1,1 +1,16 @@
-# Invalid PLC Json file
+# Invalid plc.json build configuration
+
+The `plc.json` build description file could not be read as a valid project configuration. This
+covers JSON syntax errors, missing or unknown fields during deserialization, and violations of
+the project schema, which are collected into a single message starting with `plc.json could
+not be validated due to the following errors:`.
+
+Erroneous invocation:
+
+```sh
+plc build
+# error: missing field `files` at: plc.json:1:18
+```
+
+Fix `plc.json` according to the reported message; the location points at the offending line
+and column.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E089.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E089.md
@@ -1,1 +1,24 @@
-# Invalid Call parameters
+# Invalid call parameters
+
+A named argument in a call does not match any declared parameter of the called POU, so the
+argument cannot be mapped to a parameter slot. Validation of the remaining arguments is
+skipped, and a companion diagnostic points at the unresolved name.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb_t
+VAR_INPUT
+    in1 : DINT;
+END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM main
+VAR
+    fb : fb_t;
+END_VAR
+    fb(unknown := 2); // error: Invalid call parameters
+END_PROGRAM
+```
+
+Use the parameter names exactly as declared in the called POU, here `fb(in1 := 2)`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E090.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E090.md
@@ -1,1 +1,25 @@
-# Incompatible reference assingment
+# Incompatible Reference Assignment
+
+A pointer was assigned to a type-safe pointer (`REF_TO` or `REFERENCE TO`) whose pointed-to
+type differs from the assigned value's type.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK FbA
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK FbB
+END_FUNCTION_BLOCK
+
+PROGRAM main
+    VAR
+        instance : FbB;
+        refA     : REF_TO FbA;
+    END_VAR
+
+    refA := REF(instance); // warning: Pointers REF_TO FbA and FbB have different types
+END_PROGRAM
+```
+
+Declare the pointer with the type of the value it references, e.g. `refA : REF_TO FbB`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E091.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E091.md
@@ -1,14 +1,23 @@
 # Unsafe Enum Assignment
 
-At runtime there is no way to guarantee that a non-const reference will not change its value to something out-of-bounds for enums. For example consider the following
+A value that is only known at run-time, for example a function call result, was assigned to an
+enum variable. The compiler cannot guarantee that the value corresponds to one of the enum's
+variants.
+
+Erroneous code example:
+
 ```iecst
+FUNCTION foo : DINT
+    foo := 1;
+END_FUNCTION
+
 PROGRAM main
     VAR
-        zero  : DINT := 0;
         color : (red := 0, green := 1, blue := 2);
     END_VAR
 
-    zero := 10;
-    color := zero; // Invalid because `color` accepts values from 0 to 2, but we assigned 10 to it
+    color := foo(); // warning: Value evaluated at run-time, use an enum variant from `(red := 0, green := 1, blue := 2)`
 END_PROGRAM
 ```
+
+Assign one of the enum's variants instead, e.g. `color := green;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E092.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E092.md
@@ -1,17 +1,21 @@
-# Equivalent enum value used
+# Equivalent Enum Value Used
 
-This message indicates that the assigned enum value is not part of the enum,
-but is equivalent to one of the internal values of the enum.
+An enum variable was assigned a value that is not a variant of that enum, but whose numeric
+value matches one of its variants, for example an integer literal or a variant of a different
+enum. The message suggests the matching variant.
 
-Example:
+Erroneous code example:
+
 ```iecst
-TYPE Colors : (Red, Green, Blue, Yellow) END_TYPE
-TYPE Directions : (N, S, W, E) END_TYPE
+TYPE State : (Idle := 0, Working := 1); END_TYPE
 
-VAR_GLOBAL
-    col : Colors := N; //N is equivalent to Red but is not part of the enum
-    dir : Directions := Red; //Red is equivalent to N but is not part of the enum
-END_VAR
+PROGRAM main
+    VAR
+        state : State;
+    END_VAR
+
+    state := 0; // note: Replace `0` with `Idle`
+END_PROGRAM
 ```
 
-To solve the issue, use the equivalent value indicated by the enum
+Use the suggested variant, e.g. `state := Idle;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E093.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E093.md
@@ -1,11 +1,14 @@
-# Return Value Of Void Functions
+# Return Value Assigned In Void Function
 
-Functions of type VOID can not have an explicit return value, e.g. `foo := 1` in the following example is invalid.
+A function declared without a return type is VOID, so assigning to the function name has no
+return value to set.
 
-```iecstd
+Erroneous code example:
+
+```iecst
 FUNCTION foo
-    foo := 1;
+    foo := 1; // warning: Function declared as VOID, but trying to assign a return value
 END_FUNCTION
 ```
 
-Choose a type for your function, if a value must be returned.
+Declare a return type, e.g. `FUNCTION foo : DINT`, if the function must return a value.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E094.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E094.md
@@ -1,19 +1,42 @@
 # Invalid Conditional Value
 
-Control statements such as `IF`, `FOR` and `WHILE` require specific types for their condition.
+Control statement conditions require specific types. `IF`, `WHILE` and `REPEAT` conditions
+must yield a boolean, and all `FOR` loop values must be integers.
 
-## If, While
+## Non-boolean condition
 
-`IF` and `WHILE` statements require an expression which yields a boolean, any other type is invalid and will trigger an
-error.
+A condition of any type other than `BOOL` is invalid. Integer conditions are an exception and
+do not produce this error.
 
-# For
-
-`FOR` statements require four conditional values: a `counter`, a `start` value, an `end` value and a `step` value. All
-of these need to be integers and share the same type.
+Erroneous code example:
 
 ```iecst
-FOR start := counter TO end BY step DO
-// ...
-END_FOR
+PROGRAM main
+    VAR
+        text : STRING;
+    END_VAR
+
+    IF text THEN // error: Expected a boolean, got `STRING`
+    END_IF;
+END_PROGRAM
+```
+
+## Non-integer FOR loop values
+
+The counter, start, end and step values of a `FOR` loop must all be integers; `REAL` and
+non-numerical types are rejected.
+
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        i : STRING;
+        x : BOOL;
+        y : DINT;
+    END_VAR
+
+    FOR i := 100000 TO x BY y DO // error: Expected an integer value, got `STRING`
+    END_FOR
+END_PROGRAM
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E095.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E095.md
@@ -1,1 +1,19 @@
-# Action call without parentheses
+# Action Call Without Parentheses
+
+A statement references an `ACTION` by name without a call operator. A bare reference to an
+action is not a call, so the action would never execute.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    foo; // error: A reference to fb.foo exists, but it is an ACTION. If you meant to call it, add `()` to the statement: `fb.foo()`
+END_FUNCTION_BLOCK
+
+ACTIONS
+    ACTION foo
+    END_ACTION
+END_ACTIONS
+```
+
+Add parentheses to call the action, i.e. `foo();`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E096.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E096.md
@@ -1,5 +1,19 @@
 # Integer Condition
 
-This error is generated because an integer was used in a `IF` or `WHILE` statement, when a boolean was expected.
+An `IF`, `WHILE` or `REPEAT` condition yields an integer where a boolean is expected. The
+literals `0` and `1` are accepted silently.
 
-See also `plc explain E094`
+Erroneous code example:
+
+```iecst
+PROGRAM main
+    VAR
+        x : DINT;
+    END_VAR
+
+    IF x THEN // warning: Expected a boolean, got `DINT`, consider adding an `=` or `<>` operator for better clarity
+    END_IF;
+END_PROGRAM
+```
+
+Make the comparison explicit, e.g. `IF x <> 0 THEN`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E097.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E097.md
@@ -1,4 +1,16 @@
 # Invalid Array Range
 
-Ranges such as `ARRAY [0..-1]` are invalid in ST because end values of ranges must be greater than their start values.
-A valid range for the given statement would have been `ARRAY[-1..0]`.
+An array dimension was declared with a start value greater than its end value. This applies to
+every dimension, including nested and multi-dimensional arrays.
+
+Erroneous code example:
+
+```iecst
+FUNCTION foo
+    VAR
+        arr : ARRAY[5..1] OF DINT; // error: Invalid range `5..1`, did you mean `1..5`?
+    END_VAR
+END_FUNCTION
+```
+
+Swap the bounds so the range is ascending, e.g. `ARRAY[1..5]`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E098.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E098.md
@@ -1,19 +1,26 @@
-# Invalid REF= assignment
+# Invalid REF= Assignment
 
-`REF=` assignments are considered valid if the left-hand side of the assignment is a pointer variable 
-and the right-hand side is a variable of the type that is being referenced.
+A `REF=` assignment binds a reference to a variable, so the left-hand side must be a pointer
+or `REFERENCE TO` variable and the right-hand side must be a non-constant variable of the
+referenced type. The constant check also applies to arguments of the `REF(...)` and `ADR(...)`
+built-ins.
 
-For example assignments such as the following are invalid
+Erroneous code example:
 
 ```iecst
-VAR
-    foo     : DINT;
-    bar     : DINT;
-    qux     : SINT;
-    refFoo  : REFERENCE TO DINT;
+VAR_GLOBAL CONSTANT
+    max : DINT := 5;
 END_VAR
 
-refFoo  REF= 5;         // `5` is not a variable
-foo     REF= bar;       // `foo` is not a pointer
-refFoo  REF= qux;       // `refFoo` and `qux` have different types, DINT vs SINT
+FUNCTION main
+    VAR
+        foo    : DINT;
+        bar    : DINT;
+        refFoo : REFERENCE TO DINT;
+    END_VAR
+
+    refFoo REF= 5;   // error: Invalid assignment, expected a reference
+    foo    REF= bar; // error: Invalid assignment, expected a pointer reference
+    refFoo REF= max; // error: Invalid assignment, cannot ensure constant is used as read-only
+END_FUNCTION
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E099.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E099.md
@@ -1,6 +1,38 @@
-# Invalid `REFERENCE TO` declaration
+# Invalid REFERENCE TO Declaration
 
-`REFERENCE TO` variable declarations are considered valid if the referenced type is not of the following form
-* `foo : REFERENCE TO REFERENCE TO (* ... *)`
-* `foo : ARRAY[...] OF REFERENCE TO (* ... *)`
-* `foo : REF_TO REFERENCE TO (* ... *)`
+A `REFERENCE TO` declaration references something it must not. The referenced target must be a
+type, not a variable, and automatically dereferenced references cannot be nested inside arrays
+or other pointers.
+
+## Referencing a variable
+
+Erroneous code example:
+
+```iecst
+VAR_GLOBAL
+    foo : DINT;
+END_VAR
+
+FUNCTION main
+    VAR
+        bar : REFERENCE TO foo; // error: REFERENCE TO variables can not reference other variables
+    END_VAR
+END_FUNCTION
+```
+
+Reference the variable's type instead, i.e. `bar : REFERENCE TO DINT`, and bind the variable
+with `bar REF= foo;` in the body.
+
+## Nesting automatically dereferenced references
+
+Erroneous code example:
+
+```iecst
+FUNCTION main
+    VAR
+        bar : ARRAY[1..5] OF REFERENCE TO DINT; // error: Invalid reference to declaration. Arrays of automatically dereferenced references are not allowed.
+        baz : REFERENCE TO REFERENCE TO DINT;   // error: Invalid reference to declaration. References to automatically dereferenced references are not allowed.
+        qux : REF_TO REFERENCE TO DINT;         // error: Invalid reference to declaration. References to automatically dereferenced references are not allowed.
+    END_VAR
+END_FUNCTION
+```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E100.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E100.md
@@ -1,6 +1,10 @@
 # Immutable Variable Address
 
-Alias variables are immutable with regards to their pointer address, thus re-assigning an address will return an error. For example the following code will not compile
+Alias variables declared with `AT` bind their address at declaration and are immutable with
+regards to that address. Re-assigning the address with `REF=` in the POU body is invalid.
+
+Erroneous code example:
+
 ```iecst
 FUNCTION main
     VAR
@@ -9,7 +13,7 @@ FUNCTION main
         baz : DINT;
     END_VAR
 
-    foo := baz;     // Valid, because we are changing the pointers dereferenced value
-    foo REF= baz;   // Invalid, `foo` is immutable with regards to it's pointer address
+    foo := baz;   // valid, assigns to the referenced value
+    foo REF= baz; // error: foo is an immutable alias variable, can not change the address
 END_FUNCTION
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E101.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E101.md
@@ -1,11 +1,13 @@
-# Template variable does not exist
+# Template Variable Does Not Exist
 
-A variable was configured in a `VAR_CONFIG` block, but the variable can not be found in the code.
+A variable was configured in a `VAR_CONFIG` block, but no template variable with that
+qualified name exists in the code.
 
 Erroneous code example:
+
 ```iecst
 VAR_CONFIG
-    main.foo.bar AT %IX1.0 : BOOL;
+    main.foo.bar AT %IX1.0 : BOOL; // error: Template variable `bar` does not exist
 END_VAR
 
 PROGRAM main
@@ -21,5 +23,5 @@ FUNCTION_BLOCK foo_fb
 END_FUNCTION_BLOCK
 ```
 
-In this example a variable named `bar` is configured, however the function block `foo_fb` does not contain
-a `bar` variable. The could should have been `main.foo.qux AT %IX1.0 : BOOL` instead for it to be valid.
+The function block `foo_fb` does not contain a variable named `bar`. The configuration should
+have been `main.foo.qux AT %IX1.0 : BOOL;` instead.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E102.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E102.md
@@ -1,13 +1,16 @@
-# Template variable without hardware binding
+# Template Variable Without Hardware Binding
 
-A template variable must contain a hardware binding.
-
+A `VAR_CONFIG` entry configures an instance variable whose declaration has no hardware binding
+at all. Only variables declared with an incomplete address such as `AT %I*` can be configured.
 
 Erroneous code example:
+
 ```iecst
-VAR_CONFIG
-    main.foo.bar AT %IX1.0 : BOOL;
-END_VAR
+FUNCTION_BLOCK foo_fb
+    VAR
+        bar : BOOL; // error: `foo` is missing a hardware binding
+    END_VAR
+END_FUNCTION_BLOCK
 
 PROGRAM main
     VAR
@@ -15,13 +18,10 @@ PROGRAM main
     END_VAR
 END_PROGRAM
 
-FUNCTION_BLOCK foo_fb
-    VAR
-        bar : BOOL;
-    END_VAR
-END_FUNCTION_BLOCK
+VAR_CONFIG
+    main.foo.bar AT %IX1.0 : BOOL;
+END_VAR
 ```
 
-In this example the `VAR_CONFIG` block declares the `bar` variable inside `foo_fb` as a
-template variable. However `bar` does not have a hardware binding. For the example to be
-considered valid, `bar` should have been declared as e.g. `bar AT %I* : BOOL`.
+Declare the variable as a template, e.g. `bar AT %I* : BOOL;`, so the `VAR_CONFIG` block can
+bind it to a concrete address.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E103.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E103.md
@@ -1,12 +1,17 @@
 # Immutable Hardware Binding
 
-Variables configured in a `VAR_CONFIG` block can not override their hardware binding.
+A `VAR_CONFIG` entry targets a variable that is already declared with a complete hardware
+address. Only template variables with an incomplete address such as `AT %I*` may be
+configured; a concrete address cannot be overridden.
 
 Erroneous code example:
+
 ```iecst
-VAR_CONFIG
-    main.foo.bar AT %IX1.0 : BOOL;
-END_VAR
+FUNCTION_BLOCK foo_fb
+    VAR
+        bar AT %IX1.5 : BOOL;
+    END_VAR
+END_FUNCTION_BLOCK
 
 PROGRAM main
     VAR
@@ -14,14 +19,10 @@ PROGRAM main
     END_VAR
 END_PROGRAM
 
-FUNCTION_BLOCK foo_fb
-    VAR
-        bar AT IX1.5: BOOL;
-    END_VAR
-END_FUNCTION_BLOCK
+VAR_CONFIG
+    main.foo.bar AT %IX1.0 : BOOL; // error: The configured variable is not a template, overriding non-template hardware addresses is not allowed
+END_VAR
 ```
 
-In this example the `VAR_CONFIG` block configures `bar` to have a hardware adress `IX1.0`.
-However, at the same time the `bar` inside the POU `foo_fb` assigns a hardware address `IX1.5`.
-
-For the code to be considered valid, `bar` should have been declared as `bar AT %I* : BOOL`.
+Either remove the `VAR_CONFIG` entry or declare the variable as a template, e.g.
+`bar AT %I* : BOOL;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E104.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E104.md
@@ -1,13 +1,25 @@
 # Config Variable With Incomplete Address
 
-Variables defined in a `VAR_CONFIG` block, i.e. config variables, must specify a complete address.
+A `VAR_CONFIG` entry uses an incomplete (template) address such as `%I*`. The purpose of a
+`VAR_CONFIG` block is to bind template variables to concrete addresses, so each entry must
+specify a complete address like `%IX1.0`.
 
 Erroneous code example:
+
 ```iecst
+FUNCTION_BLOCK foo_fb
+    VAR
+        bar AT %I* : BOOL;
+    END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM main
+    VAR
+        foo : foo_fb;
+    END_VAR
+END_PROGRAM
+
 VAR_CONFIG
-    main.foo.bar AT %I* : BOOL;
+    main.foo.bar AT %I* : BOOL; // error: Variables defined in a VAR_CONFIG block must have a complete address
 END_VAR
 ```
-
-In this example `main.foo.bar` has specified a placeholder hardware address. 
-For the example to be considered valid, a specific address such as `%IX1.0` should have been declared.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E105.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E105.md
@@ -1,12 +1,16 @@
-# CONSTANT keyword in POU
+# CONSTANT Pragma in POU Declaration
 
-The `CONSTANT` keyword is not allowed for POU declarations, only variables can be `CONSTANT`
+The `{constant}` pragma is reserved for compiler built-ins and is not allowed on user-defined
+POU declarations such as `FUNCTION`, `FUNCTION_BLOCK`, `PROGRAM`, `CLASS`, `METHOD`, or
+properties.
 
 Erroneous code example:
+
 ```iecst
-FUNCTION FOO : BOOL CONSTANT 
-VAR_INPUT
-END_VAR
-    // ...
+{constant} // error: Pragma {constant} is not allowed in POU declarations
+FUNCTION foo : BOOL
 END_FUNCTION
 ```
+
+Remove the pragma. Only variables can be constant, using the `CONSTANT` keyword on a variable
+block.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E106.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E106.md
@@ -1,23 +1,19 @@
-# VAR_EXTERNAL blocks have no effect
+# VAR_EXTERNAL Blocks Have No Effect
 
-Variables declared in a `VAR_EXTERNAL` block are currently ignored and the referenced globals will be used instead.
+`VAR_EXTERNAL` blocks are parsed but ignored. References resolve directly to the global
+variables, whether or not they are listed in a `VAR_EXTERNAL` block, and a `CONSTANT`
+modifier on the block is not enforced.
 
-Example:
+Erroneous code example:
+
 ```iecst
 VAR_GLOBAL
-    myArray : ARRAY [0..10] OF INT;
-    myString: STRING;
+    b : BOOL;
 END_VAR
 
-FUNCTION main
-VAR_EXTERNAL CONSTANT
-    myArray : ARRAY [0..10] OF INT;
-END_VAR
-    myArray[5] := 42;
-    myString := 'Hello, world!';
-END_FUNCTION
+FUNCTION_BLOCK foo_fb
+    VAR_EXTERNAL // warning: VAR_EXTERNAL blocks have no effect
+        b : BOOL;
+    END_VAR
+END_FUNCTION_BLOCK
 ```
-
-In this example, even though `arr` is declared as `VAR_EXTERNAL CONSTANT`, the `CONSTANT` constraint will be ignored and
-the global `myArray` will be mutated. The global `myString` can be read from and written to from within `main` even though it
-is not declared in a `VAR_EXTERNAL` block.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E107.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E107.md
@@ -1,12 +1,18 @@
-# Missing configuration for template variable
+# Missing Configuration for Template Variable
 
-A template variable was left unconfigured.
+A variable declared with an incomplete address such as `AT %I*` is a template and must be
+bound to a concrete address in a `VAR_CONFIG` block. Every instance of the template needs a
+configuration entry, otherwise it has no valid address at runtime.
 
 Erroneous code example:
+
 ```iecst
-VAR_CONFIG
-    main.foo.bar AT %IX1.0 : BOOL;
-END_VAR
+FUNCTION_BLOCK foo_fb
+    VAR
+        bar AT %I* : BOOL;
+        qux AT %I* : BOOL; // error: Template-variable must have a configuration
+    END_VAR
+END_FUNCTION_BLOCK
 
 PROGRAM main
     VAR
@@ -14,13 +20,11 @@ PROGRAM main
     END_VAR
 END_PROGRAM
 
-FUNCTION_BLOCK foo_fb
-    VAR
-        bar AT %I* : BOOL;
-        qux AT %I* : BOOL;
-    END_VAR
-END_FUNCTION_BLOCK
+VAR_CONFIG
+    main.foo.bar AT %IX1.0 : BOOL;
+END_VAR
 ```
 
-In this example a variable named `main.foo.qux` is declared as a template, however the `VAR_CONFIG`-block does not contain
-an address-configuration for it. Each template variable needs to be configured, otherwise it could lead to segmentation faults at runtime.
+Add an entry for each unconfigured instance, here `main.foo.qux AT %IX1.1 : BOOL;`. For array
+templates where only some elements are configured, the message reads "One or more
+template-elements in array have not been configured".

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E108.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E108.md
@@ -1,13 +1,17 @@
-# Template variable is configured multiple times
+# Template Variable Configured Multiple Times
 
-A template variable is configured more than once, leading to ambiguity.
+A template variable has more than one entry across `VAR_CONFIG` blocks, making it ambiguous
+which address it should map to. Exactly one configuration entry per instance variable is
+allowed.
 
 Erroneous code example:
+
 ```iecst
-VAR_CONFIG
-    main.foo.bar AT %IX1.0 : BOOL;
-    main.foo.bar AT %IX1.1 : BOOL;
-END_VAR
+FUNCTION_BLOCK foo_fb
+    VAR
+        bar AT %I* : BOOL;
+    END_VAR
+END_FUNCTION_BLOCK
 
 PROGRAM main
     VAR
@@ -15,11 +19,10 @@ PROGRAM main
     END_VAR
 END_PROGRAM
 
-FUNCTION_BLOCK foo_fb
-    VAR
-        bar AT %I* : BOOL;
-    END_VAR
-END_FUNCTION_BLOCK
+VAR_CONFIG
+    main.foo.bar AT %IX1.0 : BOOL; // error: Template variable configured multiple times
+    main.foo.bar AT %IX1.1 : BOOL;
+END_VAR
 ```
 
-In this example a variable named `main.foo.bar` has multiple configurations in the `VAR_CONFIG`-block. It is not clear which address this variable should map to - only a single configuration entry per instance-variable is allowed.
+Remove all but one of the conflicting entries.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E109.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E109.md
@@ -1,16 +1,23 @@
-# Stateful member variable initialized with temporary reference
+# Stateful Variable Initialized With Temporary Reference
 
-Stack-local variables do not yet exist at the time of initialization. Additionally, pointing to a temporary variable will lead to a dangling pointer
-as soon as it goes out of scope - potential use after free.
+A stateful member variable of a `PROGRAM`, `FUNCTION_BLOCK`, or `CLASS` takes the address of
+a `VAR_TEMP` variable via `REF(...)`, `AT`, or `REF=`. The temporary lives on the stack and
+goes out of scope after each call, leaving the member with a dangling pointer and a potential
+use after free.
 
 Erroneous code example:
+
 ```iecst
 FUNCTION_BLOCK foo
     VAR
-        a : REF_TO BOOL := REF(b);
+        s1 : REF_TO DINT := REF(t1); // error: Cannot assign address of temporary variable to a member-variable
+        s2 AT t1 : DINT;             // error: Cannot assign address of temporary variable to a member-variable
     END_VAR
     VAR_TEMP
-        b : BOOL;
+        t1 : DINT;
     END_VAR
 END_FUNCTION_BLOCK
 ```
+
+Point to a stateful variable instead, or move the pointer itself into `VAR_TEMP`. Inside a
+`FUNCTION` all variables are stack-local, so these initializations are allowed there.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E110.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E110.md
@@ -1,19 +1,31 @@
-# Invalid POU Type for Inheritance
+# Invalid POU Type for Inheritance or Interface Implementation
 
-Base Classes and Interfaces can only be used on `CLASS`es and `FUNCTION_BLOCK`s, any other POU type is invalid and will
-result in this error.
+Only `CLASS` and `FUNCTION_BLOCK` may use `EXTENDS` or `IMPLEMENTS`. Any other POU type, such
+as `PROGRAM` or `FUNCTION`, reports this error.
 
-Errouneus code example:
+## Subclassing
+
+Erroneous code example:
+
 ```iecst
-INTERFACE interfaceA
-    /* ... */
-END_INTERFACE
-
 FUNCTION_BLOCK fb
 END_FUNCTION_BLOCK
 
-FUNCTION foo EXTENDS fb IMPLEMENTS interfaceA
-    /* ... */
-END_FUNCTION_BLOCK
+PROGRAM prog EXTENDS fb // error: Subclassing is only allowed in `CLASS` and `FUNCTION_BLOCK`
+END_PROGRAM
 ```
-In the example above, the POU type of `foo` should have been `CLASS` or `FUNCTION_BLOCK`.
+
+## Interface implementation
+
+Erroneous code example:
+
+```iecst
+INTERFACE interfaceA
+END_INTERFACE
+
+PROGRAM prog IMPLEMENTS interfaceA // error: Interfaces can only be implemented by `CLASS` or `FUNCTION_BLOCK`
+END_PROGRAM
+```
+
+Change the POU type to `CLASS` or `FUNCTION_BLOCK`, or drop the `EXTENDS`/`IMPLEMENTS`
+clause.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E111.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E111.md
@@ -1,35 +1,26 @@
-# Duplicate interface methods with different signatures
+# Duplicate Interface Methods With Different Signatures
 
-POUs implementing multiple interfaces where both interfaces define a method with the same name are required
-to have the same signature for the method. A method signature is thereby defined by its name, return type and
-parameter list. 
+A POU implements multiple interfaces that declare a method with the same name but conflicting
+signatures (return type, or parameter names, types, order, or declaration kinds). The
+implementer cannot satisfy both declarations at once.
 
-Errouneus code example:
+Erroneous code example:
+
 ```iecst
 INTERFACE interfaceA
     METHOD foo : INT
-        VAR_INPUT
-            a : INT;
-        END_VAR
     END_METHOD
 END_INTERFACE
 
 INTERFACE interfaceB
     METHOD foo : DINT
-        VAR_OUTPUT
-            a : INT;
-        END_VAR
     END_METHOD
 END_INTERFACE
 
-FUNCTION_BLOCK fb IMPLEMENTS interfaceA, interfaceB
-    // Signatures for foo differs, do we implement foo as defined in interfaceA or interfaceB?
+FUNCTION_BLOCK fb IMPLEMENTS interfaceA, interfaceB // error: Method `foo` in `fb` is declared with conflicting signatures in `interfaceA` and `interfaceB`
+    METHOD foo : INT
+    END_METHOD
 END_FUNCTION_BLOCK
-
 ```
 
-In the example above, the method `foo` is defined in both interfaces `interfaceA` and `interfaceB`. 
-However, the return type of `foo` in `interfaceA` is `INT` whereas in `interfaceB` it is `DINT`. Futhermore,
-the parameter `a` in `interfaceA` is an input parameter whereas in `interfaceB` it is an output parameter.
-As a result both you and the compiler are left in doubt as to which method signature to implement in the
-function block `fb` and as a result the compiler will raise this error.
+Align the method signatures in the interfaces. Sub-diagnostics point at the exact mismatches.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E112.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E112.md
@@ -1,39 +1,42 @@
-# Incomplete interface implementation
+# Incomplete Interface Implementation
 
-Any class or function block implementing an interface must implement all methods as defined in the interface. 
-Generally speaking this error is raised when any of the following conditions are met:
-1. The method is not implemented in the class or function block at all
-2. The return type of the method is different from the return type defined in the interface
-3. The order of the parameters in the method is different from the order of the parameters in the interface
-4. The size of the parameter list does not match the size of the parameter list in the interface
-5. The parameter at any given position in the method is different from the parameter at the same position in 
-the interface (name, data type, or variable block type i.e. INPUT, OUTPUT, IN_OUT)
+A `CLASS` or `FUNCTION_BLOCK` implementing an interface must provide every method and
+property declared in it, with an identical signature: same return type and same parameter
+names, types, order, and declaration kinds (`VAR_INPUT`, `VAR_OUTPUT`, `VAR_IN_OUT`).
+Parameter order matters because implicit calls like `foo(1, 2)` assign arguments by position.
 
-Errouneus code example:
+## Missing method
+
+Erroneous code example:
+
 ```iecst
 INTERFACE interfaceA
-    METHOD foo : INT
-        VAR_INPUT
-            a : INT;
-            b : DINT;
-        END_VAR
+    METHOD methodA
     END_METHOD
 END_INTERFACE
 
-FUNCTION_BLOCK fb IMPLEMENTS interfaceA
-    METHOD foo : DINT   // Incorrect return type, should have been `INT`
-        VAR_OUPUT       // Incorrect variable block type, should have been `VAR_INPUT`
-            b : DINT;   // Incorrect order, should have been `a : INT`; as a result also an incorrect data type
-            a : INT;    // Incorrect order, should have been `b : DINT`; as a result also an incorrect data type
-            c : INT;    // Incorrect parameter list length, 3 > 2
-        END_VAR
+FUNCTION_BLOCK fb IMPLEMENTS interfaceA // error: Method `methodA` defined in interface `interfaceA` is missing in POU `fb`
+END_FUNCTION_BLOCK
+```
+
+## Conflicting signature
+
+Erroneous code example:
+
+```iecst
+INTERFACE interfaceA
+    METHOD methodA : DINT
+    END_METHOD
+END_INTERFACE
+
+FUNCTION_BLOCK fb IMPLEMENTS interfaceA // error: Derived methods with conflicting signatures, return types do not match:
+    METHOD methodA : BOOL
     END_METHOD
 END_FUNCTION_BLOCK
 ```
 
-
-**Note**: The third bullet point can be confusing, however for implicit calls the order of the parameters is
-important. For example if a interface defines the order of the parameters as `a, b` and the function block
-implements the method as `b, a` a method call such as `foo(1, 2)` should be interpreted as `foo(a := 1, b := 2)`
-but instead will be interpreted as `foo(a := 2, b := 1)`. As a result consistency between any POU implementing
-an interface can no longer be guaranteed.
+Parameter mismatches are reported as "Derived methods with conflicting signatures, parameters
+do not match:", with sub-diagnostics pointing at each offending parameter. The same code also
+covers conflicting property types, e.g. a property whose `PROPERTY_GET` and `PROPERTY_SET`
+datatypes differ, an overridden property whose type differs from the parent POU, or two
+implemented interfaces declaring the same property with different datatypes.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E113.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E113.md
@@ -1,14 +1,17 @@
-# Interface default method implementation
+# Interface Default Method Implementation
 
-Methods defined in interfaces must not have an implementation. While the compiler parses them, they are not
-used to validate and/or generate code and thus will have no effect. This may change in the future but as of 
-now is not supported.
+Methods and properties declared in an `INTERFACE` must not contain statements. Default
+implementations are not supported; interface bodies only describe signatures.
 
-Erreneous code example:
+Erroneous code example:
+
 ```iecst
 INTERFACE interfaceA
     METHOD methodA : INT
-        methodA := 5; // This counts as a default implementation and hence will return a warning
+        methodA := 5; // error: Interfaces can not have a default implementation
     END_METHOD
 END_INTERFACE
 ```
+
+Remove the statements from the interface and implement the method in the POUs that implement
+the interface. The same applies to `PROPERTY_GET` and `PROPERTY_SET` bodies.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E114.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E114.md
@@ -1,10 +1,20 @@
-# Cannot extend a POU multiple times 
+# Multiple Inheritance
 
-Multiple `EXTENDS` keywords are not allowed
+A POU declared more than one `EXTENDS` clause. POUs can only extend a single parent; every
+`EXTENDS` after the first is reported and ignored.
 
-Erreneous code example:
+Erroneous code example:
+
 ```iecst
-FUNCTION_BLOCK foo EXTENDS bar EXTENDS baz
-    // ...
+FUNCTION_BLOCK foo
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK bar
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK baz EXTENDS foo EXTENDS bar // error: Multiple inheritance. POUs can only be extended once.
 END_FUNCTION_BLOCK
 ```
+
+Keep a single `EXTENDS` clause; if behavior from several types is needed, build a chain of
+single inheritance or use interfaces.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E115.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E115.md
@@ -1,12 +1,6 @@
-# Property defined in non-stateful POU type
+# Property in Unsupported POU Type
 
-Properties may only be defined in stateful POUs such as a `PROGRAM`,`CLASS` or `FUNCTION_BLOCK`.
+Reserved for properties declared in POU types that do not support them. Properties are only
+valid in stateful POUs such as `FUNCTION_BLOCK` and `PROGRAM`.
 
-Errouneus code example:
-```
-FUNCTION foo
-    // Invalid definition
-    PROPERTY_GET bar: DINT
-        bar := 42;
-    END_PROPERTY
-END_FUNCTION
+This code is currently not emitted by the compiler.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E116.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E116.md
@@ -1,13 +1,20 @@
-# Property defined in unsupported variable block
+# Property With Unsupported Variable Block
 
-Properties only allow for variable blocks of type `VAR`.
+A property implementation declared a variable block other than `VAR` or `VAR_TEMP`. Properties
+cannot have their own `VAR_INPUT`, `VAR_OUTPUT` or `VAR_IN_OUT` blocks; their only interface is
+the property value itself.
 
-Errouneus code example:
-```
-FUNCTION foo
-    PROPERTY_GET bar: DINT
-        VAR         /* ... */   END_VAR
-        VAR_INPUT   /* ... */   END_VAR // Invalid
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    PROPERTY_GET prop : DINT // error: Properties only allow variable blocks of type VAR
+        VAR_INPUT
+            x : DINT;
+        END_VAR
+        prop := 5;
     END_PROPERTY
-END_FUNCTION
+END_FUNCTION_BLOCK
 ```
+
+Move such variables into a `VAR` block inside the property, or into the containing POU.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E117.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E117.md
@@ -1,7 +1,18 @@
-# Non-constant array boundary
+# Non-Constant Array Boundary
 
-Array boundaries must be compile-time constants.
+An array dimension referenced a variable that is not declared as `CONSTANT`. Array boundaries
+must be compile-time constants: literals, constant variables, or expressions built from them.
 
-Examples of invalid boundaries:
-- Local variables declared without `CONSTANT`
-- Expressions that are not compile-time evaluable constants
+Erroneous code example:
+
+```iecst
+FUNCTION main : DINT
+    VAR
+        x : INT := 5;
+        arr : ARRAY[1..x] OF INT; // error: Only constants are allowed as array boundaries
+    END_VAR
+END_FUNCTION
+```
+
+Declare the boundary variable in a `VAR CONSTANT` or `VAR_GLOBAL CONSTANT` block, or use a
+literal.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E118.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E118.md
@@ -1,3 +1,25 @@
-# Signature mismatch
+# Signature Mismatch Detail
 
-This error is generally a follow-up error to "E112" to give more detailed information about why the error occured. Please use `plc explain E112` get more information about the general causes of these errors.
+A note attached to a conflicting-method-signatures error that pinpoints the exact mismatch: a
+parameter name, type, or declaration type (`VAR_INPUT`, `VAR_OUTPUT`, `VAR_IN_OUT`) that
+differs, a missing or extra parameter, or conflicting array dimensions and string lengths. It
+is never reported on its own.
+
+Erroneous code example:
+
+```iecst
+FUNCTION_BLOCK fb
+    METHOD foo
+    END_METHOD
+END_FUNCTION_BLOCK
+
+FUNCTION_BLOCK fb2 EXTENDS fb
+    METHOD foo // error: Derived methods with conflicting signatures, parameters do not match:
+        VAR_INPUT
+            in1 : BOOL; // note: `foo` has more parameters than the method defined in `fb`
+        END_VAR
+    END_METHOD
+END_FUNCTION_BLOCK
+```
+
+The note tells you which parameter to fix.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E119.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E119.md
@@ -1,50 +1,33 @@
-# Invalid use of the `SUPER` keyword
+# Invalid Use of SUPER
 
-The `SUPER` keyword provides access to members of a parent POU (Program Organization Unit) in an inheritance hierarchy. However, there are several rules governing its proper use:
+`SUPER` gives access to the parent POU in an inheritance hierarchy and is only valid inside a
+POU that directly extends another POU. It also must stand alone: it cannot appear in
+member-access position (`x.SUPER^`, `SUPER^.SUPER^`), in global-access position (`.SUPER^`),
+or as the target of a type cast (`<type>#SUPER`).
 
-## Common errors
-
-1. **Using `SUPER` in a POU that doesn't extend another POU**:  
-   The `SUPER` keyword can only be used inside a POU that directly extends another POU through the `EXTENDS` keyword.
-
-2. **Not dereferencing `SUPER` to access members**:  
-   When accessing members of a superclass, `SUPER` must be dereferenced using the `^` operator: `SUPER^.member`.
-
-3. **Chaining `SUPER` references**:  
-   `SUPER` cannot be accessed as a member of another object. Expressions like `SUPER^.SUPER^` are invalid.
-
-4. **Global access position**:  
-   `SUPER` cannot be used with the global access operator (`.SUPER^.member`).
-
-5. **Using `SUPER` with type cast operators**:  
-   The type cast operator (`<type>#`) cannot be used with `SUPER`.
-
-## Examples of invalid use
+## POU does not extend anything
 
 ```iecst
-// Error: Using SUPER in a POU that doesn't extend another POU
 FUNCTION_BLOCK fb
-    SUPER^.x := 2;  // Error: Invalid use of `SUPER`
+    VAR
+        x : DINT;
+    END_VAR
+    SUPER^.x := 2; // error: Invalid use of `SUPER`. Usage is only allowed within a POU that directly extends another POU.
+END_FUNCTION_BLOCK
+```
+
+## SUPER in member-access position
+
+```iecst
+FUNCTION_BLOCK parent
+    VAR
+        x : DINT;
+    END_VAR
 END_FUNCTION_BLOCK
 
-// Error: Not dereferencing SUPER when accessing members
 FUNCTION_BLOCK child EXTENDS parent
-    SUPER.x := 20;  // Error: `SUPER` must be dereferenced to access its members
+    SUPER^.SUPER^.x := 20; // error: `SUPER` is not allowed in member-access position.
 END_FUNCTION_BLOCK
+```
 
-// Error: Chaining SUPER references/SUPER in member access
-FUNCTION_BLOCK child EXTENDS parent
-    x.SUPER^.y := 20;    
-    SUPER^.SUPER^.x := 20;  
-    // Error: `SUPER` is not allowed in member-access position
-END_FUNCTION_BLOCK
-
-// Error: Global access position
-FUNCTION_BLOCK child EXTENDS parent
-    .SUPER^.x := 20;  // Error: `SUPER` is not allowed in global-access position
-END_FUNCTION_BLOCK
-
-// Error: Using SUPER with type cast
-FUNCTION_BLOCK child EXTENDS parent
-    p := parent#SUPER;  // Error: The `<type>#` operator cannot be used with `SUPER`
-END_FUNCTION_BLOCK
+Use a single `SUPER^.member` access inside a POU that has an `EXTENDS` clause.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E120.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E120.md
@@ -1,89 +1,31 @@
-# Invalid use of the `THIS` keyword
+# Invalid Use of THIS
 
-The `THIS` keyword provides access to the current instance of a `FUNCTION_BLOCK`. However, there are several rules governing its proper use:
+`THIS` refers to the current instance and is only valid inside a `FUNCTION_BLOCK` and its
+`METHOD`s and `ACTION`s, not in a `FUNCTION` or `PROGRAM`. It also must stand alone: it cannot
+appear in member-access position (`x.THIS^`), in global-access position (`.THIS^`), or as the
+target of a type cast (`<type>#THIS`).
 
-## Common errors
-
-1. **Using `THIS` outside of a `FUNCTION_BLOCK` context**:
-   The `THIS` keyword can only be used inside a `FUNCTION_BLOCK` or its `METHOD`s or `ACTION`s. It cannot be used in `FUNCTION`s, `PROGRAM`s, or .
-
-2. **Not dereferencing `THIS` to access members**:
-   When accessing members using `THIS`, it must be dereferenced using the `^` operator: `THIS^.member`.
-
-3. **Member access position**:
-   `THIS` cannot be accessed as a member of another object. Expressions like `x.THIS^` are invalid.
-
-4. **Global access position**:
-   `THIS` cannot be used with the global access operator (`.THIS^.member`).
-
-5. **Using `THIS` with type cast operators**:
-   The type cast operator (`<type>#`) cannot be used with `THIS`.
-
-## Examples of invalid use
+## THIS outside a function block
 
 ```iecst
-// Error: Using THIS outside `FUNCTION_BLOCK` context
-FUNCTION func
-    THIS^.x := 2;  // Error: Invalid use of `THIS`
-END_FUNCTION
-
-// Error: Not dereferencing THIS when accessing members
-FUNCTION_BLOCK fb
-    THIS.x := 20;  // Error: `THIS` must be dereferenced to access its members
-END_FUNCTION_BLOCK
-
-// Error: THIS in member access position
-FUNCTION_BLOCK fb
-    x.THIS^.y := 20;  // Error: `THIS` is not allowed in member-access position
-END_FUNCTION_BLOCK
-
-// Error: Global access position
-FUNCTION_BLOCK fb
-    .THIS^.x := 20;  // Error: `THIS` is not allowed in global-access position
-END_FUNCTION_BLOCK
-
-// Error: Using THIS with type cast
-FUNCTION_BLOCK fb
-    p := fb#THIS;  // Error: The `<type>#` operator cannot be used with `THIS`
-END_FUNCTION_BLOCK
-```
-
-## Examples of valid use
-
-```iecst
-FUNCTION_BLOCK Counter
+PROGRAM prog
     VAR
-        count : INT;
-        enabled : BOOL;
+        x : DINT;
     END_VAR
+    THIS^.x := 2; // error: Invalid use of `THIS`. Usage is only allowed within `FUNCTION_BLOCK` and its `METHOD`s and `ACTION`s.
+END_PROGRAM
+```
 
-    // Valid: Direct use in FUNCTION_BLOCK implementation
-    METHOD increment
-        IF THIS^.enabled THEN
-            THIS^.count := THIS^.count + 1;
-        END_IF
-    END_METHOD
+## THIS in member-access position
 
-    // Valid: Using THIS to pass the instance to another FB
-    METHOD send_to_logger : BOOL
-        VAR_IN_OUT
-            logger : Logger;
-        END_VAR
-        logger.log_counter(THIS);
-    END_METHOD
-
-    // Valid: Using THIS to compare with another instance
-    METHOD equals : BOOL
-        VAR_IN_OUT
-            other : Counter;
-        END_VAR
-        equals := THIS^.count = other.count;
-    END_METHOD
-
-    ACTION my_action
-        IF THIS^.enabled THEN
-            THIS^.count := THIS^.count + 1;
-        END_IF
-    END_ACTION
+```iecst
+FUNCTION_BLOCK fb
+    VAR
+        other : fb;
+        x : DINT;
+    END_VAR
+    other.THIS^.x := 20; // error: `THIS` is not allowed in member-access position.
 END_FUNCTION_BLOCK
 ```
+
+Use `THIS^.member` directly inside the function block, its methods, or its actions.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E121.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E121.md
@@ -1,31 +1,14 @@
-# E121: Recursive type alias
+# Recursive Type Alias
 
-This error occurs when type aliases reference each other in a cycle, creating an infinite recursion.
+A type alias refers to itself, directly or through a chain of other aliases, so it never
+resolves to a concrete type. The message shows the full cycle, e.g.
+`type1 -> type2 -> type1`.
 
-## Example
+Erroneous code example:
 
-```st
-TYPE type1 : type2; END_TYPE
+```iecst
+TYPE type1 : type2; END_TYPE // error: Recursive type alias `type1 -> type2 -> type1`
 TYPE type2 : type1; END_TYPE
 ```
 
-In this example, `type1` is defined as `type2`, which is in turn defined as `type1`, creating a circular dependency.
-
-## Another example
-
-```st
-TYPE self_type : self_type; END_TYPE
-```
-
-This shows a type alias that directly references itself.
-
-## How to fix
-
-**Break the chain by resolving to concrete types**
-
-Break the circular dependency by ensuring that type aliases eventually resolve to concrete types:
-
-```st
-TYPE typeA : DINT; END_TYPE      (* Points to concrete type *)
-TYPE typeB : typeA; END_TYPE     (* Points to another alias, but ultimately resolves to DINT *)
-```
+Break the cycle by pointing one of the aliases at a concrete type such as `DINT`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E122.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E122.md
@@ -1,56 +1,18 @@
-# E122: Invalid enum base type
+# Invalid Enum Base Type
 
-This error occurs when an enum is declared with a base type that is not a valid integer type. Enums in IEC 61131-3 can only use integer types as their underlying representation.
+An enum was declared with a base type that is not an integer type. Only integer types such as
+`SINT`, `INT`, `DINT`, `LINT`, their unsigned variants, and the bit types `BYTE`, `WORD`,
+`DWORD`, `LWORD` are allowed; floating point, string, struct, and date or time types are not,
+even when an alias ultimately resolves to one of them.
 
-## Example
+Erroneous code example:
 
-```st
-TYPE Color : STRING (red := 1, green := 2, blue := 3);
-END_TYPE
-
-TYPE Status : REAL (active := 1, inactive := 0);
-END_TYPE
-
-TYPE Timestamp : TIME (start := 0, stop := 1);
-END_TYPE
+```iecst
+TYPE Color : REAL (red := 1, green := 2, blue := 3); END_TYPE // error: Invalid type 'REAL' for enum. Only integer types are allowed
 ```
 
-These examples show invalid base types:
-- `STRING` is not a valid base type for an enum. Only integer types are allowed.
-- `REAL` is a floating-point type, not an integer type
-- `TIME` is a time/date type, which although internally represented as an integer, should not be used as an enum base type
+Use an integer base type, or omit the type entirely to get the default of `DINT`:
 
-## Valid integer types
-
-The following integer types are valid for enum base types:
-- `INT`, `UINT` - 16-bit integers
-- `SINT`, `USINT` - 8-bit integers
-- `DINT`, `UDINT` - 32-bit integers
-- `LINT`, `ULINT` - 64-bit integers
-- `BYTE` - 8-bit unsigned
-- `WORD` - 16-bit unsigned
-- `DWORD` - 32-bit unsigned
-- `LWORD` - 64-bit unsigned
-
-## How to fix
-
-**Use a valid integer type**
-
-Change the base type to one of the supported integer types:
-
-```st
-TYPE Color : INT (red := 1, green := 2, blue := 3);
-END_TYPE
-
-TYPE Status : BYTE (active := 1, inactive := 0);
-END_TYPE
-```
-
-**Or omit the type specification**
-
-If no specific size is required, you can omit the type specification (will default to `DINT`):
-
-```st
-TYPE Color (red := 1, green := 2, blue := 3);
-END_TYPE
+```iecst
+TYPE Color : (red := 1, green := 2, blue := 3); END_TYPE
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E123.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E123.md
@@ -1,35 +1,16 @@
-# E123: Division by zero error
+# Division by Zero
 
-This error occurs when a literal or constant on the right side of a division operation is zero.
+The right-hand side of a division is provably zero at compile time, either a literal `0` or a
+constant that evaluates to zero. Non-constant variables are not checked; a zero divisor at
+runtime is not caught by this diagnostic.
 
-## Examples
+Erroneous code example:
 
-### Literal is zero
-```st
-FUNCTION main
+```iecst
+FUNCTION main : DINT
     VAR
         x : DINT;
-        divX : DINT;
     END_VAR
-
-    x := 5;
-    divX := x / 0;
-END_FUNCTION
-```
-
-### Constant is zero
-```st
-VAR_GLOBAL CONSTANT
-    ConstantZero: DINT := 0;
-END_VAR
-
-FUNCTION main
-    VAR
-        x : DINT;
-        divX : DINT;
-    END_VAR
-
-    x := 5;
-    divX := x / ConstantZero;
+    main := x / 0; // error: Division by Zero
 END_FUNCTION
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E124.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E124.md
@@ -1,54 +1,29 @@
-# E124: Invalid escape sequence in string literal
+# Invalid Escape Sequence in String Literal
 
-This error occurs when a string literal contains a `$`-escape sequence that is not valid
-per IEC 61131-3.
+A string literal contains a `$` escape that is not valid. Valid escapes are `$$`, `$'`
+(STRING), `$"` (WSTRING), the control characters `$L`/`$N`, `$R`, `$T`, `$P` (case
+insensitive), and hex escapes: exactly 2 hex digits (`$41`) in a STRING, exactly 4 (`$0041`)
+in a WSTRING. A `$` at the very end of a literal is also invalid because it has nothing to
+escape.
 
-Valid escape sequences are:
+## Unrecognized escape character
 
-| Sequence | Valid in | Result |
-|----------|----------|--------|
-| `$$`     | STRING, WSTRING | Literal `$` |
-| `$'`     | STRING          | Literal `'` |
-| `$"`     | WSTRING         | Literal `"` |
-| `$L`, `$l`, `$N`, `$n` | STRING, WSTRING | Line feed (`\n`) |
-| `$R`, `$r` | STRING, WSTRING | Carriage return (`\r`) |
-| `$T`, `$t` | STRING, WSTRING | Horizontal tab (`\t`) |
-| `$P`, `$p` | STRING, WSTRING | Form feed (`\x0C`) |
-| `$hh`    | STRING  | Byte with hex value `hh` (exactly 2 hex digits) |
-| `$hhhh`  | WSTRING | UTF-16 code unit with hex value `hhhh` (exactly 4 hex digits) |
-
-## Examples
-
-### Unrecognised escape character
-
-```st
+```iecst
 FUNCTION main : DINT
-VAR
-    s : STRING[20] := 'test$Qtest';   (* $Q is not a valid escape *)
-END_VAR
-    main := 0;
+    VAR
+        s : STRING[20] := 'test$Qtest'; // error: Invalid escape sequence in string literal: '$Q' is not a valid escape sequence
+    END_VAR
 END_FUNCTION
 ```
 
-### Incomplete hex escape
+## Incomplete hex escape
 
-```st
+```iecst
 FUNCTION main : DINT
-VAR
-    s : STRING[10] := '$A';       (* STRING needs exactly 2 hex digits: e.g. $41 *)
-    w : WSTRING[10] := "$004";    (* WSTRING needs exactly 4 hex digits: e.g. $0041 *)
-END_VAR
-    main := 0;
+    VAR
+        s : STRING[10] := '$A'; // error: Invalid escape sequence in string literal: incomplete hex escape, expected 2 hex digits after '$'
+    END_VAR
 END_FUNCTION
 ```
 
-### Trailing dollar sign
-
-```st
-FUNCTION main : DINT
-VAR
-    s : STRING[10] := 'hello$';   (* '$' at end of literal has nothing to escape *)
-END_VAR
-    main := 0;
-END_FUNCTION
-```
+Write a literal `$` as `$$`, and pad hex escapes to the required number of digits.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E125.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E125.md
@@ -1,19 +1,13 @@
-# Incompatible POINTER TO types in class/function block hierarchy
+# Incompatible Pointer Types in Inheritance Hierarchy
 
-This error occurs when a `POINTER TO` assignment involves two class or function block types
-that are not in a valid inheritance relationship. Only upcasts (child to parent) and same-type
-assignments are allowed.
+A `POINTER TO` assignment mixes class or function block types that are not in a valid
+inheritance relationship. The right-hand side must point to the same type as the pointer's
+pointee or to a subtype of it (an upcast); unrelated types, siblings, and downcasts from
+parent to child pointer are all rejected.
 
-`POINTER TO` is the recommended mechanism for polymorphism per IEC 61131-3. When working with
-class or function block hierarchies, the compiler checks that pointer assignments respect the
-`EXTENDS` chain: the right-hand side must be the same type as, or a subtype of, the left-hand
-side's pointee type.
+Erroneous code example:
 
-## Invalid examples
-
-### Unrelated types
-
-```st
+```iecst
 FUNCTION_BLOCK FbA
 END_FUNCTION_BLOCK
 
@@ -25,82 +19,10 @@ FUNCTION main
         instance : FbX;
         ptr      : POINTER TO FbA;
     END_VAR
-    ptr := ADR(instance);  // Error: FbX is not a subtype of FbA
+    ptr := ADR(instance); // error: Invalid assignment: 'FbA' and 'FbX' are not related and cannot be used polymorphically
 END_FUNCTION
 ```
 
-### Downcast (parent assigned to child pointer)
-
-```st
-FUNCTION_BLOCK FbA
-END_FUNCTION_BLOCK
-
-FUNCTION_BLOCK FbB EXTENDS FbA
-END_FUNCTION_BLOCK
-
-FUNCTION main
-    VAR
-        instance : FbA;
-        ptr      : POINTER TO FbB;
-    END_VAR
-    ptr := ADR(instance);  // Error: FbA is not a subtype of FbB
-END_FUNCTION
-```
-
-### Sibling types
-
-```st
-FUNCTION_BLOCK FbA
-END_FUNCTION_BLOCK
-
-FUNCTION_BLOCK FbB EXTENDS FbA
-END_FUNCTION_BLOCK
-
-FUNCTION_BLOCK FbC EXTENDS FbA
-END_FUNCTION_BLOCK
-
-FUNCTION main
-    VAR
-        instance : FbC;
-        ptr      : POINTER TO FbB;
-    END_VAR
-    ptr := ADR(instance);  // Error: FbC is not a subtype of FbB
-END_FUNCTION
-```
-
-## Valid examples
-
-### Same type
-
-```st
-FUNCTION_BLOCK FbA
-END_FUNCTION_BLOCK
-
-FUNCTION main
-    VAR
-        instance : FbA;
-        ptr      : POINTER TO FbA;
-    END_VAR
-    ptr := ADR(instance);  // OK
-END_FUNCTION
-```
-
-### Upcast (child assigned to parent pointer)
-
-```st
-FUNCTION_BLOCK FbA
-END_FUNCTION_BLOCK
-
-FUNCTION_BLOCK FbB EXTENDS FbA
-END_FUNCTION_BLOCK
-
-FUNCTION main
-    VAR
-        instanceB : FbB;
-        ptrA      : POINTER TO FbA;
-        ptrB      : POINTER TO FbB;
-    END_VAR
-    ptrA := ADR(instanceB);  // OK: FbB extends FbA
-    ptrA := ptrB;            // OK: same relationship
-END_FUNCTION
-```
+Only assign addresses of instances whose type extends (directly or transitively) the pointee
+type, e.g. `ptr : POINTER TO FbA` may hold `ADR(instance)` when `instance` is of a type that
+`EXTENDS FbA`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E126.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E126.md
@@ -1,19 +1,19 @@
-# Incompatible types in interface polymorphism
+# Incompatible Types in Interface Polymorphism
 
-This error occurs when an assignment or call argument involves an interface type but the
-source type does not satisfy the interface contract. There are two cases:
+An assignment involves an interface-typed variable, but the source value does not satisfy the
+interface contract. There are two cases.
 
-## Case 1: POU does not implement the interface
+## The assigned POU does not implement the interface
 
-When assigning a concrete function block or class instance to an interface-typed variable
-(or passing it as an argument), the POU must implement that interface — either directly
-via `IMPLEMENTS` or transitively through its `EXTENDS` chain.
+A function block or class instance assigned to an interface-typed variable must implement that
+interface, either directly via `IMPLEMENTS` or transitively through its `EXTENDS` chain.
 
-### Invalid
+Erroneous code example:
 
-```st
+```iecst
 INTERFACE IA
-    METHOD foo END_METHOD
+    METHOD foo
+    END_METHOD
 END_INTERFACE
 
 FUNCTION_BLOCK FbX
@@ -24,84 +24,31 @@ FUNCTION main
         instance : FbX;
         ref      : IA;
     END_VAR
-    ref := instance;  // Error: FbX does not implement IA
+    ref := instance; // error: Invalid assignment: 'FbX' does not implement interface 'IA'
 END_FUNCTION
 ```
 
-### Valid
+Declare the function block with `IMPLEMENTS IA` and provide the required methods, or assign an
+instance of a POU that already implements the interface. An implementation inherited from a
+parent function block also satisfies the contract.
 
-```st
+## The interfaces are not related
+
+Assigning one interface reference to another requires the source interface to extend the target
+interface. Unrelated interfaces are rejected, and so are downcasts from a parent interface to a
+child interface.
+
+Erroneous code example:
+
+```iecst
 INTERFACE IA
-    METHOD foo END_METHOD
-END_INTERFACE
-
-FUNCTION_BLOCK FbA IMPLEMENTS IA
-    METHOD foo END_METHOD
-END_FUNCTION_BLOCK
-
-FUNCTION main
-    VAR
-        instance : FbA;
-        ref      : IA;
-    END_VAR
-    ref := instance;  // OK: FbA implements IA
-END_FUNCTION
-```
-
-Implementation is also satisfied transitively through inheritance:
-
-```st
-FUNCTION_BLOCK FbA IMPLEMENTS IA
-    METHOD foo END_METHOD
-END_FUNCTION_BLOCK
-
-FUNCTION_BLOCK FbB EXTENDS FbA
-END_FUNCTION_BLOCK
-
-FUNCTION main
-    VAR
-        instance : FbB;
-        ref      : IA;
-    END_VAR
-    ref := instance;  // OK: FbB inherits IA implementation from FbA
-END_FUNCTION
-```
-
-## Case 2: Interfaces are not related
-
-When assigning one interface-typed variable to another, the source interface must be the
-same as or extend the target interface. Downcasts (parent to child) and assignments between
-unrelated interfaces are rejected.
-
-### Invalid — downcast
-
-```st
-INTERFACE IA
-    METHOD foo END_METHOD
-END_INTERFACE
-
-INTERFACE IB EXTENDS IA
-    METHOD bar END_METHOD
-END_INTERFACE
-
-FUNCTION main
-    VAR
-        refIA : IA;
-        refIB : IB;
-    END_VAR
-    refIB := refIA;  // Error: cannot downcast IA to IB
-END_FUNCTION
-```
-
-### Invalid — unrelated interfaces
-
-```st
-INTERFACE IA
-    METHOD foo END_METHOD
+    METHOD foo
+    END_METHOD
 END_INTERFACE
 
 INTERFACE IB
-    METHOD bar END_METHOD
+    METHOD bar
+    END_METHOD
 END_INTERFACE
 
 FUNCTION main
@@ -109,26 +56,9 @@ FUNCTION main
         refIA : IA;
         refIB : IB;
     END_VAR
-    refIA := refIB;  // Error: IB and IA are not related
+    refIA := refIB; // error: Invalid assignment: 'IA' and 'IB' are not related and cannot be used polymorphically
 END_FUNCTION
 ```
 
-### Valid — upcast
-
-```st
-INTERFACE IA
-    METHOD foo END_METHOD
-END_INTERFACE
-
-INTERFACE IB EXTENDS IA
-    METHOD bar END_METHOD
-END_INTERFACE
-
-FUNCTION main
-    VAR
-        refIA : IA;
-        refIB : IB;
-    END_VAR
-    refIA := refIB;  // OK: IB extends IA
-END_FUNCTION
-```
+Only upcasts are allowed: with `INTERFACE IB EXTENDS IA`, an `IB` reference may be assigned to an
+`IA` variable, but not the other way around.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E127.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E127.md
@@ -1,25 +1,18 @@
-# Array initialized with fewer elements than expected
+# Array Initialized With Fewer Elements Than Expected
 
-An array initializer provides fewer values than the declared array size.
-The remaining elements will be zero-initialized.
+An array initializer supplies fewer values than the declared array length. The remaining
+elements are default-initialized (zero), which may hide an incomplete initializer. It fires
+on variable initializers as well as on initializers of array type declarations.
 
-Example:
+Erroneous code example:
 
-```st
-VAR
-    arr : ARRAY[1..5] OF DINT := [1, 2, 3]; // only 3 of 5 elements
-END_VAR
+```iecst
+PROGRAM main
+    VAR
+        a : ARRAY[1..5] OF INT := [1, 2]; // warning: Fewer initial values for array `a` than expected. Expected 5, found 2.
+    END_VAR
+END_PROGRAM
 ```
 
-This is a warning because the compiler will implicitly fill the unspecified
-elements with their default (zero) value, which may or may not be intentional.
-
-To silence this warning, provide all elements explicitly or use a multiplied
-initializer to fill the rest:
-
-```st
-VAR
-    arr : ARRAY[1..5] OF DINT := [1, 2, 3, 0, 0];   // explicit
-    arr2 : ARRAY[1..5] OF DINT := [1, 2, 3, 2(0)];   // multiplied fill
-END_VAR
-```
+Provide a value for every element, or accept the default initialization of the remaining
+elements if it is intentional.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E128.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E128.md
@@ -1,48 +1,35 @@
-# Invalid assignment through a property
+# Invalid Nested Property Assignment Target
 
-Properties can only be assigned as a whole, not through member or index access.
+A write goes through a member or index access on a property, e.g. `instance.prop.x := ...` or
+`instance.prop[i] := ...`. Reading a property calls its `GET` accessor and yields a temporary
+copy, so a write into that copy would be silently lost; only assigning the property as a whole
+invokes the `SET` accessor.
 
-A setter `position` is conceptually just a method call, similar to:
+Erroneous code example:
 
-```iec61131st
-instance.set_position(value)
+```iecst
+TYPE Position : STRUCT
+    x : DINT;
+    y : DINT;
+END_STRUCT END_TYPE
+
+FUNCTION_BLOCK FbA
+    PROPERTY_GET position : Position END_PROPERTY
+    PROPERTY_SET position : Position END_PROPERTY
+END_FUNCTION_BLOCK
+
+FUNCTION main
+    VAR
+        instance : FbA;
+    END_VAR
+    instance.position.x := 5; // error: Properties can only be assigned as a whole, not through member or index access
+END_FUNCTION
 ```
 
-That means the setter updates the entire property value. It does not produce an assignable intermediate value,
-so writing through a property into nested fields or elements is not allowed.
+Read the property into a local variable, modify it, and assign it back as a whole:
 
-## Invalid
-
-Assigning to a field of a property:
-
-```iec61131st
-instance.position.x := 5;
-```
-
-Assigning to an indexed element of a property:
-
-```iec61131st
-instance.values[1] := 5;
-```
-
-Using a property as the base of a larger assignment target:
-
-```iec61131st
-instance.positions[1].x := 5;
-```
-
-## Valid
-
-Assign the full property value:
-
-```iec61131st
-instance.position := value;
-instance.values := local_array;
-```
-
-Read from a property and then access members or indices:
-
-```iec61131st
-local := instance.position.x;
-arr[instance.position.x] := 5;
+```iecst
+    pos := instance.position;
+    pos.x := 5;
+    instance.position := pos;
 ```

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E129.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E129.md
@@ -1,45 +1,24 @@
-# Interfaces cannot be called directly
+# Direct Interface Reference Call
 
-Calling an interface-typed variable directly like `myInterface()` is invalid and instead a concrete method
-must be called, e.g. `myInterface.foo()`.
+An interface-typed variable is called like a function block instance, e.g. `refIA()`. An
+interface has no body of its own, so only its methods can be called through the reference.
+This also applies to qualified references and array elements, e.g. `THIS^.refIA()` or
+`refs[i]()`.
 
-## Invalid
+Erroneous code example:
 
-```st
+```iecst
 INTERFACE IA
-    METHOD foo END_METHOD
+    METHOD foo
+    END_METHOD
 END_INTERFACE
 
 FUNCTION main
     VAR
         refIA : IA;
     END_VAR
-
-    refIA();
+    refIA(); // error: Interfaces cannot be called directly
 END_FUNCTION
 ```
 
-This also applies to qualified references and array elements:
-
-```st
-THIS^.refIA();
-refs[i]();
-```
-
-## Valid
-
-Specify the method name explicitly:
-
-```st
-INTERFACE IA
-    METHOD foo END_METHOD
-END_INTERFACE
-
-FUNCTION main
-    VAR
-        refIA : IA;
-    END_VAR
-
-    refIA.foo();
-END_FUNCTION
-```
+Call one of the interface's methods instead, e.g. `refIA.foo();`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E130.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E130.md
@@ -1,24 +1,19 @@
-# Array size exceeds supported limit
+# Array Size Exceeds Supported Limit
 
-The declared array has more elements than the compiler can safely handle.
-The total number of elements (the product of all dimension lengths) must not
-exceed `UDINT#4_294_967_295`.
+The total element count of an array, the product of all dimension lengths, exceeds the maximum
+supported size of `UDINT#4_294_967_295` elements. Dimensions with an invalid range (start
+greater than end) are not counted here and are reported separately.
 
-Extremely large arrays cause excessive compilation times and may fail to link
-because the resulting object file cannot represent them.
+Erroneous code example:
 
-## Example
-
-```st
-VAR
-    // 5 × 988_010 × 3 × 91 × ... = ~837 billion elements — exceeds UDINT max
-    huge : ARRAY[1..5, 2345324..3333333, -1..1, 10..100] OF DINT;
-END_VAR
+```iecst
+FUNCTION main : DINT
+    VAR
+        // error: Array `huge` has 837_501_496_650 elements which exceeds the maximum supported array size of UDINT#4_294_967_295 elements.
+        huge : ARRAY[1..5, 2345324..3333333, -1..1, 10..100, 33..55, -1..1, -1..1, -1..1] OF DINT;
+    END_VAR
+END_FUNCTION
 ```
 
-## Possible fixes
-
-- Reduce the array dimensions.
-- Use dynamically allocated memory via `REF_TO` and runtime allocation if
-  the platform supports it.
-- Split the data across multiple smaller arrays.
+Reduce the dimension ranges so the total element count fits within the limit, or split the data
+across several smaller arrays.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E131.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E131.md
@@ -1,25 +1,28 @@
-# Positional argument collides with later named argument
+# Positional Argument Collides With Later Named Argument
 
-In a mixed implicit/explicit call, a positional argument would naturally fill the same
-parameter that a *later* named argument also targets. The positional would spill into
-the next free slot - a silent reinterpretation that is almost never what the caller
-intended. This is an error because no legitimate code should depend on that
-disambiguation.
+In a call mixing positional and named arguments, a positional argument would naturally fill a
+parameter slot that a later named argument also targets. The resolver would silently spill the
+positional value into the next free slot, so `myfunc(1, a := 10)` becomes `a := 10, b := 1`,
+which is almost never intended. Named arguments appearing before a positional are fine; they
+deliberately reorder the filling.
+
+Erroneous code example:
 
 ```iecst
 FUNCTION myfunc : INT
-VAR_INPUT
-    a : INT;
-    b : INT;
-END_VAR
+    VAR_INPUT
+        a : INT;
+        b : INT;
+    END_VAR
 END_FUNCTION
 
 PROGRAM main
-VAR x : INT; END_VAR
-    // `1` sits in position 0 (param `a`), but `a := 10` also targets `a`.
-    x := myfunc(1, a := 10);
+    VAR
+        x : INT;
+    END_VAR
+    x := myfunc(1, a := 10); // error: Positional argument collides with later named argument `a`
 END_PROGRAM
 ```
 
-Rewrite the call so the intent is unambiguous - either name both arguments or drop the
-duplicate name.
+Name every argument, e.g. `myfunc(b := 1, a := 10)`, or drop the duplicate so each parameter is
+assigned exactly once.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E132.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E132.md
@@ -1,40 +1,27 @@
-# Mixing implicit and explicit call parameters
+# Mixing Implicit and Explicit Call Parameters
 
-A call mixes positional (implicit) arguments with named (explicit) arguments.
-The compiler accepts this, but the resolution is order-sensitive: named args
-first claim their slots, and any remaining positional args fill the leftover
-slots left-to-right. This is easy to misread and easy to break by reordering.
+A call mixes positional (implicit) arguments with named (explicit) arguments. Named arguments
+claim their slots first and the remaining positional arguments fill the leftover slots from
+left to right, which is easy to misread.
 
 Example:
 
-```st
+```iecst
 FUNCTION myfunc : INT
-VAR_INPUT
-    a : INT;
-    b : INT;
-    c : INT;
-END_VAR
+    VAR_INPUT
+        a : INT;
+        b : INT;
+        c : INT;
+    END_VAR
 END_FUNCTION
 
 PROGRAM main
-VAR x : INT; END_VAR
-    // `b := 20` claims slot 1; positional `1` fills slot 0 (a), `3` fills slot 2 (c).
-    x := myfunc(b := 20, 1, 3);
+    VAR
+        x : INT;
+    END_VAR
+    x := myfunc(b := 20, 1, 3); // Mixing implicit and explicit call parameters
 END_PROGRAM
 ```
 
-Prefer one style per call - fully positional or fully named - so a reader can
-see the mapping at a glance. If a mix is genuinely the clearest option (e.g. to
-override one default in the middle of a long parameter list), name every
-argument whose position isn't obvious.
-
-To silence this warning, rewrite the call with a single convention:
-
-```st
-    x := myfunc(1, 20, 3);                    // all positional
-    x := myfunc(a := 1, b := 20, c := 3);     // all named
-```
-
-See also `E131` — positional arg collides with later named arg — which catches
-the more dangerous case where a positional argument's natural slot is also
-named, and the resolver silently shifts it to a different parameter.
+Prefer a single convention per call, either fully positional (`myfunc(1, 20, 3)`) or fully
+named (`myfunc(a := 1, b := 20, c := 3)`).

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E133.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E133.md
@@ -1,46 +1,21 @@
-# AND_THEN / OR_ELSE Used With Non-Boolean Operands
+# AND_THEN / OR_ELSE With Non-Boolean Operands
 
-The `AND_THEN` and `OR_ELSE` operators provide explicit short-circuit evaluation semantics and are only meaningful for boolean operands.
-When used with integer types, short-circuit evaluation does not apply — use `AND` / `OR` instead for bitwise operations.
+The short-circuit operators `AND_THEN` and `OR_ELSE` require both operands to be boolean.
+On integer types short-circuit evaluation is meaningless; the bitwise operators `AND` and `OR`
+must be used instead.
 
 Erroneous code example:
 
 ```iecst
 PROGRAM main
-VAR
-    a : DINT;
-    b : DINT;
-    c : DINT;
-END_VAR
-    c := a AND_THEN b;  // ❌ AND_THEN requires BOOL operands
-    c := a OR_ELSE b;   // ❌ OR_ELSE requires BOOL operands
+    VAR
+        a : DINT;
+        b : DINT;
+        c : DINT;
+    END_VAR
+    c := a AND_THEN b; // error: `AND_THEN` requires boolean operands, use `AND` for bitwise operations on non-boolean types
 END_PROGRAM
 ```
 
-To fix, either use boolean operands:
-
-```iecst
-PROGRAM main
-VAR
-    a : BOOL;
-    b : BOOL;
-    c : BOOL;
-END_VAR
-    c := a AND_THEN b;  // ✅ correct: both operands are BOOL
-    c := a OR_ELSE b;   // ✅ correct: both operands are BOOL
-END_PROGRAM
-```
-
-Or use `AND` / `OR` for bitwise operations on integers:
-
-```iecst
-PROGRAM main
-VAR
-    a : DINT;
-    b : DINT;
-    c : DINT;
-END_VAR
-    c := a AND b;  // ✅ correct: bitwise AND
-    c := a OR b;   // ✅ correct: bitwise OR
-END_PROGRAM
-```
+Use `BOOL` operands with `AND_THEN`/`OR_ELSE`, or switch to `AND`/`OR` for bitwise operations
+on integers.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E134.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E134.md
@@ -1,24 +1,19 @@
 # Invalid Hardware Map Output Configuration
 
-This error describes a problem with the `--hwmap-file` command-line argument - most
-commonly an output path whose extension does not identify a supported serialization
-format. The hardware map sidecar is currently emitted as JSON or TOML, selected by
-the file extension.
+The `--hwmap-file` command-line argument is invalid, most commonly because the given output
+path has an extension that does not identify a supported serialization format. The hardware
+map is emitted as JSON or TOML, selected by the file extension. It is caused by the
+invocation, not the source code.
 
 Erroneous invocation:
 
 ```sh
 plc main.st --hwmap-file=output.xml
+# error: Cannot identify format type for output.xml, valid extensions : "json", "toml"
 ```
 
-To fix, use a supported extension:
-
-```sh
-plc main.st --hwmap-file=output.json
-plc main.st --hwmap-file=output.toml
-```
-
-Or omit the value to let the compiler derive `<output>.hwmap.json` next to the binary:
+Use a `.json` or `.toml` path, or pass a bare `--hwmap-file` to derive `<output>.hwmap.json`
+from the output name:
 
 ```sh
 plc main.st -o main.so --hwmap-file

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E135.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E135.md
@@ -1,31 +1,26 @@
 # `=>` Used for a Non-Output Parameter
 
-`=>` captures a value **out of** an `OUTPUT` parameter into a caller variable. Using it for an `INPUT` or `IN_OUT` parameter is a direction mismatch — those parameters expect `:=` to pass a value **into** the call.
+A call passes an input or in-out parameter with the output assignment operator `=>`. That
+operator captures a value out of a `VAR_OUTPUT` parameter into a caller variable; input and
+in-out parameters take values with `:=`.
 
 Erroneous code example:
 
 ```iecst
 FUNCTION_BLOCK fb
-VAR_INPUT in_val : DINT; END_VAR
+    VAR_INPUT
+        in_val : DINT;
+    END_VAR
 END_FUNCTION_BLOCK
 
 PROGRAM main
-VAR
-    instance : fb;
-    source   : DINT;
-END_VAR
-    instance(in_val => source);  // invalid: ':=' expected for an input parameter
+    VAR
+        instance : fb;
+        source   : DINT;
+    END_VAR
+    instance(in_val => source); // warning: 'in_val' is an input parameter; use ':=' instead of '=>'
 END_PROGRAM
 ```
 
-To fix, use `:=` for the input (or in-out) parameter:
-
-```iecst
-PROGRAM main
-VAR
-    instance : fb;
-    source   : DINT;
-END_VAR
-    instance(in_val := source);  // correct
-END_PROGRAM
-```
+Write `instance(in_val := source);` instead. For a `VAR_IN_OUT` parameter the message reads
+"is an in-out parameter" and the fix is the same.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E136.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E136.md
@@ -1,20 +1,19 @@
-# Incomplete hardware address in `FUNCTION` or `METHOD`
+# Incomplete Hardware Address in FUNCTION or METHOD
 
-Variables with an incomplete hardware address (e.g. `AT %I*`) are placeholders that
-expect a complete address to be supplied later by a `VAR_CONFIG` block. They can only
-be declared in stateful contexts: `PROGRAM`, `FUNCTION_BLOCK`, or `VAR_GLOBAL`.
-
-`FUNCTION` and `METHOD` bodies have no persistent state to bind a hardware address to,
-so an incomplete address there cannot be resolved.
+A variable with an incomplete hardware address such as `AT %I*` is declared inside a
+`FUNCTION` or `METHOD`. Incomplete addresses are placeholders resolved through persistent
+state, so they may only appear in `PROGRAM`, `FUNCTION_BLOCK`, or `VAR_GLOBAL` declarations;
+function and method bodies have no such state.
 
 Erroneous code example:
+
 ```iecst
 FUNCTION foo : DINT
-VAR
-    flag AT %I* : BOOL;
-END_VAR
+    VAR
+        flag AT %I* : BOOL; // error: Incomplete hardware address `AT %I*` is not allowed in `FUNCTION` or `METHOD`; only `PROGRAM`, `FUNCTION_BLOCK`, and `VAR_GLOBAL` may declare these
+    END_VAR
 END_FUNCTION
 ```
 
-Move the variable into a `PROGRAM`, `FUNCTION_BLOCK`, or `VAR_GLOBAL` block, or supply
-a complete address (e.g. `AT %IX1.0`) directly.
+Move the variable into a `PROGRAM`, `FUNCTION_BLOCK`, or `VAR_GLOBAL` block, or use a complete
+address such as `AT %IX1.0`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E137.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E137.md
@@ -1,42 +1,23 @@
-# FB-level VAR_TEMP referenced from a METHOD
+# FB-Level VAR_TEMP Referenced From a METHOD
 
-A `VAR_TEMP` declared in a `FUNCTION_BLOCK` belongs to the FB body's call frame.
-A `METHOD` has its own stack frame, so it cannot share that temporary.
+A method body references a `VAR_TEMP` variable declared in its parent `FUNCTION_BLOCK`.
+FB-level temporaries live in the call frame of the FB body, while each `METHOD` has its own
+stack frame, so the temporary is not visible there. The diagnostic points to the reference
+and to the `VAR_TEMP` declaration as a secondary location.
 
 Erroneous code example:
-```iecst
-FUNCTION_BLOCK Bug
-VAR_TEMP
-    scratch : BOOL;
-END_VAR
-METHOD PUBLIC DoIt
-    scratch := TRUE; // ❌ scratch is not visible here
-END_METHOD
-END_FUNCTION_BLOCK
-```
-
-To fix, either declare the variable as a member of the `FUNCTION_BLOCK` (so it
-becomes part of the instance and is visible to the method), or declare a
-`VAR_TEMP` local to the method itself:
 
 ```iecst
 FUNCTION_BLOCK Bug
-VAR
-    scratch : BOOL; // ✅ instance member, visible to methods
-END_VAR
-METHOD PUBLIC DoIt
-    scratch := TRUE;
-END_METHOD
-END_FUNCTION_BLOCK
-```
-
-```iecst
-FUNCTION_BLOCK Bug
-METHOD PUBLIC DoIt
     VAR_TEMP
-        scratch : BOOL; // ✅ method-local temporary
+        scratch : BOOL;
     END_VAR
-    scratch := TRUE;
-END_METHOD
+
+    METHOD DoIt
+        scratch := TRUE; // error: `scratch` is a VAR_TEMP of `Bug` and is not visible inside its METHODs
+    END_METHOD
 END_FUNCTION_BLOCK
 ```
+
+Declare the variable in a `VAR_TEMP` block inside the method itself, or make it an instance
+member with a plain `VAR` block in the function block so all methods can access it.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E138.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E138.md
@@ -1,30 +1,20 @@
-# Reserved keyword used as a name
+# Reserved Keyword Used as a Name
 
-A reserved keyword was used in a position that expects a user-defined name
-(variable, parameter, POU, type alias, enum variant, struct field, …).
-Reserved keywords carry syntactic meaning and cannot double as identifiers.
+A reserved keyword (such as `RETAIN`, `CONSTANT`, or a control-flow keyword) was used in a
+position that expects a user-defined name: a variable, parameter, POU, method, property, type
+alias, enum variant, or struct field. Reserved keywords carry syntactic meaning and cannot
+double as identifiers.
 
 Erroneous code example:
+
 ```iecst
 FUNCTION main
     VAR
-        retain : DINT; // `RETAIN` is reserved
+        retain : DINT; // error: `RETAIN` is a reserved keyword and cannot be used as a variable name
     END_VAR
 END_FUNCTION
 ```
 
-Rename the variable to something that is not a reserved keyword:
-```iecst
-FUNCTION main
-    VAR
-        is_retained : DINT;
-    END_VAR
-END_FUNCTION
-```
-
-The same restriction applies to POU names, parameter names, type aliases,
-enum variants, struct fields, generic parameters, method names, and property
-names.
-
-Note that `VAR RETAIN ... END_VAR` is still valid — there `RETAIN` is the
-variable-block modifier, not a variable name.
+Rename the identifier to something that is not a reserved keyword. Note that
+`VAR RETAIN ... END_VAR` remains valid; there `RETAIN` is the variable-block modifier, not a
+variable name.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E139.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E139.md
@@ -1,26 +1,11 @@
-# Linker invocation failed
+# Linker Invocation Failed
 
-`plc` could not spawn the linker subprocess, or the OS rejected the assembled
-command line before the linker had a chance to run.
+The compiler could not spawn the linker subprocess, or the operating system rejected the
+assembled command line before the linker ran. This is caused by the environment, not the
+source code.
 
-The diagnostic body includes the linker that was selected, the number of
-arguments, the assembled command-line length in bytes, and the longest single
-argument (and its value). These numbers usually point at the cause.
-
-Common causes:
-
-- **Windows `CreateProcess` command-line limit (32,767 bytes; 8,191 if the
-  spawn went through `cmd.exe`).** Visible as `os error 206`. `plc` already
-  routes long command lines through a `@response_file` to avoid this, but
-  the response file can itself fail if the temp directory is unwritable —
-  consult any preceding `warn` log lines.
-- **Windows `MAX_PATH` (260 chars) on a single path argument without the
-  `\\?\` prefix.** Also surfaces as `os error 206`. Shorten paths or relocate
-  the build closer to the drive root.
-- **Linker binary not on `PATH` / not executable.** `os error 2` or
-  `os error 13`. Check `which <linker>` or pass `--linker=<path>`.
-- **Insufficient permissions on the temp directory used for the response
-  file.** Set `TMPDIR` (Linux/macOS) or `TEMP` (Windows) to a writable path.
-
-If none of the above apply the error string returned by the OS is reproduced
-verbatim and is the primary clue.
+The message reproduces the OS error verbatim, followed by diagnostic context: the selected
+linker, the argument count, the assembled command-line length in bytes, and the longest
+single argument. Common causes are a linker binary that is not executable, an unwritable temp
+directory for the response file, and on Windows `os error 206` from the 32,767 byte
+`CreateProcess` command-line limit or a single path exceeding `MAX_PATH` (260 characters).

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E140.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E140.md
@@ -1,33 +1,23 @@
 # `:=` Used for an Output Parameter
 
-In a call's named argument list, `:=` and `=>` are direction-keyed: `:=` writes a value **into** an `INPUT` (or `IN_OUT`) parameter, while `=>` captures a value **out of** an `OUTPUT` parameter into a caller variable. Using `:=` for an `OUTPUT` parameter is a typo for `=>` and silently produces broken code.
+Named call arguments are direction-keyed: `:=` writes a value into an input or in-out
+parameter, while `=>` captures an output parameter into a caller variable. Using `:=` on a
+`VAR_OUTPUT` parameter is rejected because the value would flow in the wrong direction.
 
 Erroneous code example:
 
 ```iecst
 FUNCTION_BLOCK fb
-VAR_INPUT  in_val  : DINT; END_VAR
-VAR_OUTPUT out_val : DINT; END_VAR
-    out_val := in_val + 1;
+    VAR_OUTPUT out_val : DINT; END_VAR
 END_FUNCTION_BLOCK
 
 PROGRAM main
-VAR
-    instance : fb;
-    captured : DINT;
-END_VAR
-    instance(in_val := 5, out_val := captured);  // invalid: '=>' expected for an output parameter
+    VAR
+        instance : fb;
+        captured : DINT;
+    END_VAR
+    instance(out_val := captured); // error: 'out_val' is an output parameter; use '=>' instead of ':='
 END_PROGRAM
 ```
 
-To fix, use `=>` for the output parameter:
-
-```iecst
-PROGRAM main
-VAR
-    instance : fb;
-    captured : DINT;
-END_VAR
-    instance(in_val := 5, out_val => captured);  // correct
-END_PROGRAM
-```
+Write `instance(out_val => captured);` to capture the output.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E141.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E141.md
@@ -1,14 +1,11 @@
-# Member access on a non-auto-deref pointer base
+# Member Access on a Pointer Without Dereferencing
 
-Member access (`base.member`) requires `base` to be a struct, function-block, or class instance — not a pointer to one. The compiler will not implicitly dereference pointers when they appear on the left of a `.` (auto-dereferencing applies only to `REFERENCE TO` / alias pointers).
+Member access (`base.member`) requires `base` to be a struct, function block, or class
+instance, not a `POINTER TO` one. Only `REFERENCE TO` and alias pointers are dereferenced
+automatically; a plain pointer base needs an explicit `^`. This also applies to `THIS` and
+`SUPER`, which are pointers to the enclosing and parent POU.
 
-This rule covers three cases that share the same underlying shape — the value of `base` is a pointer, not the pointee:
-
-1. `THIS` is `POINTER TO <enclosing FUNCTION_BLOCK>`. Use `THIS^.member`.
-2. `SUPER` is `POINTER TO <parent POU>` (before dereferencing). Use `SUPER^.member`.
-3. A user-declared `POINTER TO ...` variable. Use `<pointer>^.member`.
-
-## Example of invalid use
+Erroneous code example:
 
 ```iecst
 FUNCTION_BLOCK fb
@@ -20,25 +17,13 @@ END_FUNCTION_BLOCK
 FUNCTION_BLOCK other
     VAR
         p_fb : POINTER TO fb;
-    END_VAR
-    METHOD m : DINT
-        p_fb.a := 1;   // Error: Cannot access `a` on `POINTER TO fb`
-        THIS.b := 2;   // Error: Cannot access `b` on `POINTER TO other` (THIS is a pointer)
-    END_METHOD
-END_FUNCTION_BLOCK
-```
-
-## Example of valid use
-
-```iecst
-FUNCTION_BLOCK other
-    VAR
-        p_fb : POINTER TO fb;
         b    : DINT;
     END_VAR
     METHOD m : DINT
-        p_fb^.a := 1;   // Dereference the pointer first
-        THIS^.b := 2;   // Dereference THIS first
+        p_fb.a := 1; // error: Cannot access `a` on `POINTER TO fb`; dereference with `^` first
+        THIS.b := 2; // error: Cannot access `b` on `POINTER TO other`; dereference with `^` first
     END_METHOD
 END_FUNCTION_BLOCK
 ```
+
+Dereference the pointer before the member access: `p_fb^.a := 1;` and `THIS^.b := 2;`.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E142.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E142.md
@@ -1,5 +1,15 @@
-# Undefined CFC jump target
+# Undefined CFC Jump Target
 
-A `JMP` element in a CFC network refers to a label that no `LABEL` element
-defines. The jump has nowhere to land. Add the matching label or correct the
-jump's target.
+A `JMP` element in a CFC network refers to a label that no `LABEL` element defines, so the
+jump has nowhere to land. CFC is a graphical language; the diagram below sketches the
+offending network.
+
+Erroneous network example:
+
+```text
+myCondition --> JMP missing (0)   // error: Jump refers to undefined label `missing`
+
+(no LABEL missing exists)
+```
+
+Add the matching `LABEL` element or correct the jump's target.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E143.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E143.md
@@ -1,4 +1,14 @@
-# Unused CFC label
+# Unused CFC Label
 
-A `LABEL` element in a CFC network is not the target of any `JMP`. It has no
-effect on control flow. Remove the label or wire a jump to it.
+A `LABEL` element in a CFC network is not the target of any `JMP`, so it has no effect on
+control flow. CFC is a graphical language; the diagram below sketches the offending network.
+
+Erroneous network example:
+
+```text
+x --> y (0)
+
+LABEL orphan (1)   // warning: Label `orphan` is not referenced by any jump
+```
+
+Remove the label or wire a jump to it.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E144.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E144.md
@@ -1,5 +1,15 @@
-# Duplicate CFC label
+# Duplicate CFC Label
 
-Two `LABEL` elements in a CFC network share the same name. A jump to that name
-would be ambiguous, since it could land on either one. Give each label a
-distinct name.
+Two `LABEL` elements in a CFC network share the same name, so a jump to that name would be
+ambiguous. CFC is a graphical language; the diagram below sketches the offending network.
+
+Erroneous network example:
+
+```text
+myCondition --> JMP dup (0)
+
+LABEL dup (1)
+LABEL dup (2)   // error: Label `dup` is already defined
+```
+
+Give each label a distinct name.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E145.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E145.md
@@ -1,5 +1,17 @@
-# Disconnected CFC jump
+# Disconnected CFC Jump
 
-A `JMP` element in a CFC network is not wired to a condition. A conditional jump
-only fires when its incoming value is true, so a jump with nothing connected can
-never be taken and is almost certainly a mistake.
+A `JMP` element in a CFC network is not wired to a condition. The jump lowers to a `FALSE`
+guard, so it can never be taken and the following elements always execute. CFC is a graphical
+language; the diagram below sketches the offending network.
+
+Erroneous network example:
+
+```text
+(unwired) --> JMP skipAssignment (0)   // warning: Jump element is not connected to a condition and can never be taken
+
+x --> y (1)
+
+LABEL skipAssignment (2)
+```
+
+Wire a boolean condition into the jump, or remove the jump if it is not needed.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E146.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E146.md
@@ -1,5 +1,16 @@
-# Unknown CFC block type
+# Unknown CFC Block Type
 
-A block element in a CFC network calls a POU the project does not declare. The
-call cannot be classified (a function is lowered differently than a program or
-function block), so the block is rejected.
+A block element in a CFC network calls a POU the project does not declare. The call cannot be
+classified (a function is lowered differently than a program or function block), so the block
+is rejected with the message "Block `<name>` refers to an undeclared POU".
+
+Erroneous network example:
+
+```text
+countIn --> in [counter?] out (0) --> countOut (1)   // error: Block `counter` refers to an undeclared POU
+
+(no POU named `counter` is declared in the project)
+```
+
+Declare the missing POU or fix the block's type name; this usually means the diagram
+references a POU that was renamed or removed.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E147.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E147.md
@@ -1,5 +1,16 @@
-# Undeclared CFC block output
+# Undeclared CFC Block Output
 
-A block element in a CFC network exposes an output pin the called POU does not
-declare. This usually means the diagram is stale: the callee's signature
-changed after the block was placed.
+A block element in a CFC network exposes an output pin the called POU does not declare,
+reported as "Output `<output>` is not declared by `<name>`". This usually means the diagram
+is stale: the callee's signature changed after the block was placed.
+
+Erroneous network example:
+
+```text
+a --> in1 [myAdd] myAdd
+b --> in2  (0)    oldDoubled? (stale) --> result (1)
+                  // error: Output `oldDoubled` is not declared by `myAdd`
+```
+
+Update the block to match the callee's current signature, or restore the missing
+`VAR_OUTPUT` declaration in the callee.

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E148.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E148.md
@@ -1,8 +1,21 @@
-# E148 - Temporal literal overflow or underflow
+# Temporal Literal Overflow or Underflow
 
-This warning is emitted when a temporal literal cannot be represented safely.
+A `DATE`, `DATE_AND_TIME`, `TIME_OF_DAY`, or `TIME` literal lies outside the 32-bit runtime
+storage domain of its type (`DATE`/`DT` store seconds, `TOD`/`TIME` store milliseconds).
+Values below zero report an underflow, values above the 32-bit range report an overflow, and
+the literal will not round-trip at runtime. For the long variants (`LDATE`, `LDT`, `LTOD`,
+`LTIME`) only a literal that cannot be encoded at all is reported, as "out-of-range detected".
 
-Covered temporal literals include DATE, DT, TOD, TIME and their long variants.
+Erroneous code example:
 
-For short temporal types (DATE/DT/TOD/TIME), values outside the 32-bit runtime storage domain trigger this warning.
-For long temporal types, out-of-range literal encodings also trigger this warning.
+```iecst
+PROGRAM main
+    VAR
+        t_overflow  : TIME := TIME#4294967296ms; // warning: TIME literal overflow detected
+        d_underflow : DATE := DATE#1969-12-31;   // warning: DATE literal underflow detected
+    END_VAR
+END_PROGRAM
+```
+
+Keep the literal within the representable range of the short type, or switch to the
+corresponding long type (`LTIME`, `LDATE`, ...) if the value is intentional.


### PR DESCRIPTION
Rewrite all error code documents to follow the same structure: A short problem statement, a verified erroneous example and an optional fix.

Still open:
- [ ] An AGENTS.md file within the folder to guide agents when writing new documents
- [ ] Update registry call sites, also better titles?