### PR TITLE
fix: run the backend at -Oless for unoptimized builds

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -128,7 +128,7 @@ impl<'ink> CodeGen<'ink> {
                 &triple,
                 "generic", // CPU features - generic for portability
                 "",        // CPU features - empty string for default
-                optimization_level.into(),
+                optimization_level.codegen_level(),
                 inkwell::targets::RelocMode::Default,
                 inkwell::targets::CodeModel::Default,
             )
@@ -564,7 +564,7 @@ impl<'ink> GeneratedModule<'ink> {
                 //TODO : Add cpu features as optionals
                 "generic", //TargetMachine::get_host_cpu_name().to_string().as_str(),
                 "",        //TargetMachine::get_host_cpu_features().to_string().as_str(),
-                optimization_level.into(),
+                optimization_level.codegen_level(),
                 reloc,
                 CodeModel::Default,
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,18 @@ impl OptimizationLevel {
     fn is_optimized(&self) -> bool {
         !matches!(self, OptimizationLevel::None)
     }
+
+    /// The backend (`TargetMachine`) level backing this optimization level. `None` keeps
+    /// the IR pipeline at O0 (see `opt_params` — no inlining, unrolling or other
+    /// debug-hostile IR transforms) but raises the codegen level to `Less` so the
+    /// machine pipeline runs; most importantly LLVM's stack coloring, which merges the
+    /// lifetime-bracketed call temporaries and keeps string-heavy POU frames bounded.
+    fn codegen_level(&self) -> inkwell::OptimizationLevel {
+        match self {
+            OptimizationLevel::None => inkwell::OptimizationLevel::Less,
+            _ => (*self).into(),
+        }
+    }
 }
 
 #[macro_use]


### PR DESCRIPTION
Problem: `-Onone` builds keep one dead stack slot per lowered call temporary, because LLVM stack coloring is a machine pass that only runs when the backend optimizes. String-heavy POU bodies overflow constrained task stacks at entry (a representative function block needed about 112 KB of frame).

Solution: Decouple the two optimization dials. `-Onone` keeps the IR pipeline at `default<O0>`, so no inlining, unrolling, or other debug-hostile IR transforms occur, but the `TargetMachine` is created at codegen level `Less` so the machine pipeline runs, including stack coloring. This ports #1821 from `release/1.0.x` to master, so both branches hold the same state until we decide which optimization settings make the most sense. The companion change (#1803, lifetime markers for lowered call temporaries) is already on master.

Cherry-picked from 1fe08c202132b1e93132dae94de4e58cdc00dacd.

## Testing

`cargo test --workspace`: all compiler suites pass (2599 unit tests, 415 integration tests, no snapshot drift). `cargo fmt --all` and `cargo clippy --workspace` are clean.

The `iec61131std` integration suites and `./scripts/build.sh --lit` could not run in my environment, because `cl.exe` is not available and `libiec61131std.a` cannot be produced. Both fail identically on unmodified master, so they are unrelated to this change; CI covers them.

Refs: original PR #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
