### PR TITLE
chore(stdlib): deny panicking constructs with clippy lints

### DIFF
--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -51,11 +51,12 @@ pub extern "C" fn CONCAT_DATE_TOD(in1: u32, in2: u32) -> u32 {
 
 /// .
 /// Concatenates DATE and LTOD to LDT
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn CONCAT_DATE_LTOD(in1: u32, in2: i64) -> i64 {
-    (in1 as i64) * NANOS_PER_SECOND + in2
+    (in1 as i64).wrapping_mul(NANOS_PER_SECOND).wrapping_add(in2)
 }
 
 /// .

--- a/libs/stdlib/src/date_time_numeric_functions.rs
+++ b/libs/stdlib/src/date_time_numeric_functions.rs
@@ -572,8 +572,6 @@ pub extern "C-unwind" fn DIV_LTIME__LINT(in1: i64, in2: i64) -> i64 {
 /// Divide TIME/LTIME by ANY_SIGNED_INT
 /// Panics on division by zero
 ///
-// Deliberate policy panic: dividing a TIME by zero is a programming error.
-#[allow(clippy::panic)]
 fn div_time_by_signed_int(in1: i64, in2: i64) -> i64 {
     in1.wrapping_div(in2)
 }
@@ -702,8 +700,6 @@ pub extern "C-unwind" fn DIV_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
 /// Divide TIME/LTIME by ANY_UNSIGNED_INT
 /// Panics on division by zero
 ///
-// Deliberate policy panic: dividing a TIME by zero is a programming error.
-#[allow(clippy::panic)]
 fn div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
     // a divisor above the signed range always exceeds the dividend magnitude
     match i64::try_from(in2) {
@@ -848,8 +844,6 @@ pub extern "C-unwind" fn DIV_LTIME__REAL(in1: i64, in2: f32) -> i64 {
     div_time_by_f32(in1, in2)
 }
 
-// Deliberate policy panic: dividing a TIME by zero is a programming error.
-#[allow(clippy::panic)]
 fn div_time_by_f32(in1: i64, in2: f32) -> i64 {
     let negative = in1.is_negative() ^ in2.is_sign_negative();
     let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());
@@ -1251,8 +1245,6 @@ pub extern "C-unwind" fn DIV_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
     div_time_by_f64(in1, in2)
 }
 
-// Deliberate policy panic: dividing a TIME by zero is a programming error.
-#[allow(clippy::panic)]
 fn div_time_by_f64(in1: i64, in2: f64) -> i64 {
     let negative = in1.is_negative() ^ in2.is_sign_negative();
     let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());

--- a/libs/stdlib/src/date_time_numeric_functions.rs
+++ b/libs/stdlib/src/date_time_numeric_functions.rs
@@ -572,6 +572,8 @@ pub extern "C-unwind" fn DIV_LTIME__LINT(in1: i64, in2: i64) -> i64 {
 /// Divide TIME/LTIME by ANY_SIGNED_INT
 /// Panics on division by zero
 ///
+// Deliberate policy panic: dividing a TIME by zero is a programming error.
+#[allow(clippy::panic)]
 fn div_time_by_signed_int(in1: i64, in2: i64) -> i64 {
     in1.wrapping_div(in2)
 }
@@ -700,6 +702,8 @@ pub extern "C-unwind" fn DIV_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
 /// Divide TIME/LTIME by ANY_UNSIGNED_INT
 /// Panics on division by zero
 ///
+// Deliberate policy panic: dividing a TIME by zero is a programming error.
+#[allow(clippy::panic)]
 fn div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
     // a divisor above the signed range always exceeds the dividend magnitude
     match i64::try_from(in2) {
@@ -844,6 +848,8 @@ pub extern "C-unwind" fn DIV_LTIME__REAL(in1: i64, in2: f32) -> i64 {
     div_time_by_f32(in1, in2)
 }
 
+// Deliberate policy panic: dividing a TIME by zero is a programming error.
+#[allow(clippy::panic)]
 fn div_time_by_f32(in1: i64, in2: f32) -> i64 {
     let negative = in1.is_negative() ^ in2.is_sign_negative();
     let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());
@@ -1245,6 +1251,8 @@ pub extern "C-unwind" fn DIV_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
     div_time_by_f64(in1, in2)
 }
 
+// Deliberate policy panic: dividing a TIME by zero is a programming error.
+#[allow(clippy::panic)]
 fn div_time_by_f64(in1: i64, in2: f64) -> i64 {
     let negative = in1.is_negative() ^ in2.is_sign_negative();
     let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());

--- a/libs/stdlib/src/extra_functions.rs
+++ b/libs/stdlib/src/extra_functions.rs
@@ -128,10 +128,9 @@ where
 fn parse_longest_prefix<T: num::Zero>(s: &str, parse: impl Fn(&str) -> Option<T>) -> T {
     let mut end = s.len();
     while end > 0 {
-        if s.is_char_boundary(end) {
-            if let Some(number) = parse(&s[..end]) {
-                return number;
-            }
+        // `get` returns None between char boundaries
+        if let Some(number) = s.get(..end).and_then(&parse) {
+            return number;
         }
         end -= 1;
     }

--- a/libs/stdlib/src/extra_functions.rs
+++ b/libs/stdlib/src/extra_functions.rs
@@ -106,10 +106,12 @@ where
 {
     let slice = ptr_to_slice(src);
     let (string, radix) = match slice {
-        [b'1', b'6', b'#', ..] => (std::str::from_utf8(&slice[3..]), 16),
-        [b'0', b'x', ..] | [b'0', b'X', ..] => (std::str::from_utf8(&slice[2..]), 16),
-        [b'8', b'#', ..] => (std::str::from_utf8(&slice[2..]), 8), // support c-style octal prefixes? e.g. 010 -> 10 octal
-        [b'2', b'#', ..] | [b'0', b'b', ..] | [b'0', b'B', ..] => (std::str::from_utf8(&slice[2..]), 2),
+        [b'1', b'6', b'#', rest @ ..] => (std::str::from_utf8(rest), 16),
+        [b'0', b'x', rest @ ..] | [b'0', b'X', rest @ ..] => (std::str::from_utf8(rest), 16),
+        [b'8', b'#', rest @ ..] => (std::str::from_utf8(rest), 8), // support c-style octal prefixes? e.g. 010 -> 10 octal
+        [b'2', b'#', rest @ ..] | [b'0', b'b', rest @ ..] | [b'0', b'B', rest @ ..] => {
+            (std::str::from_utf8(rest), 2)
+        }
         _ => (std::str::from_utf8(slice), 10),
     };
 

--- a/libs/stdlib/src/lib.rs
+++ b/libs/stdlib/src/lib.rs
@@ -10,7 +10,9 @@
         clippy::panic,
         clippy::todo,
         clippy::unimplemented,
+        clippy::unreachable,
         clippy::indexing_slicing,
+        clippy::string_slice,
         clippy::exit
     )
 )]

--- a/libs/stdlib/src/lib.rs
+++ b/libs/stdlib/src/lib.rs
@@ -1,5 +1,20 @@
 // Definitions of the core standard function modules for IEC61131-3
 
+// A panic in these functions aborts the whole runtime process (most are `extern "C"`),
+// so all panicking constructs are banned outside of tests.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::indexing_slicing,
+        clippy::exit
+    )
+)]
+
 pub mod arithmetic_functions;
 pub mod bistable_functionblocks;
 pub mod bit_num_conversion;

