### PR TITLE
fix(stdlib): use wrapping arithmetic in date/time functions

### DIFF
--- a/libs/stdlib/src/date_time_numeric_functions.rs
+++ b/libs/stdlib/src/date_time_numeric_functions.rs
@@ -730,7 +730,7 @@ fn wrapping_div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
 
 /// .
 /// Multiply TIME with REAL
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -740,7 +740,7 @@ pub extern "C-unwind" fn MUL__TIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Multiply TIME with REAL
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -750,7 +750,7 @@ pub extern "C-unwind" fn MUL_TIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Multiply LTIME with REAL
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -764,7 +764,7 @@ fn mul_time_with_f32(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Multiply TIME with LREAL
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -774,7 +774,7 @@ pub extern "C-unwind" fn MUL__TIME__LREAL(in1: i64, in2: f64) -> i64 {
 
 /// .
 /// Multiply TIME with LREAL
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -784,7 +784,7 @@ pub extern "C-unwind" fn MUL_TIME__LREAL(in1: i64, in2: f64) -> i64 {
 
 /// .
 /// Multiply LTIME with LREAL
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -793,17 +793,18 @@ pub extern "C-unwind" fn MUL_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
 }
 
 fn mul_time_with_f64(in1: i64, in2: f64) -> i64 {
-    let res = in1 as f64 * in2;
+    // Round to the nearest nanosecond like the previous Duration-based
+    // implementation; the float-to-int cast saturates at the i64 range.
+    let res = (in1 as f64 * in2).round();
     if res.is_nan() {
         return 0;
     }
-    // the float-to-int cast saturates at the i64 range
     res as i64
 }
 
 /// .
 /// Divide TIME by REAL
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -813,7 +814,7 @@ pub extern "C-unwind" fn DIV__TIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Divide TIME by REAL
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -823,7 +824,7 @@ pub extern "C-unwind" fn DIV_TIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Divide LTIME by REAL
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -837,7 +838,7 @@ fn div_time_by_f32(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Divide TIME by LREAL
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -927,7 +928,7 @@ pub extern "C-unwind" fn MUL__LTIME__ULINT(in1: i64, in2: u64) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by REAL.
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -937,7 +938,7 @@ pub extern "C-unwind" fn MUL__LTIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by LREAL.
-/// Wraps on overflow
+/// Saturates at the TIME range on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1027,7 +1028,7 @@ pub extern "C-unwind" fn DIV__LTIME__ULINT(in1: i64, in2: u64) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by REAL.
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1037,7 +1038,7 @@ pub extern "C-unwind" fn DIV__LTIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by LREAL.
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1197,7 +1198,7 @@ pub extern "C-unwind" fn SUB__LTIME_OF_DAY__LTIME_OF_DAY(in1: i64, in2: i64) -> 
 
 /// .
 /// Divide TIME by LREAL
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1207,7 +1208,7 @@ pub extern "C-unwind" fn DIV_TIME__LREAL(in1: i64, in2: f64) -> i64 {
 
 /// .
 /// Divide LTIME by LREAL
-/// Wraps on overflow; division by zero yields zero
+/// Saturates at the TIME range on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1219,6 +1220,7 @@ fn div_time_by_f64(in1: i64, in2: f64) -> i64 {
     if in2 == 0.0 || in2.is_nan() {
         return 0;
     }
-    // the float-to-int cast saturates at the i64 range
-    (in1 as f64 / in2) as i64
+    // Round to the nearest nanosecond like the previous Duration-based
+    // implementation; the float-to-int cast saturates at the i64 range.
+    (in1 as f64 / in2).round() as i64
 }

--- a/libs/stdlib/src/date_time_numeric_functions.rs
+++ b/libs/stdlib/src/date_time_numeric_functions.rs
@@ -1,24 +1,22 @@
-use chrono::TimeZone;
-
 const MILLIS_PER_SECOND: u32 = 1_000;
 const MILLIS_PER_DAY: u32 = 60 * 60 * 24 * MILLIS_PER_SECOND;
 
-fn checked_millis_to_seconds(input: u32) -> u32 {
+fn millis_to_seconds(input: u32) -> u32 {
     input / MILLIS_PER_SECOND
 }
 
-fn checked_seconds_to_millis(input: u32) -> u32 {
-    input.checked_mul(MILLIS_PER_SECOND).unwrap()
+fn wrapping_seconds_to_millis(input: u32) -> u32 {
+    input.wrapping_mul(MILLIS_PER_SECOND)
 }
 
 /// .
 /// This operator returns the value of adding up two TIME operands.
-/// Panics on overflow.
+/// Wraps on overflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD_TIME(in1: u32, in2: u32) -> u32 {
-    in1.checked_add(in2).unwrap()
+    in1.wrapping_add(in2)
 }
 
 /// .
@@ -33,42 +31,37 @@ pub extern "C-unwind" fn ADD_TOD_TIME(in1: u32, in2: u32) -> u32 {
 
 /// .
 /// This operator returns the value of adding up DT and TIME.
-/// Panics on overflow.
+/// Wraps on overflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD_DT_TIME(in1: u32, in2: u32) -> u32 {
-    let time_seconds = checked_millis_to_seconds(in2);
-    in1.checked_add(time_seconds).unwrap()
+    let time_seconds = millis_to_seconds(in2);
+    in1.wrapping_add(time_seconds)
 }
 
 fn add_datetime_time(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .checked_add_signed(chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .timestamp_nanos_opt()
-        .unwrap()
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two TIME operands
-/// Panics on underflow.
+/// Wraps on underflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_TIME(in1: u32, in2: u32) -> u32 {
-    in1.checked_sub(in2).unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two DATE operands
-/// Panics on underflow and when the resulting TIME would overflow.
+/// Wraps on underflow and when the resulting TIME exceeds the TIME range.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DATE_DATE(in1: u32, in2: u32) -> u32 {
-    checked_seconds_to_millis(in1.checked_sub(in2).unwrap())
+    wrapping_seconds_to_millis(in1.wrapping_sub(in2))
 }
 
 /// .
@@ -83,55 +76,46 @@ pub extern "C-unwind" fn SUB_TOD_TIME(in1: u32, in2: u32) -> u32 {
 
 /// .
 /// This operator produces the subtraction of two TOD operands
-/// Panics on underflow.
+/// Wraps on underflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_TOD_TOD(in1: u32, in2: u32) -> u32 {
-    in1.checked_sub(in2).unwrap()
+    in1.wrapping_sub(in2)
 }
 
 fn sub_datetimes(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .signed_duration_since(chrono::Utc.timestamp_nanos(in2))
-        .num_nanoseconds()
-        .unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of DT and TIME
-/// Panics on underflow.
+/// Wraps on underflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DT_TIME(in1: u32, in2: u32) -> u32 {
-    let time_seconds = checked_millis_to_seconds(in2);
-    in1.checked_sub(time_seconds).unwrap()
+    let time_seconds = millis_to_seconds(in2);
+    in1.wrapping_sub(time_seconds)
 }
 
 fn sub_datetime_duration(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .checked_sub_signed(chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .timestamp_nanos_opt()
-        .unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two DT operands
-/// Panics on underflow and when the resulting TIME would overflow.
+/// Wraps on underflow and when the resulting TIME exceeds the TIME range.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DT_DT(in1: u32, in2: u32) -> u32 {
-    checked_seconds_to_millis(in1.checked_sub(in2).unwrap())
+    wrapping_seconds_to_millis(in1.wrapping_sub(in2))
 }
 
 /// .
 /// This operator returns the value of adding up two LTIME operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -141,7 +125,7 @@ pub extern "C-unwind" fn ADD_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator returns the value of adding up LTOD and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -151,7 +135,7 @@ pub extern "C-unwind" fn ADD_LTOD_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator returns the value of adding up LDT and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -161,7 +145,7 @@ pub extern "C-unwind" fn ADD_LDT_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LTIME operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -171,7 +155,7 @@ pub extern "C-unwind" fn SUB_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LDATE operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -181,7 +165,7 @@ pub extern "C-unwind" fn SUB_LDATE_LDATE(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of LTOD and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -191,7 +175,7 @@ pub extern "C-unwind" fn SUB_LTOD_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LTOD operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -201,7 +185,7 @@ pub extern "C-unwind" fn SUB_LTOD_LTOD(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of LDT and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -211,7 +195,7 @@ pub extern "C-unwind" fn SUB_LDT_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LDT operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -221,677 +205,649 @@ pub extern "C-unwind" fn SUB_LDT_LDT(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Multiply TIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    wrapping_mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    wrapping_mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    wrapping_mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    wrapping_mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME/LTIME with ANY_SIGNED_INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
-fn checked_mul_time_with_signed_int(in1: i64, in2: i64) -> i64 {
-    in1.checked_mul(in2).unwrap()
+fn wrapping_mul_time_with_signed_int(in1: i64, in2: i64) -> i64 {
+    in1.wrapping_mul(in2)
 }
 
 /// .
 /// Multiply TIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    wrapping_mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    wrapping_mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    wrapping_mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    wrapping_mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME/LTIME with ANY_UNSIGNED_INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
-fn checked_mul_time_with_unsigned_int(in1: i64, in2: u64) -> i64 {
-    // convert in2 [u64] to [i64]
-    // if in2 is to large for [i64] the multiplication will allways overflow -> panic on try_into()
-    in1.checked_mul(in2.try_into().unwrap()).unwrap()
+fn wrapping_mul_time_with_unsigned_int(in1: i64, in2: u64) -> i64 {
+    // modular 64-bit arithmetic: the cast wraps factors beyond the i64 range,
+    // matching two's-complement multiplication
+    in1.wrapping_mul(in2 as i64)
 }
 
 /// .
 /// Divide TIME by SINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by INT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by DINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by LINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_div_time_by_signed_int(in1, in2)
+    wrapping_div_time_by_signed_int(in1, in2)
 }
 
 /// .
 /// Divide TIME by SINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by INT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by DINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by LINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_div_time_by_signed_int(in1, in2)
+    wrapping_div_time_by_signed_int(in1, in2)
 }
 
 /// .
 /// Divide LTIME by SINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by INT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by DINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    wrapping_div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by LINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_div_time_by_signed_int(in1, in2)
+    wrapping_div_time_by_signed_int(in1, in2)
 }
 
 /// .
 /// Divide TIME/LTIME with ANY_SIGNED_INT
-/// Panic on overflow or division by zero
+/// Division by zero yields zero; wraps on overflow
 ///
-fn checked_div_time_by_signed_int(in1: i64, in2: i64) -> i64 {
-    in1.checked_div(in2).unwrap()
+fn wrapping_div_time_by_signed_int(in1: i64, in2: i64) -> i64 {
+    if in2 == 0 {
+        return 0;
+    }
+    in1.wrapping_div(in2)
 }
 
 /// .
 /// Divide TIME by USINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UDINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by ULINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2)
+    wrapping_div_time_by_unsigned_int(in1, in2)
 }
 
 /// .
 /// Divide TIME by USINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UDINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by ULINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2)
+    wrapping_div_time_by_unsigned_int(in1, in2)
 }
 
 /// .
 /// Divide LTIME by USINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by UINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by UDINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    wrapping_div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by ULINT
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2)
+    wrapping_div_time_by_unsigned_int(in1, in2)
 }
 
 /// .
 /// Divide TIME/LTIME with ANY_UNSIGNED_INT
-/// Panic on overflow or division by zero
+/// Division by zero yields zero
 ///
-fn checked_div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
-    // convert in2 [u64] to [i64]
-    // if in2 is to large for [i64] the division will allways fail -> panic on try_into()
-    in1.checked_div(in2.try_into().unwrap()).unwrap()
+fn wrapping_div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
+    if in2 == 0 {
+        return 0;
+    }
+    // a divisor beyond the i64 range exceeds any possible dividend magnitude,
+    // so the quotient is always zero
+    let Ok(divisor) = i64::try_from(in2) else {
+        return 0;
+    };
+    in1.wrapping_div(divisor)
 }
 
 /// .
 /// Multiply TIME with REAL
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_mul_time_with_f32(in1, in2)
+    mul_time_with_f32(in1, in2)
 }
 
 /// .
 /// Multiply TIME with REAL
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_mul_time_with_f32(in1, in2)
+    mul_time_with_f32(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with REAL
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_mul_time_with_f32(in1, in2)
+    mul_time_with_f32(in1, in2)
 }
 
