### PR TITLE
fix(stdlib): saturate LDT date conversion, add defensive defaults

### DIFF
--- a/libs/stdlib/src/date_time_conversion.rs
+++ b/libs/stdlib/src/date_time_conversion.rs
@@ -1,8 +1,7 @@
-use chrono::{TimeZone, Timelike};
-
 const NANOS_PER_MILLISECOND: i64 = 1_000 * 1_000;
 const NANOS_PER_SECOND: i64 = 1_000 * 1_000 * 1_000;
 const SECONDS_PER_DAY: u32 = 60 * 60 * 24;
+const NANOS_PER_DAY: i64 = NANOS_PER_SECOND * SECONDS_PER_DAY as i64;
 
 /// .
 /// Converts DT to DATE
@@ -10,31 +9,18 @@ const SECONDS_PER_DAY: u32 = 60 * 60 * 24;
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_DATE(input: u32) -> u32 {
-    let input_seconds = input as i64;
-    let date_time = chrono::Utc.timestamp_opt(input_seconds, 0).single().expect("Out of range DT value");
-
-    let midnight_seconds = date_time
-        .date_naive()
-        .and_hms_opt(0, 0, 0)
-        .expect("Cannot create date time from date")
-        .and_utc()
-        .timestamp();
-
-    midnight_seconds as u32
+    (input / SECONDS_PER_DAY) * SECONDS_PER_DAY
 }
 
 /// .
 /// Converts LDT to LDATE
+/// The midnight of the first representable day lies below the LDATE range and
+/// saturates to the range minimum
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn LDATE_AND_TIME_TO_LDATE(input: i64) -> i64 {
-    let date_time = chrono::Utc.timestamp_nanos(input);
-
-    let new_date_time =
-        date_time.date_naive().and_hms_opt(0, 0, 0).expect("Cannot create date time from date");
-
-    new_date_time.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create DATE")
+    input.div_euclid(NANOS_PER_DAY).checked_mul(NANOS_PER_DAY).unwrap_or(i64::MIN)
 }
 
 /// .
@@ -43,15 +29,7 @@ pub extern "C" fn LDATE_AND_TIME_TO_LDATE(input: i64) -> i64 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_TIME_OF_DAY(input: u32) -> u32 {
-    let input_seconds = input as i64;
-    let date_time = chrono::Utc.timestamp_opt(input_seconds, 0).single().expect("Out of range DT value");
-
-    let midnight = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
-        .and_then(|date| date.and_hms_opt(date_time.hour(), date_time.minute(), date_time.second()))
-        .expect("Cannot create date time from given parameters")
-        .and_utc();
-
-    midnight.timestamp_millis() as u32
+    (input % SECONDS_PER_DAY) * 1_000
 }
 
 /// .
@@ -60,17 +38,7 @@ pub extern "C" fn DATE_AND_TIME_TO_TIME_OF_DAY(input: u32) -> u32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn LDATE_AND_TIME_TO_LTIME_OF_DAY(input: i64) -> i64 {
-    let date_time = chrono::Utc.timestamp_nanos(input);
-    let hour = date_time.hour();
-    let min = date_time.minute();
-    let sec = date_time.second();
-    let nano = date_time.timestamp_subsec_nanos();
-
-    let new_date_time = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
-        .and_then(|date| date.and_hms_nano_opt(hour, min, sec, nano))
-        .expect("Cannot create date time from given parameters");
-
-    new_date_time.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create TOD")
+    input.rem_euclid(NANOS_PER_DAY)
 }
 
 /// .

