### PR TITLE
fix(stdlib): make string codecs and format helpers panic-free

### DIFF
--- a/libs/stdlib/src/date_time_conversion.rs
+++ b/libs/stdlib/src/date_time_conversion.rs
@@ -11,16 +11,14 @@ const SECONDS_PER_DAY: u32 = 60 * 60 * 24;
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_DATE(input: u32) -> u32 {
     let input_seconds = input as i64;
-    let date_time = chrono::Utc.timestamp_opt(input_seconds, 0).single().expect("Out of range DT value");
-
-    let midnight_seconds = date_time
-        .date_naive()
-        .and_hms_opt(0, 0, 0)
-        .expect("Cannot create date time from date")
-        .and_utc()
-        .timestamp();
-
-    midnight_seconds as u32
+    // Every u32 second count is a valid chrono timestamp; fall back to the
+    // epoch defensively instead of panicking.
+    chrono::Utc
+        .timestamp_opt(input_seconds, 0)
+        .single()
+        .and_then(|date_time| date_time.date_naive().and_hms_opt(0, 0, 0))
+        .map(|midnight| midnight.and_utc().timestamp() as u32)
+        .unwrap_or(0)
 }
 
 /// .
@@ -31,10 +29,13 @@ pub extern "C" fn DATE_AND_TIME_TO_DATE(input: u32) -> u32 {
 pub extern "C" fn LDATE_AND_TIME_TO_LDATE(input: i64) -> i64 {
     let date_time = chrono::Utc.timestamp_nanos(input);
 
-    let new_date_time =
-        date_time.date_naive().and_hms_opt(0, 0, 0).expect("Cannot create date time from date");
-
-    new_date_time.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create DATE")
+    // Midnight of a date derived from an i64 nanosecond timestamp is always
+    // representable; fall back to the epoch defensively instead of panicking.
+    date_time
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .and_then(|new_date_time| new_date_time.and_utc().timestamp_nanos_opt())
+        .unwrap_or(0)
 }
 
 /// .
@@ -44,14 +45,17 @@ pub extern "C" fn LDATE_AND_TIME_TO_LDATE(input: i64) -> i64 {
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_TIME_OF_DAY(input: u32) -> u32 {
     let input_seconds = input as i64;
-    let date_time = chrono::Utc.timestamp_opt(input_seconds, 0).single().expect("Out of range DT value");
-
-    let midnight = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
-        .and_then(|date| date.and_hms_opt(date_time.hour(), date_time.minute(), date_time.second()))
-        .expect("Cannot create date time from given parameters")
-        .and_utc();
-
-    midnight.timestamp_millis() as u32
+    // Every u32 second count is a valid chrono timestamp; fall back to midnight
+    // defensively instead of panicking.
+    chrono::Utc
+        .timestamp_opt(input_seconds, 0)
+        .single()
+        .and_then(|date_time| {
+            chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
+                .and_then(|date| date.and_hms_opt(date_time.hour(), date_time.minute(), date_time.second()))
+        })
+        .map(|time_of_day| time_of_day.and_utc().timestamp_millis() as u32)
+        .unwrap_or(0)
 }
 
 /// .
@@ -66,11 +70,12 @@ pub extern "C" fn LDATE_AND_TIME_TO_LTIME_OF_DAY(input: i64) -> i64 {
     let sec = date_time.second();
     let nano = date_time.timestamp_subsec_nanos();
 
-    let new_date_time = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
+    // A time of day on 1970-01-01 is always representable; fall back to
+    // midnight defensively instead of panicking.
+    chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
         .and_then(|date| date.and_hms_nano_opt(hour, min, sec, nano))
-        .expect("Cannot create date time from given parameters");
-
-    new_date_time.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create TOD")
+        .and_then(|new_date_time| new_date_time.and_utc().timestamp_nanos_opt())
+        .unwrap_or(0)
 }
 
 /// .

--- a/libs/stdlib/src/date_time_conversion.rs
+++ b/libs/stdlib/src/date_time_conversion.rs
@@ -10,15 +10,9 @@ const SECONDS_PER_DAY: u32 = 60 * 60 * 24;
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_DATE(input: u32) -> u32 {
-    let input_seconds = input as i64;
-    // Every u32 second count is a valid chrono timestamp; fall back to the
-    // epoch defensively instead of panicking.
-    chrono::Utc
-        .timestamp_opt(input_seconds, 0)
-        .single()
-        .and_then(|date_time| date_time.date_naive().and_hms_opt(0, 0, 0))
-        .map(|midnight| midnight.and_utc().timestamp() as u32)
-        .unwrap_or(0)
+    // Truncate the seconds since the epoch to midnight of the same day,
+    // exactly like DT_TO_DATE; no fallible chrono round-trip needed.
+    (input / SECONDS_PER_DAY) * SECONDS_PER_DAY
 }
 
 /// .
@@ -44,18 +38,9 @@ pub extern "C" fn LDATE_AND_TIME_TO_LDATE(input: i64) -> i64 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_TIME_OF_DAY(input: u32) -> u32 {
-    let input_seconds = input as i64;
-    // Every u32 second count is a valid chrono timestamp; fall back to midnight
-    // defensively instead of panicking.
-    chrono::Utc
-        .timestamp_opt(input_seconds, 0)
-        .single()
-        .and_then(|date_time| {
-            chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
-                .and_then(|date| date.and_hms_opt(date_time.hour(), date_time.minute(), date_time.second()))
-        })
-        .map(|time_of_day| time_of_day.and_utc().timestamp_millis() as u32)
-        .unwrap_or(0)
+    // Keep the seconds within the day and scale to the millisecond-based TOD;
+    // no fallible chrono round-trip needed.
+    (input % SECONDS_PER_DAY) * 1_000
 }
 
 /// .

--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -6,7 +6,9 @@ const NANOS_PER_MILLISECOND: i64 = 1_000 * 1_000;
 const NANOS_PER_SECOND: i64 = 1_000 * 1_000 * 1_000;
 
 fn dt_from_epoch_seconds(seconds: u32) -> chrono::DateTime<chrono::Utc> {
-    chrono::Utc.timestamp_opt(seconds as i64, 0).single().expect("Out of range")
+    // Every u32 second count is a valid chrono timestamp; fall back to the
+    // epoch defensively instead of panicking.
+    chrono::Utc.timestamp_opt(seconds as i64, 0).single().unwrap_or_default()
 }
 
 fn split_tod_fields(millis: u32) -> (u32, u32, u32, u32) {
@@ -411,8 +413,8 @@ pub extern "C" fn concat_ldt(
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__INT(in1: u32, out1: &mut i16, out2: &mut i16, out3: &mut i16) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
+    *out1 = date.year().try_into().unwrap_or_default();
     *out2 = date.month() as i16;
     *out3 = date.day() as i16;
 
@@ -427,8 +429,8 @@ pub extern "C" fn SPLIT_DATE__INT(in1: u32, out1: &mut i16, out2: &mut i16, out3
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__UINT(in1: u32, out1: &mut u16, out2: &mut u16, out3: &mut u16) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
+    *out1 = date.year().try_into().unwrap_or_default();
     *out2 = date.month() as u16;
     *out3 = date.day() as u16;
 
@@ -456,8 +458,8 @@ pub extern "C" fn SPLIT_DATE__DINT(in1: u32, out1: &mut i32, out2: &mut i32, out
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__UDINT(in1: u32, out1: &mut u32, out2: &mut u32, out3: &mut u32) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
+    *out1 = date.year().try_into().unwrap_or_default();
     *out2 = date.month();
     *out3 = date.day();
 
@@ -487,8 +489,8 @@ pub extern "C" fn SPLIT_DATE__LINT(in1: u32, out1: &mut i64, out2: &mut i64, out
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__ULINT(in1: u32, out1: &mut u64, out2: &mut u64, out3: &mut u64) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
+    *out1 = date.year().try_into().unwrap_or_default();
     *out2 = date.month() as u64;
     *out3 = date.day() as u64;
 
@@ -764,7 +766,7 @@ pub extern "C" fn SPLIT_DT__INT(
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
     // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month() as i16;
     *out3 = dt.day() as i16;
     *out4 = dt.hour() as i16;
@@ -792,7 +794,7 @@ pub extern "C" fn SPLIT_DT__UINT(
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
     // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month() as u16;
     *out3 = dt.day() as u16;
     *out4 = dt.hour() as u16;
@@ -847,7 +849,7 @@ pub extern "C" fn SPLIT_DT__UDINT(
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
     // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month();
     *out3 = dt.day();
     *out4 = dt.hour();
@@ -903,7 +905,7 @@ pub extern "C" fn SPLIT_DT__ULINT(
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
     // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month() as u64;
     *out3 = dt.day() as u64;
     *out4 = dt.hour() as u64;
@@ -930,7 +932,7 @@ pub extern "C" fn SPLIT_LDT__INT(
     out7: &mut i16,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year.try_into().unwrap_or_default();
     *out2 = month as i16;
     *out3 = day as i16;
     *out4 = hour as i16;
@@ -957,7 +959,7 @@ pub extern "C" fn SPLIT_LDT__UINT(
     out7: &mut u16,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year.try_into().unwrap_or_default();
     *out2 = month as u16;
     *out3 = day as u16;
     *out4 = hour as u16;
@@ -1011,7 +1013,7 @@ pub extern "C" fn SPLIT_LDT__UDINT(
     out7: &mut u32,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year.try_into().unwrap_or_default();
     *out2 = month;
     *out3 = day;
     *out4 = hour;
@@ -1065,7 +1067,7 @@ pub extern "C" fn SPLIT_LDT__ULINT(
     out7: &mut u64,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year.try_into().unwrap_or_default();
     *out2 = month as u64;
     *out3 = day as u64;
     *out4 = hour as u64;

--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -423,7 +423,6 @@ pub extern "C" fn SPLIT_DATE__INT(in1: u32, out1: &mut i16, out2: &mut i16, out3
 
 /// .
 /// Splits DATE into year, month, day of type UINT
-/// Panics on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -473,7 +472,6 @@ pub extern "C" fn SPLIT_DATE__UDINT(in1: u32, out1: &mut u32, out2: &mut u32, ou
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__LINT(in1: u32, out1: &mut i64, out2: &mut i64, out3: &mut i64) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
     *out1 = date.year().into();
     *out2 = date.month() as i64;
     *out3 = date.day() as i64;
@@ -483,7 +481,6 @@ pub extern "C" fn SPLIT_DATE__LINT(in1: u32, out1: &mut i64, out2: &mut i64, out
 
 /// .
 /// Splits DATE into year, month, day of type ULINT
-/// Panics on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -765,7 +762,7 @@ pub extern "C" fn SPLIT_DT__INT(
     out7: &mut i16,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
     *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month() as i16;
     *out3 = dt.day() as i16;
@@ -793,7 +790,7 @@ pub extern "C" fn SPLIT_DT__UINT(
     out7: &mut u16,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
     *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month() as u16;
     *out3 = dt.day() as u16;
@@ -848,7 +845,7 @@ pub extern "C" fn SPLIT_DT__UDINT(
     out7: &mut u32,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
     *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month();
     *out3 = dt.day();
@@ -876,7 +873,6 @@ pub extern "C" fn SPLIT_DT__LINT(
     out7: &mut i64,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
     *out1 = dt.year().into();
     *out2 = dt.month() as i64;
     *out3 = dt.day() as i64;
@@ -904,7 +900,7 @@ pub extern "C" fn SPLIT_DT__ULINT(
     out7: &mut u64,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
+    // the year of any representable DATE fits every target type; write 0 defensively otherwise
     *out1 = dt.year().try_into().unwrap_or_default();
     *out2 = dt.month() as u64;
     *out3 = dt.day() as u64;

--- a/libs/stdlib/src/extra_functions.rs
+++ b/libs/stdlib/src/extra_functions.rs
@@ -20,7 +20,8 @@ const NANOS_PER_SECOND: i64 = 1_000 * NANOS_PER_MILLISECOND;
 // --------- x_TO_STRING
 
 /// Formats `args` into `dest` and appends the null terminator the IEC string layout
-/// requires. Returns the number of content bytes written (excluding the terminator).
+/// requires. Output that does not fit into `capacity - 1` bytes is truncated. Returns
+/// the number of content bytes written (excluding the terminator).
 /// Writers must not rely on the destination being zero-initialized; the buffer may
 /// hold arbitrary bytes.
 ///
@@ -29,7 +30,9 @@ const NANOS_PER_SECOND: i64 = 1_000 * NANOS_PER_MILLISECOND;
 unsafe fn write_terminated(dest: *mut u8, capacity: usize, args: std::fmt::Arguments) -> usize {
     let content = core::slice::from_raw_parts_mut(dest, capacity - 1);
     let mut cursor = std::io::Cursor::new(content);
-    cursor.write_fmt(args).unwrap();
+    // A full buffer truncates the output instead of failing: a too-long string must
+    // not bring down the runtime.
+    let _ = cursor.write_fmt(args);
     let written = cursor.position() as usize;
     *dest.add(written) = 0;
     written

--- a/libs/stdlib/src/string_functions.rs
+++ b/libs/stdlib/src/string_functions.rs
@@ -44,7 +44,42 @@ pub unsafe fn ptr_to_slice<'a, T: PrimInt>(src: *const T) -> &'a [T] {
 }
 
 type Utf16Iterator<'a> = std::char::DecodeUtf16<std::iter::Copied<std::slice::Iter<'a, u16>>>;
-type Utf8Iterator<'a> = core::str::Chars<'a>;
+type Utf8Iterator<'a> = Utf8LossyChars<'a>;
+
+/// Iterator over the characters of a byte slice, decoding UTF-8 lossily. Invalid sequences
+/// yield one [`char::REPLACEMENT_CHARACTER`] each instead of failing, mirroring
+/// [`String::from_utf8_lossy`] without allocating. Strings handed to the standard library
+/// come from raw PLC memory and are not guaranteed to hold valid UTF-8.
+pub struct Utf8LossyChars<'a> {
+    chunks: std::str::Utf8Chunks<'a>,
+    valid: core::str::Chars<'a>,
+    replacement_pending: bool,
+}
+
+impl<'a> Utf8LossyChars<'a> {
+    fn new(slice: &'a [u8]) -> Self {
+        Self { chunks: slice.utf8_chunks(), valid: "".chars(), replacement_pending: false }
+    }
+}
+
+impl<'a> Iterator for Utf8LossyChars<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        loop {
+            if let Some(c) = self.valid.next() {
+                return Some(c);
+            }
+            if self.replacement_pending {
+                self.replacement_pending = false;
+                return Some(char::REPLACEMENT_CHARACTER);
+            }
+            let chunk = self.chunks.next()?;
+            self.valid = chunk.valid().chars();
+            self.replacement_pending = !chunk.invalid().is_empty();
+        }
+    }
+}
 
 pub trait CharsDecoder<T: PrimInt> {
     type IteratorType: Iterator;
@@ -98,7 +133,7 @@ impl<'a> CharsDecoder<u8> for EncodedCharsIter<Utf8Iterator<'a>> {
     type IteratorType = Utf8Iterator<'a>;
     unsafe fn decode(src: *const u8) -> Self {
         let slice = ptr_to_slice(src);
-        Self { iter: std::str::from_utf8(slice).unwrap().chars() }
+        Self { iter: Utf8LossyChars::new(slice) }
     }
 }
 
@@ -140,7 +175,8 @@ impl<I: Iterator<Item = Result<char, DecodeUtf16Error>>> CharsEncoder<u16> for I
         let mut remaining = max_elements;
         let mut written = 0;
         for c in self {
-            let c = c.unwrap();
+            // Unpaired surrogates in raw PLC memory must not bring down the runtime.
+            let c = c.unwrap_or(char::REPLACEMENT_CHARACTER);
             let len = c.len_utf16();
             // Stop before we would exceed the budget; never truncate mid-character.
             if len > remaining {
@@ -219,8 +255,9 @@ pub unsafe extern "C" fn FIND__STRING(src1: *const u8, src2: *const u8) -> i32 {
     }
 
     if let Some(idx) = haystack.windows(needle.len()).position(|window| window == needle) {
-        // get chars until byte index
-        let char_index = core::str::from_utf8(std::slice::from_raw_parts(src1, idx)).unwrap().chars().count();
+        // get chars until byte index; decode lossily so invalid UTF-8 counts as one
+        // character per invalid sequence instead of failing
+        let char_index = Utf8LossyChars::new(std::slice::from_raw_parts(src1, idx)).count();
         // correct for ST indexing
         char_index as i32 + 1
     } else {
@@ -705,8 +742,6 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__WSTRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn CONCAT__STRING(dest: *mut u8, argc: i32, argv: *const *const u8) {
@@ -722,13 +757,13 @@ pub unsafe extern "C" fn CONCAT__STRING(dest: *mut u8, argc: i32, argv: *const *
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn CONCAT_EXT__STRING(dest: *mut u8, argc: i32, argv: *const *const u8) -> i32 {
+    // Generated code always passes valid pointers; nothing sensible can be
+    // written through a null destination, so bail out instead of panicking.
     if argv.is_null() || dest.is_null() {
-        panic!("Received null-pointer.")
+        return 0;
     }
     let mut dest = dest;
     let mut argv = argv;
@@ -753,8 +788,6 @@ pub unsafe extern "C-unwind" fn CONCAT_EXT__STRING(dest: *mut u8, argc: i32, arg
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn CONCAT__WSTRING(dest: *mut u16, argc: i32, argv: *const *const u16) {
@@ -770,8 +803,6 @@ pub unsafe extern "C" fn CONCAT__WSTRING(dest: *mut u16, argc: i32, argv: *const
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn CONCAT_EXT__WSTRING(
@@ -779,8 +810,10 @@ pub unsafe extern "C-unwind" fn CONCAT_EXT__WSTRING(
     argc: i32,
     argv: *const *const u16,
 ) -> i32 {
+    // Generated code always passes valid pointers; nothing sensible can be
+    // written through a null destination, so bail out instead of panicking.
     if argv.is_null() || dest.is_null() {
-        panic!("Received null-pointer.")
+        return 0;
     }
     let mut dest = dest;
     let mut argv = argv;
@@ -801,8 +834,10 @@ fn compare<T>(argc: i32, argv: *const *const T, predicate_func: fn(Ordering) -> 
 where
     T: Ord + PrimInt,
 {
+    // Generated code always passes at least two arguments; a chain of zero
+    // comparisons is vacuously true.
     if argc < 2 {
-        panic!("Too few arguments for function call.")
+        return true;
     }
     let mut argv = argv;
     unsafe {
@@ -1820,5 +1855,66 @@ mod test {
         }
         let argc = argv.len() as i32;
         unsafe { assert!(__WSTRING_LESS(argc, argv.as_ptr())) }
+    }
+
+    #[test]
+    fn test_len_counts_invalid_utf8_bytes_as_replacement_chars() {
+        let src = [b'a', 0xFF, b'b', 0];
+        unsafe {
+            assert_eq!(LEN__STRING(src.as_ptr()), 3);
+        }
+    }
+
+    #[test]
+    fn test_find_with_invalid_utf8_prefix() {
+        let haystack = [b'a', 0xFF, b'b', 0];
+        let needle = b"b\0";
+        unsafe {
+            assert_eq!(FIND__STRING(haystack.as_ptr(), needle.as_ptr()), 3);
+        }
+    }
+
+    #[test]
+    fn test_concat_with_invalid_utf8_replaces_bad_bytes() {
+        let argvec: [&[u8]; 2] = [&[b'a', 0xFF, 0], b"b\0"];
+        let mut argv: [*const u8; 2] = [std::ptr::null(); 2];
+        for (i, arg) in argvec.iter().enumerate() {
+            argv[i] = arg.as_ptr();
+        }
+        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
+        unsafe {
+            CONCAT_EXT__STRING(dest.as_mut_ptr(), argv.len() as i32, argv.as_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!(string, "a\u{FFFD}b");
+        }
+    }
+
+    #[test]
+    fn test_concat_with_null_pointers_is_a_no_op() {
+        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
+        unsafe {
+            assert_eq!(CONCAT_EXT__STRING(dest.as_mut_ptr(), 2, std::ptr::null()), 0);
+            assert_eq!(CONCAT_EXT__STRING(std::ptr::null_mut(), 2, std::ptr::null()), 0);
+        }
+    }
+
+    #[test]
+    fn test_compare_with_too_few_arguments_is_vacuously_true() {
+        unsafe {
+            assert!(__STRING_EQUAL(0, std::ptr::null()));
+            assert!(__STRING_GREATER(1, std::ptr::null()));
+        }
+    }
+
+    #[test]
+    fn test_left_ext_wstring_with_unpaired_surrogate() {
+        let src: [u16; 4] = [0xD800, 'b' as u16, 'c' as u16, 0];
+        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
+        unsafe {
+            LEFT_EXT__WSTRING(src.as_ptr(), 2, dest.as_mut_ptr());
+        }
+        let expected: Vec<u16> = "\u{FFFD}b".encode_utf16().collect();
+        assert_eq!(&dest[..2], expected.as_slice());
+        assert_eq!(dest[2], 0);
     }
 }

--- a/libs/stdlib/src/string_functions.rs
+++ b/libs/stdlib/src/string_functions.rs
@@ -314,7 +314,10 @@ pub unsafe extern "C-unwind" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32
         panic!("Requested substring length exceeds string length.")
     }
     let chars = EncodedCharsIter::decode(src).take(substr_len);
-    chars.encode(&mut dest);
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`);
+    // lossy decoding can expand invalid sequences into wider replacement chars.
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -341,7 +344,10 @@ pub unsafe extern "C-unwind" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i
         panic!("Requested substring length exceeds string length.")
     }
     let chars = EncodedCharsIter::decode(src).take(substr_len);
-    chars.encode(&mut dest);
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`);
+    // lossy decoding can expand invalid sequences into wider replacement chars.
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -368,7 +374,10 @@ pub unsafe extern "C-unwind" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i3
         panic!("Requested substring length exceeds string length.")
     }
     let chars = EncodedCharsIter::decode(src).skip(nchars - substr_len);
-    chars.encode(&mut dest);
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`);
+    // lossy decoding can expand invalid sequences into wider replacement chars.
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -395,7 +404,10 @@ pub unsafe extern "C-unwind" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: 
         panic!("Requested substring length exceeds string length.")
     }
     let chars = EncodedCharsIter::decode(src).skip(nchars - substr_len);
-    chars.encode(&mut dest);
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`);
+    // lossy decoding can expand invalid sequences into wider replacement chars.
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
     0
 }
 
@@ -433,7 +445,10 @@ pub unsafe extern "C-unwind" fn MID_EXT__STRING(
         panic!("Requested substring length {substr_len} from position {start_index} exceeds string length.")
     }
     let chars = EncodedCharsIter::decode(src).skip(start_index).take(substr_len);
-    chars.encode(&mut dest);
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`);
+    // lossy decoding can expand invalid sequences into wider replacement chars.
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -472,7 +487,10 @@ pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
         panic!("Requested substring length {substr_len} from position {start_index} exceeds string length.")
     }
     let chars = EncodedCharsIter::decode(src).skip(start_index).take(substr_len);
-    chars.encode(&mut dest);
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`);
+    // lossy decoding can expand invalid sequences into wider replacement chars.
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -583,10 +601,12 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
         )
     }
 
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`).
     EncodedCharsIter::decode(src)
         .take(pos)
         .chain(EncodedCharsIter::decode(src).skip(ndel + pos))
-        .encode(&mut dest);
+        .encode_bounded(&mut dest, STRING_RESULT_LEN);
     0
 }
 
@@ -626,10 +646,12 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
         )
     }
 
+    // Truncate at the result-buffer capacity so we never overflow the caller's
+    // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`).
     EncodedCharsIter::decode(src)
         .take(pos)
         .chain(EncodedCharsIter::decode(src).skip(pos + ndel))
-        .encode(&mut dest);
+        .encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -993,6 +1015,33 @@ mod test {
         unsafe {
             let res = FIND__STRING(haystack.as_ptr(), needle.as_ptr());
             assert_eq!(res, 10)
+        }
+    }
+
+    #[test]
+    fn test_left_ext_str_invalid_utf8_expansion_truncates_at_result_capacity() {
+        // 2048 invalid bytes decode to 2048 replacement chars, which would
+        // re-encode to 6144 bytes; the write must stop at STRING_RESULT_LEN
+        // on a character boundary instead of overflowing the result buffer.
+        let mut src = [0xFF_u8; DEFAULT_STRING_SIZE + 1];
+        src[DEFAULT_STRING_SIZE] = 0;
+        let mut dest = [0_u8; DEFAULT_STRING_SIZE + 1];
+        unsafe {
+            LEFT_EXT__STRING(src.as_ptr(), DEFAULT_STRING_SIZE as i32, dest.as_mut_ptr());
+            let str1 = CStr::from_bytes_until_nul(&dest).unwrap().to_str().unwrap();
+            assert_eq!(str1, "\u{FFFD}".repeat(682)); // 682 * 3 = 2046 <= 2048
+        }
+    }
+
+    #[test]
+    fn test_delete_ext_str_invalid_utf8_expansion_truncates_at_result_capacity() {
+        let mut src = [0xFF_u8; DEFAULT_STRING_SIZE + 1];
+        src[DEFAULT_STRING_SIZE] = 0;
+        let mut dest = [0_u8; DEFAULT_STRING_SIZE + 1];
+        unsafe {
+            DELETE_EXT__STRING(src.as_ptr(), 1, 1, dest.as_mut_ptr());
+            let str1 = CStr::from_bytes_until_nul(&dest).unwrap().to_str().unwrap();
+            assert_eq!(str1, "\u{FFFD}".repeat(682));
         }
     }
 

--- a/libs/stdlib/src/string_functions.rs
+++ b/libs/stdlib/src/string_functions.rs
@@ -254,7 +254,15 @@ pub unsafe extern "C" fn FIND__STRING(src1: *const u8, src2: *const u8) -> i32 {
         return 0;
     }
 
-    if let Some(idx) = haystack.windows(needle.len()).position(|window| window == needle) {
+    // Skip byte-level matches that start on a UTF-8 continuation byte: they lie
+    // inside a multi-byte character and would report an index inconsistent with LEN.
+    let position = haystack
+        .windows(needle.len())
+        .enumerate()
+        .find(|(idx, window)| *window == needle && (haystack[*idx] & 0xC0) != 0x80)
+        .map(|(idx, _)| idx);
+
+    if let Some(idx) = position {
         // get chars until byte index; decode lossily so invalid UTF-8 counts as one
         // character per invalid sequence instead of failing
         let char_index = Utf8LossyChars::new(std::slice::from_raw_parts(src1, idx)).count();
@@ -281,7 +289,20 @@ pub unsafe extern "C" fn FIND__WSTRING(src1: *const u16, src2: *const u16) -> i3
         return 0;
     }
 
-    if let Some(idx) = haystack.windows(needle.len()).position(|window| window == needle) {
+    // Skip matches that start on the low half of a surrogate pair: they lie
+    // inside a single character and would report an index inconsistent with LEN.
+    let position = haystack
+        .windows(needle.len())
+        .enumerate()
+        .find(|(idx, window)| {
+            *window == needle
+                && !((0xDC00..=0xDFFF).contains(&haystack[*idx])
+                    && *idx > 0
+                    && (0xD800..=0xDBFF).contains(&haystack[*idx - 1]))
+        })
+        .map(|(idx, _)| idx);
+
+    if let Some(idx) = position {
         // match found. count utf16 chars to window position
         let char_index = decode_utf16(std::slice::from_raw_parts(src1, idx).iter().copied()).count();
 
@@ -1015,6 +1036,30 @@ mod test {
         unsafe {
             let res = FIND__STRING(haystack.as_ptr(), needle.as_ptr());
             assert_eq!(res, 10)
+        }
+    }
+
+    #[test]
+    fn test_find_no_match_inside_multibyte_char() {
+        // The needle bytes match inside 'é' (C3 A9), but no character-aligned
+        // occurrence exists, so FIND reports 'not found' instead of an index
+        // beyond LEN.
+        let haystack = [0xC3_u8, 0xA9, 0];
+        let needle = [0xA9_u8, 0];
+        unsafe {
+            let res = FIND__STRING(haystack.as_ptr(), needle.as_ptr());
+            assert_eq!(res, 0)
+        }
+    }
+
+    #[test]
+    fn test_find_wstring_no_match_inside_surrogate_pair() {
+        // The needle matches the low half of a surrogate pair (U+10000).
+        let haystack = [0xD800_u16, 0xDC00, 0x0061, 0];
+        let needle = [0xDC00_u16, 0];
+        unsafe {
+            let res = FIND__WSTRING(haystack.as_ptr(), needle.as_ptr());
+            assert_eq!(res, 0)
         }
     }
 

--- a/libs/stdlib/src/timers.rs
+++ b/libs/stdlib/src/timers.rs
@@ -61,12 +61,13 @@ impl TimerParams {
     }
 
     fn update_elapsed_time(&mut self) {
+        // `is_running` and `start_time` are always set together; if the start time is
+        // ever missing regardless, keep the previous elapsed time instead of panicking.
         if self.is_running() {
-            let elapsed_millis =
-                self.get_run_time().expect("Timer should be running").as_millis().min(u32::MAX as u128)
-                    as u32;
-
-            self.set_elapsed_time(std::cmp::min(self.preset_time, elapsed_millis));
+            if let Some(run_time) = self.get_run_time() {
+                let elapsed_millis = run_time.as_millis().min(u32::MAX as u128) as u32;
+                self.set_elapsed_time(std::cmp::min(self.preset_time, elapsed_millis));
+            }
         }
     }
 
@@ -114,11 +115,12 @@ impl TimerParamsLTime {
     }
 
     fn update_elapsed_time(&mut self) {
+        // `is_running` and `start_time` are always set together; if the start time is
+        // ever missing regardless, keep the previous elapsed time instead of panicking.
         if self.is_running() {
-            self.set_elapsed_time(std::cmp::min(
-                self.preset_time,
-                self.get_run_time().expect("Timer should be running").as_nanos() as i64,
-            ));
+            if let Some(run_time) = self.get_run_time() {
+                self.set_elapsed_time(std::cmp::min(self.preset_time, run_time.as_nanos() as i64));
+            }
         }
     }
 

--- a/libs/stdlib/src/types.rs
+++ b/libs/stdlib/src/types.rs
@@ -16,28 +16,28 @@ macro_rules! define_float_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $max_name(size: u32, value: *const $rust_type) -> $rust_type {
-            // Declare array for value
-            let arr = if !value.is_null() {
-                slice::from_raw_parts(value, size as usize)
-            } else {
-                panic!("Null pointer for value");
-            };
+            // Generated code always passes a valid array with at least one element;
+            // degrade to the type default instead of panicking if it ever does not.
+            if value.is_null() {
+                return <$rust_type>::default();
+            }
+            let arr = slice::from_raw_parts(value, size as usize);
 
-            arr.iter().map(|it| *it).reduce(<$rust_type>::max).expect("A max will always exist")
+            arr.iter().copied().reduce(<$rust_type>::max).unwrap_or_default()
         }
         /// # Safety
         /// Dealing with raw pointers
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $min_name(size: u32, value: *const $rust_type) -> $rust_type {
-            // Declare array for value
-            let arr = if !value.is_null() {
-                slice::from_raw_parts(value, size as usize)
-            } else {
-                panic!("Null pointer for value");
-            };
+            // Generated code always passes a valid array with at least one element;
+            // degrade to the type default instead of panicking if it ever does not.
+            if value.is_null() {
+                return <$rust_type>::default();
+            }
+            let arr = slice::from_raw_parts(value, size as usize);
 
-            arr.iter().map(|it| *it).reduce(<$rust_type>::min).expect("A max will always exist")
+            arr.iter().copied().reduce(<$rust_type>::min).unwrap_or_default()
         }
 
         //Limit
@@ -58,12 +58,13 @@ macro_rules! define_order_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $max_name(size: u32, value: *const $rust_type) -> $rust_type {
-            if !value.is_null() {
-                let arr = slice::from_raw_parts(value, size as usize);
-                *arr.iter().max().expect("A max will always exist")
-            } else {
-                panic!("Null pointer for value");
+            // Generated code always passes a valid array with at least one element;
+            // degrade to the type default instead of panicking if it ever does not.
+            if value.is_null() {
+                return <$rust_type>::default();
             }
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().max().copied().unwrap_or_default()
         }
         //Min impl
         /// # Safety
@@ -71,12 +72,13 @@ macro_rules! define_order_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $min_name(size: u32, value: *const $rust_type) -> $rust_type {
-            if !value.is_null() {
-                let arr = slice::from_raw_parts(value, size as usize);
-                *arr.iter().min().expect("A min will always exist")
-            } else {
-                panic!("Null pointer for value");
+            // Generated code always passes a valid array with at least one element;
+            // degrade to the type default instead of panicking if it ever does not.
+            if value.is_null() {
+                return <$rust_type>::default();
             }
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().min().copied().unwrap_or_default()
         }
 
         //Limit


### PR DESCRIPTION
Problem: Invalid bytes in PLC string memory abort the whole runtime process. The stdlib helpers unwrap strict UTF-8/UTF-16 decoding inside `extern "C"` functions, which cannot unwind. CODESYS is byte-transparent for the same inputs and never faults.

Solution: Decode lossily instead (U+FFFD for invalid sequences and unpaired surrogates), bound every string write to the result-buffer capacity since lossy decoding can expand invalid bytes, skip FIND matches that start inside a multi-byte character, and turn the remaining unreachable panic sites into defensive defaults. No public signatures change.

Refs: PRG-4419
