### PR TITLE
fix(stdlib): clamp out-of-range string function parameters

### DIFF
--- a/libs/stdlib/src/string_functions.rs
+++ b/libs/stdlib/src/string_functions.rs
@@ -262,20 +262,14 @@ pub unsafe extern "C" fn FIND__WSTRING(src1: *const u16, src2: *const u16) -> i3
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).take(substr_len);
     chars.encode(&mut dest);
 
@@ -289,20 +283,14 @@ pub unsafe extern "C-unwind" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).take(substr_len);
     chars.encode(&mut dest);
 
@@ -316,20 +304,14 @@ pub unsafe extern "C-unwind" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).skip(nchars - substr_len);
     chars.encode(&mut dest);
 
@@ -343,20 +325,14 @@ pub unsafe extern "C-unwind" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i3
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).skip(nchars - substr_len);
     chars.encode(&mut dest);
     0
@@ -369,9 +345,8 @@ pub unsafe extern "C-unwind" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: 
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length or position are negative
-/// or the substring length exceeds the remaining characters from the
-/// starting position of the base string.
+/// The length is clamped to the remaining characters; an out-of-range
+/// position yields an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn MID_EXT__STRING(
@@ -380,21 +355,16 @@ pub unsafe extern "C-unwind" fn MID_EXT__STRING(
     start_index: i32,
     dest: *mut u8,
 ) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
-    let start_index = start_index as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if start_index < 1 || start_index > nchars {
-        panic!("Position is out of bounds.")
+    if start_index < 1 || start_index > nchars as i32 {
+        // out-of-range positions yield an empty string
+        *dest = 0;
+        return 0;
     }
     // correct for 0-indexing
-    let start_index = start_index - 1;
-    if nchars < substr_len + start_index {
-        panic!("Requested substring length {substr_len} from position {start_index} exceeds string length.")
-    }
+    let start_index = start_index as usize - 1;
+    let substr_len = (substr_len.max(0) as usize).min(nchars - start_index);
     let chars = EncodedCharsIter::decode(src).skip(start_index).take(substr_len);
     chars.encode(&mut dest);
 
@@ -408,9 +378,8 @@ pub unsafe extern "C-unwind" fn MID_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length or position are negative
-/// or the substring length exceeds the remaining characters from the
-/// starting position of the base string.
+/// The length is clamped to the remaining characters; an out-of-range
+/// position yields an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
@@ -419,21 +388,16 @@ pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
     start_index: i32,
     dest: *mut u16,
 ) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