--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -6,7 +6,16 @@ const NANOS_PER_MILLISECOND: i64 = 1_000 * 1_000;
 const NANOS_PER_SECOND: i64 = 1_000 * 1_000 * 1_000;
 
 fn dt_from_epoch_seconds(seconds: u32) -> chrono::DateTime<chrono::Utc> {
-    chrono::Utc.timestamp_opt(seconds as i64, 0).single().expect("Out of range")
+    // every u32 second count is a valid timestamp (1970 to 2106)
+    chrono::Utc.timestamp_opt(seconds as i64, 0).single().unwrap_or(chrono::DateTime::UNIX_EPOCH)
+}
+
+/// Narrows a year to the split output type. DATE/DT years span 1970-2106 and LDT
+/// years span 1677-2262, so every target type fits; the default covers a future
+/// change of those representations.
+fn year_component<T: TryFrom<i32> + Default>(year: i32) -> T {
+    debug_assert!(T::try_from(year).is_ok(), "year out of range for the target type");
+    T::try_from(year).unwrap_or_default()
 }
 
 fn split_tod_fields(millis: u32) -> (u32, u32, u32, u32) {
@@ -417,8 +426,7 @@ pub extern "C" fn concat_ldt(
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__INT(in1: u32, out1: &mut i16, out2: &mut i16, out3: &mut i16) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month() as i16;
     *out3 = date.day() as i16;
 
@@ -427,14 +435,12 @@ pub extern "C" fn SPLIT_DATE__INT(in1: u32, out1: &mut i16, out2: &mut i16, out3
 
 /// .
 /// Splits DATE into year, month, day of type UINT
-/// Panics on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__UINT(in1: u32, out1: &mut u16, out2: &mut u16, out3: &mut u16) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month() as u16;
     *out3 = date.day() as u16;
 
@@ -462,8 +468,7 @@ pub extern "C" fn SPLIT_DATE__DINT(in1: u32, out1: &mut i32, out2: &mut i32, out
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__UDINT(in1: u32, out1: &mut u32, out2: &mut u32, out3: &mut u32) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month();
     *out3 = date.day();
 
@@ -477,7 +482,6 @@ pub extern "C" fn SPLIT_DATE__UDINT(in1: u32, out1: &mut u32, out2: &mut u32, ou
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__LINT(in1: u32, out1: &mut i64, out2: &mut i64, out3: &mut i64) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
     *out1 = date.year().into();
     *out2 = date.month() as i64;
     *out3 = date.day() as i64;
@@ -487,14 +491,12 @@ pub extern "C" fn SPLIT_DATE__LINT(in1: u32, out1: &mut i64, out2: &mut i64, out
 
 /// .
 /// Splits DATE into year, month, day of type ULINT
-/// Panics on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__ULINT(in1: u32, out1: &mut u64, out2: &mut u64, out3: &mut u64) -> i16 {
     let date = dt_from_epoch_seconds(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month() as u64;
     *out3 = date.day() as u64;
 
@@ -769,8 +771,7 @@ pub extern "C" fn SPLIT_DT__INT(
     out7: &mut i16,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month() as i16;
     *out3 = dt.day() as i16;
     *out4 = dt.hour() as i16;
@@ -797,8 +798,7 @@ pub extern "C" fn SPLIT_DT__UINT(
     out7: &mut u16,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month() as u16;
     *out3 = dt.day() as u16;
     *out4 = dt.hour() as u16;
@@ -852,8 +852,7 @@ pub extern "C" fn SPLIT_DT__UDINT(
     out7: &mut u32,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month();
     *out3 = dt.day();
     *out4 = dt.hour();
@@ -880,7 +879,6 @@ pub extern "C" fn SPLIT_DT__LINT(
     out7: &mut i64,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
     *out1 = dt.year().into();
     *out2 = dt.month() as i64;
     *out3 = dt.day() as i64;
@@ -908,8 +906,7 @@ pub extern "C" fn SPLIT_DT__ULINT(
     out7: &mut u64,
 ) -> i16 {
     let dt = dt_from_epoch_seconds(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month() as u64;
     *out3 = dt.day() as u64;
     *out4 = dt.hour() as u64;
@@ -936,7 +933,7 @@ pub extern "C" fn SPLIT_LDT__INT(
     out7: &mut i16,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year_component(year);
     *out2 = month as i16;
     *out3 = day as i16;
     *out4 = hour as i16;
@@ -963,7 +960,7 @@ pub extern "C" fn SPLIT_LDT__UINT(
     out7: &mut u16,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year_component(year);
     *out2 = month as u16;
     *out3 = day as u16;
     *out4 = hour as u16;
@@ -1017,7 +1014,7 @@ pub extern "C" fn SPLIT_LDT__UDINT(
     out7: &mut u32,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year_component(year);
     *out2 = month;
     *out3 = day;
     *out4 = hour;
@@ -1071,7 +1068,7 @@ pub extern "C" fn SPLIT_LDT__ULINT(
     out7: &mut u64,
 ) -> i16 {
     let (year, month, day, hour, minute, second, millisecond) = split_ldt_fields(in1);
-    *out1 = year.try_into().unwrap();
+    *out1 = year_component(year);
     *out2 = month as u64;
     *out3 = day as u64;
     *out4 = hour as u64;

--- a/libs/stdlib/src/timers.rs
+++ b/libs/stdlib/src/timers.rs
@@ -62,9 +62,9 @@ impl TimerParams {
 
     fn update_elapsed_time(&mut self) {
         if self.is_running() {
+            debug_assert!(self.start_time.is_some(), "a running timer must have a start time");
             let elapsed_millis =
-                self.get_run_time().expect("Timer should be running").as_millis().min(u32::MAX as u128)
-                    as u32;
+                self.get_run_time().unwrap_or_default().as_millis().min(u32::MAX as u128) as u32;
 
             self.set_elapsed_time(std::cmp::min(self.preset_time, elapsed_millis));
         }
@@ -115,9 +115,10 @@ impl TimerParamsLTime {
 
     fn update_elapsed_time(&mut self) {
         if self.is_running() {
+            debug_assert!(self.start_time.is_some(), "a running timer must have a start time");
             self.set_elapsed_time(std::cmp::min(
                 self.preset_time,
-                self.get_run_time().expect("Timer should be running").as_nanos() as i64,
+                self.get_run_time().unwrap_or_default().as_nanos() as i64,
             ));
         }
     }

--- a/libs/stdlib/src/types.rs
+++ b/libs/stdlib/src/types.rs
@@ -16,28 +16,26 @@ macro_rules! define_float_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $max_name(size: u32, value: *const $rust_type) -> $rust_type {
-            // Declare array for value
-            let arr = if !value.is_null() {
-                slice::from_raw_parts(value, size as usize)
-            } else {
-                panic!("Null pointer for value");
-            };
+            debug_assert!(!value.is_null() && size > 0, "MAX requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
+            }
 
-            arr.iter().map(|it| *it).reduce(<$rust_type>::max).expect("A max will always exist")
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().map(|it| *it).reduce(<$rust_type>::max).unwrap_or_default()
         }
         /// # Safety
         /// Dealing with raw pointers
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $min_name(size: u32, value: *const $rust_type) -> $rust_type {
-            // Declare array for value
-            let arr = if !value.is_null() {
-                slice::from_raw_parts(value, size as usize)
-            } else {
-                panic!("Null pointer for value");
-            };
+            debug_assert!(!value.is_null() && size > 0, "MIN requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
+            }
 
-            arr.iter().map(|it| *it).reduce(<$rust_type>::min).expect("A max will always exist")
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().map(|it| *it).reduce(<$rust_type>::min).unwrap_or_default()
         }
 
         //Limit
@@ -58,12 +56,13 @@ macro_rules! define_order_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $max_name(size: u32, value: *const $rust_type) -> $rust_type {
-            if !value.is_null() {
-                let arr = slice::from_raw_parts(value, size as usize);
-                *arr.iter().max().expect("A max will always exist")
-            } else {
-                panic!("Null pointer for value");
+            debug_assert!(!value.is_null() && size > 0, "MAX requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
             }
+
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().max().copied().unwrap_or_default()
         }
         //Min impl
         /// # Safety
@@ -71,12 +70,13 @@ macro_rules! define_order_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $min_name(size: u32, value: *const $rust_type) -> $rust_type {
-            if !value.is_null() {
-                let arr = slice::from_raw_parts(value, size as usize);
-                *arr.iter().min().expect("A min will always exist")
-            } else {
-                panic!("Null pointer for value");
+            debug_assert!(!value.is_null() && size > 0, "MIN requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
             }
+
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().min().copied().unwrap_or_default()
         }
 
         //Limit

--- a/libs/stdlib/tests/date_time_conversion_tests.rs
+++ b/libs/stdlib/tests/date_time_conversion_tests.rs
@@ -1,4 +1,5 @@
 use common::{compile_and_run, get_includes};
+use iec61131std::date_time_conversion as dtc;
 
 // Import common functionality into the integration tests
 mod common;
@@ -277,4 +278,56 @@ fn tod_to_ltod_conversion() {
             .timestamp_nanos_opt()
             .unwrap()
     );
+}
+
+// The conversions are total integer arithmetic; these tests pin the values the
+// previous chrono-based implementation produced and the saturation at the LDT
+// range minimum (midnight of the first representable day lies below i64::MIN).
+#[test]
+fn ldate_and_time_to_ldate_saturates_on_the_first_representable_day() {
+    assert_eq!(dtc::LDATE_AND_TIME_TO_LDATE(i64::MIN), i64::MIN);
+
+    let noon_first_day = i64::MIN + 12 * 3_600 * 1_000_000_000;
+    assert_eq!(dtc::LDATE_AND_TIME_TO_LDATE(noon_first_day), i64::MIN);
+}
+
+#[test]
+fn ldate_and_time_to_ldate_returns_midnight() {
+    let datetime = chrono::NaiveDate::from_ymd_opt(2024, 5, 5)
+        .and_then(|date| date.and_hms_opt(13, 30, 15))
+        .expect("valid date");
+    let midnight = chrono::NaiveDate::from_ymd_opt(2024, 5, 5)
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .expect("valid date");
+
+    assert_eq!(
+        dtc::LDATE_AND_TIME_TO_LDATE(datetime.and_utc().timestamp_nanos_opt().expect("in range")),
+        midnight.and_utc().timestamp_nanos_opt().expect("in range")
+    );
+
+    // pre-1970 values floor to the day boundary below, not toward zero
+    let before_epoch = chrono::NaiveDate::from_ymd_opt(1969, 12, 31)
+        .and_then(|date| date.and_hms_opt(23, 0, 0))
+        .expect("valid date");
+    let before_epoch_midnight = chrono::NaiveDate::from_ymd_opt(1969, 12, 31)
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .expect("valid date");
+
+    assert_eq!(
+        dtc::LDATE_AND_TIME_TO_LDATE(before_epoch.and_utc().timestamp_nanos_opt().expect("in range")),
+        before_epoch_midnight.and_utc().timestamp_nanos_opt().expect("in range")
+    );
+}
+
+#[test]
+fn date_and_time_conversions_match_previous_values_at_the_range_bounds() {
+    assert_eq!(dtc::DATE_AND_TIME_TO_DATE(0), 0);
+    assert_eq!(dtc::DATE_AND_TIME_TO_DATE(u32::MAX), 4_294_944_000);
+    assert_eq!(dtc::DATE_AND_TIME_TO_TIME_OF_DAY(0), 0);
+    assert_eq!(dtc::DATE_AND_TIME_TO_TIME_OF_DAY(u32::MAX), 23_295_000);
+
+    let noon_nanos = 12 * 3_600 * 1_000_000_000_i64;
+    assert_eq!(dtc::LDATE_AND_TIME_TO_LTIME_OF_DAY(noon_nanos), noon_nanos);
+    // one hour before the epoch is 23:00 on the previous day
+    assert_eq!(dtc::LDATE_AND_TIME_TO_LTIME_OF_DAY(-3_600 * 1_000_000_000), 23 * 3_600 * 1_000_000_000);
 }

--- a/tests/lit/single/stdlib_overflow/README.md
+++ b/tests/lit/single/stdlib_overflow/README.md
@@ -26,6 +26,7 @@ The stdlib ADD/SUB/MUL date and time functions wrap on overflow, exactly like th
 - `dt_tod_overflow.st` - ADD_DT_TIME/SUB_DT_TIME past the DT range and SUB_TOD_TOD below zero wrap mod 2^32
 - `concat_invalid_inputs.st` - CONCAT_DATE/CONCAT_TOD yield 0 for unrepresentable inputs and clamp to the DATE range
 - `lreal_to_string_huge_negative.st` - LREAL_TO_STRING picks scientific notation by magnitude instead of overflowing the buffer
+- `ldt_to_ldate_first_day.st` - LDATE_AND_TIME_TO_LDATE saturates at the LDATE range minimum on the first representable day
 
 ### Float Factors (saturating)
 

--- a/tests/lit/single/stdlib_overflow/ldt_to_ldate_first_day.st
+++ b/tests/lit/single/stdlib_overflow/ldt_to_ldate_first_day.st
@@ -1,0 +1,24 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that LDATE_AND_TIME_TO_LDATE saturates at the LDATE range minimum for
+// values on the first representable day (its midnight lies below the range)
+// instead of aborting the process
+
+FUNCTION main : DINT
+VAR
+    a : LDATE;
+    b : LDATE;
+END_VAR
+    a := LDATE_AND_TIME_TO_LDATE(LDT#1677-09-21-12:00:00);
+    IF a = LDT#1677-09-21-00:12:43.145224192 THEN
+        // CHECK: saturated_ok
+        printf('saturated_ok$N');
+    END_IF
+
+    b := LDATE_AND_TIME_TO_LDATE(LDT#2024-05-05-13:30:15);
+    IF b = LDATE#2024-05-05 THEN
+        // CHECK: midnight_ok
+        printf('midnight_ok$N');
+    END_IF
+
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Problem: LDATE_AND_TIME_TO_LDATE aborts the whole process for any LDT on the first representable day (for example LDT#1677-09-21-12:00:00), because that day's midnight lies below the LDT range. Several other functions carry panics on invariants they do not control, such as the Option<Instant> niche layout in the timers or the callers of the exported MAX/MIN symbols.

Solution: Compute the date and time-of-day conversions with total integer arithmetic, saturating at the LDT range minimum. The invariant panics become debug_assert plus a defined default, so violations stay loud in test builds but never abort a production runtime.

Refs: PRG-4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)