### PR TITLE
fix(stdlib): use wrapping arithmetic in date/time functions

### DIFF
--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -37,7 +37,7 @@ fn split_ldt_fields(nanos: i64) -> (i32, u32, u32, u32, u32, u32, u32) {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn CONCAT_DATE_TOD(in1: u32, in2: u32) -> u32 {
-    in1 + in2 / MILLIS_PER_SECOND
+    in1.wrapping_add(in2 / MILLIS_PER_SECOND)
 }
 
 /// .

--- a/libs/stdlib/src/date_time_numeric_functions.rs
+++ b/libs/stdlib/src/date_time_numeric_functions.rs
@@ -1,24 +1,22 @@
-use chrono::TimeZone;
-
 const MILLIS_PER_SECOND: u32 = 1_000;
 const MILLIS_PER_DAY: u32 = 60 * 60 * 24 * MILLIS_PER_SECOND;
 
-fn checked_millis_to_seconds(input: u32) -> u32 {
+fn millis_to_seconds(input: u32) -> u32 {
     input / MILLIS_PER_SECOND
 }
 
-fn checked_seconds_to_millis(input: u32) -> u32 {
-    input.checked_mul(MILLIS_PER_SECOND).unwrap()
+fn seconds_to_millis(input: u32) -> u32 {
+    input.wrapping_mul(MILLIS_PER_SECOND)
 }
 
 /// .
 /// This operator returns the value of adding up two TIME operands.
-/// Panics on overflow.
+/// Wraps on overflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD_TIME(in1: u32, in2: u32) -> u32 {
-    in1.checked_add(in2).unwrap()
+    in1.wrapping_add(in2)
 }
 
 /// .
@@ -33,42 +31,33 @@ pub extern "C-unwind" fn ADD_TOD_TIME(in1: u32, in2: u32) -> u32 {
 
 /// .
 /// This operator returns the value of adding up DT and TIME.
-/// Panics on overflow.
+/// Wraps on overflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD_DT_TIME(in1: u32, in2: u32) -> u32 {
-    let time_seconds = checked_millis_to_seconds(in2);
-    in1.checked_add(time_seconds).unwrap()
-}
-
-fn add_datetime_time(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .checked_add_signed(chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .timestamp_nanos_opt()
-        .unwrap()
+    let time_seconds = millis_to_seconds(in2);
+    in1.wrapping_add(time_seconds)
 }
 
 /// .
 /// This operator produces the subtraction of two TIME operands
-/// Panics on underflow.
+/// Wraps on underflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_TIME(in1: u32, in2: u32) -> u32 {
-    in1.checked_sub(in2).unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two DATE operands
-/// Panics on underflow and when the resulting TIME would overflow.
+/// Wraps on underflow and on TIME overflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DATE_DATE(in1: u32, in2: u32) -> u32 {
-    checked_seconds_to_millis(in1.checked_sub(in2).unwrap())
+    seconds_to_millis(in1.wrapping_sub(in2))
 }
 
 /// .
@@ -83,55 +72,38 @@ pub extern "C-unwind" fn SUB_TOD_TIME(in1: u32, in2: u32) -> u32 {
 
 /// .
 /// This operator produces the subtraction of two TOD operands
-/// Panics on underflow.
+/// Wraps on underflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_TOD_TOD(in1: u32, in2: u32) -> u32 {
-    in1.checked_sub(in2).unwrap()
-}
-
-fn sub_datetimes(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .signed_duration_since(chrono::Utc.timestamp_nanos(in2))
-        .num_nanoseconds()
-        .unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of DT and TIME
-/// Panics on underflow.
+/// Wraps on underflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DT_TIME(in1: u32, in2: u32) -> u32 {
-    let time_seconds = checked_millis_to_seconds(in2);
-    in1.checked_sub(time_seconds).unwrap()
-}
-
-fn sub_datetime_duration(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .checked_sub_signed(chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .timestamp_nanos_opt()
-        .unwrap()
+    let time_seconds = millis_to_seconds(in2);
+    in1.wrapping_sub(time_seconds)
 }
 
 /// .
 /// This operator produces the subtraction of two DT operands
-/// Panics on underflow and when the resulting TIME would overflow.
+/// Wraps on underflow and on TIME overflow.
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DT_DT(in1: u32, in2: u32) -> u32 {
-    checked_seconds_to_millis(in1.checked_sub(in2).unwrap())
+    seconds_to_millis(in1.wrapping_sub(in2))
 }
 
 /// .
 /// This operator returns the value of adding up two LTIME operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -141,7 +113,7 @@ pub extern "C-unwind" fn ADD_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator returns the value of adding up LTOD and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -151,7 +123,7 @@ pub extern "C-unwind" fn ADD_LTOD_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator returns the value of adding up LDT and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -161,7 +133,7 @@ pub extern "C-unwind" fn ADD_LDT_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LTIME operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -171,7 +143,7 @@ pub extern "C-unwind" fn SUB_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LDATE operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -181,7 +153,7 @@ pub extern "C-unwind" fn SUB_LDATE_LDATE(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of LTOD and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -191,7 +163,7 @@ pub extern "C-unwind" fn SUB_LTOD_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LTOD operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -201,7 +173,7 @@ pub extern "C-unwind" fn SUB_LTOD_LTOD(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of LDT and LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -211,7 +183,7 @@ pub extern "C-unwind" fn SUB_LDT_LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// This operator produces the subtraction of two LDT operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -221,260 +193,259 @@ pub extern "C-unwind" fn SUB_LDT_LDT(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Multiply TIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME/LTIME with ANY_SIGNED_INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
-fn checked_mul_time_with_signed_int(in1: i64, in2: i64) -> i64 {
-    in1.checked_mul(in2).unwrap()
+fn mul_time_with_signed_int(in1: i64, in2: i64) -> i64 {
+    in1.wrapping_mul(in2)
 }
 
 /// .
 /// Multiply TIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME/LTIME with ANY_UNSIGNED_INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
-fn checked_mul_time_with_unsigned_int(in1: i64, in2: u64) -> i64 {
-    // convert in2 [u64] to [i64]
-    // if in2 is to large for [i64] the multiplication will allways overflow -> panic on try_into()
-    in1.checked_mul(in2.try_into().unwrap()).unwrap()
+fn mul_time_with_unsigned_int(in1: i64, in2: u64) -> i64 {
+    // the u64 to i64 cast keeps the result correct modulo 2^64
+    in1.wrapping_mul(in2 as i64)
 }
 
 /// .
@@ -891,7 +862,7 @@ pub extern "C-unwind" fn DIV__TIME__LREAL(in1: i64, in2: f64) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by SINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -901,7 +872,7 @@ pub extern "C-unwind" fn MUL__LTIME__SINT(in1: i64, in2: i8) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by INT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -911,7 +882,7 @@ pub extern "C-unwind" fn MUL__LTIME__INT(in1: i64, in2: i16) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by DINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -921,7 +892,7 @@ pub extern "C-unwind" fn MUL__LTIME__DINT(in1: i64, in2: i32) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by LINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -931,7 +902,7 @@ pub extern "C-unwind" fn MUL__LTIME__LINT(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by USINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -941,7 +912,7 @@ pub extern "C-unwind" fn MUL__LTIME__USINT(in1: i64, in2: u8) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by UINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -951,7 +922,7 @@ pub extern "C-unwind" fn MUL__LTIME__UINT(in1: i64, in2: u16) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by UDINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -961,7 +932,7 @@ pub extern "C-unwind" fn MUL__LTIME__UDINT(in1: i64, in2: u32) -> i64 {
 
 /// .
 /// Compatibility alias for multiplying LTIME by ULINT.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1091,97 +1062,97 @@ pub extern "C-unwind" fn DIV__LTIME__LREAL(in1: i64, in2: f64) -> i64 {
 
 /// .
 /// Compatibility symbol for LTIME + LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD__LTIME__LTIME(in1: i64, in2: i64) -> i64 {
-    in1.checked_add(in2).unwrap()
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// Compatibility symbol for LTOD + LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD__LTOD__LTIME(in1: i64, in2: i64) -> i64 {
-    add_datetime_time(in1, in2)
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// Compatibility symbol for LDT + LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD__LDT__LTIME(in1: i64, in2: i64) -> i64 {
-    add_datetime_time(in1, in2)
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// Compatibility symbol for LTIME - LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB__LTIME__LTIME(in1: i64, in2: i64) -> i64 {
-    in1.checked_sub(in2).unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Compatibility symbol for LDATE - LDATE overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB__LDATE__LDATE(in1: i64, in2: i64) -> i64 {
-    sub_datetimes(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Compatibility symbol for LTOD - LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB__LTOD__LTIME(in1: i64, in2: i64) -> i64 {
-    sub_datetime_duration(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Compatibility symbol for LTOD - LTOD overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB__LTOD__LTOD(in1: i64, in2: i64) -> i64 {
-    sub_datetimes(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Compatibility symbol for LDT - LTIME overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB__LDT__LTIME(in1: i64, in2: i64) -> i64 {
-    sub_datetime_duration(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Compatibility symbol for LDT - LDT overload resolution.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB__LDT__LDT(in1: i64, in2: i64) -> i64 {
-    sub_datetimes(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Compatibility alias for LDATE_AND_TIME + LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1191,7 +1162,7 @@ pub extern "C-unwind" fn ADD__LDATE_AND_TIME__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LTIME_OF_DAY + LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1201,7 +1172,7 @@ pub extern "C-unwind" fn ADD__LTIME_OF_DAY__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LDATE_AND_TIME - LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1211,7 +1182,7 @@ pub extern "C-unwind" fn SUB__LDATE_AND_TIME__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LDATE_AND_TIME - LDATE_AND_TIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1221,7 +1192,7 @@ pub extern "C-unwind" fn SUB__LDATE_AND_TIME__LDATE_AND_TIME(in1: i64, in2: i64)
 
 /// .
 /// Compatibility alias for LTIME_OF_DAY - LTIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -1231,7 +1202,7 @@ pub extern "C-unwind" fn SUB__LTIME_OF_DAY__LTIME(in1: i64, in2: i64) -> i64 {
 
 /// .
 /// Compatibility alias for LTIME_OF_DAY - LTIME_OF_DAY.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]

--- a/libs/stdlib/tests/date_time_numeric_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_numeric_functions_tests.rs
@@ -1174,101 +1174,141 @@ fn date_time_overloaded_add_and_numerical_add_compile_correctly() {
     assert_eq!(18.0, maintype.b);
 }
 
-macro_rules! panic_i64_i64_tests {
-    ($(($name:ident, $func:path, $lhs:expr, $rhs:expr)),+ $(,)?) => {
+macro_rules! wrapping_tests {
+    ($(($name:ident, $func:path, $lhs:expr, $rhs:expr, $expected:expr)),+ $(,)?) => {
         $(
             #[test]
-            #[should_panic]
             fn $name() {
-                let _ = $func($lhs, $rhs);
+                assert_eq!($func($lhs, $rhs), $expected);
             }
         )+
     };
 }
 
-macro_rules! panic_i64_i8_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_i8);
-            }
-        )+
-    };
-}
+// Overflow at the top of the range: MAX + 1 rolls over to the minimum (0 or i64::MIN).
+wrapping_tests!(
+    (add_time_wraps_on_overflow, dtf::ADD_TIME, u32::MAX, 1, 0),
+    (add_dt_time_wraps_on_overflow, dtf::ADD_DT_TIME, u32::MAX, 1_000, 0),
+    (add_ltime_wraps_on_overflow, dtf::ADD_LTIME, i64::MAX, 1, i64::MIN),
+    (add_ltod_ltime_wraps_on_overflow, dtf::ADD_LTOD_LTIME, i64::MAX, 1, i64::MIN),
+    (add_ldt_ltime_wraps_on_overflow, dtf::ADD_LDT_LTIME, i64::MAX, 1, i64::MIN),
+);
 
-macro_rules! panic_i64_i16_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_i16);
-            }
-        )+
-    };
-}
+// Underflow below zero: the deficit reappears at the top of the range,
+// e.g. 2_000 - 5_000 = MAX - 2_999; the largest delta MAX - MIN wraps to -1.
+wrapping_tests!(
+    (sub_time_wraps_on_underflow, dtf::SUB_TIME, 2_000, 5_000, u32::MAX - 2_999),
+    (sub_tod_tod_wraps_on_underflow, dtf::SUB_TOD_TOD, 1_000, 2_000, u32::MAX - 999),
+    (sub_dt_time_wraps_on_underflow, dtf::SUB_DT_TIME, 0, 1_000, u32::MAX),
+    (sub_ltime_wraps_on_underflow, dtf::SUB_LTIME, i64::MIN, 1, i64::MAX),
+    (sub_ltod_ltime_wraps_on_underflow, dtf::SUB_LTOD_LTIME, i64::MIN, 1, i64::MAX),
+    (sub_ldt_ltime_wraps_on_underflow, dtf::SUB_LDT_LTIME, i64::MIN, 1, i64::MAX),
+    (sub_ldate_ldate_wraps_on_large_delta, dtf::SUB_LDATE_LDATE, i64::MAX, i64::MIN, -1),
+    (sub_ltod_ltod_wraps_on_large_delta, dtf::SUB_LTOD_LTOD, i64::MAX, i64::MIN, -1),
+    (sub_ldt_ldt_wraps_on_large_delta, dtf::SUB_LDT_LDT, i64::MAX, i64::MIN, -1),
+);
 
-macro_rules! panic_i64_i32_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_i32);
-            }
-        )+
-    };
-}
+// DATE/DT differences return TIME in milliseconds. A delta above the ~49.7 day TIME range
+// wraps during the seconds to milliseconds conversion:
+// 50 days = 4_320_000_000 ms = 25_032_704 mod 2^32.
+wrapping_tests!(
+    (
+        sub_date_date_wraps_when_time_difference_exceeds_time_range,
+        dtf::SUB_DATE_DATE,
+        50 * 24 * 60 * 60,
+        0,
+        25_032_704
+    ),
+    (
+        sub_dt_dt_wraps_when_time_difference_exceeds_time_range,
+        dtf::SUB_DT_DT,
+        50 * 24 * 60 * 60,
+        0,
+        25_032_704
+    ),
+);
 
-macro_rules! panic_i64_u8_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u8);
-            }
-        )+
-    };
-}
+// The compatibility aliases carry their own wrapping bodies, so every exported symbol
+// is checked with the same boundary values as the named functions above.
+wrapping_tests!(
+    (add_alias_ltime_ltime_wraps_on_overflow, dtf::ADD__LTIME__LTIME, i64::MAX, 1, i64::MIN),
+    (add_alias_ltod_ltime_wraps_on_overflow, dtf::ADD__LTOD__LTIME, i64::MAX, 1, i64::MIN),
+    (add_alias_ldt_ltime_wraps_on_overflow, dtf::ADD__LDT__LTIME, i64::MAX, 1, i64::MIN),
+    (sub_alias_ltime_ltime_wraps_on_underflow, dtf::SUB__LTIME__LTIME, i64::MIN, 1, i64::MAX),
+    (sub_alias_ldate_ldate_wraps_on_large_delta, dtf::SUB__LDATE__LDATE, i64::MAX, i64::MIN, -1),
+    (sub_alias_ltod_ltime_wraps_on_underflow, dtf::SUB__LTOD__LTIME, i64::MIN, 1, i64::MAX),
+    (sub_alias_ltod_ltod_wraps_on_large_delta, dtf::SUB__LTOD__LTOD, i64::MAX, i64::MIN, -1),
+    (sub_alias_ldt_ltime_wraps_on_underflow, dtf::SUB__LDT__LTIME, i64::MIN, 1, i64::MAX),
+    (sub_alias_ldt_ldt_wraps_on_large_delta, dtf::SUB__LDT__LDT, i64::MAX, i64::MIN, -1),
+    (
+        add_alias_ldate_and_time_ltime_wraps_on_overflow,
+        dtf::ADD__LDATE_AND_TIME__LTIME,
+        i64::MAX,
+        1,
+        i64::MIN
+    ),
+    (add_alias_ltime_of_day_ltime_wraps_on_overflow, dtf::ADD__LTIME_OF_DAY__LTIME, i64::MAX, 1, i64::MIN),
+    (
+        sub_alias_ldate_and_time_ltime_wraps_on_underflow,
+        dtf::SUB__LDATE_AND_TIME__LTIME,
+        i64::MIN,
+        1,
+        i64::MAX
+    ),
+    (
+        sub_alias_ldate_and_time_ldate_and_time_wraps_on_large_delta,
+        dtf::SUB__LDATE_AND_TIME__LDATE_AND_TIME,
+        i64::MAX,
+        i64::MIN,
+        -1
+    ),
+    (sub_alias_ltime_of_day_ltime_wraps_on_underflow, dtf::SUB__LTIME_OF_DAY__LTIME, i64::MIN, 1, i64::MAX),
+    (
+        sub_alias_ltime_of_day_ltime_of_day_wraps_on_large_delta,
+        dtf::SUB__LTIME_OF_DAY__LTIME_OF_DAY,
+        i64::MAX,
+        i64::MIN,
+        -1
+    ),
+);
 
