### PR TITLE
feat(cfc): negations

### DIFF
--- a/compiler/plc_cfc/fixtures/blocks/invalid/function_inout_negated/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/invalid/function_inout_negated/README.md
@@ -1,0 +1,15 @@
+What: negation bubbles on an inout wire (source side and pin side). The IDE
+permits drawing them, and the resolver transpiles them as on any input pin,
+`acc := NOT NOT acc1` — but an inout passes by reference and a NOT expression
+has no storage behind it, so the later validation stage rejects the call with
+E031 ("Expected a reference for parameter acc"). The transpiler-level tests
+therefore see no diagnostic; the end-to-end rejection is pinned by the
+`tests/lit/cfc/blocks/function_inout_negated` lit test.
+
+Illustrated:
+```
+             +-------- addInto -------+
+a1 ----------| delta          addInto |--------> b1 (1)
+acc1 o-----o-| acc                    |
+             +------------------------+ (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/invalid/function_inout_negated/addInto.st
+++ b/compiler/plc_cfc/fixtures/blocks/invalid/function_inout_negated/addInto.st
@@ -1,0 +1,10 @@
+FUNCTION addInto : DINT
+VAR_INPUT
+    delta : DINT;
+END_VAR
+VAR_IN_OUT
+    acc : DINT;
+END_VAR
+    acc := acc + delta;
+    addInto := acc;
+END_FUNCTION

--- a/compiler/plc_cfc/fixtures/blocks/invalid/function_inout_negated/function_inout_negated.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/invalid/function_inout_negated/function_inout_negated.cfc
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_inout_negated">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM function_inout_negated
+VAR
+    a1, acc1, b1 : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="addInto" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1070" y="60"/>
+                    <ppx:Size x="120" y="60"/>
+                    <ppx:InOutVariables>
+                        <ppx:InOutVariable parameterName="acc" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="6"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InOutVariable>
+                    </ppx:InOutVariables>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="delta" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="addInto" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="120" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="3">
+                    <ppx:RelPosition x="950" y="80"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="acc1" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="950" y="100"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="6">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1240" y="80"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_pins/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_pins/README.md
@@ -1,0 +1,10 @@
+What: negation bubbles on the pins of a stateful block (a function-block
+instance): the input pin inverts the passed value, the output pin inverts the
+member read. Verbatim IDE export.
+
+Illustrated:
+```
+           +---- inst : counter ----+
+a1 ------o-| in                 out |-o------> b1 (1)
+           +------------------------+ (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_pins/counter.st
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_pins/counter.st
@@ -1,0 +1,9 @@
+FUNCTION_BLOCK counter
+VAR_INPUT
+    in : DINT;
+END_VAR
+VAR_OUTPUT
+    out : DINT;
+END_VAR
+    out := out + in;
+END_FUNCTION_BLOCK

--- a/compiler/plc_cfc/fixtures/blocks/valid/fb_pins/fb_pins.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/fb_pins/fb_pins.cfc
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="fb_pins">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM fb_pins
+VAR
+    inst : counter;
+    a1, b1 : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="counter" instanceName="inst" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1300" y="330"/>
+                    <ppx:Size x="90" y="40"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="out" negated="true">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="90" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="3">
+                    <ppx:RelPosition x="1190" y="350"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1420" y="350"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_args/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_args/README.md
@@ -1,0 +1,12 @@
+What: negation bubbles on the variable side of block wires, and stacked with
+pin bubbles on the same wire: the `in1` wire and the return-pin wire carry a
+bubble on both ends (the NOTs nest), the `in2` and `myAddDoubled` wires carry
+one on the variable side only. Verbatim IDE export.
+
+Illustrated:
+```
+           +-------- myAdd ---------+
+a1 o-----o-| in1              myAdd |-o-----o> b1 (1)
+a2 o-------| in2       myAddDoubled |-------o> b2 (2)
+           +------------------------+ (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_args/function_args.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_args/function_args.cfc
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_args">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM function_args
+VAR
+    a1, a2, b1, b2 : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="myAdd" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1160" y="460"/>
+                    <ppx:Size x="130" y="60"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in1" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="5"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                        <ppx:InputVariable parameterName="in2" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="8"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="myAdd" negated="true">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="130" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                        <ppx:OutputVariable parameterName="myAddDoubled" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="3">
+<ppx:RelPosition x="130" y="50"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1030" y="480"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a2" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1030" y="500"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="8">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="9">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1340" y="480"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b2" globalId="11">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1340" y="500"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="3"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_args/myAdd.st
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_args/myAdd.st
@@ -1,0 +1,11 @@
+FUNCTION myAdd : DINT
+VAR_INPUT
+    in1 : DINT;
+    in2 : DINT;
+END_VAR
+VAR_OUTPUT
+    myAddDoubled : DINT;
+END_VAR
+    myAdd := in1 + in2;
+    myAddDoubled := (in1 + in2) * 2;
+END_FUNCTION

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_pins/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_pins/README.md
@@ -1,0 +1,13 @@
+What: negation bubbles on the pins of a function block element only (parameter
+side): the `IN1` input pin, the return pin, and the declared output pin. All
+sources and sinks stay plain. Verbatim IDE export; note the IDE wrote the input
+pins as `IN1`/`IN2` although `myAdd` declares `in1`/`in2` (matching is
+case-insensitive).
+
+Illustrated:
+```
+           +-------- myAdd ---------+
+a1 ------o-| IN1              myAdd |-o------> b1 (2)
+a2 --------| IN2       myAddDoubled |-o------> b2 (1)
+           +------------------------+ (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_pins/function_pins.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_pins/function_pins.cfc
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_pins">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM function_pins
+VAR
+    a1, a2, b1, b2 : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="myAdd" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="980" y="240"/>
+                    <ppx:Size x="130" y="60"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="IN1" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="5"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                        <ppx:InputVariable parameterName="IN2" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="7"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="myAdd" negated="true">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="130" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                        <ppx:OutputVariable parameterName="myAddDoubled" negated="true">
+                            <ppx:ConnectionPointOut connectionPointOutId="3">
+<ppx:RelPosition x="130" y="50"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="4">
+                    <ppx:RelPosition x="860" y="260"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a2" globalId="6">
+                    <ppx:RelPosition x="860" y="280"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="7">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="8">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1150" y="260"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b2" globalId="10">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1150" y="280"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="3"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/blocks/valid/function_pins/myAdd.st
+++ b/compiler/plc_cfc/fixtures/blocks/valid/function_pins/myAdd.st
@@ -1,0 +1,11 @@
+FUNCTION myAdd : DINT
+VAR_INPUT
+    in1 : DINT;
+    in2 : DINT;
+END_VAR
+VAR_OUTPUT
+    myAddDoubled : DINT;
+END_VAR
+    myAdd := in1 + in2;
+    myAddDoubled := (in1 + in2) * 2;
+END_FUNCTION

--- a/compiler/plc_cfc/fixtures/blocks/valid/variadic_negated/README.md
+++ b/compiler/plc_cfc/fixtures/blocks/valid/variadic_negated/README.md
@@ -1,0 +1,13 @@
+What: negation bubbles on the extensible pins of the builtin variadic `ADD`:
+one wire negated on the source side, one on the pin side, one on both (the
+NOTs nest). Extended variadic pins export with an empty `parameterName`; the
+values pass by pin order. Verbatim IDE export.
+
+Illustrated:
+```
+           +------ ADD ------+
+a1 o-------| IN1             |
+a2 ------o-|             ADD |--------> b1 (1)
+a3 o-----o-|                 |
+           +-----------------+ (0)
+```

--- a/compiler/plc_cfc/fixtures/blocks/valid/variadic_negated/variadic_negated.cfc
+++ b/compiler/plc_cfc/fixtures/blocks/valid/variadic_negated/variadic_negated.cfc
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="variadic_negated">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM variadic_negated
+VAR
+    a1, a2, a3, b1 : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="ADD" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1300" y="220"/>
+                    <ppx:Size x="80" y="80"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="IN1" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                        <ppx:InputVariable parameterName="" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="6"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                        <ppx:InputVariable parameterName="" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="70"/>
+<ppx:Connection refConnectionPointOutId="8"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="ADD" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="80" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1150" y="240"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a2" globalId="5">
+                    <ppx:RelPosition x="1150" y="260"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="6">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a3" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1150" y="280"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="8">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="9">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1420" y="240"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/connectors/valid/negated_both/README.md
+++ b/compiler/plc_cfc/fixtures/connectors/valid/negated_both/README.md
@@ -1,0 +1,8 @@
+What: negation bubbles on the source and the sink of a route through a
+connector/continuation pair; each inserts its own NOT, so they cancel at
+runtime, `bar := NOT NOT foo`.
+
+Illustrated:
+```
+foo o--> x    x --o bar (0)
+```

--- a/compiler/plc_cfc/fixtures/connectors/valid/negated_both/negated_both.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/negated_both/negated_both.cfc
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_both">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_both
+VAR
+    foo, bar: BOOL;
+END_VAR
+</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="350" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="690" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="x" globalId="5">
+                    <ppx:RelPosition x="480" y="220"/>
+                    <ppx:Size x="50" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="x" globalId="6">
+                    <ppx:RelPosition x="600" y="220"/>
+                    <ppx:Size x="60" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="60" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/connectors/valid/negated_sink/README.md
+++ b/compiler/plc_cfc/fixtures/connectors/valid/negated_sink/README.md
@@ -1,0 +1,8 @@
+What: a sink whose negation bubble inverts a value that arrives through a
+connector/continuation pair, `bar := NOT foo`. Connectors and continuations
+themselves can not be negated, only the nodes wired to them.
+
+Illustrated:
+```
+foo --> x    x --o bar (0)
+```

--- a/compiler/plc_cfc/fixtures/connectors/valid/negated_sink/negated_sink.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/negated_sink/negated_sink.cfc
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_sink">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_sink
+VAR
+    foo, bar: BOOL;
+END_VAR
+</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:RelPosition x="350" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="690" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="x" globalId="5">
+                    <ppx:RelPosition x="480" y="220"/>
+                    <ppx:Size x="50" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="x" globalId="6">
+                    <ppx:RelPosition x="600" y="220"/>
+                    <ppx:Size x="60" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="60" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/connectors/valid/negated_source/README.md
+++ b/compiler/plc_cfc/fixtures/connectors/valid/negated_source/README.md
@@ -1,0 +1,8 @@
+What: a negated source routed through a connector/continuation pair; the
+bubble travels with the traced source, `bar := NOT foo`. Connectors and
+continuations themselves can not be negated, only the nodes wired to them.
+
+Illustrated:
+```
+foo o--> x    x --> bar (0)
+```

--- a/compiler/plc_cfc/fixtures/connectors/valid/negated_source/negated_source.cfc
+++ b/compiler/plc_cfc/fixtures/connectors/valid/negated_source/negated_source.cfc
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_source">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_source
+VAR
+    foo, bar: BOOL;
+END_VAR
+</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="350" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="690" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="4"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="x" globalId="5">
+                    <ppx:RelPosition x="480" y="220"/>
+                    <ppx:Size x="50" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="x" globalId="6">
+                    <ppx:RelPosition x="600" y="220"/>
+                    <ppx:Size x="60" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="60" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/jumps/invalid/duplicate_label/duplicate_label.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/invalid/duplicate_label/duplicate_label.cfc
@@ -22,7 +22,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="dup" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/jumps/invalid/undefined_jump_target/undefined_jump_target.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/invalid/undefined_jump_target/undefined_jump_target.cfc
@@ -22,7 +22,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="missing" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/jumps/reference/conditional_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/reference/conditional_jump.cfc
@@ -16,7 +16,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/jumps/reference/disconnected_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/reference/disconnected_jump.cfc
@@ -16,7 +16,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/jumps/valid/backward_jump/backward_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/backward_jump/backward_jump.cfc
@@ -16,7 +16,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="top" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="2"/>

--- a/compiler/plc_cfc/fixtures/jumps/valid/conditional_jump/conditional_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/conditional_jump/conditional_jump.cfc
@@ -16,7 +16,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/jumps/valid/disconnected_jump/disconnected_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/disconnected_jump/disconnected_jump.cfc
@@ -16,7 +16,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/jumps/valid/negated_jump/negated_jump.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/negated_jump/negated_jump.cfc
@@ -16,7 +16,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="true"/>
+                            <bmx:Negation inNegated="true"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_both/README.md
+++ b/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_both/README.md
@@ -1,0 +1,12 @@
+What: a jump with negation bubbles on both the source and the jump element;
+each inserts its own NOT, so they cancel at runtime and the jump fires when the
+condition is true, `JMP skipAssignment IF NOT NOT myCondition`.
+
+Illustrated:
+```
+myCondition o--o JMP skipAssignment (0)
+
+x --> y (1)
+
+LABEL skipAssignment (2)
+```

--- a/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_both/negated_jump_both.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_both/negated_jump_both.cfc
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_jump_both">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_jump_both
+VAR
+    x, y: DINT;
+    myCondition: BOOL;
+END_VAR
+</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="900" y="230"/>
+                    <ppx:Size x="150" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="3"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="skipAssignment" globalId="2">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1300" y="230"/>
+                    <ppx:Size x="130" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="750" y="230"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="3">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="x" globalId="5">
+                    <ppx:RelPosition x="1070" y="230"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="6">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="y" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1190" y="230"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="6"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_source/README.md
+++ b/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_source/README.md
@@ -1,0 +1,13 @@
+What: a jump guarded by a source whose negation bubble inverts the condition it
+feeds (the jump fires when the condition is false). The bubble sits on the
+source, not on the jump element (the IDE still writes an explicit
+`inNegated="false"` there).
+
+Illustrated:
+```
+myCondition o-- JMP skipAssignment (0)
+
+x --> y (1)
+
+LABEL skipAssignment (2)
+```

--- a/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_source/negated_jump_source.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/negated_jump_source/negated_jump_source.cfc
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_jump_source">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_jump_source
+VAR
+    x, y: DINT;
+    myCondition: BOOL;
+END_VAR
+</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="900" y="230"/>
+                    <ppx:Size x="150" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="3"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="skipAssignment" globalId="2">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1300" y="230"/>
+                    <ppx:Size x="130" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="750" y="230"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="3">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="x" globalId="5">
+                    <ppx:RelPosition x="1070" y="230"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="6">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="y" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1190" y="230"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="6"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/jumps/valid/scrambled/scrambled.cfc
+++ b/compiler/plc_cfc/fixtures/jumps/valid/scrambled/scrambled.cfc
@@ -25,7 +25,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="end" globalId="6">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="5"/>
@@ -54,7 +54,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="mid" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>
@@ -119,7 +119,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="end" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="2"/>

--- a/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/disconnected_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/invalid/disconnected_return/disconnected_return.cfc
@@ -21,7 +21,7 @@ END_VAR</bmx:TextDeclaration>
                 <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>
@@ -37,7 +37,7 @@ END_VAR</bmx:TextDeclaration>
                 <ppx:FbdObject xsi:type="ppx:Return" globalId="4">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="1"/>

--- a/compiler/plc_cfc/fixtures/returns/reference/conditional_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/reference/conditional_return.cfc
@@ -21,7 +21,7 @@ END_VAR</bmx:TextDeclaration>
                 <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>
@@ -37,7 +37,7 @@ END_VAR</bmx:TextDeclaration>
                 <ppx:FbdObject xsi:type="ppx:Return" globalId="4">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="1"/>

--- a/compiler/plc_cfc/fixtures/returns/reference/negated_returns_jumps.cfc
+++ b/compiler/plc_cfc/fixtures/returns/reference/negated_returns_jumps.cfc
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="program_1">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM program_1
+VAR
+
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="1">
+                    <ppx:RelPosition x="340" y="290"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="290"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a2" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="320"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="320"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a3" globalId="7">
+                    <ppx:RelPosition x="340" y="350"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="8">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="9">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="350"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="8"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a4" globalId="10">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="380"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="11">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="12">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="3"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="380"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="11"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a5" globalId="13">
+                    <ppx:RelPosition x="340" y="440"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="14">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="jmpA5" globalId="15">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="4"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="440"/>
+                    <ppx:Size x="90" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="14"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="jmpA5" globalId="16">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="5"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="640" y="440"/>
+                    <ppx:Size x="80" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a6" globalId="17">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="470"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="18">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="jmpA6" globalId="19">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="6"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="470"/>
+                    <ppx:Size x="90" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="18"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="jmpA6" globalId="20">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="7"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="640" y="470"/>
+                    <ppx:Size x="80" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a7" globalId="21">
+                    <ppx:RelPosition x="340" y="500"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="22">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="jmpA7" globalId="23">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="8"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="500"/>
+                    <ppx:Size x="90" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="22"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="jmpA7" globalId="24">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="9"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="640" y="500"/>
+                    <ppx:Size x="80" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a8" globalId="25">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="530"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="26">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="jmpA8" globalId="27">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="10"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="510" y="530"/>
+                    <ppx:Size x="90" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="26"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="jmpA8" globalId="28">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="11"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="640" y="530"/>
+                    <ppx:Size x="80" y="20"/>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/returns/valid/conditional_return/conditional_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/conditional_return/conditional_return.cfc
@@ -21,7 +21,7 @@ END_VAR</bmx:TextDeclaration>
                 <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return/negated_return.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return/negated_return.cfc
@@ -21,7 +21,7 @@ END_VAR</bmx:TextDeclaration>
                 <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="true"/>
+                            <bmx:Negation inNegated="true"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return_both/README.md
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return_both/README.md
@@ -1,0 +1,8 @@
+What: a return with negation bubbles on both the source and the return element;
+each inserts its own NOT, so they cancel at runtime,
+`RETURN NOT NOT myCondition`.
+
+Illustrated:
+```
+myCondition o--o RETURN (0)
+```

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return_both/negated_return_both.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return_both/negated_return_both.cfc
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_return_both">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>FUNCTION negated_return_both : INT
+VAR
+    myCondition: BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="430" y="190"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="190"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return_source/README.md
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return_source/README.md
@@ -1,0 +1,8 @@
+What: a return guarded by a source whose negation bubble inverts the condition
+it feeds, `RETURN NOT myCondition`. The bubble sits on the source, not on the
+return element (the IDE still writes an explicit `inNegated="false"` there).
+
+Illustrated:
+```
+myCondition o-- RETURN (0)
+```

--- a/compiler/plc_cfc/fixtures/returns/valid/negated_return_source/negated_return_source.cfc
+++ b/compiler/plc_cfc/fixtures/returns/valid/negated_return_source/negated_return_source.cfc
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Function xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_return_source">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>FUNCTION negated_return_source : INT
+VAR
+    myCondition: BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="myCondition" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="430" y="190"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="190"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Function>

--- a/compiler/plc_cfc/fixtures/variables/reference/negations.cfc
+++ b/compiler/plc_cfc/fixtures/variables/reference/negations.cfc
@@ -1,0 +1,419 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="generic_unresolved">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM generic_unresolved
+VAR
+    acc : DINT;
+END_VAR  </bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="10">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="-70"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="11">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="12">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="220" y="-70"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="11"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a2" globalId="14">
+                    <ppx:RelPosition x="70" y="-40"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="15">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b2" globalId="16">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="220" y="-40"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="15"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a3" globalId="18">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="-10"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="19">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b3" globalId="20">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="220" y="-10"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="19"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="jmp1" globalId="29">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="3"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="220" y="90"/>
+                    <ppx:Size x="90" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="31"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a4" globalId="30">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="90"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="31">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="jmp1" globalId="32">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="4"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="90"/>
+                    <ppx:Size x="80" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a5" globalId="33">
+                    <ppx:RelPosition x="70" y="120"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="36">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="jmp2" globalId="38">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="5"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="220" y="120"/>
+                    <ppx:Size x="90" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="36"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="jmp2" globalId="39">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="6"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="120"/>
+                    <ppx:Size x="80" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a6" globalId="40">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="150"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="41">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="jmp3" globalId="42">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="7"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="220" y="150"/>
+                    <ppx:Size x="90" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="41"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="jmp3" globalId="43">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="8"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="340" y="150"/>
+                    <ppx:Size x="80" y="20"/>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a7" globalId="44">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="250"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="45">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="46">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="9"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="230" y="250"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="45"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a8" globalId="47">
+                    <ppx:RelPosition x="70" y="280"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="48">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="49">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="10"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="230" y="280"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="48"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a9" globalId="50">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="310"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="51">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="52">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="11"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="230" y="310"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="51"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Comment" globalId="53">
+                    <ppx:RelPosition x="70" y="-100"/>
+                    <ppx:Size x="220" y="20"/>
+                    <ppx:Content xsi:type="ppx:SimpleText">Assignments (Data Sinks &amp; Sources)</ppx:Content>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Comment" globalId="54">
+                    <ppx:RelPosition x="70" y="60"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:Content xsi:type="ppx:SimpleText">Jumps</ppx:Content>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Comment" globalId="55">
+                    <ppx:RelPosition x="70" y="220"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:Content xsi:type="ppx:SimpleText">Returns</ppx:Content>
+                </ppx:CommonObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a10" globalId="57">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="410"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="58">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="connection1" globalId="59">
+                    <ppx:RelPosition x="230" y="410"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="58"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Comment" globalId="60">
+                    <ppx:RelPosition x="70" y="380"/>
+                    <ppx:Size x="670" y="20"/>
+                    <ppx:Content xsi:type="ppx:SimpleText">Connections (Connections and Continuation elements can not be negated, only the node that is connected to it)</ppx:Content>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="connection1" globalId="61">
+                    <ppx:RelPosition x="400" y="410"/>
+                    <ppx:Size x="120" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="62">
+                        <ppx:RelPosition x="120" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b10" globalId="63">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="12"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="410"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="62"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a11" globalId="65">
+                    <ppx:RelPosition x="70" y="440"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="66">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="connection1" globalId="67">
+                    <ppx:RelPosition x="230" y="440"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="66"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="connection1" globalId="68">
+                    <ppx:RelPosition x="400" y="440"/>
+                    <ppx:Size x="120" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="69">
+                        <ppx:RelPosition x="120" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b11" globalId="70">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="13"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="440"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="69"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="b12" globalId="71">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="70" y="470"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="72">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="connection1" globalId="73">
+                    <ppx:RelPosition x="230" y="470"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="72"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="connection1" globalId="74">
+                    <ppx:RelPosition x="400" y="470"/>
+                    <ppx:Size x="120" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="75">
+                        <ppx:RelPosition x="120" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b12" globalId="76">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="14"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="570" y="470"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="75"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/variables/valid/negated_both/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/negated_both/README.md
@@ -1,0 +1,8 @@
+What: negation bubbles on both ends of one wire; each inserts its own NOT, so
+they cancel at runtime, `bar := NOT NOT foo`. The transpiler keeps both to map
+the diagram one-to-one.
+
+Illustrated:
+```
+foo o--o bar (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/negated_both/negated_both.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/negated_both/negated_both.cfc
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_both">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_both
+VAR
+    foo : BOOL;
+    bar : BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/variables/valid/negated_sink/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/negated_sink/README.md
@@ -1,0 +1,8 @@
+What: a sink whose negation bubble inverts the incoming value before it is
+stored, `bar := NOT foo`. The bubble sits on the sink's input pin; there is no
+negated lvalue.
+
+Illustrated:
+```
+foo --o bar (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/negated_sink/negated_sink.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/negated_sink/negated_sink.cfc
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_sink">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_sink
+VAR
+    foo : BOOL;
+    bar : BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/variables/valid/negated_source/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/negated_source/README.md
@@ -1,0 +1,7 @@
+What: a source whose negation bubble inverts the value it feeds into the
+assignment, `bar := NOT foo`.
+
+Illustrated:
+```
+foo o--> bar (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/negated_source/negated_source.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/negated_source/negated_source.cfc
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_source">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_source
+VAR
+    foo : BOOL;
+    bar : BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="foo" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="bar" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/src/model.rs
+++ b/compiler/plc_cfc/src/model.rs
@@ -55,8 +55,8 @@ pub struct Data {
     #[serde(rename = "EvaluationPriority")]
     pub evaluation_priority: Option<EvaluationPriority>,
 
-    #[serde(rename = "negated")]
-    pub negated: Option<Negated>,
+    #[serde(rename = "Negation")]
+    pub negation: Option<Negation>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -71,10 +71,15 @@ pub struct EvaluationPriority {
     pub priority: usize,
 }
 
+// The negation bubbles on an element's connection points; an element carries
+// at most the side(s) it has pins for (e.g. a `DataSource` only `outNegated`).
 #[derive(Debug, Deserialize)]
-pub struct Negated {
-    #[serde(rename = "@value")]
-    pub value: bool,
+pub struct Negation {
+    #[serde(rename = "@inNegated", default)]
+    pub in_negated: bool,
+
+    #[serde(rename = "@outNegated", default)]
+    pub out_negated: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -258,8 +263,12 @@ impl FbdObject {
         self.inout_variables.as_ref().map_or(&[], |group| &group.pins)
     }
 
-    pub fn negated(&self) -> bool {
-        self.data(|data| data.negated.as_ref()).is_some_and(|negated| negated.value)
+    pub fn in_negated(&self) -> bool {
+        self.data(|data| data.negation.as_ref()).is_some_and(|negation| negation.in_negated)
+    }
+
+    pub fn out_negated(&self) -> bool {
+        self.data(|data| data.negation.as_ref()).is_some_and(|negation| negation.out_negated)
     }
 
     pub fn priority(&self) -> Option<usize> {

--- a/compiler/plc_cfc/src/resolver.rs
+++ b/compiler/plc_cfc/src/resolver.rs
@@ -80,11 +80,13 @@ impl<'index> Resolver<'index> {
         for object in network.elements() {
             match Role::from(object) {
                 Role::Sink => match trace(consumes(object), &survey) {
-                    // The traced source becomes the sink's assigned value.
+                    // The traced source becomes the sink's assigned value,
+                    // negated once more by the sink's own inversion bubble.
                     Trace::Reached(source) => {
                         let location = self.factory.create_block_location(object.global_id);
                         let sink = self.expression(object, &location);
                         let source = self.value(&source, &location);
+                        let source = self.negate_if(source, &location, object.in_negated());
 
                         let statement = Statement::Assignment { sink, source };
                         statements.push((object.priority(), statement));
@@ -401,23 +403,31 @@ impl<'index> Resolver<'index> {
         node
     }
 
-    // The value a source produces: a vetted plain expression, or a block-output member read.
+    // The value a source produces: a vetted plain expression, or a block-output
+    // member read; either negated by the producer's inversion bubble.
     fn value(&mut self, source: &Source, location: &SourceLocation) -> AstNode {
         match source {
-            Source::Variable(object) => self.expression(object, location),
+            Source::Variable(object) => {
+                let node = self.expression(object, location);
+                self.negate_if(node, location, object.out_negated())
+            }
             Source::Output { block, pin } => self.member_read(block, pin, location),
         }
     }
 
-    // Creates an AST node, wrapped in a NOT expression if the consumer is negated in the graph.
+    // Creates an AST node, wrapped in a NOT expression for each inversion
+    // bubble on the wire: the producer's, then the consumer's on top.
     fn condition(&mut self, consumer: &FbdObject, source: &Source, location: &SourceLocation) -> AstNode {
         // Unvetted; a condition may be any ST expression.
         let node = match source {
-            Source::Variable(object) => self.parse(object, location),
+            Source::Variable(object) => {
+                let node = self.parse(object, location);
+                self.negate_if(node, location, object.out_negated())
+            }
             Source::Output { block, pin } => self.member_read(block, pin, location),
         };
 
-        self.negate_if(node, location, consumer.negated())
+        self.negate_if(node, location, consumer.in_negated())
     }
 
     fn member_read(&mut self, block: &FbdObject, pin: &Pin, location: &SourceLocation) -> AstNode {
@@ -724,6 +734,21 @@ mod tests {
         }
 
         #[test]
+        fn negated_source() {
+            insta::assert_snapshot!(resolve_project("variables/valid/negated_source"), @"bar := NOT foo");
+        }
+
+        #[test]
+        fn negated_sink() {
+            insta::assert_snapshot!(resolve_project("variables/valid/negated_sink"), @"bar := NOT foo");
+        }
+
+        #[test]
+        fn negated_both() {
+            insta::assert_snapshot!(resolve_project("variables/valid/negated_both"), @"bar := NOT NOT foo");
+        }
+
+        #[test]
         fn unconnected_variables() {
             insta::assert_snapshot!(resolve_project("variables/valid/unconnected_variables"), @"bar := foo");
             insta::assert_snapshot!(diagnostics("variables/valid/unconnected_variables"), @r"
@@ -761,6 +786,21 @@ mod tests {
         fn unused_is_quiet() {
             insta::assert_snapshot!(diagnostics("connectors/valid/unused"), @"");
         }
+
+        #[test]
+        fn negated_source() {
+            insta::assert_snapshot!(resolve_project("connectors/valid/negated_source"), @"bar := NOT foo");
+        }
+
+        #[test]
+        fn negated_sink() {
+            insta::assert_snapshot!(resolve_project("connectors/valid/negated_sink"), @"bar := NOT foo");
+        }
+
+        #[test]
+        fn negated_both() {
+            insta::assert_snapshot!(resolve_project("connectors/valid/negated_both"), @"bar := NOT NOT foo");
+        }
     }
 
     mod returns {
@@ -774,6 +814,16 @@ mod tests {
         #[test]
         fn negated_return() {
             insta::assert_snapshot!(resolve_project("returns/valid/negated_return"), @"RETURN NOT myCondition");
+        }
+
+        #[test]
+        fn negated_return_source() {
+            insta::assert_snapshot!(resolve_project("returns/valid/negated_return_source"), @"RETURN NOT myCondition");
+        }
+
+        #[test]
+        fn negated_return_both() {
+            insta::assert_snapshot!(resolve_project("returns/valid/negated_return_both"), @"RETURN NOT NOT myCondition");
         }
     }
 
@@ -793,6 +843,22 @@ mod tests {
         fn negated_jump() {
             insta::assert_snapshot!(resolve_project("jumps/valid/negated_jump"), @r"
             JMP skipAssignment IF NOT myCondition
+            y := x
+            LABEL skipAssignment");
+        }
+
+        #[test]
+        fn negated_jump_source() {
+            insta::assert_snapshot!(resolve_project("jumps/valid/negated_jump_source"), @r"
+            JMP skipAssignment IF NOT myCondition
+            y := x
+            LABEL skipAssignment");
+        }
+
+        #[test]
+        fn negated_jump_both() {
+            insta::assert_snapshot!(resolve_project("jumps/valid/negated_jump_both"), @r"
+            JMP skipAssignment IF NOT NOT myCondition
             y := x
             LABEL skipAssignment");
         }
@@ -877,6 +943,43 @@ mod tests {
         #[test]
         fn program_feedback() {
             insta::assert_snapshot!(resolve_project("blocks/valid/program_feedback"), @"counter(in := counter.out)");
+        }
+
+        #[test]
+        fn fb_pins() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/fb_pins"), @r"
+            inst(in := NOT a1)
+            b1 := NOT inst.out");
+        }
+
+        #[test]
+        fn function_pins() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/function_pins"), @r"
+            __out_myAdd_1 := myAdd(IN1 := NOT a1, IN2 := a2, myAddDoubled => __out_myAddDoubled_1)
+            b2 := NOT __out_myAddDoubled_1
+            b1 := NOT __out_myAdd_1");
+        }
+
+        #[test]
+        fn function_args() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/function_args"), @r"
+            __out_myAdd_1 := myAdd(in1 := NOT NOT a1, in2 := NOT a2, myAddDoubled => __out_myAddDoubled_1)
+            b1 := NOT NOT __out_myAdd_1
+            b2 := NOT __out_myAddDoubled_1");
+        }
+
+        #[test]
+        fn variadic_negated() {
+            insta::assert_snapshot!(resolve_project("blocks/valid/variadic_negated"), @r"
+            __out_ADD_1 := ADD(NOT a1, NOT a2, NOT NOT a3)
+            b1 := __out_ADD_1");
+        }
+
+        #[test]
+        fn function_inout_negated() {
+            insta::assert_snapshot!(resolve_project("blocks/invalid/function_inout_negated"), @r"
+            __out_addInto_1 := addInto(delta := a1, acc := NOT NOT acc1)
+            b1 := __out_addInto_1");
         }
 
         #[test]

--- a/compiler/plc_cfc/src/transpiler.rs
+++ b/compiler/plc_cfc/src/transpiler.rs
@@ -193,6 +193,42 @@ mod tests {
             bar := foo;
         END_FUNCTION");
         }
+
+        #[test]
+        fn negated_source() {
+            insta::assert_snapshot!(transpile_project("variables/valid/negated_source").unwrap(), @r"
+        PROGRAM negated_source
+        VAR
+            foo : BOOL;
+            bar : BOOL;
+        END_VAR
+            bar := NOT foo;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn negated_sink() {
+            insta::assert_snapshot!(transpile_project("variables/valid/negated_sink").unwrap(), @r"
+        PROGRAM negated_sink
+        VAR
+            foo : BOOL;
+            bar : BOOL;
+        END_VAR
+            bar := NOT foo;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn negated_both() {
+            insta::assert_snapshot!(transpile_project("variables/valid/negated_both").unwrap(), @r"
+        PROGRAM negated_both
+        VAR
+            foo : BOOL;
+            bar : BOOL;
+        END_VAR
+            bar := NOT NOT foo;
+        END_PROGRAM");
+        }
     }
 
     mod returns {
@@ -217,6 +253,28 @@ mod tests {
             myCondition : BOOL;
         END_VAR
             IF NOT myCondition THEN RETURN; END_IF;
+        END_FUNCTION");
+        }
+
+        #[test]
+        fn negated_return_source() {
+            insta::assert_snapshot!(transpile_project("returns/valid/negated_return_source").unwrap(), @r"
+        FUNCTION negated_return_source : INT
+        VAR
+            myCondition : BOOL;
+        END_VAR
+            IF NOT myCondition THEN RETURN; END_IF;
+        END_FUNCTION");
+        }
+
+        #[test]
+        fn negated_return_both() {
+            insta::assert_snapshot!(transpile_project("returns/valid/negated_return_both").unwrap(), @r"
+        FUNCTION negated_return_both : INT
+        VAR
+            myCondition : BOOL;
+        END_VAR
+            IF NOT NOT myCondition THEN RETURN; END_IF;
         END_FUNCTION");
         }
     }
@@ -249,6 +307,36 @@ mod tests {
             myCondition : BOOL;
         END_VAR
             IF NOT myCondition THEN GOTO skipAssignment;
+            y := x;
+            LABEL: skipAssignment
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn negated_jump_source() {
+            insta::assert_snapshot!(transpile_project("jumps/valid/negated_jump_source").unwrap(), @r"
+        PROGRAM negated_jump_source
+        VAR
+            x : DINT;
+            y : DINT;
+            myCondition : BOOL;
+        END_VAR
+            IF NOT myCondition THEN GOTO skipAssignment;
+            y := x;
+            LABEL: skipAssignment
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn negated_jump_both() {
+            insta::assert_snapshot!(transpile_project("jumps/valid/negated_jump_both").unwrap(), @r"
+        PROGRAM negated_jump_both
+        VAR
+            x : DINT;
+            y : DINT;
+            myCondition : BOOL;
+        END_VAR
+            IF NOT NOT myCondition THEN GOTO skipAssignment;
             y := x;
             LABEL: skipAssignment
         END_PROGRAM");
@@ -358,6 +446,42 @@ mod tests {
             foo : DINT;
             bar : DINT;
         END_VAR
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn negated_source() {
+            insta::assert_snapshot!(transpile_project("connectors/valid/negated_source").unwrap(), @r"
+        PROGRAM negated_source
+        VAR
+            foo : BOOL;
+            bar : BOOL;
+        END_VAR
+            bar := NOT foo;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn negated_sink() {
+            insta::assert_snapshot!(transpile_project("connectors/valid/negated_sink").unwrap(), @r"
+        PROGRAM negated_sink
+        VAR
+            foo : BOOL;
+            bar : BOOL;
+        END_VAR
+            bar := NOT foo;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn negated_both() {
+            insta::assert_snapshot!(transpile_project("connectors/valid/negated_both").unwrap(), @r"
+        PROGRAM negated_both
+        VAR
+            foo : BOOL;
+            bar : BOOL;
+        END_VAR
+            bar := NOT NOT foo;
         END_PROGRAM");
         }
     }
@@ -494,6 +618,20 @@ mod tests {
         END_VAR
             program_0(in := NOT localIn, inout := NOT localInOut);
             localOut := NOT program_0.out;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn fb_pins() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/fb_pins").unwrap(), @r"
+        PROGRAM fb_pins
+        VAR
+            inst : counter;
+            a1 : DINT;
+            b1 : DINT;
+        END_VAR
+            inst(in := NOT a1);
+            b1 := NOT inst.out;
         END_PROGRAM");
         }
 
@@ -744,6 +882,65 @@ mod tests {
         }
 
         #[test]
+        fn function_pins() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/function_pins").unwrap(), @r"
+        PROGRAM function_pins
+        VAR
+            a1 : DINT;
+            a2 : DINT;
+            b1 : DINT;
+            b2 : DINT;
+        END_VAR
+        VAR
+            __out_myAdd_1 : DINT;
+            __out_myAddDoubled_1 : DINT;
+        END_VAR
+            __out_myAdd_1 := myAdd(IN1 := NOT a1, IN2 := a2, myAddDoubled => __out_myAddDoubled_1);
+            b2 := NOT __out_myAddDoubled_1;
+            b1 := NOT __out_myAdd_1;
+        END_PROGRAM");
+        }
+
+        #[test]
+        fn function_args() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/function_args").unwrap(), @r"
+        PROGRAM function_args
+        VAR
+            a1 : DINT;
+            a2 : DINT;
+            b1 : DINT;
+            b2 : DINT;
+        END_VAR
+        VAR
+            __out_myAdd_1 : DINT;
+            __out_myAddDoubled_1 : DINT;
+        END_VAR
+            __out_myAdd_1 := myAdd(in1 := NOT NOT a1, in2 := NOT a2, myAddDoubled => __out_myAddDoubled_1);
+            b1 := NOT NOT __out_myAdd_1;
+            b2 := NOT __out_myAddDoubled_1;
+        END_PROGRAM");
+        }
+
+        // Transpiles without a diagnostic; the later validation stage rejects
+        // the negated inout (E031), pinned by the lit test of the same name.
+        #[test]
+        fn function_inout_negated() {
+            insta::assert_snapshot!(transpile_project("blocks/invalid/function_inout_negated").unwrap(), @r"
+        PROGRAM function_inout_negated
+        VAR
+            a1 : DINT;
+            acc1 : DINT;
+            b1 : DINT;
+        END_VAR
+        VAR
+            __out_addInto_1 : DINT;
+        END_VAR
+            __out_addInto_1 := addInto(delta := a1, acc := NOT NOT acc1);
+            b1 := __out_addInto_1;
+        END_PROGRAM");
+        }
+
+        #[test]
         fn function_bare() {
             insta::assert_snapshot!(transpile_project("blocks/valid/function_bare").unwrap(), @r"
         PROGRAM function_bare
@@ -932,6 +1129,24 @@ mod tests {
                 result := __out_ADD_1;
             END_PROGRAM
             ");
+        }
+
+        #[test]
+        fn variadic_negated() {
+            insta::assert_snapshot!(transpile_project("blocks/valid/variadic_negated").unwrap(), @r"
+            PROGRAM variadic_negated
+            VAR
+                a1 : DINT;
+                a2 : DINT;
+                a3 : DINT;
+                b1 : DINT;
+            END_VAR
+            VAR
+                __out_ADD_1 : DINT;
+            END_VAR
+                __out_ADD_1 := ADD(NOT a1, NOT a2, NOT NOT a3);
+                b1 := __out_ADD_1;
+            END_PROGRAM");
         }
     }
 }

--- a/tests/lit/cfc/blocks/action_call/README.md
+++ b/tests/lit/cfc/blocks/action_call/README.md
@@ -1,0 +1,8 @@
+What: a call to a function-block action (`typeName="counter.bump"` on the
+instance `inst`); the action mutates the instance's state. `main` runs two
+cycles with `amount = 3` and checks the accumulated count (`count = 6`).
+
+Illustrated:
+```
+amount --> step [inst.bump] count --> result (0, 1)
+```

--- a/tests/lit/cfc/blocks/fb_call/README.md
+++ b/tests/lit/cfc/blocks/fb_call/README.md
@@ -1,0 +1,9 @@
+What: two instances of the same function block called in one network; each
+keeps its own state. `main` runs two cycles and checks the accumulators stayed
+separate (`a = 2, b = 20` from `sa = 1`, `sb = 10`).
+
+Illustrated:
+```
+sa --> step [a : counter] total --> outA (0, 1)
+sb --> step [b : counter] total --> outB (2, 3)
+```

--- a/tests/lit/cfc/blocks/function_call/README.md
+++ b/tests/lit/cfc/blocks/function_call/README.md
@@ -1,0 +1,10 @@
+What: the CFC POU is itself a `FUNCTION` with inputs, a return value, and a
+declared output, its body one `myAdd` call wiring the POU's interface through
+the block. `main` calls it directly (`function_call(in1 := 3, in2 := 4,
+doubledOut => doubled)`) and checks `result = 7, doubled = 14`.
+
+Illustrated:
+```
+in1 --> in1 [myAdd] myAdd        --> function_call (0, 1)
+in2 --> in2         myAddDoubled --> doubledOut    (2)
+```

--- a/tests/lit/cfc/blocks/function_chain/README.md
+++ b/tests/lit/cfc/blocks/function_chain/README.md
@@ -1,0 +1,9 @@
+What: two `myAdd` calls in series; the first return value feeds the second
+call's input, captured through a temporary. `main` checks the chained sum
+(`(seed + k) + k = 11` for `seed = 3, k = 4`).
+
+Illustrated:
+```
+seed --> in1 [myAdd] --> in1 [myAdd] --> result (0, 1, 2)
+k ------> in2         k --> in2
+```

--- a/tests/lit/cfc/blocks/function_feedback/README.md
+++ b/tests/lit/cfc/blocks/function_feedback/README.md
@@ -1,0 +1,11 @@
+What: a function whose return value feeds back into its own input pin; the
+captured temporary carries last cycle's value. `main` runs two cycles with
+`seed = 5` and checks the accumulation (`acc = 10`).
+
+Illustrated:
+```
+     +--<-- myAdd <--+
+     |               |
+     +--> in1 [myAdd]+--> acc (0, 1)
+seed ---> in2
+```

--- a/tests/lit/cfc/blocks/function_inout/README.md
+++ b/tests/lit/cfc/blocks/function_inout/README.md
@@ -1,0 +1,10 @@
+What: a function with an inout parameter wired to a program variable; the
+callee reads and writes `total` through the pin, and the return value lands in
+`result`. `main` runs two cycles and checks the write-back stuck
+(`total = 10, result = 10` for `delta = 5`).
+
+Illustrated:
+```
+5 -------> delta [addInto] addInto --> result (0, 1)
+total <--> acc
+```

--- a/tests/lit/cfc/blocks/function_inout_negated/README.md
+++ b/tests/lit/cfc/blocks/function_inout_negated/README.md
@@ -1,0 +1,11 @@
+What: negation bubbles on an inout wire (source side and pin side). The IDE
+permits drawing them and the resolver transpiles them like any input pin, but
+an inout passes by reference and a NOT expression has no storage behind it, so
+the validation stage rejects the build (E031). The RUN line asserts the
+failure.
+
+Illustrated:
+```
+a1 ------> delta [addInto] addInto --> b1 (0, 1)
+acc1 o---o acc
+```

--- a/tests/lit/cfc/blocks/function_inout_negated/addInto.st
+++ b/tests/lit/cfc/blocks/function_inout_negated/addInto.st
@@ -1,0 +1,10 @@
+FUNCTION addInto : DINT
+VAR_INPUT
+    delta : DINT;
+END_VAR
+VAR_IN_OUT
+    acc : DINT;
+END_VAR
+    acc := acc + delta;
+    addInto := acc;
+END_FUNCTION

--- a/tests/lit/cfc/blocks/function_inout_negated/function_inout_negated.cfc
+++ b/tests/lit/cfc/blocks/function_inout_negated/function_inout_negated.cfc
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_inout_negated">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM function_inout_negated
+VAR
+    a1, acc1, b1 : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="addInto" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1070" y="60"/>
+                    <ppx:Size x="120" y="60"/>
+                    <ppx:InOutVariables>
+                        <ppx:InOutVariable parameterName="acc" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="6"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InOutVariable>
+                    </ppx:InOutVariables>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="delta" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="4"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="addInto" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="120" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="3">
+                    <ppx:RelPosition x="950" y="80"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="4">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="acc1" globalId="5">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="950" y="100"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="6">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1240" y="80"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/blocks/function_inout_negated/main.st
+++ b/tests/lit/cfc/blocks/function_inout_negated/main.st
@@ -1,0 +1,7 @@
+// A negated inout pin transpiles like an input pin, but an inout passes by
+// reference and a NOT expression has no storage behind it, so validation
+// rejects the call.
+// CHECK: {{.*}}error[E031]: Expected a reference for parameter acc because their type is InOut
+// CHECK: error: Compilation aborted due to critical errors
+FUNCTION main : DINT
+END_FUNCTION

--- a/tests/lit/cfc/blocks/function_inout_negated/plc.json
+++ b/tests/lit/cfc/blocks/function_inout_negated/plc.json
@@ -1,0 +1,12 @@
+{
+	"name" : "cfc_function_inout_negated",
+	"files" : [
+		"function_inout_negated.cfc",
+		"addInto.st",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/blocks/function_inout_negated/run.test
+++ b/tests/lit/cfc/blocks/function_inout_negated/run.test
@@ -1,0 +1,1 @@
+RUN: not %COMPILE --error-format clang build plc.json 2>&1 | %CHECK main.st

--- a/tests/lit/cfc/blocks/function_inout_unwired/README.md
+++ b/tests/lit/cfc/blocks/function_inout_unwired/README.md
@@ -1,0 +1,9 @@
+What: an inout pin left unwired transpiles to an empty argument, which the
+validation stage rejects — an inout must receive a real reference (E031). The
+RUN line asserts the failure.
+
+Illustrated:
+```
+5 --> delta [addInto] addInto --> result (0, 1)
+      acc (unwired)
+```

--- a/tests/lit/cfc/blocks/function_void/README.md
+++ b/tests/lit/cfc/blocks/function_void/README.md
@@ -1,0 +1,7 @@
+What: a call to a function without a return value; only the declared output is
+captured. `main` checks the output arrived (`result = 6` for `localIn = 3`).
+
+Illustrated:
+```
+localIn --> in [myVoid] out --> localOut (0, 1)
+```

--- a/tests/lit/cfc/blocks/negated_pins/README.md
+++ b/tests/lit/cfc/blocks/negated_pins/README.md
@@ -1,0 +1,11 @@
+What: the full block negation matrix at runtime (the verbatim `function_args`
+IDE export): a wire negated on both ends (`in1 := NOT NOT a1`, and the
+return-pin-to-`b1` wire), and wires negated on the variable side only
+(`in2 := NOT a2`, `b2 := NOT myAddDoubled`). NOT on DINT is the bitwise
+complement, so `main` checks `b1 = 6, b2 = -13` for `a1 = 10, a2 = 3`.
+
+Illustrated:
+```
+a1 o---o in1 [myAdd] myAdd        o---o b1 (0, 1)
+a2 o---- in2 [     ] myAddDoubled ----o b2 (2)
+```

--- a/tests/lit/cfc/blocks/negated_pins/function_args.cfc
+++ b/tests/lit/cfc/blocks/negated_pins/function_args.cfc
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="function_args">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM function_args
+VAR
+    a1, a2, b1, b2 : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:Block" typeName="myAdd" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1160" y="460"/>
+                    <ppx:Size x="130" y="60"/>
+                    <ppx:InOutVariables/>
+                    <ppx:InputVariables>
+                        <ppx:InputVariable parameterName="in1" negated="true">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="30"/>
+<ppx:Connection refConnectionPointOutId="5"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                        <ppx:InputVariable parameterName="in2" negated="false">
+                            <ppx:ConnectionPointIn>
+<ppx:RelPosition x="0" y="50"/>
+<ppx:Connection refConnectionPointOutId="8"/>
+                            </ppx:ConnectionPointIn>
+                        </ppx:InputVariable>
+                    </ppx:InputVariables>
+                    <ppx:OutputVariables>
+                        <ppx:OutputVariable parameterName="myAdd" negated="true">
+                            <ppx:ConnectionPointOut connectionPointOutId="2">
+<ppx:RelPosition x="130" y="30"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                        <ppx:OutputVariable parameterName="myAddDoubled" negated="false">
+                            <ppx:ConnectionPointOut connectionPointOutId="3">
+<ppx:RelPosition x="130" y="50"/>
+                            </ppx:ConnectionPointOut>
+                        </ppx:OutputVariable>
+                    </ppx:OutputVariables>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="4">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1030" y="480"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a2" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1030" y="500"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="8">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="9">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1340" y="480"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b2" globalId="11">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="1340" y="500"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="3"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/blocks/negated_pins/main.st
+++ b/tests/lit/cfc/blocks/negated_pins/main.st
@@ -1,0 +1,10 @@
+FUNCTION main : DINT
+    // NOT on DINT is the bitwise complement, NOT x = -x - 1.
+    // in1 := NOT NOT a1 = 10; in2 := NOT a2 = -4; myAdd = 6;
+    // b1 := NOT NOT myAdd = 6; b2 := NOT myAddDoubled = NOT 12 = -13.
+    function_args.a1 := 10;
+    function_args.a2 := 3;
+    function_args();
+    // CHECK: b1 = 6, b2 = -13
+    printf('b1 = %d, b2 = %d$N', function_args.b1, function_args.b2);
+END_FUNCTION

--- a/tests/lit/cfc/blocks/negated_pins/myAdd.st
+++ b/tests/lit/cfc/blocks/negated_pins/myAdd.st
@@ -1,0 +1,11 @@
+FUNCTION myAdd : DINT
+VAR_INPUT
+    in1 : DINT;
+    in2 : DINT;
+END_VAR
+VAR_OUTPUT
+    myAddDoubled : DINT;
+END_VAR
+    myAdd := in1 + in2;
+    myAddDoubled := (in1 + in2) * 2;
+END_FUNCTION

--- a/tests/lit/cfc/blocks/negated_pins/plc.json
+++ b/tests/lit/cfc/blocks/negated_pins/plc.json
@@ -1,0 +1,12 @@
+{
+	"name" : "cfc_negated_pins",
+	"files" : [
+		"function_args.cfc",
+		"myAdd.st",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/blocks/negated_pins/run.test
+++ b/tests/lit/cfc/blocks/negated_pins/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/blocks/program_call/README.md
+++ b/tests/lit/cfc/blocks/program_call/README.md
@@ -1,0 +1,9 @@
+What: a call to another program with an input, an inout, and an output pin;
+the inout writes back into the caller's variable. `main` runs two cycles with
+`stepValue = 3` and checks state and output (`total = 6, result = 12`).
+
+Illustrated:
+```
+stepValue -------> step [accumulator] doubled --> result (0, 1)
+runningTotal <--> total
+```

--- a/tests/lit/cfc/connectors/chain/README.md
+++ b/tests/lit/cfc/connectors/chain/README.md
@@ -1,0 +1,8 @@
+What: a value routed through three connector/continuation pairs in series;
+the trace walks the whole chain back to the source. `main` checks the value
+survived the routing (`bar = 7`).
+
+Illustrated:
+```
+foo --> a    a --> b    b --> c    c --> bar (0)
+```

--- a/tests/lit/cfc/connectors/fan_out/README.md
+++ b/tests/lit/cfc/connectors/fan_out/README.md
@@ -1,0 +1,9 @@
+What: one connector consumed by two continuations with the same label; the
+routed value fans out into two sinks. `main` checks both received it
+(`bar = 42, baz = 42`).
+
+Illustrated:
+```
+foo --> x    x --> bar (0)
+             x --> baz (1)
+```

--- a/tests/lit/cfc/connectors/negated_route/README.md
+++ b/tests/lit/cfc/connectors/negated_route/README.md
@@ -1,0 +1,10 @@
+What: negation bubbles on the endpoints of connector routes — a source bubble
+ahead of one connector (`b := NOT a`) and a sink bubble behind another
+continuation (`d := NOT c`). Connectors and continuations themselves can not
+be negated. `main` checks both directions with flipped inputs.
+
+Illustrated:
+```
+a o--> route1    route1 --> b (0)
+c ---> route2    route2 --o d (1)
+```

--- a/tests/lit/cfc/connectors/negated_route/main.st
+++ b/tests/lit/cfc/connectors/negated_route/main.st
@@ -1,0 +1,15 @@
+FUNCTION main : DINT
+    // b := NOT a (source bubble ahead of the connector),
+    // d := NOT c (sink bubble behind the continuation).
+    negated_route.a := FALSE;
+    negated_route.c := TRUE;
+    negated_route();
+    // CHECK: b = 1, d = 0
+    printf('b = %d, d = %d$N', negated_route.b, negated_route.d);
+
+    negated_route.a := TRUE;
+    negated_route.c := FALSE;
+    negated_route();
+    // CHECK: b = 0, d = 1
+    printf('b = %d, d = %d$N', negated_route.b, negated_route.d);
+END_FUNCTION

--- a/tests/lit/cfc/connectors/negated_route/negated_route.cfc
+++ b/tests/lit/cfc/connectors/negated_route/negated_route.cfc
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_route">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_route
+VAR
+    a, b, c, d : BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="route1" globalId="3">
+                    <ppx:RelPosition x="380" y="140"/>
+                    <ppx:Size x="70" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="route1" globalId="4">
+                    <ppx:RelPosition x="500" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="630" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="c" globalId="7">
+                    <ppx:RelPosition x="250" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="8">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:CommonObject xsi:type="ppx:Connector" label="route2" globalId="9">
+                    <ppx:RelPosition x="380" y="180"/>
+                    <ppx:Size x="70" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="8"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:CommonObject>
+                <ppx:CommonObject xsi:type="ppx:Continuation" label="route2" globalId="10">
+                    <ppx:RelPosition x="500" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="11">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:CommonObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="d" globalId="12">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="630" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="11"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/connectors/negated_route/plc.json
+++ b/tests/lit/cfc/connectors/negated_route/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_negated_route",
+	"files" : [
+		"negated_route.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/connectors/negated_route/run.test
+++ b/tests/lit/cfc/connectors/negated_route/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/generics/add_chain/README.md
+++ b/tests/lit/cfc/generics/add_chain/README.md
@@ -1,0 +1,9 @@
+What: two builtin variadic `ADD` blocks in series; the intermediate temporary
+resolves through generic inference. `main` checks the chained sum
+(`(a + b) + c = 103000`).
+
+Illustrated:
+```
+a --> [ADD] --> [ADD] --> result (0, 1, 2)
+b -->      c -->
+```

--- a/tests/lit/cfc/generics/add_feedback/README.md
+++ b/tests/lit/cfc/generics/add_feedback/README.md
@@ -1,0 +1,12 @@
+What: a builtin `ADD` whose output feeds back into its own input; the
+accumulator temporary must resolve to DINT through the feedback binding.
+`main` seeds `2^24 + 1` (not representable in REAL) and runs three cycles —
+the exact sum (`acc = 50331651`) proves no floating-point promotion happened.
+
+Illustrated:
+```
+     +--<-- ADD <--+
+     |             |
+     +--> [ADD]----+--> acc (0, 1)
+seed ---->
+```

--- a/tests/lit/cfc/generics/generic_chain/README.md
+++ b/tests/lit/cfc/generics/generic_chain/README.md
@@ -1,0 +1,10 @@
+What: two user-defined generic `myGenAdd<T: ANY_NUM>` calls in series with
+mixed input widths (INT inputs into the first link, DINT into the second);
+each link resolves its own binding. `main` checks the chained sum
+(`result = 103000`).
+
+Illustrated:
+```
+a --> [myGenAdd] --> [myGenAdd] --> result (0, 1, 2)
+b -->            c -->
+```

--- a/tests/lit/cfc/generics/generic_feedback/README.md
+++ b/tests/lit/cfc/generics/generic_feedback/README.md
@@ -1,0 +1,11 @@
+What: a user-defined generic function whose return value feeds back into its
+own input; the temporary's type must resolve through the feedback loop. `main`
+runs three cycles with `seed = 5` and checks the accumulation (`acc = 15`).
+
+Illustrated:
+```
+     +--<-- myGenAdd <--+
+     |                  |
+     +--> a [myGenAdd]--+--> acc (0, 1)
+seed ---> b
+```

--- a/tests/lit/cfc/generics/generic_output/README.md
+++ b/tests/lit/cfc/generics/generic_output/README.md
@@ -1,0 +1,8 @@
+What: a generic function without a return value whose generic type is decided
+by its input, read through the declared output pin. `main` checks the doubled
+value (`y = 42` for `x = 21`).
+
+Illustrated:
+```
+x --> a [myGenOut] doubled --> y (0, 1)
+```

--- a/tests/lit/cfc/generics/sel_call/README.md
+++ b/tests/lit/cfc/generics/sel_call/README.md
@@ -1,0 +1,10 @@
+What: a call to the builtin generic `SEL` selector. `main` checks both
+selector positions: `cond = FALSE` yields the first input (`first = 10`),
+`cond = TRUE` the second (`second = 20`).
+
+Illustrated:
+```
+cond --> G   [SEL] SEL --> result (0, 1)
+in0 ---> IN0
+in1 ---> IN1
+```

--- a/tests/lit/cfc/jumps/guarded_jump/README.md
+++ b/tests/lit/cfc/jumps/guarded_jump/README.md
@@ -1,0 +1,10 @@
+What: a conditional jump over an assignment. `main` checks both branches: a
+false guard falls through and the assignment runs (`y = 42`); a true guard
+takes the jump and `y` keeps its prior value (`y = 7`).
+
+Illustrated:
+```
+cond --> JMP skip (0)
+x --> y (1)
+LABEL skip (2)
+```

--- a/tests/lit/cfc/jumps/guarded_jump/guarded_jump.cfc
+++ b/tests/lit/cfc/jumps/guarded_jump/guarded_jump.cfc
@@ -16,7 +16,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skip" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/tests/lit/cfc/jumps/negated_jump/README.md
+++ b/tests/lit/cfc/jumps/negated_jump/README.md
@@ -1,0 +1,10 @@
+What: a jump guarded by a source whose negation bubble inverts the condition;
+the jump fires when the guard is false. `main` checks a false guard skips the
+assignment (`result = 0`) and a true guard runs it (`result = 42`).
+
+Illustrated:
+```
+guard o--> JMP skipAssignment (0)
+42 --> result (1)
+LABEL skipAssignment (2)
+```

--- a/tests/lit/cfc/jumps/negated_jump/main.st
+++ b/tests/lit/cfc/jumps/negated_jump/main.st
@@ -1,0 +1,16 @@
+FUNCTION main : DINT
+    // The source bubble inverts the guard: a false guard takes the jump,
+    // skipping the assignment.
+    negated_jump.guard := FALSE;
+    negated_jump.result := 0;
+    negated_jump();
+    // CHECK: result = 0
+    printf('result = %d$N', negated_jump.result);
+
+    // A true guard does not jump, so the assignment runs.
+    negated_jump.guard := TRUE;
+    negated_jump.result := 0;
+    negated_jump();
+    // CHECK: result = 42
+    printf('result = %d$N', negated_jump.result);
+END_FUNCTION

--- a/tests/lit/cfc/jumps/negated_jump/negated_jump.cfc
+++ b/tests/lit/cfc/jumps/negated_jump/negated_jump.cfc
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_jump">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_jump
+VAR
+    guard : BOOL;
+    result : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="guard" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="skipAssignment" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="false"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="420" y="140"/>
+                    <ppx:Size x="150" y="20"/>
+                    <bmx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </bmx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="42" globalId="4">
+                    <ppx:RelPosition x="250" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="420" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="bmx:CfcLabel" label="skipAssignment" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="220"/>
+                    <ppx:Size x="130" y="20"/>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/jumps/negated_jump/plc.json
+++ b/tests/lit/cfc/jumps/negated_jump/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_negated_jump",
+	"files" : [
+		"negated_jump.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/jumps/negated_jump/run.test
+++ b/tests/lit/cfc/jumps/negated_jump/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/jumps/scrambled/README.md
+++ b/tests/lit/cfc/jumps/scrambled/README.md
@@ -1,0 +1,16 @@
+What: a network whose document order is shuffled against evaluation priority,
+with three guarded jumps (two fanning into one label `end`) and two labels.
+`main` drives all four guard combinations and checks which assignments each
+skip covers.
+
+Illustrated (in priority order):
+```
+g1 --> JMP mid  (0)
+x  --> a        (1)
+g2 --> JMP end  (2)
+LABEL mid       (3)
+x  --> b        (4)
+g3 --> JMP end  (5)
+x  --> c        (6)
+LABEL end       (7)
+```

--- a/tests/lit/cfc/jumps/scrambled/scrambled.cfc
+++ b/tests/lit/cfc/jumps/scrambled/scrambled.cfc
@@ -25,7 +25,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="end" globalId="6">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="5"/>
@@ -54,7 +54,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="mid" globalId="1">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>
@@ -119,7 +119,7 @@ END_VAR
                 <ppx:FbdObject xsi:type="bmx:CfcJump" targetLabel="end" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="2"/>

--- a/tests/lit/cfc/returns/guarded_return/README.md
+++ b/tests/lit/cfc/returns/guarded_return/README.md
@@ -1,0 +1,9 @@
+What: a conditional early return ahead of an assignment. `main` checks a false
+guard falls through and the assignment runs (`result = 42`), while a true
+guard returns early and `result` keeps its prior value (`result = 7`).
+
+Illustrated:
+```
+guard --> RETURN (0)
+42 --> result (1)
+```

--- a/tests/lit/cfc/returns/guarded_return/guarded_return.cfc
+++ b/tests/lit/cfc/returns/guarded_return/guarded_return.cfc
@@ -22,7 +22,7 @@ END_VAR</bmx:TextDeclaration>
                 <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
                     <ppx:AddData>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
-                            <negated value="false"/>
+                            <bmx:Negation inNegated="false"/>
                         </ppx:Data>
                         <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
                             <EvaluationPriority priorityInNetwork="0"/>

--- a/tests/lit/cfc/returns/negated_return/README.md
+++ b/tests/lit/cfc/returns/negated_return/README.md
@@ -1,0 +1,9 @@
+What: a return whose negation bubble inverts its wired condition; the early
+return fires when the guard is false. `main` checks a false guard skips the
+assignment (`result = 0`) and a true guard runs it (`result = 42`).
+
+Illustrated:
+```
+guard --o RETURN (0)
+42 --> result (1)
+```

--- a/tests/lit/cfc/returns/negated_return/main.st
+++ b/tests/lit/cfc/returns/negated_return/main.st
@@ -1,0 +1,15 @@
+FUNCTION main : DINT
+    // The negated return fires on a false guard, skipping the assignment.
+    negated_return.guard := FALSE;
+    negated_return.result := 0;
+    negated_return();
+    // CHECK: result = 0
+    printf('result = %d$N', negated_return.result);
+
+    // A true guard does not return early, so the assignment runs.
+    negated_return.guard := TRUE;
+    negated_return.result := 0;
+    negated_return();
+    // CHECK: result = 42
+    printf('result = %d$N', negated_return.result);
+END_FUNCTION

--- a/tests/lit/cfc/returns/negated_return/negated_return.cfc
+++ b/tests/lit/cfc/returns/negated_return/negated_return.cfc
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_return">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_return
+VAR
+    guard : BOOL;
+    result : DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="guard" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="110" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="110" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:Return" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="420" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="42" globalId="4">
+                    <ppx:RelPosition x="250" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="result" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="420" y="180"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/returns/negated_return/plc.json
+++ b/tests/lit/cfc/returns/negated_return/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_negated_return",
+	"files" : [
+		"negated_return.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/returns/negated_return/run.test
+++ b/tests/lit/cfc/returns/negated_return/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/variables/evaluation_order/README.md
+++ b/tests/lit/cfc/variables/evaluation_order/README.md
@@ -1,0 +1,11 @@
+What: three assignments to interleaved variables run purely in
+`EvaluationPriority` order, not document order. `main` checks that `b`
+captured the intermediate value of `a` before the second write (`a = 2,
+b = 1`).
+
+Illustrated:
+```
+1 --> a (0)
+a --> b (1)
+2 --> a (2)
+```

--- a/tests/lit/cfc/variables/fan_out/README.md
+++ b/tests/lit/cfc/variables/fan_out/README.md
@@ -1,0 +1,10 @@
+What: a literal seeds `src`, which then fans out into two sinks; one
+`ConnectionPointOut` is referenced by multiple wires. `main` checks both sinks
+received the value (`x = 5, y = 5`).
+
+Illustrated:
+```
+5 --> src (0)
+src --+--> x (1)
+      +--> y (2)
+```

--- a/tests/lit/cfc/variables/literal_assignment/README.md
+++ b/tests/lit/cfc/variables/literal_assignment/README.md
@@ -1,0 +1,7 @@
+What: a literal source assigned straight into a variable. `main` checks the
+value arrived (`x = 42`).
+
+Illustrated:
+```
+42 --> x (0)
+```

--- a/tests/lit/cfc/variables/negated_assignment/README.md
+++ b/tests/lit/cfc/variables/negated_assignment/README.md
@@ -1,0 +1,11 @@
+What: the three negation-bubble flavors on plain assignments — source bubble
+(`b1 := NOT a1`), sink bubble (`b2 := NOT a2`), and both (`b3 := NOT NOT a3`,
+the NOTs cancel). `main` runs an all-false and an all-true round and checks
+each sink.
+
+Illustrated:
+```
+a1 o--> b1 (0)
+a2 --o> b2 (1)
+a3 o-o> b3 (2)
+```

--- a/tests/lit/cfc/variables/negated_assignment/main.st
+++ b/tests/lit/cfc/variables/negated_assignment/main.st
@@ -1,0 +1,17 @@
+FUNCTION main : DINT
+    // b1 := NOT a1 (source bubble), b2 := NOT a2 (sink bubble),
+    // b3 := NOT NOT a3 (both bubbles cancel).
+    negated_assignment.a1 := FALSE;
+    negated_assignment.a2 := FALSE;
+    negated_assignment.a3 := FALSE;
+    negated_assignment();
+    // CHECK: all false: b1 = 1, b2 = 1, b3 = 0
+    printf('all false: b1 = %d, b2 = %d, b3 = %d$N', negated_assignment.b1, negated_assignment.b2, negated_assignment.b3);
+
+    negated_assignment.a1 := TRUE;
+    negated_assignment.a2 := TRUE;
+    negated_assignment.a3 := TRUE;
+    negated_assignment();
+    // CHECK: all true: b1 = 0, b2 = 0, b3 = 1
+    printf('all true: b1 = %d, b2 = %d, b3 = %d$N', negated_assignment.b1, negated_assignment.b2, negated_assignment.b3);
+END_FUNCTION

--- a/tests/lit/cfc/variables/negated_assignment/negated_assignment.cfc
+++ b/tests/lit/cfc/variables/negated_assignment/negated_assignment.cfc
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="negated_assignment">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM negated_assignment
+VAR
+    a1, a2, a3 : BOOL;
+    b1, b2, b3 : BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a1" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b1" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a2" globalId="4">
+                    <ppx:RelPosition x="250" y="170"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b2" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="170"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a3" globalId="7">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="200"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="8">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b3" globalId="9">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="2"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="200"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="8"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/tests/lit/cfc/variables/negated_assignment/plc.json
+++ b/tests/lit/cfc/variables/negated_assignment/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_negated_assignment",
+	"files" : [
+		"negated_assignment.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/variables/negated_assignment/run.test
+++ b/tests/lit/cfc/variables/negated_assignment/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st


### PR DESCRIPTION
Problem: Previously we used the `<negated value="true|false"/>` XML element from the old IDE export format to indicate whether a CFC node is negated. The current IDE however exports its own extension,
`<bmx:Negation inNegated="..." outNegated="..."/>`, so negations in real exports were silently ignored.

Fix: Adapt the model to the format exported by the IDE and apply the negation on all elements that support it. Every bubble on a wire inserts one NOT, two bubbles nest (`b := NOT NOT a`).