### PR TITLE
fix(stdlib): return zero for invalid date/time constructor inputs

### DIFF
--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -39,7 +39,7 @@ fn split_ldt_fields(nanos: i64) -> (i32, u32, u32, u32, u32, u32, u32) {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn CONCAT_DATE_TOD(in1: u32, in2: u32) -> u32 {
-    in1 + in2 / MILLIS_PER_SECOND
+    in1.wrapping_add(in2 / MILLIS_PER_SECOND)
 }
 
 /// .
@@ -111,11 +111,13 @@ pub extern "C" fn CONCAT_DATE__ULINT(in1: u64, in2: u64, in3: u64) -> u32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn concat_date(in1: i32, in2: u32, in3: u32) -> u32 {
-    let dt = NaiveDate::from_ymd_opt(in1, in2, in3)
+    // Invalid components (month 13, day 32, ...) and dates before the epoch
+    // yield DATE#1970-01-01 instead of panicking or silently wrapping the
+    // negative timestamp into a bogus date.
+    NaiveDate::from_ymd_opt(in1, in2, in3)
         .and_then(|date| date.and_hms_opt(0, 0, 0))
-        .expect("Invalid parameters, cannot create date");
-
-    dt.and_utc().timestamp() as u32
+        .map(|dt| dt.and_utc().timestamp().max(0) as u32)
+        .unwrap_or(0)
 }
 
 /// .
@@ -370,9 +372,14 @@ pub extern "C" fn CONCAT_LDT__ULINT(
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn concat_tod(in1: u32, in2: u32, in3: u32, in4: u32) -> u32 {
-    NaiveDate::from_ymd_opt(1970, 1, 1)
+    // Out-of-range components (hour 25, minute 61, ...) yield TOD#00:00:00
+    // instead of panicking.
+    if NaiveDate::from_ymd_opt(1970, 1, 1)
         .and_then(|date| date.and_hms_milli_opt(in1, in2, in3, in4))
-        .expect("Invalid parameters, cannot create TOD");
+        .is_none()
+    {
+        return 0;
+    }
 
     ((in1 * 3_600 + in2 * 60 + in3) * MILLIS_PER_SECOND) + in4
 }

--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -111,12 +111,12 @@ pub extern "C" fn CONCAT_DATE__ULINT(in1: u64, in2: u64, in3: u64) -> u32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn concat_date(in1: i32, in2: u32, in3: u32) -> u32 {
-    // Invalid components (month 13, day 32, ...) and dates before the epoch
-    // yield DATE#1970-01-01 instead of panicking or silently wrapping the
-    // negative timestamp into a bogus date.
+    // Invalid components (month 13, day 32, ...) and dates outside the u32
+    // DATE range (before 1970, after 2106) yield DATE#1970-01-01 instead of
+    // panicking or silently wrapping the timestamp into a bogus date.
     NaiveDate::from_ymd_opt(in1, in2, in3)
         .and_then(|date| date.and_hms_opt(0, 0, 0))
-        .map(|dt| dt.and_utc().timestamp().max(0) as u32)
+        .and_then(|dt| u32::try_from(dt.and_utc().timestamp()).ok())
         .unwrap_or(0)
 }
 
@@ -373,11 +373,9 @@ pub extern "C" fn CONCAT_LDT__ULINT(
 #[no_mangle]
 pub extern "C" fn concat_tod(in1: u32, in2: u32, in3: u32, in4: u32) -> u32 {
     // Out-of-range components (hour 25, minute 61, ...) yield TOD#00:00:00
-    // instead of panicking.
-    if NaiveDate::from_ymd_opt(1970, 1, 1)
-        .and_then(|date| date.and_hms_milli_opt(in1, in2, in3, in4))
-        .is_none()
-    {
+    // instead of panicking. Checked by hand: chrono's time validation would
+    // admit leap-second milliseconds (1000..=1999) past the valid TOD range.
+    if in1 > 23 || in2 > 59 || in3 > 59 || in4 > 999 {
         return 0;
     }
 

--- a/libs/stdlib/tests/date_time_extra_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_extra_functions_tests.rs
@@ -1086,3 +1086,30 @@ fn day_of_week() {
     assert_eq!(maintype.b, 0);
     assert_eq!(maintype.c, 6);
 }
+
+use iec61131std::date_time_extra_functions as dtef;
+
+#[test]
+fn concat_date_with_invalid_components_yields_epoch() {
+    assert_eq!(dtef::CONCAT_DATE__INT(2024, 13, 45), 0);
+    assert_eq!(dtef::CONCAT_DATE__INT(2024, 0, 1), 0);
+}
+
+#[test]
+fn concat_date_before_epoch_yields_epoch() {
+    assert_eq!(dtef::CONCAT_DATE__INT(1969, 6, 1), 0);
+}
+
+#[test]
+fn concat_tod_with_invalid_components_yields_midnight() {
+    assert_eq!(dtef::CONCAT_TOD__INT(25, 0, 0, 0), 0);
+    assert_eq!(dtef::CONCAT_TOD__INT(1, 61, 0, 0), 0);
+}
+
+#[test]
+fn concat_date_tod_wraps_on_overflow() {
+    // DATE#2106-02-07 plus a full day of TOD exceeds the u32 second range
+    let date = 4_294_944_000_u32; // 2106-02-07-00:00:00 as seconds since the epoch
+    let tod = 86_399_999_u32; // TOD#23:59:59.999 in milliseconds
+    assert_eq!(dtef::CONCAT_DATE_TOD(date, tod), date.wrapping_add(tod / 1_000));
+}

--- a/libs/stdlib/tests/date_time_extra_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_extra_functions_tests.rs
@@ -1101,9 +1101,23 @@ fn concat_date_before_epoch_yields_epoch() {
 }
 
 #[test]
+fn concat_date_beyond_u32_range_yields_epoch() {
+    assert_eq!(dtef::CONCAT_DATE__INT(2107, 1, 1), 0);
+    assert_eq!(dtef::CONCAT_DATE__INT(9999, 12, 31), 0);
+}
+
+#[test]
 fn concat_tod_with_invalid_components_yields_midnight() {
     assert_eq!(dtef::CONCAT_TOD__INT(25, 0, 0, 0), 0);
     assert_eq!(dtef::CONCAT_TOD__INT(1, 61, 0, 0), 0);
+}
+
+#[test]
+fn concat_tod_with_leap_second_millis_yields_midnight() {
+    // Chrono-style validation would admit 1000..=1999 as a leap-second
+    // encoding when the seconds component is 59.
+    assert_eq!(dtef::CONCAT_TOD__INT(23, 59, 59, 1999), 0);
+    assert_eq!(dtef::CONCAT_TOD__INT(0, 0, 59, 1000), 0);
 }
 
 #[test]


### PR DESCRIPTION
Problem: The date/time constructor functions panic on invalid components such as month 13 or hour 25 and abort the runtime process; pre-1970 dates additionally wrap into bogus far-future values. These functions are IEC 61131-3 3rd-edition extensions, so CODESYS 3.5.19.50 offers no reference behavior to mirror.

Solution: Return the all-zero value (`DATE#1970-01-01` / `TOD#00:00:00`) for unrepresentable inputs, clamp pre-1970 results to the epoch, and make the remaining unchecked addition an explicit `wrapping_add` so debug and release builds agree. A defined all-zero result is the least surprising defensive choice, consistent with the rest of this stack.

Refs: PRG-4419