-fn checked_mul_time_with_f32(in1: i64, in2: f32) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.mul_f32(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
-    }
+fn mul_time_with_f32(in1: i64, in2: f32) -> i64 {
+    mul_time_with_f64(in1, in2 as f64)
 }
 
 /// .
 /// Multiply TIME with LREAL
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_mul_time_with_f64(in1, in2)
+    mul_time_with_f64(in1, in2)
 }
 
 /// .
 /// Multiply TIME with LREAL
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_mul_time_with_f64(in1, in2)
+    mul_time_with_f64(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with LREAL
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_mul_time_with_f64(in1, in2)
+    mul_time_with_f64(in1, in2)
 }
 
-fn checked_mul_time_with_f64(in1: i64, in2: f64) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.mul_f64(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
+fn mul_time_with_f64(in1: i64, in2: f64) -> i64 {
+    let res = in1 as f64 * in2;
+    if res.is_nan() {
+        return 0;
     }
+    // the float-to-int cast saturates at the i64 range
+    res as i64
 }
 
 /// .
 /// Divide TIME by REAL
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_div_time_by_f32(in1, in2)
+    div_time_by_f32(in1, in2)
 }
 
 /// .
 /// Divide TIME by REAL
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_div_time_by_f32(in1, in2)
+    div_time_by_f32(in1, in2)
 }
 
 /// .
 /// Divide LTIME by REAL
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_div_time_by_f32(in1, in2)
+    div_time_by_f32(in1, in2)
 }
 
