### PR TITLE
fix: link the driver probe to a real path and plumb the sysroot onto the target

### DIFF
--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -24,7 +24,7 @@ use plc::{
     codegen::CodegenContext,
     linker::LinkerType,
     output::{FormatOption, RelocationPreference},
-    DebugLevel, ErrorFormat, OnlineChange, OptimizationLevel,
+    DebugLevel, ErrorFormat, OnlineChange, OptimizationLevel, Target,
 };
 
 use plc_diagnostics::{diagnostician::Diagnostician, diagnostics::Diagnostic, reporter::DiagnosticReporter};
@@ -185,12 +185,28 @@ pub fn compile<T: AsRef<str> + AsRef<OsStr> + Debug>(args: &[T]) -> Result<()> {
     compile_with_pipeline(pipeline)
 }
 
+/// Resolve the build target, folding the separately-parsed `--sysroot` into it.
+///
+/// `--target` and `--sysroot` are independent CLI parameters, and `FromStr for Target`
+/// can only produce a target with no sysroot. Without this merge `Target::get_sysroot()`
+/// is always `None`, so the sysroot reaches neither the driver-linker support probe nor
+/// the real link.
+///
+/// Note that a sysroot is only carried by [`Target::Param`]: with no `--target` the
+/// default [`Target::System`] keeps no sysroot, which is correct for a native build.
+fn resolve_target(params: Option<&CompileParameters>) -> Target {
+    params
+        .and_then(|it| it.target.clone())
+        .unwrap_or_default()
+        .with_sysroot(params.and_then(|it| it.sysroot.clone()))
+}
+
 pub fn compile_with_pipeline<T: SourceContainer + Clone + 'static>(
     mut pipeline: BuildPipeline<T>,
 ) -> Result<()> {
     //register participants
     pipeline.register_default_mut_participants();
-    let target = pipeline.compile_parameters.as_ref().and_then(|it| it.target.clone()).unwrap_or_default();
+    let target = resolve_target(pipeline.compile_parameters.as_ref());
     let codegen_participant = CodegenParticipant {
         compile_options: pipeline.get_compile_options().unwrap(),
         link_options: pipeline.get_link_options().unwrap(),

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -1187,8 +1187,11 @@ impl GeneratedProject {
             _ => {
                 // Only initialize a linker if we need to use it
                 let target_triple = self.target.get_target_triple();
-                let mut linker =
-                    plc::linker::Linker::new(&target_triple.as_str().to_string_lossy(), link_options.linker)?;
+                let mut linker = plc::linker::Linker::new(
+                    &target_triple.as_str().to_string_lossy(),
+                    self.target.get_sysroot(),
+                    link_options.linker,
+                )?;
                 if let Some(fuse) = &link_options.fuse_linker {
                     log::debug!("Applying --fuse-ld={fuse}");
                     linker.set_fuse_ld(fuse);

--- a/compiler/plc_driver/src/tests.rs
+++ b/compiler/plc_driver/src/tests.rs
@@ -20,6 +20,58 @@ mod external_files;
 mod header_generator;
 mod multi_files;
 
+/// `--target` and `--sysroot` are parsed as independent parameters; these cover the merge
+/// that puts the sysroot onto the target so it reaches the linker probe and the real link.
+mod target_resolution {
+    use crate::{cli::CompileParameters, resolve_target};
+
+    fn params(args: &[&str]) -> CompileParameters {
+        CompileParameters::parse(args).unwrap()
+    }
+
+    #[test]
+    fn sysroot_is_merged_into_the_target() {
+        let params =
+            params(&["plc", "alpha.st", "--target", "x86_64-linux-gnu", "--sysroot", "/sysroots/amd64"]);
+
+        let target = resolve_target(Some(&params));
+
+        assert_eq!(target.try_get_name(), Some("x86_64-linux-gnu"));
+        assert_eq!(target.get_sysroot(), Some("/sysroots/amd64"));
+    }
+
+    #[test]
+    fn target_without_sysroot_carries_none() {
+        let params = params(&["plc", "alpha.st", "--target", "x86_64-linux-gnu"]);
+
+        let target = resolve_target(Some(&params));
+
+        assert_eq!(target.try_get_name(), Some("x86_64-linux-gnu"));
+        assert_eq!(target.get_sysroot(), None);
+    }
+
+    /// A sysroot is only carried by `Target::Param`, so without `--target` the default
+    /// `Target::System` keeps none. That is correct for a native build, where the host
+    /// toolchain supplies its own defaults.
+    #[test]
+    fn sysroot_without_target_is_dropped() {
+        let params = params(&["plc", "alpha.st", "--sysroot", "/sysroots/amd64"]);
+
+        let target = resolve_target(Some(&params));
+
+        assert_eq!(target.try_get_name(), None);
+        assert_eq!(target.get_sysroot(), None);
+    }
+
+    #[test]
+    fn absent_parameters_resolve_to_the_default_target() {
+        let target = resolve_target(None);
+
+        assert_eq!(target.try_get_name(), None);
+        assert_eq!(target.get_sysroot(), None);
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(bound(deserialize = "'de: 'static"))]
 pub struct ParsedProjectWrapper {

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -38,12 +38,12 @@ impl From<Option<&str>> for LinkerType {
 }
 
 impl Linker {
-    pub fn new(target: &str, linker: LinkerType) -> Result<Linker, LinkerError> {
+    pub fn new(target: &str, sysroot: Option<&str>, linker: LinkerType) -> Result<Linker, LinkerError> {
         Ok(Linker {
             errors: Vec::default(),
             linker: match linker {
-                LinkerType::Internal => Box::new(resolve_internal_linker(target)?),
-                LinkerType::External(linker) => Box::new(resolve_external_linker(target, &linker)?),
+                LinkerType::Internal => Box::new(resolve_internal_linker(target, sysroot)?),
+                LinkerType::External(linker) => Box::new(resolve_external_linker(target, sysroot, &linker)?),
                 LinkerType::Test(linker) => Box::new(linker),
             },
         })
@@ -155,17 +155,17 @@ impl Linker {
 }
 
 /// Resolve the internal linker in this order: `cc` -> `clang` -> `ld.lld` -> `ld`.
-fn resolve_internal_linker(target: &str) -> Result<CcLinker, LinkerError> {
+fn resolve_internal_linker(target: &str, sysroot: Option<&str>) -> Result<CcLinker, LinkerError> {
     log::debug!("Resolving internal linker for target `{target}`");
 
     // Prefer compiler drivers for correct default platform setup.
     if which("cc").is_ok() {
         log::trace!("Candidate linker available: cc");
-        return resolve_driver_linker("cc", target).or_else(|err| {
+        return resolve_driver_linker("cc", target, sysroot).or_else(|err| {
             log::debug!("cc rejected for target `{target}`: {err:?}");
             if which("clang").is_ok() {
                 log::trace!("Falling back to clang");
-                resolve_driver_linker("clang", target).or_else(|err| {
+                resolve_driver_linker("clang", target, sysroot).or_else(|err| {
                     log::debug!("clang rejected for target `{target}`: {err:?}");
                     resolve_direct_linker_fallback()
                 })
@@ -178,7 +178,7 @@ fn resolve_internal_linker(target: &str) -> Result<CcLinker, LinkerError> {
 
     if which("clang").is_ok() {
         log::trace!("cc unavailable, trying clang");
-        return resolve_driver_linker("clang", target).or_else(|err| {
+        return resolve_driver_linker("clang", target, sysroot).or_else(|err| {
             log::debug!("clang rejected for target `{target}`: {err:?}");
             resolve_direct_linker_fallback()
         });
@@ -192,11 +192,15 @@ fn resolve_internal_linker(target: &str) -> Result<CcLinker, LinkerError> {
 ///
 /// Driver-like linkers (e.g. `cc`, `clang`, `gcc`) get driver semantics,
 /// all others are treated as direct linkers.
-fn resolve_external_linker(target: &str, linker: &str) -> Result<CcLinker, LinkerError> {
+fn resolve_external_linker(
+    target: &str,
+    sysroot: Option<&str>,
+    linker: &str,
+) -> Result<CcLinker, LinkerError> {
     log::debug!("Resolving external linker `{linker}` for target `{target}`");
     if is_driver_linker(linker) {
         log::trace!("External linker `{linker}` detected as compiler-driver linker");
-        resolve_driver_linker(linker, target)
+        resolve_driver_linker(linker, target, sysroot)
     } else {
         log::trace!("External linker `{linker}` treated as direct linker");
         Ok(CcLinker::new(linker))
@@ -231,7 +235,7 @@ fn is_driver_linker(linker: &str) -> bool {
 }
 
 /// Resolve a compiler-driver linker and compute default pre-arguments.
-fn resolve_driver_linker(linker: &str, target: &str) -> Result<CcLinker, LinkerError> {
+fn resolve_driver_linker(linker: &str, target: &str, sysroot: Option<&str>) -> Result<CcLinker, LinkerError> {
     if which(linker).is_err() {
         log::debug!("Requested driver linker `{linker}` is not available on PATH");
         return Err(LinkerError::Link(format!("Linker not found: {linker}")));
@@ -241,7 +245,7 @@ fn resolve_driver_linker(linker: &str, target: &str) -> Result<CcLinker, LinkerE
     let cross_target = !target_matches_host(target);
     log::trace!("Driver linker `{linker}` cross-target={cross_target} target=`{target}`");
 
-    if supports_target_flag(linker, target, &pre_args) {
+    if supports_target_flag(linker, target, sysroot, &pre_args) {
         pre_args.push(format!("--target={target}"));
         log::trace!("Driver linker `{linker}` supports --target; added target flag");
     } else if cross_target {
@@ -269,6 +273,24 @@ fn default_driver_pre_args() -> Vec<String> {
     args
 }
 
+/// Assemble the argument list for the driver-support probe.
+///
+/// The probe must carry the flags of the real link that decide whether the target's
+/// crt files and libc resolve — most importantly the sysroot: a cross link (e.g.
+/// Windows host, `linux-gnu` target) can never succeed without it, and omitting it
+/// would reject a perfectly usable driver.
+fn probe_args(target: &str, sysroot: Option<&str>, pre_args: &[String]) -> Vec<String> {
+    let null_output = if cfg!(windows) { "NUL" } else { "/dev/null" };
+
+    let mut args = vec![format!("--target={target}")];
+    if let Some(sysroot) = sysroot {
+        args.push(format!("--sysroot={sysroot}"));
+    }
+    args.extend(pre_args.iter().cloned());
+    args.extend(["-x", "c", "-o", null_output, "-"].map(String::from));
+    args
+}
+
 /// Probe whether a driver linker can actually compile **and link** for `target`.
 ///
 /// The probe includes `pre_args` (e.g. `-fuse-ld=lld`) so that it tests the same
@@ -276,17 +298,14 @@ fn default_driver_pre_args() -> Vec<String> {
 /// program *without* `-nostdlib` so the probe also verifies that the target's
 /// sysroot (crt files, libc, etc.) is available — matching what a real link will
 /// need.
-fn supports_target_flag(linker: &str, target: &str, pre_args: &[String]) -> bool {
+fn supports_target_flag(linker: &str, target: &str, sysroot: Option<&str>, pre_args: &[String]) -> bool {
     use std::time::{Duration, Instant};
 
-    let null_output = if cfg!(windows) { "NUL" } else { "/dev/null" };
     let probe_src = "int main(){return 0;}";
     let timeout = Duration::from_secs(10);
 
     let supported = Command::new(linker)
-        .arg(format!("--target={target}"))
-        .args(pre_args)
-        .args(["-x", "c", "-o", null_output, "-"])
+        .args(probe_args(target, sysroot, pre_args))
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -318,7 +337,7 @@ fn supports_target_flag(linker: &str, target: &str, pre_args: &[String]) -> bool
         .unwrap_or(false);
 
     log::trace!(
-        "supports_target_flag(linker=`{linker}`, target=`{target}`, pre_args={pre_args:?}) => {supported}"
+        "supports_target_flag(linker=`{linker}`, target=`{target}`, sysroot={sysroot:?}, pre_args={pre_args:?}) => {supported}"
     );
     supported
 }
@@ -759,7 +778,7 @@ fn quote_response_file_arg(arg: &str) -> String {
 
 #[cfg(test)]
 mod test {
-    use crate::linker::{CcLinker, Linker, LinkerInterface, LinkerType};
+    use crate::linker::{probe_args, resolve_external_linker, CcLinker, Linker, LinkerInterface, LinkerType};
 
     #[test]
     fn windows_target_triple_should_result_in_ok() {
@@ -777,7 +796,7 @@ mod test {
             "i686-windows-gnu",
             "i686-win32-gnu",
         ] {
-            assert!(Linker::new(target, LinkerType::Internal).is_ok());
+            assert!(Linker::new(target, None, LinkerType::Internal).is_ok());
         }
     }
 
@@ -786,7 +805,7 @@ mod test {
         for target in
             &["x86_64-linux-gnu", "x86_64-pc-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
         {
-            assert!(Linker::new(target, LinkerType::Internal).is_ok());
+            assert!(Linker::new(target, None, LinkerType::Internal).is_ok());
         }
     }
 
@@ -830,6 +849,60 @@ mod test {
         let mut linker = CcLinker::new("ld.lld");
         linker.add_lib(":libfoo.so.1");
         assert_eq!(linker.command_args(), vec!["-l:libfoo.so.1"]);
+    }
+
+    #[test]
+    fn probe_args_include_sysroot_when_present() {
+        let args = probe_args("x86_64-linux-gnu", Some("/sysroots/amd64"), &["-fuse-ld=lld".to_string()]);
+        assert_eq!(args[0], "--target=x86_64-linux-gnu");
+        assert_eq!(args[1], "--sysroot=/sysroots/amd64");
+        assert_eq!(args[2], "-fuse-ld=lld");
+    }
+
+    #[test]
+    fn probe_args_omit_sysroot_when_absent() {
+        let args = probe_args("x86_64-linux-gnu", None, &[]);
+        assert_eq!(args[0], "--target=x86_64-linux-gnu");
+        assert!(!args.iter().any(|it| it.starts_with("--sysroot")));
+    }
+
+    /// Cross-compilation resolution: a driver that can only link the target when given a
+    /// sysroot (the Windows-host/linux-target case) must be selected when the build supplies
+    /// one, and rejected when it does not.
+    #[cfg(unix)]
+    #[test]
+    fn cross_target_driver_resolution_depends_on_sysroot_in_probe() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // A stand-in driver: the probe link succeeds only when a sysroot is passed. The name
+        // must contain `clang` so it classifies as a compiler-driver linker.
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("fake-clang");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    --sysroot=*) exit 0 ;;
+  esac
+done
+exit 1
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let script = script.to_string_lossy();
+
+        // The target arch never matches the host, so resolution must go through the probe.
+        let target = "imaginary-arch-linux-gnu";
+
+        // With a sysroot the probe passes and the driver is selected with the target flag.
+        let linker = resolve_external_linker(target, Some("/sysroots/amd64"), &script)
+            .expect("driver must be accepted when the probe carries the sysroot");
+        assert!(linker.command_args().contains(&format!("--target={target}")));
+
+        // Without a sysroot the probe link fails and the cross-target driver is rejected.
+        assert!(resolve_external_linker(target, None, &script).is_err());
     }
 
     use crate::linker::{diagnose_spawn_error, LinkerError};

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -279,15 +279,18 @@ fn default_driver_pre_args() -> Vec<String> {
 /// crt files and libc resolve — most importantly the sysroot: a cross link (e.g.
 /// Windows host, `linux-gnu` target) can never succeed without it, and omitting it
 /// would reject a perfectly usable driver.
-fn probe_args(target: &str, sysroot: Option<&str>, pre_args: &[String]) -> Vec<String> {
-    let null_output = if cfg!(windows) { "NUL" } else { "/dev/null" };
-
+///
+/// `output` must likewise be a path the linker can actually create. The null device is
+/// *not* usable: on Windows `ld.lld` treats `-o NUL` as a regular file and fails with
+/// "failed to write output 'NUL': permission denied", which would again reject an
+/// otherwise-capable driver.
+fn probe_args(target: &str, sysroot: Option<&str>, pre_args: &[String], output: &str) -> Vec<String> {
     let mut args = vec![format!("--target={target}")];
     if let Some(sysroot) = sysroot {
         args.push(format!("--sysroot={sysroot}"));
     }
     args.extend(pre_args.iter().cloned());
-    args.extend(["-x", "c", "-o", null_output, "-"].map(String::from));
+    args.extend(["-x", "c", "-o", output, "-"].map(String::from));
     args
 }
 
@@ -304,8 +307,19 @@ fn supports_target_flag(linker: &str, target: &str, sysroot: Option<&str>, pre_a
     let probe_src = "int main(){return 0;}";
     let timeout = Duration::from_secs(10);
 
+    // The probe must link to a real, writable path — see `probe_args`.
+    let probe_dir = match tempfile::tempdir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            log::debug!("supports_target_flag: could not create probe directory: {err}");
+            return false;
+        }
+    };
+    let probe_out = probe_dir.path().join("plc-linker-probe.out");
+    let probe_out = probe_out.to_string_lossy().to_string();
+
     let supported = Command::new(linker)
-        .args(probe_args(target, sysroot, pre_args))
+        .args(probe_args(target, sysroot, pre_args, &probe_out))
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -853,56 +867,124 @@ mod test {
 
     #[test]
     fn probe_args_include_sysroot_when_present() {
-        let args = probe_args("x86_64-linux-gnu", Some("/sysroots/amd64"), &["-fuse-ld=lld".to_string()]);
+        let args = probe_args(
+            "x86_64-linux-gnu",
+            Some("/sysroots/amd64"),
+            &["-fuse-ld=lld".to_string()],
+            "/tmp/p.out",
+        );
         assert_eq!(args[0], "--target=x86_64-linux-gnu");
         assert_eq!(args[1], "--sysroot=/sysroots/amd64");
         assert_eq!(args[2], "-fuse-ld=lld");
     }
 
+    /// The probe's `-o` operand must be the caller-supplied path, never a null device.
+    /// See `probe_does_not_link_to_the_null_device` for the behavioural counterpart.
+    #[test]
+    fn probe_args_never_target_the_null_device() {
+        let args = probe_args("x86_64-linux-gnu", Some("/sysroots/amd64"), &[], "/tmp/probe.out");
+
+        let output_idx = args.iter().position(|it| it == "-o").expect("probe must pass -o") + 1;
+        assert_eq!(args[output_idx], "/tmp/probe.out");
+        assert!(!args.iter().any(|it| it == "NUL" || it == "/dev/null"));
+    }
+
     #[test]
     fn probe_args_omit_sysroot_when_absent() {
-        let args = probe_args("x86_64-linux-gnu", None, &[]);
+        let args = probe_args("x86_64-linux-gnu", None, &[], "/tmp/p.out");
         assert_eq!(args[0], "--target=x86_64-linux-gnu");
         assert!(!args.iter().any(|it| it.starts_with("--sysroot")));
+    }
+
+    /// What a stand-in compiler driver accepts, so a probe can be steered from a test.
+    enum FakeDriver {
+        /// Exits 0 only when the probe passes a `--sysroot=`.
+        RequiresSysroot,
+        /// Exits 0 only when the probe's output path is *not* a null device.
+        RejectsNullOutput,
+    }
+
+    /// Write a stand-in compiler driver and return its path.
+    ///
+    /// The file name contains `clang` so `is_driver_linker` classifies it as a compiler
+    /// driver. Both host families are covered: a POSIX shell script on unix, a batch file
+    /// on Windows — the Windows variant matters most here, since the null-device defect
+    /// this guards against is Windows-specific.
+    fn write_fake_driver(dir: &Path, behaviour: FakeDriver) -> String {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let body = match behaviour {
+                FakeDriver::RequiresSysroot => {
+                    "for arg in \"$@\"; do\n  case \"$arg\" in --sysroot=*) exit 0 ;; esac\ndone\nexit 1\n"
+                }
+                FakeDriver::RejectsNullOutput => {
+                    "prev=\"\"\nfor arg in \"$@\"; do\n  if [ \"$prev\" = \"-o\" ]; then\n    case \"$arg\" in /dev/null|NUL) exit 1 ;; esac\n  fi\n  prev=\"$arg\"\ndone\nexit 0\n"
+                }
+            };
+
+            let script = dir.join("fake-clang");
+            std::fs::write(&script, format!("#!/bin/sh\n{body}")).unwrap();
+            std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+            script.to_string_lossy().into_owned()
+        }
+
+        #[cfg(windows)]
+        {
+            // `findstr` sets errorlevel 1 when the pattern is absent.
+            let body = match behaviour {
+                FakeDriver::RequiresSysroot => {
+                    "echo %* | findstr /C:\"--sysroot=\" >nul\r\nif errorlevel 1 exit /b 1\r\nexit /b 0\r\n"
+                }
+                FakeDriver::RejectsNullOutput => {
+                    "echo %* | findstr /C:\"-o NUL\" /C:\"-o /dev/null\" >nul\r\nif errorlevel 1 exit /b 0\r\nexit /b 1\r\n"
+                }
+            };
+
+            let script = dir.join("fake-clang.bat");
+            std::fs::write(&script, format!("@echo off\r\n{body}")).unwrap();
+            script.to_string_lossy().into_owned()
+        }
     }
 
     /// Cross-compilation resolution: a driver that can only link the target when given a
     /// sysroot (the Windows-host/linux-target case) must be selected when the build supplies
     /// one, and rejected when it does not.
-    #[cfg(unix)]
     #[test]
     fn cross_target_driver_resolution_depends_on_sysroot_in_probe() {
-        use std::os::unix::fs::PermissionsExt;
-
-        // A stand-in driver: the probe link succeeds only when a sysroot is passed. The name
-        // must contain `clang` so it classifies as a compiler-driver linker.
         let dir = tempfile::tempdir().unwrap();
-        let script = dir.path().join("fake-clang");
-        std::fs::write(
-            &script,
-            r#"#!/bin/sh
-for arg in "$@"; do
-  case "$arg" in
-    --sysroot=*) exit 0 ;;
-  esac
-done
-exit 1
-"#,
-        )
-        .unwrap();
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let script = script.to_string_lossy();
+        let driver = write_fake_driver(dir.path(), FakeDriver::RequiresSysroot);
 
         // The target arch never matches the host, so resolution must go through the probe.
         let target = "imaginary-arch-linux-gnu";
 
         // With a sysroot the probe passes and the driver is selected with the target flag.
-        let linker = resolve_external_linker(target, Some("/sysroots/amd64"), &script)
+        let linker = resolve_external_linker(target, Some("/sysroots/amd64"), &driver)
             .expect("driver must be accepted when the probe carries the sysroot");
         assert!(linker.command_args().contains(&format!("--target={target}")));
 
         // Without a sysroot the probe link fails and the cross-target driver is rejected.
-        assert!(resolve_external_linker(target, None, &script).is_err());
+        assert!(resolve_external_linker(target, None, &driver).is_err());
+    }
+
+    /// Regression: the probe must link to a real, writable path.
+    ///
+    /// It previously linked to the null device (`NUL` on Windows, `/dev/null` elsewhere).
+    /// `ld.lld` treats `-o NUL` as an ordinary file and fails with "failed to write output
+    /// 'NUL': permission denied", so on a Windows host the probe rejected every otherwise
+    /// capable driver and resolution silently fell back to a direct linker — which carries
+    /// no default libraries and left `libc` symbols undefined.
+    #[test]
+    fn probe_does_not_link_to_the_null_device() {
+        let dir = tempfile::tempdir().unwrap();
+        let driver = write_fake_driver(dir.path(), FakeDriver::RejectsNullOutput);
+
+        let target = "imaginary-arch-linux-gnu";
+
+        let linker = resolve_external_linker(target, Some("/sysroots/amd64"), &driver)
+            .expect("probe must not use the null device as its output path");
+        assert!(linker.command_args().contains(&format!("--target={target}")));
     }
 
     use crate::linker::{diagnose_spawn_error, LinkerError};


### PR DESCRIPTION
## Problem

On a Windows host cross-building for a `linux-gnu` target, the driver-linker probe rejected a perfectly capable `cc`/`clang`. Resolution then fell back silently to a direct `ld.lld` link, which carries no default libraries, so shared objects kept undefined libc references and the `--no-undefined` default rejected them:

```
ld.lld: error: undefined symbol: printf
>>> referenced by mainProg.st:127
error: An error occurred during linking
```

## Cause

Two independent defects. Fixing either one alone changes nothing.

**1. The probe linked to the null device.** `ld.lld` treats `-o NUL` as an ordinary file and fails with `failed to write output 'NUL': permission denied`. This is **host-specific, not target-specific** — it broke resolution for *every* cross target on Windows, not just this one.

**2. The sysroot never reached the probe.** `--target` and `--sysroot` are parsed as independent parameters, and `FromStr for Target` can only build a target with no sysroot, so `Target::get_sysroot()` was unconditionally `None`. That made the first commit here a no-op. It also meant the **real link** never received `--sysroot` either, since `add_sysroot` sits behind the same `None` guard.

## Measured

The probe links only with a sysroot *and* a writable output path:

| sysroot | output | exit |
|---|---|---|
| yes | real file | **0** |
| no | real file | 1 |
| yes | `NUL` | 1 |

## Changes

- `src/linker.rs` — probe links into a `tempfile::tempdir()` path; `probe_args` takes an `output` parameter.
- `compiler/plc_driver/src/lib.rs` — `resolve_target` extracted (purely to make the merge testable) folds `params.sysroot` onto the target.
- `compiler/plc_driver/src/tests.rs` — new `target_resolution` module.

## Tests

Each fix has a guard verified to **fail when that fix is reverted**:

- `probe_does_not_link_to_the_null_device` — fails with the exact `does not support '--target=...'` rejection when the output goes back to `NUL`.
- `sysroot_is_merged_into_the_target` — fails when `.with_sysroot(...)` is dropped.

`cross_target_driver_resolution_depends_on_sysroot_in_probe` **was `#[cfg(unix)]`** — the platform carrying the defect was the one not testing it. The fake driver is now cross-platform (POSIX `sh` script / Windows `.bat`), so it runs on both.

## Reviewer notes

- `sysroot_without_target_is_dropped` pins *existing* behaviour as correct: `--sysroot` without `--target` silently does nothing, since only `Target::Param` carries a sysroot. Correct for native builds — but if it should warn instead, that test encodes the decision and should change with it.
- The Windows fake driver is a `.bat` using `findstr`; it is the least conventional thing in the diff.

Verified end to end against the reporting IDE build: `clang` is now selected as a compiler driver with the lld backend and `printf` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