-macro_rules! panic_i64_u16_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u16);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u32_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u32);
-            }
-        )+
-    };
-}
-
-macro_rules! panic_i64_u64_tests {
-    ($(($name:ident, $func:path)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func(i64::MAX, 2_u64);
-            }
-        )+
-    };
-}
+// MUL: i64::MAX * 2 wraps to -2 for every factor width. The last case uses a factor
+// above i64::MAX to check that the u64 to i64 cast keeps the result correct mod 2^64.
+wrapping_tests!(
+    (mul_time_lint_wraps_on_overflow, dtf::MUL__TIME__LINT, i64::MAX, 2, -2),
+    (mul_time_lint_alias_wraps_on_overflow, dtf::MUL_TIME__LINT, i64::MAX, 2, -2),
+    (mul_ltime_lint_wraps_on_overflow, dtf::MUL_LTIME__LINT, i64::MAX, 2, -2),
+    (mul_alias_ltime_lint_wraps_on_overflow, dtf::MUL__LTIME__LINT, i64::MAX, 2, -2),
+    (mul_time_sint_wraps_on_overflow, dtf::MUL__TIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_time_sint_alias_wraps_on_overflow, dtf::MUL_TIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_ltime_sint_wraps_on_overflow, dtf::MUL_LTIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_alias_ltime_sint_wraps_on_overflow, dtf::MUL__LTIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_time_int_wraps_on_overflow, dtf::MUL__TIME__INT, i64::MAX, 2_i16, -2),
+    (mul_time_int_alias_wraps_on_overflow, dtf::MUL_TIME__INT, i64::MAX, 2_i16, -2),
+    (mul_ltime_int_wraps_on_overflow, dtf::MUL_LTIME__INT, i64::MAX, 2_i16, -2),
+    (mul_alias_ltime_int_wraps_on_overflow, dtf::MUL__LTIME__INT, i64::MAX, 2_i16, -2),
+    (mul_time_dint_wraps_on_overflow, dtf::MUL__TIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_time_dint_alias_wraps_on_overflow, dtf::MUL_TIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_ltime_dint_wraps_on_overflow, dtf::MUL_LTIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_alias_ltime_dint_wraps_on_overflow, dtf::MUL__LTIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_time_usint_wraps_on_overflow, dtf::MUL__TIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_time_usint_alias_wraps_on_overflow, dtf::MUL_TIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_ltime_usint_wraps_on_overflow, dtf::MUL_LTIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_alias_ltime_usint_wraps_on_overflow, dtf::MUL__LTIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_time_uint_wraps_on_overflow, dtf::MUL__TIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_time_uint_alias_wraps_on_overflow, dtf::MUL_TIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_ltime_uint_wraps_on_overflow, dtf::MUL_LTIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_alias_ltime_uint_wraps_on_overflow, dtf::MUL__LTIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_time_udint_wraps_on_overflow, dtf::MUL__TIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_time_udint_alias_wraps_on_overflow, dtf::MUL_TIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_ltime_udint_wraps_on_overflow, dtf::MUL_LTIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_alias_ltime_udint_wraps_on_overflow, dtf::MUL__LTIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_time_ulint_wraps_on_overflow, dtf::MUL__TIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_time_ulint_alias_wraps_on_overflow, dtf::MUL_TIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_ltime_ulint_wraps_on_overflow, dtf::MUL_LTIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_alias_ltime_ulint_wraps_on_overflow, dtf::MUL__LTIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_time_ulint_wraps_when_factor_exceeds_lint, dtf::MUL__TIME__ULINT, 1, u64::MAX, -1),
+);
 
 macro_rules! panic_i64_f32_mul_tests {
     ($(($name:ident, $func:path)),+ $(,)?) => {
@@ -1413,118 +1453,6 @@ macro_rules! panic_i64_f64_div_zero_tests {
         )+
     };
 }