-fn checked_div_time_by_f32(in1: i64, in2: f32) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.div_f32(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
-    }
+fn div_time_by_f32(in1: i64, in2: f32) -> i64 {
+    div_time_by_f64(in1, in2 as f64)
 }
 
 /// .
 /// Divide TIME by LREAL
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_div_time_by_f64(in1, in2)
+    div_time_by_f64(in1, in2)
 }
 
 /// .
 /// Compatibility alias for multiplying LTIME by SINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -901,7 +857,7 @@ pub extern "C-unwind" fn MUL__LTIME__SINT(in1: i64, in2: i8) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by INT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -911,7 +867,7 @@ pub extern "C-unwind" fn MUL__LTIME__INT(in1: i64, in2: i16) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by DINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -921,7 +877,7 @@ pub extern "C-unwind" fn MUL__LTIME__DINT(in1: i64, in2: i32) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by LINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -931,7 +887,7 @@ pub extern "C-unwind" fn MUL__LTIME__LINT(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by USINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -941,7 +897,7 @@ pub extern "C-unwind" fn MUL__LTIME__USINT(in1: i64, in2: u8) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by UINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -951,7 +907,7 @@ pub extern "C-unwind" fn MUL__LTIME__UINT(in1: i64, in2: u16) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by UDINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -961,7 +917,7 @@ pub extern "C-unwind" fn MUL__LTIME__UDINT(in1: i64, in2: u32) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by ULINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -971,7 +927,7 @@ pub extern "C-unwind" fn MUL__LTIME__ULINT(in1: i64, in2: u64) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by REAL.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -981,7 +937,7 @@ pub extern "C-unwind" fn MUL__LTIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by LREAL.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -991,7 +947,7 @@ pub extern "C-unwind" fn MUL__LTIME__LREAL(in1: i64, in2: f64) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by SINT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1001,7 +957,7 @@ pub extern "C-unwind" fn DIV__LTIME__SINT(in1: i64, in2: i8) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by INT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1011,7 +967,7 @@ pub extern "C-unwind" fn DIV__LTIME__INT(in1: i64, in2: i16) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by DINT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1021,7 +977,7 @@ pub extern "C-unwind" fn DIV__LTIME__DINT(in1: i64, in2: i32) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by LINT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1031,7 +987,7 @@ pub extern "C-unwind" fn DIV__LTIME__LINT(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by USINT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1041,7 +997,7 @@ pub extern "C-unwind" fn DIV__LTIME__USINT(in1: i64, in2: u8) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by UINT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1051,7 +1007,7 @@ pub extern "C-unwind" fn DIV__LTIME__UINT(in1: i64, in2: u16) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by UDINT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1061,7 +1017,7 @@ pub extern "C-unwind" fn DIV__LTIME__UDINT(in1: i64, in2: u32) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by ULINT.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1071,7 +1027,7 @@ pub extern "C-unwind" fn DIV__LTIME__ULINT(in1: i64, in2: u64) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by REAL.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1081,7 +1037,7 @@ pub extern "C-unwind" fn DIV__LTIME__REAL(in1: i64, in2: f32) -> i64 {
 
 /// .
 /// Compatibility alias for dividing LTIME by LREAL.
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1091,17 +1047,17 @@ pub extern "C-unwind" fn DIV__LTIME__LREAL(in1: i64, in2: f64) -> i64 {
 
 /// .
 /// Compatibility symbol for LTIME + LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD__LTIME__LTIME(in1: i64, in2: i64) -> i64 {
-    in1.checked_add(in2).unwrap()
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// Compatibility symbol for LTOD + LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1111,7 +1067,7 @@ pub extern "C-unwind" fn ADD__LTOD__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility symbol for LDT + LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1121,17 +1077,17 @@ pub extern "C-unwind" fn ADD__LDT__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility symbol for LTIME - LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB__LTIME__LTIME(in1: i64, in2: i64) -> i64 {
-    in1.checked_sub(in2).unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Compatibility symbol for LDATE - LDATE overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1141,7 +1097,7 @@ pub extern "C-unwind" fn SUB__LDATE__LDATE(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility symbol for LTOD - LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1151,7 +1107,7 @@ pub extern "C-unwind" fn SUB__LTOD__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility symbol for LTOD - LTOD overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1161,7 +1117,7 @@ pub extern "C-unwind" fn SUB__LTOD__LTOD(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility symbol for LDT - LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1171,7 +1127,7 @@ pub extern "C-unwind" fn SUB__LDT__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility symbol for LDT - LDT overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1181,7 +1137,7 @@ pub extern "C-unwind" fn SUB__LDT__LDT(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LDATE_AND_TIME + LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1191,7 +1147,7 @@ pub extern "C-unwind" fn ADD__LDATE_AND_TIME__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LTIME_OF_DAY + LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1201,7 +1157,7 @@ pub extern "C-unwind" fn ADD__LTIME_OF_DAY__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LDATE_AND_TIME - LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1211,7 +1167,7 @@ pub extern "C-unwind" fn SUB__LDATE_AND_TIME__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LDATE_AND_TIME - LDATE_AND_TIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1221,7 +1177,7 @@ pub extern "C-unwind" fn SUB__LDATE_AND_TIME__LDATE_AND_TIME(in1: i64, in2: i64)
 
 /// .
 /// Compatibility alias for LTIME_OF_DAY - LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1231,7 +1187,7 @@ pub extern "C-unwind" fn SUB__LTIME_OF_DAY__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LTIME_OF_DAY - LTIME_OF_DAY.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1241,38 +1197,28 @@ pub extern "C-unwind" fn SUB__LTIME_OF_DAY__LTIME_OF_DAY(in1: i64, in2: i64) -> 
 
 /// .
 /// Divide TIME by LREAL
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_div_time_by_f64(in1, in2)
+    div_time_by_f64(in1, in2)
 }
 
 /// .
 /// Divide LTIME by LREAL
-/// Panic on overflow or division by zero
+/// Wraps on overflow; division by zero yields zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_div_time_by_f64(in1, in2)
+    div_time_by_f64(in1, in2)
 }
 
-fn checked_div_time_by_f64(in1: i64, in2: f64) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.div_f64(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
+fn div_time_by_f64(in1: i64, in2: f64) -> i64 {
+    if in2 == 0.0 || in2.is_nan() {
+        return 0;
     }
+    // the float-to-int cast saturates at the i64 range
+    (in1 as f64 / in2) as i64
 }

--- a/libs/stdlib/tests/date_time_numeric_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_numeric_functions_tests.rs
@@ -1310,6 +1310,18 @@ defensive_arithmetic_tests!(
     (mul_time_lreal_nan_yields_zero, dtf::MUL__TIME__LREAL, 1_000, f64::NAN, 0),
 );
 
+// Float scaling rounds to the nearest nanosecond instead of truncating toward zero
+defensive_arithmetic_tests!(
+    (
+        mul_time_lreal_rounds_to_nearest_nano,
+        dtf::MUL__TIME__LREAL,
+        1_000_000_000,
+        0.9999999995_f64,
+        1_000_000_000
+    ),
+    (div_time_lreal_rounds_to_nearest_nano, dtf::DIV__TIME__LREAL, 7, 2.0_f64, 4),
+);
+
 // TIME/LTIME division by zero yields zero instead of panicking
 defensive_arithmetic_tests!(
     (div_time_sint_returns_zero_on_zero_divisor, dtf::DIV__TIME__SINT, 1, 0_i8, 0),

--- a/libs/stdlib/tests/date_time_numeric_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_numeric_functions_tests.rs
@@ -1174,438 +1174,183 @@ fn date_time_overloaded_add_and_numerical_add_compile_correctly() {
     assert_eq!(18.0, maintype.b);
 }
 
-macro_rules! panic_i64_i64_tests {
-    ($(($name:ident, $func:path, $lhs:expr, $rhs:expr)),+ $(,)?) => {
+macro_rules! defensive_arithmetic_tests {
+    ($(($name:ident, $func:path, $lhs:expr, $rhs:expr, $expected:expr)),+ $(,)?) => {
         $(
             #[test]
-            #[should_panic]
             fn $name() {
-                let _ = $func($lhs, $rhs);
+                assert_eq!($func($lhs, $rhs), $expected);
             }
         )+
     };
 }
 
-macro_rules! panic_i64_i8_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_i8);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_i16_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_i16);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_i32_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_i32);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u8_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u8);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u16_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u16);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u32_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u32);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u64_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u64);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_f32_mul_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2.0_f32);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_f64_mul_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2.0_f64);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_i8_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_i8);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_i16_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_i16);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_i32_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_i32);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_i64_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_i64);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u8_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_u8);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u16_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_u16);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u32_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_u32);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u64_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0_u64);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_f32_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0.0_f32);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_f64_div_zero_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(1, 0.0_f64);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_u32_u32_tests {
-    ($(($name:ident, $func:path, $lhs:expr, $rhs:expr)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func($lhs, $rhs);
-            }
-        )+
-    };
-}
-
-panic_u32_u32_tests!(
-    (add_time_panics_on_overflow, dtf::ADD_TIME, u32::MAX, 1),
-    (add_dt_time_panics_on_overflow, dtf::ADD_DT_TIME, u32::MAX, 1_000),
-    (sub_time_panics_on_underflow, dtf::SUB_TIME, 2_000, 5_000),
-    (sub_date_date_panics_when_time_difference_exceeds_time_range, dtf::SUB_DATE_DATE, 50 * 24 * 60 * 60, 0),
-    (sub_tod_tod_panics_on_underflow, dtf::SUB_TOD_TOD, 1_000, 2_000),
-    (sub_dt_time_panics_on_underflow, dtf::SUB_DT_TIME, 0, 1_000),
-    (sub_dt_dt_panics_when_time_difference_exceeds_time_range, dtf::SUB_DT_DT, 50 * 24 * 60 * 60, 0)
+// 32-bit TIME/DT/DATE/TOD arithmetic wraps modulo 2^32 instead of panicking
+defensive_arithmetic_tests!(
+    (add_time_wraps_on_overflow, dtf::ADD_TIME, u32::MAX, 1, 0),
+    (add_dt_time_wraps_on_overflow, dtf::ADD_DT_TIME, u32::MAX, 1_000, 0),
+    (sub_time_wraps_on_underflow, dtf::SUB_TIME, 2_000, 5_000, 2_000_u32.wrapping_sub(5_000)),
+    (
+        sub_date_date_wraps_when_time_difference_exceeds_time_range,
+        dtf::SUB_DATE_DATE,
+        50 * 24 * 60 * 60,
+        0,
+        (50_u32 * 24 * 60 * 60).wrapping_mul(1_000)
+    ),
+    (sub_tod_tod_wraps_on_underflow, dtf::SUB_TOD_TOD, 1_000, 2_000, 1_000_u32.wrapping_sub(2_000)),
+    (sub_dt_time_wraps_on_underflow, dtf::SUB_DT_TIME, 0, 1_000, u32::MAX),
+    (
+        sub_dt_dt_wraps_when_time_difference_exceeds_time_range,
+        dtf::SUB_DT_DT,
+        50 * 24 * 60 * 60,
+        0,
+        (50_u32 * 24 * 60 * 60).wrapping_mul(1_000)
+    ),
 );
 
-panic_i64_i64_tests!(
-    (add_ltime_panics_on_overflow, dtf::ADD_LTIME, i64::MAX, 1),
-    (add_ltod_ltime_panics_on_overflow, dtf::ADD_LTOD_LTIME, i64::MAX, 1),
-    (add_ldt_ltime_panics_on_overflow, dtf::ADD_LDT_LTIME, i64::MAX, 1),
-    (sub_ltime_panics_on_underflow, dtf::SUB_LTIME, i64::MIN, 1),
-    (sub_ldate_ldate_panics_on_large_delta, dtf::SUB_LDATE_LDATE, i64::MAX, i64::MIN),
-    (sub_ltod_ltime_panics_on_underflow, dtf::SUB_LTOD_LTIME, i64::MIN, 1),
-    (sub_ltod_ltod_panics_on_large_delta, dtf::SUB_LTOD_LTOD, i64::MAX, i64::MIN),
-    (sub_ldt_ltime_panics_on_underflow, dtf::SUB_LDT_LTIME, i64::MIN, 1),
-    (sub_ldt_ldt_panics_on_large_delta, dtf::SUB_LDT_LDT, i64::MAX, i64::MIN),
-    (add_alias_ltime_ltime_panics_on_overflow, dtf::ADD__LTIME__LTIME, i64::MAX, 1),
-    (add_alias_ltod_ltime_panics_on_overflow, dtf::ADD__LTOD__LTIME, i64::MAX, 1),
-    (add_alias_ldt_ltime_panics_on_overflow, dtf::ADD__LDT__LTIME, i64::MAX, 1),
-    (sub_alias_ltime_ltime_panics_on_underflow, dtf::SUB__LTIME__LTIME, i64::MIN, 1),
-    (sub_alias_ldate_ldate_panics_on_large_delta, dtf::SUB__LDATE__LDATE, i64::MAX, i64::MIN),
-    (sub_alias_ltod_ltime_panics_on_underflow, dtf::SUB__LTOD__LTIME, i64::MIN, 1),
-    (sub_alias_ltod_ltod_panics_on_large_delta, dtf::SUB__LTOD__LTOD, i64::MAX, i64::MIN),
-    (sub_alias_ldt_ltime_panics_on_underflow, dtf::SUB__LDT__LTIME, i64::MIN, 1),
-    (sub_alias_ldt_ldt_panics_on_large_delta, dtf::SUB__LDT__LDT, i64::MAX, i64::MIN),
-    (add_alias_ldate_and_time_ltime_panics_on_overflow, dtf::ADD__LDATE_AND_TIME__LTIME, i64::MAX, 1),
-    (add_alias_ltime_of_day_ltime_panics_on_overflow, dtf::ADD__LTIME_OF_DAY__LTIME, i64::MAX, 1),
-    (sub_alias_ldate_and_time_ltime_panics_on_underflow, dtf::SUB__LDATE_AND_TIME__LTIME, i64::MIN, 1),
+// 64-bit LTIME/LDT/LDATE/LTOD arithmetic wraps modulo 2^64 instead of panicking
+defensive_arithmetic_tests!(
+    (add_ltime_wraps_on_overflow, dtf::ADD_LTIME, i64::MAX, 1, i64::MIN),
+    (add_ltod_ltime_wraps_on_overflow, dtf::ADD_LTOD_LTIME, i64::MAX, 1, i64::MIN),
+    (add_ldt_ltime_wraps_on_overflow, dtf::ADD_LDT_LTIME, i64::MAX, 1, i64::MIN),
+    (sub_ltime_wraps_on_underflow, dtf::SUB_LTIME, i64::MIN, 1, i64::MAX),
+    (sub_ldate_ldate_wraps_on_large_delta, dtf::SUB_LDATE_LDATE, i64::MAX, i64::MIN, -1),
+    (sub_ltod_ltime_wraps_on_underflow, dtf::SUB_LTOD_LTIME, i64::MIN, 1, i64::MAX),
+    (sub_ltod_ltod_wraps_on_large_delta, dtf::SUB_LTOD_LTOD, i64::MAX, i64::MIN, -1),
+    (sub_ldt_ltime_wraps_on_underflow, dtf::SUB_LDT_LTIME, i64::MIN, 1, i64::MAX),
+    (sub_ldt_ldt_wraps_on_large_delta, dtf::SUB_LDT_LDT, i64::MAX, i64::MIN, -1),
+    (add_alias_ltime_ltime_wraps_on_overflow, dtf::ADD__LTIME__LTIME, i64::MAX, 1, i64::MIN),
+    (add_alias_ltod_ltime_wraps_on_overflow, dtf::ADD__LTOD__LTIME, i64::MAX, 1, i64::MIN),
+    (add_alias_ldt_ltime_wraps_on_overflow, dtf::ADD__LDT__LTIME, i64::MAX, 1, i64::MIN),
+    (sub_alias_ltime_ltime_wraps_on_underflow, dtf::SUB__LTIME__LTIME, i64::MIN, 1, i64::MAX),
+    (sub_alias_ldate_ldate_wraps_on_large_delta, dtf::SUB__LDATE__LDATE, i64::MAX, i64::MIN, -1),
+    (sub_alias_ltod_ltime_wraps_on_underflow, dtf::SUB__LTOD__LTIME, i64::MIN, 1, i64::MAX),
+    (sub_alias_ltod_ltod_wraps_on_large_delta, dtf::SUB__LTOD__LTOD, i64::MAX, i64::MIN, -1),
+    (sub_alias_ldt_ltime_wraps_on_underflow, dtf::SUB__LDT__LTIME, i64::MIN, 1, i64::MAX),
+    (sub_alias_ldt_ldt_wraps_on_large_delta, dtf::SUB__LDT__LDT, i64::MAX, i64::MIN, -1),
     (
-        sub_alias_ldate_and_time_ldate_and_time_panics_on_large_delta,
+        add_alias_ldate_and_time_ltime_wraps_on_overflow,
+        dtf::ADD__LDATE_AND_TIME__LTIME,
+        i64::MAX,
+        1,
+        i64::MIN
+    ),
+    (add_alias_ltime_of_day_ltime_wraps_on_overflow, dtf::ADD__LTIME_OF_DAY__LTIME, i64::MAX, 1, i64::MIN),
+    (
+        sub_alias_ldate_and_time_ltime_wraps_on_underflow,
+        dtf::SUB__LDATE_AND_TIME__LTIME,
+        i64::MIN,
+        1,
+        i64::MAX
+    ),
+    (
+        sub_alias_ldate_and_time_ldate_and_time_wraps_on_large_delta,
         dtf::SUB__LDATE_AND_TIME__LDATE_AND_TIME,
         i64::MAX,
-        i64::MIN
+        i64::MIN,
+        -1
     ),
-    (sub_alias_ltime_of_day_ltime_panics_on_underflow, dtf::SUB__LTIME_OF_DAY__LTIME, i64::MIN, 1),
+    (sub_alias_ltime_of_day_ltime_wraps_on_underflow, dtf::SUB__LTIME_OF_DAY__LTIME, i64::MIN, 1, i64::MAX),
     (
-        sub_alias_ltime_of_day_ltime_of_day_panics_on_large_delta,
+        sub_alias_ltime_of_day_ltime_of_day_wraps_on_large_delta,
         dtf::SUB__LTIME_OF_DAY__LTIME_OF_DAY,
         i64::MAX,
-        i64::MIN
+        i64::MIN,
+        -1
     ),
-    (mul_time_lint_panics_on_overflow, dtf::MUL__TIME__LINT, i64::MAX, 2),
-    (mul_time_lint_alias_panics_on_overflow, dtf::MUL_TIME__LINT, i64::MAX, 2),
-    (mul_ltime_lint_panics_on_overflow, dtf::MUL_LTIME__LINT, i64::MAX, 2),
-    (mul_alias_ltime_lint_panics_on_overflow, dtf::MUL__LTIME__LINT, i64::MAX, 2)
 );
 
-panic_i64_i8_tests!(
-    (mul_time_sint_panics_on_overflow, dtf::MUL__TIME__SINT),
-    (mul_time_sint_alias_panics_on_overflow, dtf::MUL_TIME__SINT),
-    (mul_ltime_sint_panics_on_overflow, dtf::MUL_LTIME__SINT),
-    (mul_alias_ltime_sint_panics_on_overflow, dtf::MUL__LTIME__SINT)
+// TIME/LTIME multiplication with integers wraps modulo 2^64 instead of panicking
+defensive_arithmetic_tests!(
+    (mul_time_lint_wraps_on_overflow, dtf::MUL__TIME__LINT, i64::MAX, 2, -2),
+    (mul_time_lint_alias_wraps_on_overflow, dtf::MUL_TIME__LINT, i64::MAX, 2, -2),
+    (mul_ltime_lint_wraps_on_overflow, dtf::MUL_LTIME__LINT, i64::MAX, 2, -2),
+    (mul_alias_ltime_lint_wraps_on_overflow, dtf::MUL__LTIME__LINT, i64::MAX, 2, -2),
+    (mul_time_sint_wraps_on_overflow, dtf::MUL__TIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_time_sint_alias_wraps_on_overflow, dtf::MUL_TIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_ltime_sint_wraps_on_overflow, dtf::MUL_LTIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_alias_ltime_sint_wraps_on_overflow, dtf::MUL__LTIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_time_int_wraps_on_overflow, dtf::MUL__TIME__INT, i64::MAX, 2_i16, -2),
+    (mul_time_int_alias_wraps_on_overflow, dtf::MUL_TIME__INT, i64::MAX, 2_i16, -2),
+    (mul_ltime_int_wraps_on_overflow, dtf::MUL_LTIME__INT, i64::MAX, 2_i16, -2),
+    (mul_alias_ltime_int_wraps_on_overflow, dtf::MUL__LTIME__INT, i64::MAX, 2_i16, -2),
+    (mul_time_dint_wraps_on_overflow, dtf::MUL__TIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_time_dint_alias_wraps_on_overflow, dtf::MUL_TIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_ltime_dint_wraps_on_overflow, dtf::MUL_LTIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_alias_ltime_dint_wraps_on_overflow, dtf::MUL__LTIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_time_usint_wraps_on_overflow, dtf::MUL__TIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_time_usint_alias_wraps_on_overflow, dtf::MUL_TIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_ltime_usint_wraps_on_overflow, dtf::MUL_LTIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_alias_ltime_usint_wraps_on_overflow, dtf::MUL__LTIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_time_uint_wraps_on_overflow, dtf::MUL__TIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_time_uint_alias_wraps_on_overflow, dtf::MUL_TIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_ltime_uint_wraps_on_overflow, dtf::MUL_LTIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_alias_ltime_uint_wraps_on_overflow, dtf::MUL__LTIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_time_udint_wraps_on_overflow, dtf::MUL__TIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_time_udint_alias_wraps_on_overflow, dtf::MUL_TIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_ltime_udint_wraps_on_overflow, dtf::MUL_LTIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_alias_ltime_udint_wraps_on_overflow, dtf::MUL__LTIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_time_ulint_wraps_on_overflow, dtf::MUL__TIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_time_ulint_alias_wraps_on_overflow, dtf::MUL_TIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_ltime_ulint_wraps_on_overflow, dtf::MUL_LTIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_alias_ltime_ulint_wraps_on_overflow, dtf::MUL__LTIME__ULINT, i64::MAX, 2_u64, -2),
 );
 
-panic_i64_i16_tests!(
-    (mul_time_int_panics_on_overflow, dtf::MUL__TIME__INT),
-    (mul_time_int_alias_panics_on_overflow, dtf::MUL_TIME__INT),
-    (mul_ltime_int_panics_on_overflow, dtf::MUL_LTIME__INT),
-    (mul_alias_ltime_int_panics_on_overflow, dtf::MUL__LTIME__INT)
+// TIME/LTIME multiplication with floats saturates at the i64 range instead of panicking
+defensive_arithmetic_tests!(
+    (mul_time_real_saturates_on_overflow, dtf::MUL__TIME__REAL, i64::MAX, 2.0_f32, i64::MAX),
+    (mul_time_real_alias_saturates_on_overflow, dtf::MUL_TIME__REAL, i64::MAX, 2.0_f32, i64::MAX),
+    (mul_ltime_real_saturates_on_overflow, dtf::MUL_LTIME__REAL, i64::MAX, 2.0_f32, i64::MAX),
+    (mul_alias_ltime_real_saturates_on_overflow, dtf::MUL__LTIME__REAL, i64::MAX, 2.0_f32, i64::MAX),
+    (mul_time_lreal_saturates_on_overflow, dtf::MUL__TIME__LREAL, i64::MAX, 2.0_f64, i64::MAX),
+    (mul_time_lreal_alias_saturates_on_overflow, dtf::MUL_TIME__LREAL, i64::MAX, 2.0_f64, i64::MAX),
+    (mul_ltime_lreal_saturates_on_overflow, dtf::MUL_LTIME__LREAL, i64::MAX, 2.0_f64, i64::MAX),
+    (mul_alias_ltime_lreal_saturates_on_overflow, dtf::MUL__LTIME__LREAL, i64::MAX, 2.0_f64, i64::MAX),
+    (mul_time_real_nan_yields_zero, dtf::MUL__TIME__REAL, 1_000, f32::NAN, 0),
+    (mul_time_lreal_nan_yields_zero, dtf::MUL__TIME__LREAL, 1_000, f64::NAN, 0),
 );
 
-panic_i64_i32_tests!(
-    (mul_time_dint_panics_on_overflow, dtf::MUL__TIME__DINT),
-    (mul_time_dint_alias_panics_on_overflow, dtf::MUL_TIME__DINT),
-    (mul_ltime_dint_panics_on_overflow, dtf::MUL_LTIME__DINT),
-    (mul_alias_ltime_dint_panics_on_overflow, dtf::MUL__LTIME__DINT)
-);
-
-panic_i64_u8_tests!(
-    (mul_time_usint_panics_on_overflow, dtf::MUL__TIME__USINT),
-    (mul_time_usint_alias_panics_on_overflow, dtf::MUL_TIME__USINT),
-    (mul_ltime_usint_panics_on_overflow, dtf::MUL_LTIME__USINT),
-    (mul_alias_ltime_usint_panics_on_overflow, dtf::MUL__LTIME__USINT)
-);
-
-panic_i64_u16_tests!(
-    (mul_time_uint_panics_on_overflow, dtf::MUL__TIME__UINT),
-    (mul_time_uint_alias_panics_on_overflow, dtf::MUL_TIME__UINT),
-    (mul_ltime_uint_panics_on_overflow, dtf::MUL_LTIME__UINT),
-    (mul_alias_ltime_uint_panics_on_overflow, dtf::MUL__LTIME__UINT)
-);
-
-panic_i64_u32_tests!(
-    (mul_time_udint_panics_on_overflow, dtf::MUL__TIME__UDINT),
-    (mul_time_udint_alias_panics_on_overflow, dtf::MUL_TIME__UDINT),
-    (mul_ltime_udint_panics_on_overflow, dtf::MUL_LTIME__UDINT),
-    (mul_alias_ltime_udint_panics_on_overflow, dtf::MUL__LTIME__UDINT)
-);
-
-panic_i64_u64_tests!(
-    (mul_time_ulint_panics_on_overflow, dtf::MUL__TIME__ULINT),
-    (mul_time_ulint_alias_panics_on_overflow, dtf::MUL_TIME__ULINT),
-    (mul_ltime_ulint_panics_on_overflow, dtf::MUL_LTIME__ULINT),
-    (mul_alias_ltime_ulint_panics_on_overflow, dtf::MUL__LTIME__ULINT)
-);
-
-panic_i64_f32_mul_tests!(
-    (mul_time_real_panics_on_overflow, dtf::MUL__TIME__REAL),
-    (mul_time_real_alias_panics_on_overflow, dtf::MUL_TIME__REAL),
-    (mul_ltime_real_panics_on_overflow, dtf::MUL_LTIME__REAL),
-    (mul_alias_ltime_real_panics_on_overflow, dtf::MUL__LTIME__REAL)
-);
-
-panic_i64_f64_mul_tests!(
-    (mul_time_lreal_panics_on_overflow, dtf::MUL__TIME__LREAL),
-    (mul_time_lreal_alias_panics_on_overflow, dtf::MUL_TIME__LREAL),
-    (mul_ltime_lreal_panics_on_overflow, dtf::MUL_LTIME__LREAL),
-    (mul_alias_ltime_lreal_panics_on_overflow, dtf::MUL__LTIME__LREAL)
-);
-
-panic_i64_i8_div_zero_tests!(
-    (div_time_sint_panics_on_zero, dtf::DIV__TIME__SINT),
-    (div_time_sint_alias_panics_on_zero, dtf::DIV_TIME__SINT),
-    (div_ltime_sint_panics_on_zero, dtf::DIV_LTIME__SINT),
-    (div_alias_ltime_sint_panics_on_zero, dtf::DIV__LTIME__SINT)
-);
-
-panic_i64_i16_div_zero_tests!(
-    (div_time_int_panics_on_zero, dtf::DIV__TIME__INT),
-    (div_time_int_alias_panics_on_zero, dtf::DIV_TIME__INT),
-    (div_ltime_int_panics_on_zero, dtf::DIV_LTIME__INT),
-    (div_alias_ltime_int_panics_on_zero, dtf::DIV__LTIME__INT)
-);
-
-panic_i64_i32_div_zero_tests!(
-    (div_time_dint_panics_on_zero, dtf::DIV__TIME__DINT),
-    (div_time_dint_alias_panics_on_zero, dtf::DIV_TIME__DINT),
-    (div_ltime_dint_panics_on_zero, dtf::DIV_LTIME__DINT),
-    (div_alias_ltime_dint_panics_on_zero, dtf::DIV__LTIME__DINT)
-);
-
-panic_i64_i64_div_zero_tests!(
-    (div_time_lint_panics_on_zero, dtf::DIV__TIME__LINT),
-    (div_time_lint_alias_panics_on_zero, dtf::DIV_TIME__LINT),
-    (div_ltime_lint_panics_on_zero, dtf::DIV_LTIME__LINT),
-    (div_alias_ltime_lint_panics_on_zero, dtf::DIV__LTIME__LINT)
-);
-
-panic_i64_u8_div_zero_tests!(
-    (div_time_usint_panics_on_zero, dtf::DIV__TIME__USINT),
-    (div_time_usint_alias_panics_on_zero, dtf::DIV_TIME__USINT),
-    (div_ltime_usint_panics_on_zero, dtf::DIV_LTIME__USINT),
-    (div_alias_ltime_usint_panics_on_zero, dtf::DIV__LTIME__USINT)
-);
-
-panic_i64_u16_div_zero_tests!(
-    (div_time_uint_panics_on_zero, dtf::DIV__TIME__UINT),
-    (div_time_uint_alias_panics_on_zero, dtf::DIV_TIME__UINT),
-    (div_ltime_uint_panics_on_zero, dtf::DIV_LTIME__UINT),
-    (div_alias_ltime_uint_panics_on_zero, dtf::DIV__LTIME__UINT)
-);
-
-panic_i64_u32_div_zero_tests!(
-    (div_time_udint_panics_on_zero, dtf::DIV__TIME__UDINT),
-    (div_time_udint_alias_panics_on_zero, dtf::DIV_TIME__UDINT),
-    (div_ltime_udint_panics_on_zero, dtf::DIV_LTIME__UDINT),
-    (div_alias_ltime_udint_panics_on_zero, dtf::DIV__LTIME__UDINT)
-);
-
-panic_i64_u64_div_zero_tests!(
-    (div_time_ulint_panics_on_zero, dtf::DIV__TIME__ULINT),
-    (div_time_ulint_alias_panics_on_zero, dtf::DIV_TIME__ULINT),
-    (div_ltime_ulint_panics_on_zero, dtf::DIV_LTIME__ULINT),
-    (div_alias_ltime_ulint_panics_on_zero, dtf::DIV__LTIME__ULINT)
-);
-
-panic_i64_f32_div_zero_tests!(
-    (div_time_real_panics_on_zero, dtf::DIV__TIME__REAL),
-    (div_time_real_alias_panics_on_zero, dtf::DIV_TIME__REAL),
-    (div_ltime_real_panics_on_zero, dtf::DIV_LTIME__REAL),
-    (div_alias_ltime_real_panics_on_zero, dtf::DIV__LTIME__REAL)
-);
-
-panic_i64_f64_div_zero_tests!(
-    (div_time_lreal_panics_on_zero, dtf::DIV__TIME__LREAL),
-    (div_time_lreal_alias_panics_on_zero, dtf::DIV_TIME__LREAL),
-    (div_ltime_lreal_panics_on_zero, dtf::DIV_LTIME__LREAL),
-    (div_alias_ltime_lreal_panics_on_zero, dtf::DIV__LTIME__LREAL)
+// TIME/LTIME division by zero yields zero instead of panicking
+defensive_arithmetic_tests!(
+    (div_time_sint_returns_zero_on_zero_divisor, dtf::DIV__TIME__SINT, 1, 0_i8, 0),
+    (div_time_sint_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__SINT, 1, 0_i8, 0),
+    (div_ltime_sint_returns_zero_on_zero_divisor, dtf::DIV_LTIME__SINT, 1, 0_i8, 0),
+    (div_alias_ltime_sint_returns_zero_on_zero_divisor, dtf::DIV__LTIME__SINT, 1, 0_i8, 0),
+    (div_time_int_returns_zero_on_zero_divisor, dtf::DIV__TIME__INT, 1, 0_i16, 0),
+    (div_time_int_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__INT, 1, 0_i16, 0),
+    (div_ltime_int_returns_zero_on_zero_divisor, dtf::DIV_LTIME__INT, 1, 0_i16, 0),
+    (div_alias_ltime_int_returns_zero_on_zero_divisor, dtf::DIV__LTIME__INT, 1, 0_i16, 0),
+    (div_time_dint_returns_zero_on_zero_divisor, dtf::DIV__TIME__DINT, 1, 0_i32, 0),
+    (div_time_dint_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__DINT, 1, 0_i32, 0),
+    (div_ltime_dint_returns_zero_on_zero_divisor, dtf::DIV_LTIME__DINT, 1, 0_i32, 0),
+    (div_alias_ltime_dint_returns_zero_on_zero_divisor, dtf::DIV__LTIME__DINT, 1, 0_i32, 0),
+    (div_time_lint_returns_zero_on_zero_divisor, dtf::DIV__TIME__LINT, 1, 0_i64, 0),
+    (div_time_lint_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__LINT, 1, 0_i64, 0),
+    (div_ltime_lint_returns_zero_on_zero_divisor, dtf::DIV_LTIME__LINT, 1, 0_i64, 0),
+    (div_alias_ltime_lint_returns_zero_on_zero_divisor, dtf::DIV__LTIME__LINT, 1, 0_i64, 0),
+    (div_time_usint_returns_zero_on_zero_divisor, dtf::DIV__TIME__USINT, 1, 0_u8, 0),
+    (div_time_usint_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__USINT, 1, 0_u8, 0),
+    (div_ltime_usint_returns_zero_on_zero_divisor, dtf::DIV_LTIME__USINT, 1, 0_u8, 0),
+    (div_alias_ltime_usint_returns_zero_on_zero_divisor, dtf::DIV__LTIME__USINT, 1, 0_u8, 0),
+    (div_time_uint_returns_zero_on_zero_divisor, dtf::DIV__TIME__UINT, 1, 0_u16, 0),
+    (div_time_uint_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__UINT, 1, 0_u16, 0),
+    (div_ltime_uint_returns_zero_on_zero_divisor, dtf::DIV_LTIME__UINT, 1, 0_u16, 0),
+    (div_alias_ltime_uint_returns_zero_on_zero_divisor, dtf::DIV__LTIME__UINT, 1, 0_u16, 0),
+    (div_time_udint_returns_zero_on_zero_divisor, dtf::DIV__TIME__UDINT, 1, 0_u32, 0),
+    (div_time_udint_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__UDINT, 1, 0_u32, 0),
+    (div_ltime_udint_returns_zero_on_zero_divisor, dtf::DIV_LTIME__UDINT, 1, 0_u32, 0),
+    (div_alias_ltime_udint_returns_zero_on_zero_divisor, dtf::DIV__LTIME__UDINT, 1, 0_u32, 0),
+    (div_time_ulint_returns_zero_on_zero_divisor, dtf::DIV__TIME__ULINT, 1, 0_u64, 0),
+    (div_time_ulint_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__ULINT, 1, 0_u64, 0),
+    (div_ltime_ulint_returns_zero_on_zero_divisor, dtf::DIV_LTIME__ULINT, 1, 0_u64, 0),
+    (div_alias_ltime_ulint_returns_zero_on_zero_divisor, dtf::DIV__LTIME__ULINT, 1, 0_u64, 0),
+    (div_time_real_returns_zero_on_zero_divisor, dtf::DIV__TIME__REAL, 1, 0.0_f32, 0),
+    (div_time_real_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__REAL, 1, 0.0_f32, 0),
+    (div_ltime_real_returns_zero_on_zero_divisor, dtf::DIV_LTIME__REAL, 1, 0.0_f32, 0),
+    (div_alias_ltime_real_returns_zero_on_zero_divisor, dtf::DIV__LTIME__REAL, 1, 0.0_f32, 0),
+    (div_time_lreal_returns_zero_on_zero_divisor, dtf::DIV__TIME__LREAL, 1, 0.0_f64, 0),
+    (div_time_lreal_alias_returns_zero_on_zero_divisor, dtf::DIV_TIME__LREAL, 1, 0.0_f64, 0),
+    (div_ltime_lreal_returns_zero_on_zero_divisor, dtf::DIV_LTIME__LREAL, 1, 0.0_f64, 0),
+    (div_alias_ltime_lreal_returns_zero_on_zero_divisor, dtf::DIV__LTIME__LREAL, 1, 0.0_f64, 0),
+    (div_time_ulint_huge_divisor_returns_zero, dtf::DIV__TIME__ULINT, 1, u64::MAX, 0),
 );

--- a/tests/lit/single/stdlib_overflow/README.md
+++ b/tests/lit/single/stdlib_overflow/README.md
@@ -1,85 +1,44 @@
-# Standard Library Overflow Tests
+# Standard Library Edge-Case Tests
 
-This directory contains integration tests for stdlib functions that are expected to panic on overflow or division by zero conditions.
+This directory contains integration tests for stdlib functions on inputs that
+used to panic (overflow, underflow, division by zero, out-of-range string
+arguments). The functions now handle these defensively — a misbehaving PLC
+program must not bring down the runtime process — so every test asserts a
+concrete result instead of expecting a crash.
 
-## Background
+## Behavior under test
 
-These tests were originally part of the Rust integration test suite in `libs/stdlib/tests/date_time_numeric_functions_tests.rs`, but they could not be properly tested there because:
+### TIME arithmetic (32-bit, milliseconds)
+- `add_time_overflow.st` / `sub_time_overflow.st` — wraps modulo 2^32
+- `mul_time_signed_overflow.st` / `mul_time_unsigned_overflow.st` — wraps in
+  modular 64-bit arithmetic, truncated to the 32-bit TIME result
+- `mul_time_real_overflow.st` / `mul_time_lreal_overflow.st` — saturates at the
+  LINT range
+- `div_time_by_zero.st` / `div_time_by_real_zero.st` /
+  `div_time_by_lreal_zero.st` — yields zero
 
-1. The Rust test infrastructure compiles PLC code into a shared library and loads it dynamically using `libloading`
-2. When a panic occurs in dynamically loaded code, Rust's panic unwinding mechanism cannot cross the FFI boundary
-3. Even with `#[should_panic]` or `std::panic::catch_unwind()`, the panic causes an abort with the error:
-   ```
-   fatal runtime error: Rust cannot catch foreign exceptions, aborting
-   ```
+The wrapping semantics match both CODESYS and the native code the compiler
+emits for the corresponding operators on TIME values.
 
-## Solution
+### String functions
+- `right_string_substring_too_long.st` / `right_wstring_substring_too_long.st`
+  — over-long substring requests are clamped to the whole string
 
-These tests have been moved to the lit test framework where they can be marked with `XFAIL: *` to indicate they are expected to fail at runtime. This properly documents the expected panic behavior without breaking the test suite.
+## History
 
-## Test Coverage
+These tests originally documented the panicking behavior via `XFAIL: *` (a
+panic cannot unwind across the FFI boundary in the Rust integration tests, see
+the git history of this directory). Since the standard library no longer
+panics, they are regular positive tests now.
 
-The following overflow/panic conditions are tested:
+## Running the tests
 
-### TIME Arithmetic Overflow
-- `add_time_overflow.st` - Adding to max TIME value
-- `sub_time_overflow.st` - Subtracting from min TIME value
-
-### TIME Multiplication Overflow
-- `mul_time_signed_overflow.st` - Multiplying TIME by max LINT
-- `mul_time_unsigned_overflow.st` - Multiplying TIME by max ULINT
-- `mul_time_real_overflow.st` - Multiplying TIME by max REAL
-- `mul_time_lreal_overflow.st` - Multiplying TIME by large LREAL
-
-### Division by Zero
-- `div_time_by_zero.st` - Dividing TIME by zero (LINT)
-- `div_time_by_real_zero.st` - Dividing TIME by zero (REAL)
-- `div_time_by_lreal_zero.st` - Dividing TIME by zero (LREAL)
-
-## Test Format
-
-All tests follow this pattern:
-
-```st
-// RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test description
-
-PROGRAM main
-VAR
-    a : TIME;
-END_VAR
-    // Operation that causes overflow/panic
-    a := <operation>;
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
-```
-
-The `XFAIL: *` directive tells lit that this test is expected to fail (panic), so a non-zero exit code is treated as success.
-
-## Running the Tests
-
-To run all stdlib overflow tests:
 ```bash
 lit -v tests/lit/single/stdlib_overflow/
 ```
 
 Or run the entire lit test suite:
+
 ```bash
 ./scripts/build.sh --build --lit
 ```
-
-## Expected Output
-
-When running these tests, you should see:
-```
-XFAIL: <unnamed> :: single/stdlib_overflow/add_time_overflow.st
-XFAIL: <unnamed> :: single/stdlib_overflow/sub_time_overflow.st
-...
-
-Total Discovered Tests: 9
-  Expectedly Failed: 9 (100.00%)
-```
-
-This indicates all tests behaved as expected (they panicked).

--- a/tests/lit/single/stdlib_overflow/add_time_overflow.st
+++ b/tests/lit/single/stdlib_overflow/add_time_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that ADD with TIME overflow causes a panic
+// Test that ADD with TIME wraps on overflow instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Adding 1ms to max TIME value should overflow and panic
-    a := ADD(TIME#9223372036854775807ms, TIME#1ms);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    // 4294967294ms + 10000ms wraps modulo 2^32 to 9998ms
+    a := ADD(TIME#49d17h2m47s294ms, TIME#10s);
+    // CHECK: result: 9998
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/div_time_by_lreal_zero.st
+++ b/tests/lit/single/stdlib_overflow/div_time_by_lreal_zero.st
@@ -1,13 +1,12 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that DIV with TIME by LREAL zero causes a panic
+// Test that DIV with TIME by LREAL zero yields zero instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Dividing TIME by zero (LREAL) should panic
-    a := DIV(TIME#10ns, LREAL#0.0);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := DIV(TIME#10s, LREAL#0.0);
+    // CHECK: result: 0
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/div_time_by_real_zero.st
+++ b/tests/lit/single/stdlib_overflow/div_time_by_real_zero.st
@@ -1,13 +1,12 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that DIV with TIME by REAL zero causes a panic
+// Test that DIV with TIME by REAL zero yields zero instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Dividing TIME by zero (REAL) should panic
-    a := DIV(TIME#10ns, REAL#0.0);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := DIV(TIME#10s, REAL#0.0);
+    // CHECK: result: 0
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/div_time_by_zero.st
+++ b/tests/lit/single/stdlib_overflow/div_time_by_zero.st
@@ -1,13 +1,12 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that DIV with TIME by zero causes a panic
+// Test that DIV with TIME by zero yields zero instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Dividing TIME by zero should panic
-    a := DIV(TIME#10ns, LINT#0);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := DIV(TIME#10s, LINT#0);
+    // CHECK: result: 0
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_lreal_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_lreal_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and LREAL overflow causes a panic
+// Test that MUL with TIME and LREAL saturates on overflow instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by large LREAL value should overflow and panic
-    a := MUL(TIME#-2s700ms, LREAL#3.40282347e38);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    // The product saturates at the LINT maximum; its low 32 bits are all ones
+    a := MUL(TIME#1s, LREAL#1.0E300);
+    // CHECK: result: 4294967295
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_real_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_real_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and REAL overflow causes a panic
+// Test that MUL with TIME and REAL saturates on overflow instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by max REAL value should overflow and panic
-    a := MUL(TIME#-2s700ms, REAL#3.40282347e38);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    // The product saturates at the LINT maximum; its low 32 bits are all ones
+    a := MUL(TIME#1s, REAL#3.40282347e38);
+    // CHECK: result: 4294967295
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_signed_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_signed_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and signed integer overflow causes a panic
+// Test that MUL with TIME and a signed integer wraps on overflow instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by max LINT value should overflow and panic
-    a := MUL(TIME#10ns, LINT#9223372036854775807);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    // 1728000000ms * 200 = 345600000000ms wraps modulo 2^32 to 2002616320ms
+    a := MUL(TIME#20d, LINT#200);
+    // CHECK: result: 2002616320
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_unsigned_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_unsigned_overflow.st
@@ -1,13 +1,14 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and unsigned integer overflow causes a panic
+// Test that MUL with TIME and an unsigned integer beyond the LINT range wraps instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by max ULINT value should overflow and panic
-    a := MUL(TIME#1ns, ULINT#9223372036854775808);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    // The factor wraps to LINT minimum in modular 64-bit arithmetic; the low
+    // 32 bits of the product are zero
+    a := MUL(TIME#1ms, ULINT#9223372036854775808);
+    // CHECK: result: 0
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/sub_time_overflow.st
+++ b/tests/lit/single/stdlib_overflow/sub_time_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that SUB with TIME overflow causes a panic
+// Test that SUB with TIME wraps on underflow instead of panicking
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Subtracting from minimum TIME value should overflow and panic
-    a := SUB(TIME#-9223372036854775807ms, TIME#1ms);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    // 1000ms - 5000ms wraps modulo 2^32 to 4294963296ms
+    a := SUB(TIME#1s, TIME#5s);
+    // CHECK: result: 4294963296
+    printf('result: %u$N', a);
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Problem: The date/time arithmetic functions use `checked_*().unwrap()` and panic on overflow or division by zero, aborting the runtime process; even valid inputs crash, since a 152-day DATE difference already exceeds the millisecond-based 32-bit TIME range. This also contradicts the compiler itself, which lowers the equivalent operators to plain wrapping machine arithmetic.

Solution: Use wrapping arithmetic throughout, matching both CODESYS 3.5.19.50 (verified through its scripting API) and RuSTy's own operator lowering. Division by zero and NaN yield 0 instead of crashing, because the ticket asks for no-crash semantics that keep the PLC running. The REAL/LREAL scalings round to the nearest nanosecond and saturate at the TIME range instead of wrapping.

Refs: PRG-4419
