### PR TITLE
ci: introduce entmoot

### DIFF
--- a/.github/workflows/entmoot.yml
+++ b/.github/workflows/entmoot.yml
@@ -1,0 +1,32 @@
+name: Entmoot
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: entmoot-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin -- "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npx --yes github:volsa/entmoot review
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduces Entmoot (https://github.com/volsa/entmoot), example PR https://github.com/volsa/entmoot/pull/15.

wip, need to request an OpenRouter API key still and address some security issues.