-
-macro_rules! panic_u32_u32_tests {
-    ($(($name:ident, $func:path, $lhs:expr, $rhs:expr)),+ $(,)?) => {
-        $(
-            #[test]
-            #[should_panic]
-            fn $name() {
-                let _ = $func($lhs, $rhs);
-            }
-        )+
-    };
-}
-
-panic_u32_u32_tests!(
-    (add_time_panics_on_overflow, dtf::ADD_TIME, u32::MAX, 1),
-    (add_dt_time_panics_on_overflow, dtf::ADD_DT_TIME, u32::MAX, 1_000),
-    (sub_time_panics_on_underflow, dtf::SUB_TIME, 2_000, 5_000),
-    (sub_date_date_panics_when_time_difference_exceeds_time_range, dtf::SUB_DATE_DATE, 50 * 24 * 60 * 60, 0),
-    (sub_tod_tod_panics_on_underflow, dtf::SUB_TOD_TOD, 1_000, 2_000),
-    (sub_dt_time_panics_on_underflow, dtf::SUB_DT_TIME, 0, 1_000),
-    (sub_dt_dt_panics_when_time_difference_exceeds_time_range, dtf::SUB_DT_DT, 50 * 24 * 60 * 60, 0)
-);
-
-panic_i64_i64_tests!(
-    (add_ltime_panics_on_overflow, dtf::ADD_LTIME, i64::MAX, 1),
-    (add_ltod_ltime_panics_on_overflow, dtf::ADD_LTOD_LTIME, i64::MAX, 1),
-    (add_ldt_ltime_panics_on_overflow, dtf::ADD_LDT_LTIME, i64::MAX, 1),
-    (sub_ltime_panics_on_underflow, dtf::SUB_LTIME, i64::MIN, 1),
-    (sub_ldate_ldate_panics_on_large_delta, dtf::SUB_LDATE_LDATE, i64::MAX, i64::MIN),
-    (sub_ltod_ltime_panics_on_underflow, dtf::SUB_LTOD_LTIME, i64::MIN, 1),
-    (sub_ltod_ltod_panics_on_large_delta, dtf::SUB_LTOD_LTOD, i64::MAX, i64::MIN),
-    (sub_ldt_ltime_panics_on_underflow, dtf::SUB_LDT_LTIME, i64::MIN, 1),
-    (sub_ldt_ldt_panics_on_large_delta, dtf::SUB_LDT_LDT, i64::MAX, i64::MIN),
-    (add_alias_ltime_ltime_panics_on_overflow, dtf::ADD__LTIME__LTIME, i64::MAX, 1),
-    (add_alias_ltod_ltime_panics_on_overflow, dtf::ADD__LTOD__LTIME, i64::MAX, 1),
-    (add_alias_ldt_ltime_panics_on_overflow, dtf::ADD__LDT__LTIME, i64::MAX, 1),
-    (sub_alias_ltime_ltime_panics_on_underflow, dtf::SUB__LTIME__LTIME, i64::MIN, 1),
-    (sub_alias_ldate_ldate_panics_on_large_delta, dtf::SUB__LDATE__LDATE, i64::MAX, i64::MIN),
-    (sub_alias_ltod_ltime_panics_on_underflow, dtf::SUB__LTOD__LTIME, i64::MIN, 1),
-    (sub_alias_ltod_ltod_panics_on_large_delta, dtf::SUB__LTOD__LTOD, i64::MAX, i64::MIN),
-    (sub_alias_ldt_ltime_panics_on_underflow, dtf::SUB__LDT__LTIME, i64::MIN, 1),
-    (sub_alias_ldt_ldt_panics_on_large_delta, dtf::SUB__LDT__LDT, i64::MAX, i64::MIN),
-    (add_alias_ldate_and_time_ltime_panics_on_overflow, dtf::ADD__LDATE_AND_TIME__LTIME, i64::MAX, 1),
-    (add_alias_ltime_of_day_ltime_panics_on_overflow, dtf::ADD__LTIME_OF_DAY__LTIME, i64::MAX, 1),
-    (sub_alias_ldate_and_time_ltime_panics_on_underflow, dtf::SUB__LDATE_AND_TIME__LTIME, i64::MIN, 1),
-    (
-        sub_alias_ldate_and_time_ldate_and_time_panics_on_large_delta,
-        dtf::SUB__LDATE_AND_TIME__LDATE_AND_TIME,
-        i64::MAX,
-        i64::MIN
-    ),
-    (sub_alias_ltime_of_day_ltime_panics_on_underflow, dtf::SUB__LTIME_OF_DAY__LTIME, i64::MIN, 1),
-    (
-        sub_alias_ltime_of_day_ltime_of_day_panics_on_large_delta,
-        dtf::SUB__LTIME_OF_DAY__LTIME_OF_DAY,
-        i64::MAX,
-        i64::MIN
-    ),
-    (mul_time_lint_panics_on_overflow, dtf::MUL__TIME__LINT, i64::MAX, 2),
-    (mul_time_lint_alias_panics_on_overflow, dtf::MUL_TIME__LINT, i64::MAX, 2),
-    (mul_ltime_lint_panics_on_overflow, dtf::MUL_LTIME__LINT, i64::MAX, 2),
-    (mul_alias_ltime_lint_panics_on_overflow, dtf::MUL__LTIME__LINT, i64::MAX, 2)
-);
-
-panic_i64_i8_tests!(
-    (mul_time_sint_panics_on_overflow, dtf::MUL__TIME__SINT),
-    (mul_time_sint_alias_panics_on_overflow, dtf::MUL_TIME__SINT),
-    (mul_ltime_sint_panics_on_overflow, dtf::MUL_LTIME__SINT),
-    (mul_alias_ltime_sint_panics_on_overflow, dtf::MUL__LTIME__SINT)
-);
-
-panic_i64_i16_tests!(
-    (mul_time_int_panics_on_overflow, dtf::MUL__TIME__INT),
-    (mul_time_int_alias_panics_on_overflow, dtf::MUL_TIME__INT),
-    (mul_ltime_int_panics_on_overflow, dtf::MUL_LTIME__INT),
-    (mul_alias_ltime_int_panics_on_overflow, dtf::MUL__LTIME__INT)
-);
-
-panic_i64_i32_tests!(
-    (mul_time_dint_panics_on_overflow, dtf::MUL__TIME__DINT),
-    (mul_time_dint_alias_panics_on_overflow, dtf::MUL_TIME__DINT),
-    (mul_ltime_dint_panics_on_overflow, dtf::MUL_LTIME__DINT),
-    (mul_alias_ltime_dint_panics_on_overflow, dtf::MUL__LTIME__DINT)
-);
-
-panic_i64_u8_tests!(
-    (mul_time_usint_panics_on_overflow, dtf::MUL__TIME__USINT),
-    (mul_time_usint_alias_panics_on_overflow, dtf::MUL_TIME__USINT),
-    (mul_ltime_usint_panics_on_overflow, dtf::MUL_LTIME__USINT),
-    (mul_alias_ltime_usint_panics_on_overflow, dtf::MUL__LTIME__USINT)
-);
-
-panic_i64_u16_tests!(
-    (mul_time_uint_panics_on_overflow, dtf::MUL__TIME__UINT),
-    (mul_time_uint_alias_panics_on_overflow, dtf::MUL_TIME__UINT),
-    (mul_ltime_uint_panics_on_overflow, dtf::MUL_LTIME__UINT),
-    (mul_alias_ltime_uint_panics_on_overflow, dtf::MUL__LTIME__UINT)
-);
-
-panic_i64_u32_tests!(
-    (mul_time_udint_panics_on_overflow, dtf::MUL__TIME__UDINT),
-    (mul_time_udint_alias_panics_on_overflow, dtf::MUL_TIME__UDINT),
-    (mul_ltime_udint_panics_on_overflow, dtf::MUL_LTIME__UDINT),
-    (mul_alias_ltime_udint_panics_on_overflow, dtf::MUL__LTIME__UDINT)
-);
-
-panic_i64_u64_tests!(
-    (mul_time_ulint_panics_on_overflow, dtf::MUL__TIME__ULINT),
-    (mul_time_ulint_alias_panics_on_overflow, dtf::MUL_TIME__ULINT),
-    (mul_ltime_ulint_panics_on_overflow, dtf::MUL_LTIME__ULINT),
-    (mul_alias_ltime_ulint_panics_on_overflow, dtf::MUL__LTIME__ULINT)
-);
 
 panic_i64_f32_mul_tests!(
     (mul_time_real_panics_on_overflow, dtf::MUL__TIME__REAL),

--- a/tests/lit/single/stdlib_overflow/README.md
+++ b/tests/lit/single/stdlib_overflow/README.md
@@ -1,10 +1,10 @@
 # Standard Library Overflow Tests
 
-This directory contains integration tests for stdlib functions that are expected to panic on overflow or division by zero conditions.
+This directory contains integration tests for stdlib functions on overflow, underflow, and division-by-zero inputs.
 
 ## Background
 
-These tests were originally part of the Rust integration test suite in `libs/stdlib/tests/date_time_numeric_functions_tests.rs`, but they could not be properly tested there because:
+These tests were originally part of the Rust integration test suite in `libs/stdlib/tests/date_time_numeric_functions_tests.rs`, but panic behavior could not be tested there because:
 
 1. The Rust test infrastructure compiles PLC code into a shared library and loads it dynamically using `libloading`
 2. When a panic occurs in dynamically loaded code, Rust's panic unwinding mechanism cannot cross the FFI boundary
@@ -13,73 +13,37 @@ These tests were originally part of the Rust integration test suite in `libs/std
    fatal runtime error: Rust cannot catch foreign exceptions, aborting
    ```
 
-## Solution
-
-These tests have been moved to the lit test framework where they can be marked with `XFAIL: *` to indicate they are expected to fail at runtime. This properly documents the expected panic behavior without breaking the test suite.
-
 ## Test Coverage
 
-The following overflow/panic conditions are tested:
+### TIME Arithmetic (wrapping)
 
-### TIME Arithmetic Overflow
-- `add_time_overflow.st` - Adding to max TIME value
-- `sub_time_overflow.st` - Subtracting from min TIME value
+The stdlib ADD/SUB/MUL date and time functions wrap on overflow, exactly like the CODESYS operators. These tests run to completion and check the wrapped values:
 
-### TIME Multiplication Overflow
-- `mul_time_signed_overflow.st` - Multiplying TIME by max LINT
-- `mul_time_unsigned_overflow.st` - Multiplying TIME by max ULINT
+- `add_time_overflow.st` - ADD/ADD_TIME past the TIME range wraps mod 2^32
+- `sub_time_overflow.st` - SUB/SUB_TIME below zero and SUB_DATE_DATE past the TIME range wrap mod 2^32
+- `mul_time_signed_overflow.st` - MUL with a signed integer wraps mod 2^64
+- `mul_time_unsigned_overflow.st` - MUL with an unsigned integer wraps mod 2^64
+- `dt_tod_overflow.st` - ADD_DT_TIME/SUB_DT_TIME past the DT range and SUB_TOD_TOD below zero wrap mod 2^32
+
+### Panic Conditions (`XFAIL: *`)
+
+The remaining conditions still panic at runtime. Their tests carry `XFAIL: *`, so a non-zero exit code is treated as success:
+
 - `mul_time_real_overflow.st` - Multiplying TIME by max REAL
 - `mul_time_lreal_overflow.st` - Multiplying TIME by large LREAL
-
-### Division by Zero
 - `div_time_by_zero.st` - Dividing TIME by zero (LINT)
 - `div_time_by_real_zero.st` - Dividing TIME by zero (REAL)
 - `div_time_by_lreal_zero.st` - Dividing TIME by zero (LREAL)
-
-## Test Format
-
-All tests follow this pattern:
-
-```st
-// RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test description
-
-PROGRAM main
-VAR
-    a : TIME;
-END_VAR
-    // Operation that causes overflow/panic
-    a := <operation>;
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
-```
-
-The `XFAIL: *` directive tells lit that this test is expected to fail (panic), so a non-zero exit code is treated as success.
+- `right_string_substring_too_long.st` / `right_wstring_substring_too_long.st` - RIGHT with a length above the string length
 
 ## Running the Tests
 
 To run all stdlib overflow tests:
 ```bash
-lit -v tests/lit/single/stdlib_overflow/
+lit -v -DLIB=output -DCOMPILER=target/debug/plc tests/lit/single/stdlib_overflow/
 ```
 
 Or run the entire lit test suite:
 ```bash
-./scripts/build.sh --build --lit
+./scripts/build.sh --lit
 ```
-
-## Expected Output
-
-When running these tests, you should see:
-```
-XFAIL: <unnamed> :: single/stdlib_overflow/add_time_overflow.st
-XFAIL: <unnamed> :: single/stdlib_overflow/sub_time_overflow.st
-...
-
-Total Discovered Tests: 9
-  Expectedly Failed: 9 (100.00%)
-```
-
-This indicates all tests behaved as expected (they panicked).

--- a/tests/lit/single/stdlib_overflow/add_time_overflow.st
+++ b/tests/lit/single/stdlib_overflow/add_time_overflow.st
@@ -1,13 +1,18 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that ADD with TIME overflow causes a panic
+// Test that ADD with TIME wraps mod 2^32 on overflow, matching CODESYS
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
+    b : TIME;
 END_VAR
-    // Adding 1ms to max TIME value should overflow and panic
-    a := ADD(TIME#9223372036854775807ms, TIME#1ms);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := ADD(TIME#4294967295ms, TIME#1ms);
+    // CHECK: 0
+    printf('%u$N', a);
+
+    b := ADD_TIME(TIME#49d17h2m47s294ms, TIME#10s);
+    // CHECK: 9998
+    printf('%u$N', b);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/dt_tod_overflow.st
+++ b/tests/lit/single/stdlib_overflow/dt_tod_overflow.st
@@ -1,0 +1,23 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that DT and TOD arithmetic wraps mod 2^32 on overflow and underflow
+
+FUNCTION main : DINT
+VAR
+    a : DT;
+    b : DT;
+    c : TIME;
+END_VAR
+    a := ADD_DT_TIME(DT#2106-02-07-06:28:00, TIME#1m);
+    // CHECK: 44
+    printf('%u$N', a);
+
+    b := SUB_DT_TIME(DT#1970-01-01-01:00:00, TIME#2h);
+    // CHECK: 4294963696
+    printf('%u$N', b);
+
+    c := SUB_TOD_TOD(TOD#01:00:00, TOD#02:00:00);
+    // CHECK: 4291367296
+    printf('%u$N', c);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_signed_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_signed_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and signed integer overflow causes a panic
+// Test that MUL with TIME and a signed integer wraps mod 2^64 on overflow
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by max LINT value should overflow and panic
-    a := MUL(TIME#10ns, LINT#9223372036854775807);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := MUL(TIME#2ms, LINT#9223372036854775807);
+    // CHECK: 4294967294
+    printf('%u$N', a);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_unsigned_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_unsigned_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and unsigned integer overflow causes a panic
+// Test that MUL with TIME and an unsigned integer wraps mod 2^64 on overflow
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by max ULINT value should overflow and panic
-    a := MUL(TIME#1ns, ULINT#9223372036854775808);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := MUL(TIME#1ms, ULINT#18446744073709551615);
+    // CHECK: 4294967295
+    printf('%u$N', a);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/sub_time_overflow.st
+++ b/tests/lit/single/stdlib_overflow/sub_time_overflow.st
@@ -1,13 +1,24 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that SUB with TIME overflow causes a panic
+// Test that SUB with TIME and DATE wraps mod 2^32 on underflow, matching CODESYS
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
+    b : TIME;
+    c : TIME;
 END_VAR
-    // Subtracting from minimum TIME value should overflow and panic
-    a := SUB(TIME#-9223372036854775807ms, TIME#1ms);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := SUB(TIME#1s, TIME#5s);
+    // CHECK: 4294963296
+    printf('%u$N', a);
+
+    b := SUB_TIME(TIME#2s, TIME#5s);
+    // CHECK: 4294964296
+    printf('%u$N', b);
+
+    // 152 days exceed the TIME range in milliseconds; the result wraps
+    c := SUB_DATE_DATE(DATE#2024-06-01, DATE#2024-01-01);
+    // CHECK: 247898112
+    printf('%u$N', c);
+
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Problem: The stdlib ADD/SUB/MUL date and time functions use checked arithmetic and abort the whole runtime process on overflow or underflow. Even valid inputs crash, for example SUB_DATE_DATE with dates more than 49 days apart, because a DATE difference does not always fit the TIME result type.

Solution: Compute with wrapping arithmetic mod 2^32/2^64, matching the behavior of RuSTy's own operator lowering, and assert the wrapped values in unit, integration, and lit tests.

Refs: PRG-4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)