### PR TITLE
fix: program retain variables with inline type definitions (1.0.x)

### DIFF
--- a/compiler/plc_lowering/src/retain.rs
+++ b/compiler/plc_lowering/src/retain.rs
@@ -326,6 +326,52 @@ mod tests {
     }
 
     #[test]
+    fn test_retain_lowering_on_program_with_inline_types() {
+        let source: SourceCode = r#"
+        PROGRAM Test
+        VAR RETAIN
+            arr : ARRAY[0..2] OF DINT := [1, 2, 3];
+            sub : DINT(0..100) := 50;
+            str : STRING[20] := 'start';
+            col : (RED, GREEN, BLUE) := GREEN;
+            mat : ARRAY[0..1, 0..2] OF DINT;
+            nst : ARRAY[0..1] OF ARRAY[0..2] OF DINT;
+            rec : STRUCT a : DINT; b : DINT; END_STRUCT
+        END_VAR
+        END_PROGRAM
+        "#
+        .into();
+
+        let (_, project) =
+            parse_and_annotate("test", vec![source]).expect("Failed to parse compilation unit");
+        let unit = project.units[0].get_unit();
+
+        // The extracted inline types and the generated retain pointer types must not clash
+        let mut type_names: Vec<&str> =
+            unit.user_types.iter().filter_map(|it| it.data_type.get_name()).collect();
+        type_names.sort_unstable();
+        let duplicates: Vec<&str> =
+            type_names.windows(2).filter(|pair| pair[0] == pair[1]).map(|pair| pair[0]).collect();
+        assert!(duplicates.is_empty(), "duplicate user types after retain lowering: {duplicates:?}");
+
+        // Every member is extracted into the global retain block
+        let retain_block = find_retain_block(unit);
+        let variable_names: Vec<&str> = retain_block.variables.iter().map(|v| v.get_name()).collect();
+        assert_eq!(
+            variable_names,
+            vec![
+                "__Test_arr__retain",
+                "__Test_sub__retain",
+                "__Test_str__retain",
+                "__Test_col__retain",
+                "__Test_mat__retain",
+                "__Test_nst__retain",
+                "__Test_rec__retain",
+            ]
+        );
+    }
+
+    #[test]
     fn test_retain_in_global_nested_should_move_to_retain_block() {
         let source: SourceCode = r#"
         FUNCTION_BLOCK FB

--- a/compiler/plc_lowering/src/retain.rs
+++ b/compiler/plc_lowering/src/retain.rs
@@ -38,7 +38,8 @@
 
 use plc_ast::{
     ast::{
-        AccessModifier, AstFactory, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration, Variable,
+        AccessModifier, AstFactory, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration,
+        LinkageType, UserTypeDeclaration, Variable,
     },
     mut_visitor::{AstVisitorMut, WalkerMut},
     provider::IdProvider,
@@ -71,13 +72,19 @@ struct RetainLowerer {
 #[derive(Debug, Default)]
 struct Context {
     container_name: Option<String>,
+    container_linkage: Option<LinkageType>,
     in_program: bool,
     retain_variables: Vec<Variable>,
+    pointer_types: Vec<UserTypeDeclaration>,
 }
 
 impl AstVisitorMut for RetainLowerer {
     fn visit_compilation_unit(&mut self, unit: &mut CompilationUnit) {
         unit.walk(self);
+
+        // Register the pointer types synthesized for extracted program retain variables.
+        unit.user_types.append(&mut self.context.pointer_types);
+
         // After visiting the compilation unit, add all retain variables to the global vars
         if !self.context.retain_variables.is_empty() {
             // Find an existing retain global variable block or create a new one if it doesn't exist
@@ -104,9 +111,11 @@ impl AstVisitorMut for RetainLowerer {
     fn visit_pou(&mut self, pou: &mut plc_ast::ast::Pou) {
         self.context.in_program = matches!(pou.kind, plc_ast::ast::PouType::Program);
         self.context.container_name = Some(pou.name.clone());
+        self.context.container_linkage = Some(pou.linkage);
         pou.walk(self);
         self.context.in_program = false;
         self.context.container_name = None;
+        self.context.container_linkage = None;
     }
 
     fn visit_variable_block(&mut self, block: &mut plc_ast::ast::VariableBlock) {
@@ -154,7 +163,7 @@ impl RetainLowerer {
             self.context.container_name.as_deref().unwrap_or_default(),
             variable.get_name()
         );
-        // Create a global variable called __<pou_name>_<var_name> and move the initializer and datatype to the global variable
+        // Create a global variable called __<pou_name>_<var_name>__retain and move the initializer and datatype to the global variable
         let new_var = Variable {
             name: new_name,
             data_type_declaration: variable.data_type_declaration.clone(),
@@ -162,17 +171,35 @@ impl RetainLowerer {
             location: variable.location.clone(),
             address: None,
         };
-        variable.data_type_declaration = DataTypeDeclaration::Definition {
-            data_type: Box::new(DataType::PointerType {
-                name: None,
-                referenced_type: Box::new(variable.data_type_declaration.clone()),
+
+        // Register the auto-deref pointer type under its own name. An inline definition would be
+        // extracted by the pre-processor as `__<pou>_<var>`, which clashes with the type of the
+        // same name the pre-processor already created when the variable's type was declared
+        // inline (e.g. an array).
+        let pointer_type_name = format!("{}_ptr", new_var.get_name());
+        let location = variable.data_type_declaration.get_location();
+        let referenced_type = std::mem::replace(
+            &mut variable.data_type_declaration,
+            DataTypeDeclaration::Reference {
+                referenced_type: pointer_type_name.clone(),
+                location: location.clone(),
+            },
+        );
+        self.context.pointer_types.push(UserTypeDeclaration {
+            data_type: DataType::PointerType {
+                name: Some(pointer_type_name),
+                referenced_type: Box::new(referenced_type),
                 auto_deref: Some(AutoDerefType::Alias),
                 type_safe: true,
                 is_function: false,
-            }),
-            location: variable.data_type_declaration.get_location(),
+            },
+            initializer: None,
+            location,
             scope: self.context.container_name.clone(),
-        };
+            linkage: self.context.container_linkage.unwrap_or(LinkageType::Internal),
+        });
+
+        // Initialize the program variable with a reference to the global retain variable.
         variable.initializer = Some(AstFactory::create_member_reference(
             AstFactory::create_identifier(&new_var.name, variable.location.clone(), self.ids.next_id()),
             None,
@@ -246,7 +273,7 @@ mod tests {
         // The program's variable should be replaced with an auto-deref pointer
         let pou_var = find_pou_variable(unit, "Test", "x");
         // The type should now reference the generated pointer type, not INT directly
-        assert_eq!(referenced_type_name(&pou_var.data_type_declaration), "__Test_x");
+        assert_eq!(referenced_type_name(&pou_var.data_type_declaration), "__Test_x__retain_ptr");
         assert!(pou_var.initializer.is_some(), "program variable should have a reference initializer");
 
         // The program's variable block should no longer be marked retain
@@ -294,7 +321,7 @@ mod tests {
 
         // The program's variable should be replaced with an auto-deref pointer to the retain global
         let pou_var = find_pou_variable(unit, "Test", "x");
-        assert_eq!(referenced_type_name(&pou_var.data_type_declaration), "__Test_x");
+        assert_eq!(referenced_type_name(&pou_var.data_type_declaration), "__Test_x__retain_ptr");
         assert!(pou_var.initializer.is_some(), "program variable should have a reference initializer");
     }
 

--- a/src/codegen/tests/retain_tests.rs
+++ b/src/codegen/tests/retain_tests.rs
@@ -63,28 +63,28 @@ fn retain_variables_in_programs_are_in_retain_linker_section() {
       %deref = load ptr, ptr %self, align [filtered]
       %x = getelementptr inbounds nuw %main, ptr %deref, i32 0, i32 0
       %deref1 = load ptr, ptr %x, align [filtered]
-      call void @__main_x__ctor(ptr %deref1)
+      call void @__main_x__retain_ptr__ctor(ptr %deref1)
       %deref2 = load ptr, ptr %self, align [filtered]
       %x3 = getelementptr inbounds nuw %main, ptr %deref2, i32 0, i32 0
       store ptr @__main_x__retain, ptr %x3, align [filtered]
       %deref4 = load ptr, ptr %self, align [filtered]
       %y = getelementptr inbounds nuw %main, ptr %deref4, i32 0, i32 1
       %deref5 = load ptr, ptr %y, align [filtered]
-      call void @__main_y__ctor(ptr %deref5)
+      call void @__main_y__retain_ptr__ctor(ptr %deref5)
       %deref6 = load ptr, ptr %self, align [filtered]
       %y7 = getelementptr inbounds nuw %main, ptr %deref6, i32 0, i32 1
       store ptr @__main_y__retain, ptr %y7, align [filtered]
       ret void
     }
 
-    define void @__main_x__ctor(ptr %0) {
+    define void @__main_x__retain_ptr__ctor(ptr %0) {
     entry:
       %self = alloca ptr, align [filtered]
       store ptr %0, ptr %self, align [filtered]
       ret void
     }
 
-    define void @__main_y__ctor(ptr %0) {
+    define void @__main_y__retain_ptr__ctor(ptr %0) {
     entry:
       %self = alloca ptr, align [filtered]
       store ptr %0, ptr %self, align [filtered]

--- a/tests/lit/single/retain/transitive_fb.st
+++ b/tests/lit/single/retain/transitive_fb.st
@@ -1,0 +1,34 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// FB retain members with inline type definitions keep their in-place layout; the
+// instances get the retain treatment transitively: the program instance is extracted
+// into a retain global, the plain global instance moves to a retain block.
+FUNCTION_BLOCK Fb
+    VAR RETAIN
+        arr : ARRAY[0..2] OF DINT := [1, 2, 3];
+        sub : DINT(0..100) := 50;
+    END_VAR
+END_FUNCTION_BLOCK
+
+PROGRAM mainProg
+    VAR
+        inst : Fb;
+    END_VAR
+
+    inst.arr[0] := inst.arr[0] + 1;
+    inst.sub := inst.sub + 1;
+END_PROGRAM
+
+VAR_GLOBAL
+    gInst : Fb;
+END_VAR
+
+FUNCTION main : DINT
+    mainProg();
+    gInst.arr[2] := 99;
+    gInst.sub := gInst.sub + 2;
+    printf('%d %d %d$N', mainProg.inst.arr[0], mainProg.inst.arr[1], mainProg.inst.arr[2]); //CHECK: 2 2 3
+    printf('%d$N', mainProg.inst.sub);                                                      //CHECK-NEXT: 51
+    // Implicitly created global variable backing the program instance
+    printf('%d %d$N', __mainProg_inst__retain.arr[0], __mainProg_inst__retain.sub);         //CHECK-NEXT: 2 51
+    printf('%d %d$N', gInst.arr[2], gInst.sub);                                             //CHECK-NEXT: 99 52
+END_FUNCTION

--- a/tests/lit/single/retain/type_shapes.st
+++ b/tests/lit/single/retain/type_shapes.st
@@ -1,0 +1,33 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Program retain variables with inline type definitions: the extracted inline type
+// and the generated retain pointer type must not clash (they both used to be named
+// `__<pou>_<var>`), and initializers must land on the generated retain globals.
+PROGRAM mainProg
+    VAR RETAIN
+        arr : ARRAY[0..2] OF DINT := [11, 22, 33];
+        sub : DINT(0..100) := 50;
+        str : STRING[20] := 'start';
+        col : (RED, GREEN, BLUE) := GREEN;
+        mat : ARRAY[0..1, 0..2] OF DINT;
+        nst : ARRAY[0..1] OF ARRAY[0..2] OF DINT;
+        rec : STRUCT a : DINT; b : DINT; END_STRUCT
+    END_VAR
+
+    arr[0] := arr[0] + 1;
+    sub := sub + 1;
+    mat[1, 2] := 42;
+    nst[1][2] := 43;
+    rec.a := rec.a + 1;
+END_PROGRAM
+
+FUNCTION main : DINT
+    mainProg();
+    printf('%d %d %d$N', mainProg.arr[0], mainProg.arr[1], mainProg.arr[2]); //CHECK: 12 22 33
+    printf('%d$N', __mainProg_arr__retain[0]);                               //CHECK-NEXT: 12
+    printf('%d %d$N', mainProg.sub, __mainProg_sub__retain);                 //CHECK-NEXT: 51 51
+    printf('%s %s$N', REF(mainProg.str), REF(__mainProg_str__retain));       //CHECK-NEXT: start start
+    printf('%d %d$N', mainProg.col, __mainProg_col__retain);                 //CHECK-NEXT: 1 1
+    printf('%d %d$N', mainProg.mat[1, 2], __mainProg_mat__retain[1, 2]);     //CHECK-NEXT: 42 42
+    printf('%d %d$N', mainProg.nst[1][2], __mainProg_nst__retain[1][2]);     //CHECK-NEXT: 43 43
+    printf('%d %d$N', mainProg.rec.a, __mainProg_rec__retain.a);             //CHECK-NEXT: 1 1
+END_FUNCTION

--- a/tests/lit/single/retain/wiring.st
+++ b/tests/lit/single/retain/wiring.st
@@ -6,10 +6,12 @@ END_VAR
 PROGRAM mainProg
     VAR RETAIN
         prgVar : DINT;
+        prgArr : ARRAY[0..100] OF DINT;
     END_VAR
 
     prgVar := 20;
     globalVar := 50;
+    prgArr[100] := 30;
 END_PROGRAM
 
 FUNCTION main : DINT
@@ -18,4 +20,7 @@ FUNCTION main : DINT
     // Implicitly created global variable
     printf('%d$N', __mainProg_prgVar__retain); //CHECK-NEXT: 20
     printf('%d$N', globalVar); //CHECK-NEXT: 50
+    // Variables with an inline type definition get the same treatment
+    printf('%d$N', mainProg.prgArr[100]); //CHECK-NEXT: 30
+    printf('%d$N', __mainProg_prgArr__retain[100]); //CHECK-NEXT: 30
 END_FUNCTION


### PR DESCRIPTION
Backport of #1863 to `release/1.0.x` (clean cherry-pick, the affected files are identical on both branches).

## Summary

Program `VAR RETAIN` members are lowered to auto-deref pointers into generated retain globals. The pointer type was left as an inline definition, which the pre-processor extracted as `__<pou>_<var>` during re-indexing — colliding with the identically named type it had already extracted when the member's own type was declared inline. Every inline type shape was affected (arrays, sized strings/wstrings, subranges, inline enums/structs, nested and multi-dimensional arrays):

```st
PROGRAM mainProg
VAR RETAIN
    y : ARRAY[0..100] OF DINT; // error[E004]: __mainProg_y: Ambiguous datatype.
END_VAR
END_PROGRAM
```

The retain lowerer now registers the auto-deref pointer type itself under its own name (`__<pou>_<var>__retain_ptr`) and rewrites the member to a plain reference, so the second pre-process pass has nothing left to extract. Generated retain globals keep their `__<pou>_<var>__retain` names, section placement, and DWARF type info.

## Tests

Same as #1863: two new lit tests (`retain/type_shapes.st`, `retain/transitive_fb.st`), an array member added to `retain/wiring.st`, and a lowering unit test that fails pre-fix with one duplicate type per shape. Full lit suite and retain unit/codegen tests pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)