-    let start_index = start_index as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if start_index < 1 || start_index > nchars {
-        panic!("Position is out of bounds.")
+    if start_index < 1 || start_index > nchars as i32 {
+        // out-of-range positions yield an empty string
+        *dest = 0;
+        return 0;
     }
     // correct for 0-indexing
-    let start_index = start_index - 1;
-    if nchars < substr_len + start_index {
-        panic!("Requested substring length {substr_len} from position {start_index} exceeds string length.")
-    }
+    let start_index = start_index as usize - 1;
+    let substr_len = (substr_len.max(0) as usize).min(nchars - start_index);
     let chars = EncodedCharsIter::decode(src).skip(start_index).take(substr_len);
     chars.encode(&mut dest);
 
@@ -448,8 +412,7 @@ pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter exceeds the
-/// source array bounds.
+/// An out-of-range position returns the base string unchanged.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn INSERT_EXT__STRING(
@@ -461,7 +424,9 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__STRING(
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src_base).count();
     if pos < 0 || pos > nchars as i32 {
-        panic! {"Positional parameter is out of bounds."}
+        // out-of-range positions return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     let pos = pos as usize;
     // Truncate at the result-buffer capacity so we never overflow the caller's
@@ -483,8 +448,7 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter exceeds the
-/// source array bounds.
+/// An out-of-range position returns the base string unchanged.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn INSERT_EXT__WSTRING(
@@ -496,7 +460,9 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__WSTRING(
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src_base).count();
     if pos < 0 || pos > nchars as i32 {
-        panic! {"Positional parameter is out of bounds."}
+        // out-of-range positions return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     let pos = pos as usize;
     // Truncate at the result-buffer capacity so we never overflow the caller's
@@ -518,8 +484,8 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__WSTRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter is out of bounds of the
-/// array or if trying to delete too many characters.
+/// An out-of-range position or a negative count returns the string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
@@ -530,21 +496,14 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
 ) -> i32 {
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src).count();
-    if pos < 1 || pos > nchars as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nchars as i32 || num_chars_to_delete < 0 {
+        // out-of-range positions and negative counts return the string unchanged
+        EncodedCharsIter::decode(src).encode(&mut dest);
+        return 0;
     }
     // correct for 0-indexing
     let pos = pos as usize - 1;
-    let ndel = num_chars_to_delete as usize;
-    if ndel + pos > nchars {
-        panic!(
-            r#"Cannot delete {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            num_chars_to_delete,
-            pos + 1
-        )
-    }
+    let ndel = (num_chars_to_delete as usize).min(nchars - pos);
 
     EncodedCharsIter::decode(src)
         .take(pos)
@@ -561,8 +520,8 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter is out of bounds of the
-/// array or if trying to delete too many characters.
+/// An out-of-range position or a negative count returns the string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
@@ -573,21 +532,14 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
 ) -> i32 {
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src).count();
-    if pos < 1 || pos > nchars as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nchars as i32 || num_chars_to_delete < 0 {
+        // out-of-range positions and negative counts return the string unchanged
+        EncodedCharsIter::decode(src).encode(&mut dest);
+        return 0;
     }
     // correct for 0-indexing
     let pos = pos as usize - 1;
-    let ndel = num_chars_to_delete as usize;
-    if ndel + pos > nchars {
-        panic!(
-            r#"Cannot delete {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            num_chars_to_delete,
-            pos + 1
-        )
-    }
+    let ndel = (num_chars_to_delete as usize).min(nchars - pos);
 
     EncodedCharsIter::decode(src)
         .take(pos)
@@ -605,8 +557,8 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// An out-of-range position or a negative count returns the base string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn REPLACE_EXT__STRING(
@@ -618,22 +570,14 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__STRING(
 ) -> i32 {
     let mut dest = dest;
     let nbase = EncodedCharsIter::decode(src_base).count();
-    if pos < 1 || pos > nbase as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nbase as i32 || num_chars_to_replace < 0 {
+        // out-of-range positions and negative counts return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     // correct for 0-indexing
     let pos = (pos - 1) as usize;
-    let nreplace = num_chars_to_replace as usize;
-
-    if nreplace + pos > nbase {
-        panic!(
-            r#"Cannot replace {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            nreplace,
-            pos + 1
-        )
-    }
+    let nreplace = (num_chars_to_replace as usize).min(nbase - pos);
     // Truncate at the result-buffer capacity so we never overflow the caller's
     // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`).
     EncodedCharsIter::decode(src_base)
@@ -655,8 +599,8 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// An out-of-range position or a negative count returns the base string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn REPLACE_EXT__WSTRING(
@@ -668,21 +612,14 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__WSTRING(
 ) -> i32 {
     let mut dest = dest;
     let nbase = EncodedCharsIter::decode(src_base).count();
-    if pos < 1 || pos > nbase as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nbase as i32 || num_chars_to_replace < 0 {
+        // out-of-range positions and negative counts return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     // correct for 0-indexing
     let pos = (pos - 1) as usize;
-    let nreplace = num_chars_to_replace as usize;
-    if nreplace + pos > nbase {
-        panic!(
-            r#"Cannot replace {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            nreplace,
-            pos + 1
-        )
-    }
+    let nreplace = (num_chars_to_replace as usize).min(nbase - pos);
     // Truncate at the result-buffer capacity so we never overflow the caller's
     // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`).
     EncodedCharsIter::decode(src_base)
@@ -1013,13 +950,25 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_left_ext_str_len_out_of_range() {
+    fn test_left_ext_str_len_clamps_to_string_bounds() {
         let src = "hello\0 world";
-        let len = 7;
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
-            LEFT_EXT__STRING(src.as_ptr(), len, dest.as_mut_ptr());
+            LEFT_EXT__STRING(src.as_ptr(), 7, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello", string);
+
+            LEFT_EXT__STRING(src.as_ptr(), -1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            RIGHT_EXT__STRING(src.as_ptr(), 7, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello", string);
+
+            RIGHT_EXT__STRING(src.as_ptr(), -1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
         }
     }
 
@@ -1074,13 +1023,23 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_mid_ext_str_start_index_out_of_range() {
+    fn test_mid_ext_str_out_of_range_position_yields_empty_string() {
         let src = "hello world\0";
-        let len = 5;
-        let start_index = 12;
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe { MID_EXT__STRING(src.as_ptr(), len, start_index, dest.as_mut_ptr()) };
+        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0xAA; DEFAULT_STRING_SIZE];
+        unsafe {
+            MID_EXT__STRING(src.as_ptr(), 5, 12, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            MID_EXT__STRING(src.as_ptr(), 5, 0, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            // a valid position clamps the length to the remaining characters
+            MID_EXT__STRING(src.as_ptr(), 10, 7, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("world", string);
+        }
     }
 
     #[test]
@@ -1120,24 +1079,18 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_insert_ext_str_pos_out_of_range() {
+    fn test_insert_ext_str_out_of_range_position_returns_base() {
         let base = "hello world\0";
         let insert = "brave new \0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             INSERT_EXT__STRING(base.as_ptr(), insert.as_ptr(), base.len() as i32, dest.as_mut_ptr());
-        }
-    }
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
 
-    #[test]
-    #[should_panic]
-    fn test_insert_ext_str_pos_negative() {
-        let base = "hello world\0";
-        let insert = "brave new \0";
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             INSERT_EXT__STRING(base.as_ptr(), insert.as_ptr(), -2, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
         }
     }
 
@@ -1187,32 +1140,36 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_str_too_many_del_chars() {
+    fn test_delete_ext_str_count_clamps_to_end_of_string() {
         let src = "hello world\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__STRING(src.as_ptr(), 12, 1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            DELETE_EXT__STRING(src.as_ptr(), 12, 4, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hel", string);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_str_pos_out_of_range_lower() {
+    fn test_delete_ext_str_out_of_range_position_returns_base() {
         let src = "hello world\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__STRING(src.as_ptr(), 11, 0, dest.as_mut_ptr());
-        }
-    }
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
 
-    #[test]
-    #[should_panic]
-    fn test_delete_ext_str_pos_out_of_range_upper() {
-        let src = "hello world\0";
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             DELETE_EXT__STRING(src.as_ptr(), 11, 12, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
+
+            DELETE_EXT__STRING(src.as_ptr(), -1, 2, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
         }
     }
 
@@ -1253,35 +1210,34 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_str_replace_too_many_chars() {
+    fn test_replace_ext_str_count_clamps_to_end_of_string() {
         let base = "hello world\0";
         let replacement = "aldo, how are you\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), 12, 1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("aldo, how are you", string);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_str_pos_out_of_bounds_lower() {
+    fn test_replace_ext_str_out_of_range_position_returns_base() {
         let base = "hello world\0";
         let replacement = "aldo, how are you\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), 8, 0, dest.as_mut_ptr());
-        }
-    }
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
 
-    #[test]
-    #[should_panic]
-    fn test_replace_ext_str_pos_out_of_bounds_upper() {
-        let base = "hello world\0";
-        let replacement = "aldo, how are you\0";
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), 8, 12, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
+
+            REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), -1, 2, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
         }
     }
 
@@ -1445,13 +1401,24 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_left_ext_wstring_len_out_of_range() {
+    fn test_left_ext_wstring_len_clamps_to_string_bounds() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             LEFT_EXT__WSTRING(src_ptr, 14, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
+
+            LEFT_EXT__WSTRING(src_ptr, -1, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("", res);
         }
     }
 
@@ -1503,13 +1470,17 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_mid_ext_wstring_index_out_of_range() {
+    fn test_mid_ext_wstring_out_of_range_position_yields_empty_string() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
-        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
+        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0xAA; DEFAULT_STRING_SIZE];
         unsafe {
             MID_EXT__WSTRING(src_ptr, 4, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("", res);
         }
     }
 
@@ -1565,8 +1536,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_insert_ext_wstring_pos_out_of_range() {
+    fn test_insert_ext_wstring_out_of_range_position_returns_base() {
         let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let base_ptr = base.as_slice().as_ptr();
         let to_insert = "brave new \0".encode_utf16().collect::<Vec<u16>>();
@@ -1574,6 +1544,11 @@ mod test {
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             INSERT_EXT__WSTRING(base_ptr, to_insert_ptr, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
         }
     }
 
@@ -1609,35 +1584,39 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_wstring_too_many_del_chars() {
+    fn test_delete_ext_wstring_count_clamps_to_end_of_string() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__WSTRING(src_ptr, 10, 3, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("he", res);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_wstring_pos_out_of_range_lower() {
+    fn test_delete_ext_wstring_out_of_range_position_returns_base() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__WSTRING(src_ptr, 9, 0, dest.as_mut_ptr());
-        }
-    }
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
 
-    #[test]
-    #[should_panic]
-    fn test_delete_ext_wstring_pos_out_of_range_upper() {
-        let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
-        let src_ptr = src.as_slice().as_ptr();
-        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             DELETE_EXT__WSTRING(src_ptr, 9, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
         }
     }
 
@@ -1695,8 +1674,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_wstring_replace_too_many_chars() {
+    fn test_replace_ext_wstring_count_clamps_to_end_of_string() {
         let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let base_ptr = base.as_slice().as_ptr();
         let replacement = " is out of this \0".encode_utf16().collect::<Vec<u16>>();
@@ -1704,12 +1682,16 @@ mod test {
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__WSTRING(base_ptr, replacement_ptr, 12, 1, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!(" is out of this ", res);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_wstring_pos_out_of_bounds_lower() {
+    fn test_replace_ext_wstring_out_of_range_position_returns_base() {
         let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let base_ptr = base.as_slice().as_ptr();
         let replacement = " is out of this \0".encode_utf16().collect::<Vec<u16>>();
@@ -1717,19 +1699,18 @@ mod test {
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__WSTRING(base_ptr, replacement_ptr, 8, 0, dest.as_mut_ptr());
-        }
-    }
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
 
-    #[test]
-    #[should_panic]
-    fn test_replace_ext_wstring_pos_out_of_bounds_upper() {
-        let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
-        let base_ptr = base.as_slice().as_ptr();
-        let replacement = " is out of this \0".encode_utf16().collect::<Vec<u16>>();
-        let replacement_ptr = replacement.as_slice().as_ptr();
-        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             REPLACE_EXT__WSTRING(base_ptr, replacement_ptr, 8, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
         }
     }
 

--- a/tests/lit/single/stdlib_overflow/README.md
+++ b/tests/lit/single/stdlib_overflow/README.md
@@ -37,12 +37,18 @@ MUL and DIV with a REAL/LREAL factor cannot wrap meaningfully; the functions fol
 - `div_time_by_real_zero.st` - Dividing TIME by zero (REAL)
 - `div_time_by_lreal_zero.st` - Dividing TIME by zero (LREAL)
 
+### String Parameters (clamping)
+
+Out-of-range string function parameters clamp or leave the base string unchanged, matching CODESYS:
+
+- `string_param_clamping.st` - LEFT/MID/INSERT/DELETE/REPLACE with out-of-range lengths and positions
+- `right_string_substring_too_long.st` / `right_wstring_substring_too_long.st` - RIGHT with a length above the string length clamps to the whole string
+
 ### Panic Conditions (`XFAIL: *`)
 
 The remaining conditions panic at runtime by design (integer division by zero is treated as a programming error). Their tests carry `XFAIL: *`, so a non-zero exit code is treated as success:
 
 - `div_time_by_zero.st` - Dividing TIME by zero (LINT)
-- `right_string_substring_too_long.st` / `right_wstring_substring_too_long.st` - RIGHT with a length above the string length
 
 ## Running the Tests
 

--- a/tests/lit/single/stdlib_overflow/right_string_substring_too_long.st
+++ b/tests/lit/single/stdlib_overflow/right_string_substring_too_long.st
@@ -1,16 +1,20 @@
-// RUN: (%COMPILE %s && %RUN 2>&1) | %CHECK %s
-// XFAIL: *
-// Test that RIGHT with substring length > string length causes a panic
-// Expected failure message: Requested substring length exceeds string length.
-// CHECK: Requested substring length exceeds string length.
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that RIGHT with a substring length above the string length clamps
+// to the whole string, matching CODESYS
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     s : STRING;
 END_VAR
-    s := 'sample text';
-    // Length 12 exceeds string length 11 -> should panic
-    s := RIGHT(s, 12);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    s := RIGHT('sample text', 12);
+    // CHECK: sample text
+    printf('%s$N', REF(s));
+
+    s := RIGHT('sample text', -1);
+    // CHECK: negative_length_yields_empty
+    IF s = '' THEN
+        printf('negative_length_yields_empty$N');
+    END_IF
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/right_wstring_substring_too_long.st
+++ b/tests/lit/single/stdlib_overflow/right_wstring_substring_too_long.st
@@ -1,17 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that RIGHT with a substring length above the string length clamps
+// to the whole string for WSTRING, matching the STRING behavior
 
-// RUN: (%COMPILE %s && %RUN 2>&1) | %CHECK %s
-// XFAIL: *
-// Test that RIGHT with substring length > string length causes a panic
-// Expected failure message: Requested substring length exceeds string length.
-// CHECK: Requested substring length exceeds string length.
-
-PROGRAM main
+FUNCTION main : DINT
 VAR
     s : WSTRING;
 END_VAR
-    s := "sa𝄞ple text";
-    // Length 12 exceeds string length 11 -> should panic
-    s := RIGHT(s, 12);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    s := RIGHT(WSTRING#"sa𝄞ple text", 12);
+    // CHECK: length_clamps_to_string
+    IF s = "sa𝄞ple text" THEN
+        printf('length_clamps_to_string$N');
+    END_IF
+
+    s := RIGHT(WSTRING#"sa𝄞ple text", -1);
+    // CHECK: negative_length_yields_empty
+    IF s = "" THEN
+        printf('negative_length_yields_empty$N');
+    END_IF
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/string_param_clamping.st
+++ b/tests/lit/single/stdlib_overflow/string_param_clamping.st
@@ -1,0 +1,45 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that out-of-range string function parameters clamp or leave the
+// base string unchanged, matching CODESYS (except the position-0 quirk
+// of DELETE/REPLACE, which is treated as an invalid position here)
+
+FUNCTION main : DINT
+VAR
+    s : STRING;
+END_VAR
+    s := LEFT('hello', 10);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    s := MID('hello', 10, 3);
+    // CHECK: llo
+    printf('%s$N', REF(s));
+
+    s := MID('hello', 2, 10);
+    // CHECK: mid_invalid_position_yields_empty
+    IF s = '' THEN
+        printf('mid_invalid_position_yields_empty$N');
+    END_IF
+
+    s := INSERT('hello', 'XX', 10);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    s := DELETE('hello', 3, 4);
+    // CHECK: hel
+    printf('%s$N', REF(s));
+
+    s := DELETE('hello', 2, 10);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    s := REPLACE('hello', 'X', 3, 4);
+    // CHECK: helX
+    printf('%s$N', REF(s));
+
+    s := REPLACE('hello', 'X', 2, 0);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Problem: LEFT, RIGHT, MID, INSERT, DELETE, and REPLACE abort the whole process when a length or position parameter lies outside the string bounds, for example LEFT('hello', 10).

Solution: Clamp lengths into the string bounds and return the base string unchanged for invalid positions (MID yields an empty string), matching the reference runtime behavior. Position 0 for DELETE/REPLACE is treated as invalid instead of replicating the reference off-by-one range overhang.

Refs: PRG-4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)