### PR TITLE
fix: ensuring unary not validates that it requires a bit or integer

### DIFF
--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -252,6 +252,7 @@ lazy_static! {
         E148,   Warning,    include_str!("./error_codes/E148.md"),  // Temporal literal overflow or underflow
         E149,   Error,      include_str!("./error_codes/E149.md"),  // Unresolved generic CFC block output
         E150,   Warning,    include_str!("./error_codes/E150.md"),  // ABS on an unsigned value has no effect
+        E151,   Error,      include_str!("./error_codes/E151.md"),  // Unary NOT with unsupported operand type
     );
 }
 

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E151.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E151.md
@@ -1,0 +1,36 @@
+# Unary `NOT` Used With an Unsupported Operand Type
+
+The `NOT` operator is valid for boolean, integer and bit-oriented operands. Other types, such as structs,
+arrays and strings, are not supported.
+
+Erroneous code example:
+
+```iecst
+TYPE Wrapper : STRUCT
+    out : BOOL;
+END_STRUCT
+END_TYPE
+
+PROGRAM mainProg
+VAR
+    value : Wrapper;
+END_VAR
+    value := NOT value;
+END_PROGRAM
+```
+
+To fix this, apply `NOT` to the actual scalar field instead:
+
+```iecst
+TYPE Wrapper : STRUCT
+    out : BOOL;
+END_STRUCT
+END_TYPE
+
+PROGRAM mainProg
+VAR
+    value : Wrapper;
+END_VAR
+    value.out := NOT value.out;
+END_PROGRAM
+```