--- a/libs/stdlib/tests/date_time_extra_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_extra_functions_tests.rs
@@ -1120,3 +1120,9 @@ fn concat_ldt_with_invalid_fields_yields_epoch_defaults() {
     assert_eq!(dtef::CONCAT_LDT__INT(2024, 13, 1, 0, 0, 0, 0), 0);
     assert_eq!(dtef::concat_ldt(1969, 6, 1, 1, 0, 0, 0), 3_600_000_000_000);
 }
+
+#[test]
+fn concat_date_ltod_wraps_on_overflow() {
+    assert_eq!(dtef::CONCAT_DATE_LTOD(86_400, 3_600_000_000_000), 90_000_000_000_000);
+    assert_eq!(dtef::CONCAT_DATE_LTOD(u32::MAX, i64::MAX), -4_928_404_741_854_775_809);
+}


### PR DESCRIPTION
Problem: The stdlib runs as extern "C" code inside the PLC runtime, where a panic aborts the whole process. Nothing prevents new panicking code (unwrap, panic!, unchecked indexing, str slicing) from being merged, and CONCAT_DATE_LTOD still carried plain arithmetic that overflows on out-of-range LTOD inputs.

Solution: Deny the panicking clippy lints crate-wide outside of tests, including string_slice and unreachable. The integer-prefix parser uses subslice bindings and the checked str::get instead of slice indexing, and CONCAT_DATE_LTOD wraps like the rest of the date/time functions.

Refs: PRG-4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)