### PR TITLE
fix(stdlib): use scientific notation for large negative reals in TO_STRING

### DIFF
--- a/libs/stdlib/iec61131-st/extra_functions.st
+++ b/libs/stdlib/iec61131-st/extra_functions.st
@@ -98,6 +98,18 @@ VAR_IN_OUT
 END_VAR
 END_FUNCTION
 
+(* The value arrives widened to LREAL, but is formatted with REAL's
+   scientific-notation threshold. *)
+{external}
+FUNCTION REAL_TO_STRING_EXT : DINT
+VAR_INPUT
+    IN : LREAL;
+END_VAR
+VAR_IN_OUT
+    OUT : STRING[__STRING_LENGTH];
+END_VAR
+END_FUNCTION
+
 (******************************************************************************
 *
 * Converts DT to STRING.
@@ -331,7 +343,7 @@ FUNCTION REAL_TO_STRING : STRING[__STRING_LENGTH]
 VAR_INPUT
     IN : REAL;
 END_VAR
-    LREAL_TO_STRING_EXT(IN, REAL_TO_STRING);
+    REAL_TO_STRING_EXT(IN, REAL_TO_STRING);
 END_FUNCTION
 
 (******************************************************************************

--- a/libs/stdlib/src/extra_functions.rs
+++ b/libs/stdlib/src/extra_functions.rs
@@ -73,8 +73,10 @@ pub unsafe extern "C" fn LINT_TO_STRING_EXT(input: i64, dest: *mut u8) -> i32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn LREAL_TO_STRING_EXT(input: f64, dest: *mut u8) -> i32 {
-    // double: 52 bits are used for the mantissa (about 16 decimal digits)
-    if input.floor() < 1e14 {
+    // double: 52 bits are used for the mantissa (about 16 decimal digits);
+    // compare the magnitude so large negative values also use scientific
+    // notation instead of overflowing the result buffer with plain digits
+    if input.abs() < 1e14 {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6}"));
     } else {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6e}"));
@@ -88,10 +90,11 @@ pub unsafe extern "C" fn LREAL_TO_STRING_EXT(input: f64, dest: *mut u8) -> i32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn REAL_TO_STRING_EXT(input: f64, dest: *mut u8) -> i32 {
-    // float: 23 bits are used for the mantissa (about 7 decimal digits)
+    // float: 23 bits are used for the mantissa (about 7 decimal digits);
+    // compare the magnitude so large negative values also use scientific notation
 
     // TODO: discuss when scientific notation should be displayed
-    if input.floor() < 1e6 {
+    if input.abs() < 1e6 {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6}"));
     } else {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6e}"));
@@ -454,6 +457,30 @@ mod test {
             std::str::from_utf8(unsafe { core::slice::from_raw_parts(dest_ptr, 81) }).unwrap();
 
         assert_eq!(format!("{e_notation:.6e}"), res_scientific.trim_end_matches('\0'));
+    }
+
+    #[test]
+    fn lreal_to_string_conversion_large_negative_values_use_scientific_notation() {
+        // a plain-decimal rendering of -1e300 has over 300 digits and used to
+        // overflow the 80-byte result buffer
+        let huge_negative = -1.0e300;
+        let mut dest = [0_u8; 81];
+        let dest_ptr = dest.as_mut_ptr();
+        let _ = unsafe { LREAL_TO_STRING_EXT(huge_negative, dest_ptr) };
+        let res = std::str::from_utf8(unsafe { core::slice::from_raw_parts(dest_ptr, 81) }).unwrap();
+
+        assert_eq!(format!("{huge_negative:.6e}"), res.trim_end_matches('\0'));
+    }
+
+    #[test]
+    fn real_to_string_conversion_large_negative_values_use_scientific_notation() {
+        let large_negative = -2_000_000.0;
+        let mut dest = [0_u8; 81];
+        let dest_ptr = dest.as_mut_ptr();
+        let _ = unsafe { REAL_TO_STRING_EXT(large_negative, dest_ptr) };
+        let res = std::str::from_utf8(unsafe { core::slice::from_raw_parts(dest_ptr, 81) }).unwrap();
+
+        assert_eq!(format!("{large_negative:.6e}"), res.trim_end_matches('\0'));
     }
 
     #[test]

--- a/libs/stdlib/tests/extra_function_tests.rs
+++ b/libs/stdlib/tests/extra_function_tests.rs
@@ -441,6 +441,33 @@ fn real_to_string_conversion() {
 }
 
 #[test]
+fn real_to_string_conversion_large_value_uses_real_threshold() {
+    // REAL_TO_STRING routes through REAL_TO_STRING_EXT, so REAL's 1e6
+    // scientific-notation threshold applies instead of LREAL's 1e14.
+    let mut maintype = MainType { s: [0_u8; STR_SIZE] };
+    let src = r#"
+    FUNCTION main : STRING
+    VAR
+        in: REAL := 2000000.0;
+    END_VAR
+        main := REAL_TO_STRING(in);
+    END_FUNCTION
+    "#;
+
+    let includes = get_includes(&[
+        "string_functions.st",
+        "string_conversion.st",
+        "extra_functions.st",
+        "numerical_functions.st",
+    ]);
+
+    let expected = format!("{:.6e}", 2000000.0_f64);
+    let _: i32 = compile_and_run(vec![src.into()], includes, &mut maintype);
+    let res = unsafe { std::str::from_utf8_unchecked(&maintype.s) }.trim_end_matches('\0');
+    assert_eq!(expected, res);
+}
+
+#[test]
 fn real_to_wstring_conversion() {
     let mut maintype = MainType { s: [0_u16; STR_SIZE] };
     let src = r#"


### PR DESCRIPTION
Problem: The REAL/LREAL to-string helpers select scientific notation via `input.floor() < threshold`, which is true for every negative number, so a large negative value renders hundreds of plain-decimal digits into the 80-byte result buffer and aborts the runtime process. CODESYS 3.5.19.50 renders scientific notation for the same input. The ST interface also routed REAL_TO_STRING through the LREAL helper, so REAL's own threshold was unreachable.

Solution: Compare the magnitude (`input.abs()`) instead, so large negative values switch to scientific notation exactly like positive ones, and route REAL_TO_STRING through REAL_TO_STRING_EXT so REAL values use REAL's 1e6 threshold instead of LREAL's 1e14.

Refs: PRG-4419