--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -456,7 +456,18 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
     ) -> Result<BasicValueEnum<'ink>, CodegenError> {
         let value = match unary_operator {
             Operator::Not => {
-                let operator = self.generate_expression(expression)?.into_int_value();
+                let generated = self.generate_expression(expression)?;
+                if !generated.is_int_value() {
+                    let type_name = self.get_type_hint_for(expression)?.get_name();
+                    return Err(Diagnostic::new(format!(
+                        "Unary `NOT` requires a bit or integer operand, got `{type_name}`"
+                    ))
+                    .with_error_code("E151")
+                    .with_location(expression)
+                    .into());
+                }
+
+                let operator = generated.into_int_value();
                 let operator = if self
                     .get_type_hint_for(expression)
                     .map(|it| it.get_type_information().is_bool())

--- a/src/validation/statement.rs
+++ b/src/validation/statement.rs
@@ -141,6 +141,7 @@ pub fn visit_statement<T: AnnotationMap>(
         }
         AstStatement::UnaryExpression(data) => {
             visit_statement(validator, &data.value, context);
+            validate_unary_expression(validator, statement, &data.operator, &data.value, context);
         }
         AstStatement::ExpressionList(expressions) => {
             expressions.iter().for_each(|element| visit_statement(validator, element, context))
@@ -1089,6 +1090,31 @@ fn validate_binary_expression<T: AnnotationMap>(
             );
         }
     }
+}
+
+fn validate_unary_expression<T: AnnotationMap>(
+    validator: &mut Validator,
+    statement: &AstNode,
+    operator: &Operator,
+    value: &AstNode,
+    context: &ValidationContext<T>,
+) {
+    if !matches!(operator, Operator::Not) {
+        return;
+    }
+
+    let kind = context.annotations.get_type_or_void(value, context.index);
+    let kind_info = kind.get_type_information();
+    if kind.is_bit() || kind_info.is_int() {
+        return;
+    }
+
+    let slice = validator.get_type_name_or_slice(kind);
+    validator.push_diagnostic(
+        Diagnostic::new(format!("Unary `NOT` requires a bit or integer operand, got `{slice}`"))
+            .with_error_code("E151")
+            .with_location(statement),
+    );
 }
 
 fn compare_function_exists<T: AnnotationMap>(

--- a/src/validation/tests/statement_validation_tests.rs
+++ b/src/validation/tests/statement_validation_tests.rs
@@ -2626,6 +2626,89 @@ fn while_loop_triggers_error_if_condition_is_not_boolean() {
 }
 
 #[test]
+fn unary_not_on_aggregate_operand_is_rejected() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE PI_T_mainTask_bToggle1 : STRUCT
+            out : BOOL;
+        END_STRUCT
+        END_TYPE
+
+        TYPE PI_T_mainTask : STRUCT
+            bToggle1 AT %QX1.2.3.4 : PI_T_mainTask_bToggle1;
+        END_STRUCT
+        END_TYPE
+
+        VAR_GLOBAL
+            mainTask_pi : PI_T_mainTask;
+        END_VAR
+
+        PROGRAM mainProg
+        VAR
+            cycleCnt : UDINT := 1;
+        END_VAR
+
+        cycleCnt := cycleCnt + 1;
+        mainTask_pi.bToggle1 := NOT mainTask_pi.bToggle1;
+        END_PROGRAM
+        ",
+    );
+
+    assert_snapshot!(&diagnostics, @"
+    error[E151]: Unary `NOT` requires a bit or integer operand, got `PI_T_mainTask_bToggle1`
+       ┌─ <internal>:22:33
+       │
+    22 │         mainTask_pi.bToggle1 := NOT mainTask_pi.bToggle1;
+       │                                 ^^^^^^^^^^^^^^^^^^^^^^^^ Unary `NOT` requires a bit or integer operand, got `PI_T_mainTask_bToggle1`
+    ");
+}
+
+#[test]
+fn unary_not_on_qualified_addressed_leaf_is_allowed() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        TYPE PI_T_mainTask_bToggle1 : STRUCT
+            out : BOOL;
+        END_STRUCT
+        END_TYPE
+
+        TYPE PI_T_mainTask : STRUCT
+            bToggle1 AT %QX1.2.3.4 : PI_T_mainTask_bToggle1;
+        END_STRUCT
+        END_TYPE
+
+        VAR_GLOBAL
+            mainTask_pi : PI_T_mainTask;
+        END_VAR
+
+        PROGRAM mainProg
+            mainTask_pi.bToggle1.out := NOT mainTask_pi.bToggle1.out;
+        END_PROGRAM
+        ",
+    );
+
+    assert!(diagnostics.is_empty(), "expected clean diagnostics, got:\n{diagnostics}");
+}
+
+#[test]
+fn unary_not_on_integer_operand_is_allowed() {
+    let diagnostics = parse_and_validate_buffered(
+        "
+        PROGRAM mainProg
+        VAR
+            input  : UINT;
+            output : UINT;
+        END_VAR
+
+            output := NOT input;
+        END_PROGRAM
+        ",
+    );
+
+    assert!(diagnostics.is_empty(), "expected clean diagnostics, got:\n{diagnostics}");
+}
+
+#[test]
 fn action_calls_without_parentheses() {
     // Given a POU with defined actions,
     // when trying to call them without parentheses

--- a/tests/lit/single/address/aliased_iec_member_leaf_roundtrip.st
+++ b/tests/lit/single/address/aliased_iec_member_leaf_roundtrip.st
@@ -1,0 +1,30 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Positive coverage for the qualified leaf path: the addressed wrapper member itself is not a
+// BOOL, but its `.out` leaf is. Toggling through `.out` must compile and run.
+
+TYPE PI_T_mainTask_bToggle1 : STRUCT
+    out : BOOL;
+END_STRUCT
+END_TYPE
+
+TYPE PI_T_mainTask : STRUCT
+    bToggle1 AT %QX1.2.3.4 : PI_T_mainTask_bToggle1;
+END_STRUCT
+END_TYPE
+
+VAR_GLOBAL
+    mainTask_pi : PI_T_mainTask;
+END_VAR
+
+PROGRAM mainProg
+    mainTask_pi.bToggle1.out := FALSE;
+    mainTask_pi.bToggle1.out := NOT mainTask_pi.bToggle1.out;
+    printf('%u$N', mainTask_pi.bToggle1.out); // CHECK: 1
+
+    mainTask_pi.bToggle1.out := NOT mainTask_pi.bToggle1.out;
+    printf('%u$N', mainTask_pi.bToggle1.out); // CHECK: 0
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+END_FUNCTION

--- a/tests/lit/single/address/aliased_iec_member_leaf_via_temp.st
+++ b/tests/lit/single/address/aliased_iec_member_leaf_via_temp.st
@@ -1,0 +1,31 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Positive coverage for using the qualified leaf as an operand in a larger BOOL flow.
+
+TYPE PI_T_mainTask_bToggle1 : STRUCT
+    out : BOOL;
+END_STRUCT
+END_TYPE
+
+TYPE PI_T_mainTask : STRUCT
+    bToggle1 AT %QX1.2.3.4 : PI_T_mainTask_bToggle1;
+END_STRUCT
+END_TYPE
+
+VAR_GLOBAL
+    mainTask_pi : PI_T_mainTask;
+END_VAR
+
+PROGRAM mainProg
+VAR
+    toggled : BOOL;
+END_VAR
+
+    mainTask_pi.bToggle1.out := FALSE;
+    toggled := NOT mainTask_pi.bToggle1.out;
+    mainTask_pi.bToggle1.out := toggled;
+    printf('%u$N', mainTask_pi.bToggle1.out); // CHECK: 1
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+END_FUNCTION

--- a/tests/lit/single/address/aliased_iec_member_requires_leaf_qualification.st
+++ b/tests/lit/single/address/aliased_iec_member_requires_leaf_qualification.st
@@ -1,0 +1,34 @@
+// RUN: not %COMPILE %s 2>&1 | %CHECK %s
+// Regression coverage for addressed aggregate members: `bToggle1` is the addressed wrapper,
+// so using it as a BOOL without `.out` should fail validation.
+
+// CHECK: {{.*Unary `NOT` requires a bit or integer operand, got `PI_T_mainTask_bToggle1`.*}}
+// CHECK: {{.*Compilation aborted due to critical errors.}}
+
+TYPE PI_T_mainTask_bToggle1 : STRUCT
+    out : BOOL;
+END_STRUCT
+END_TYPE
+
+TYPE PI_T_mainTask : STRUCT
+    bToggle1 AT %QX1.2.3.4 : PI_T_mainTask_bToggle1;
+END_STRUCT
+END_TYPE
+
+VAR_GLOBAL
+    mainTask_pi : PI_T_mainTask;
+END_VAR
+
+PROGRAM mainProg
+VAR
+    cycleCnt : UDINT := 1;
+END_VAR
+
+cycleCnt := cycleCnt + 1;
+mainTask_pi.bToggle1 := NOT mainTask_pi.bToggle1;
+
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+END_FUNCTION


### PR DESCRIPTION
**Changed**
- Ensuring unary not validates that it requires a bit or integer

**Testing** 
- Added unit and lit tests to test the happy and negative cases