### PR TITLE
chore(stdlib): deny panicking constructs via clippy lints

### DIFF
--- a/libs/stdlib/src/lib.rs
+++ b/libs/stdlib/src/lib.rs
@@ -1,5 +1,21 @@
 // Definitions of the core standard function modules for IEC61131-3
 
+// A panic in the standard library aborts the PLC runtime process (most functions
+// are extern "C" and cannot unwind), so panicking constructs are forbidden in
+// non-test code. Handle invalid input defensively instead: clamp, wrap or return
+// a default value.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo,
+        clippy::unimplemented
+    )
+)]
+
 pub mod arithmetic_functions;
 pub mod bistable_functionblocks;
 pub mod bit_num_conversion;


### PR DESCRIPTION
Problem: A panic in the standard library aborts the whole PLC runtime process, because most functions are `extern "C"` and cannot unwind. The preceding PRs in this stack removed every panicking construct, but nothing prevents new ones from sneaking back in.

Solution: Deny the panicking clippy lints (`unwrap_used`, `expect_used`, `panic`, `unreachable`, `todo`, `unimplemented`) for non-test code via a crate-level `cfg_attr(not(test), deny(...))`. Unit tests keep using these constructs freely.

Refs: PRG-4419
