### PR TITLE
fix: counter will no longer count after removing LD or R

### DIFF
--- a/libs/stdlib/src/counters.rs
+++ b/libs/stdlib/src/counters.rs
@@ -39,9 +39,10 @@ fn ctu<T>(params: &mut CTUParams<T>)
 where
     T: Integer + Copy + Bounded,
 {
+    let cu_r_edge = params.r_edge();
     if params.r {
         params.reset();
-    } else if params.r_edge() & (params.cv < T::max_value()) {
+    } else if cu_r_edge & (params.cv < T::max_value()) {
         params.inc();
     }
     params.update_q();
@@ -138,9 +139,10 @@ fn ctd<T>(params: &mut CTDParams<T>)
 where
     T: Integer + Copy + Bounded,
 {
+    let cd_r_edge = params.r_edge();
     if params.ld {
         params.load();
-    } else if params.r_edge() & (params.cv > T::min_value()) {
+    } else if cd_r_edge & (params.cv > T::min_value()) {
         params.dec();
     }
     params.update_q();

--- a/libs/stdlib/tests/counters_tests.rs
+++ b/libs/stdlib/tests/counters_tests.rs
@@ -16,6 +16,51 @@ struct CTUType<T> {
     cv: T,
 }
 
+#[repr(C)]
+#[derive(Default, Debug)]
+struct CTUResetType {
+    fb: CTUParams<i16>,
+    step: i16,
+    q: bool,
+    cv: i16,
+}
+
+#[test]
+fn ctu_reset_tracks_cu_edge() {
+    let prog = r#"
+        PROGRAM main
+        VAR
+            ctu_inst : CTU;
+            step : INT;
+            Q_res : BOOL;
+            CV_res : INT;
+        END_VAR
+            CASE step OF
+                0: ctu_inst(CU := TRUE, R := FALSE, PV := INT#3, Q => Q_res, CV => CV_res);
+                1: ctu_inst(CU := FALSE, R := FALSE, PV := INT#3, Q => Q_res, CV => CV_res);
+                2: ctu_inst(CU := TRUE, R := TRUE, PV := INT#3, Q => Q_res, CV => CV_res);
+                3: ctu_inst(CU := TRUE, R := FALSE, PV := INT#3, Q => Q_res, CV => CV_res);
+            END_CASE
+            step := step + 1;
+        END_PROGRAM
+    "#;
+
+    let source = vec![prog.into()];
+    let includes = get_includes(&["counters.st"]);
+    let context = CodegenContext::create();
+    let module = compile_and_load(&context, source, includes);
+    let mut main_inst = CTUResetType::default();
+
+    module.run::<_, ()>("main", &mut main_inst);
+    assert_eq!(main_inst.cv, 1);
+    module.run::<_, ()>("main", &mut main_inst);
+    assert_eq!(main_inst.cv, 1);
+    module.run::<_, ()>("main", &mut main_inst);
+    assert_eq!(main_inst.cv, 0);
+    module.run::<_, ()>("main", &mut main_inst);
+    assert_eq!(main_inst.cv, 0);
+}
+
 #[test]
 fn ctu() {
     let prog = r#"
@@ -309,6 +354,10 @@ fn ctd() {
     let context = CodegenContext::create();
     let module = compile_and_load(&context, source, includes);
     let mut main_inst = CTDType::<i16> { load: true, ..CTDType::default() };
+    // load without counting down
+    module.run::<_, ()>("main", &mut main_inst);
+    assert!(!main_inst.q);
+    assert_eq!(main_inst.cv, 3);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
@@ -321,10 +370,6 @@ fn ctd() {
     module.run::<_, ()>("main", &mut main_inst);
     assert!(main_inst.q);
     assert_eq!(main_inst.cv, 0);
-    // count down
-    module.run::<_, ()>("main", &mut main_inst);
-    assert!(main_inst.q);
-    assert_eq!(main_inst.cv, -1);
 }
 
 #[test]
@@ -353,6 +398,10 @@ fn ctd_int() {
     let context = CodegenContext::create();
     let module = compile_and_load(&context, source, includes);
     let mut main_inst = CTDType::<i16> { load: true, ..CTDType::default() };
+    // load without counting down
+    module.run::<_, ()>("main", &mut main_inst);
+    assert!(!main_inst.q);
+    assert_eq!(main_inst.cv, 3);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
@@ -365,10 +414,6 @@ fn ctd_int() {
     module.run::<_, ()>("main", &mut main_inst);
     assert!(main_inst.q);
     assert_eq!(main_inst.cv, 0);
-    // count down
-    module.run::<_, ()>("main", &mut main_inst);
-    assert!(main_inst.q);
-    assert_eq!(main_inst.cv, -1);
 }
 
 #[test]
@@ -397,6 +442,10 @@ fn ctd_dint() {
     let context = CodegenContext::create();
     let module = compile_and_load(&context, source, includes);
     let mut main_inst = CTDType::<i32> { load: true, ..CTDType::default() };
+    // load without counting down
+    module.run::<_, ()>("main", &mut main_inst);
+    assert!(!main_inst.q);
+    assert_eq!(main_inst.cv, 3);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
@@ -409,10 +458,6 @@ fn ctd_dint() {
     module.run::<_, ()>("main", &mut main_inst);
     assert!(main_inst.q);
     assert_eq!(main_inst.cv, 0);
-    // count down
-    module.run::<_, ()>("main", &mut main_inst);
-    assert!(main_inst.q);
-    assert_eq!(main_inst.cv, -1);
 }
 
 #[test]
@@ -441,6 +486,10 @@ fn ctd_udint() {
     let context = CodegenContext::create();
     let module = compile_and_load(&context, source, includes);
     let mut main_inst = CTDType::<u32> { load: true, ..CTDType::default() };
+    // load without counting down
+    module.run::<_, ()>("main", &mut main_inst);
+    assert!(!main_inst.q);
+    assert_eq!(main_inst.cv, 3);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
@@ -449,10 +498,6 @@ fn ctd_udint() {
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
     assert_eq!(main_inst.cv, 1);
-    // count down
-    module.run::<_, ()>("main", &mut main_inst);
-    assert!(main_inst.q);
-    assert_eq!(main_inst.cv, 0);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(main_inst.q);
@@ -485,6 +530,10 @@ fn ctd_lint() {
     let context = CodegenContext::create();
     let module = compile_and_load(&context, source, includes);
     let mut main_inst = CTDType::<i64> { load: true, ..CTDType::default() };
+    // load without counting down
+    module.run::<_, ()>("main", &mut main_inst);
+    assert!(!main_inst.q);
+    assert_eq!(main_inst.cv, 3);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
@@ -497,10 +546,6 @@ fn ctd_lint() {
     module.run::<_, ()>("main", &mut main_inst);
     assert!(main_inst.q);
     assert_eq!(main_inst.cv, 0);
-    // count down
-    module.run::<_, ()>("main", &mut main_inst);
-    assert!(main_inst.q);
-    assert_eq!(main_inst.cv, -1);
 }
 
 #[test]
@@ -529,6 +574,10 @@ fn ctd_ulint() {
     let context = CodegenContext::create();
     let module = compile_and_load(&context, source, includes);
     let mut main_inst = CTDType::<u64> { load: true, ..CTDType::default() };
+    // load without counting down
+    module.run::<_, ()>("main", &mut main_inst);
+    assert!(!main_inst.q);
+    assert_eq!(main_inst.cv, 3);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
@@ -537,10 +586,6 @@ fn ctd_ulint() {
     module.run::<_, ()>("main", &mut main_inst);
     assert!(!main_inst.q);
     assert_eq!(main_inst.cv, 1);
-    // count down
-    module.run::<_, ()>("main", &mut main_inst);
-    assert!(main_inst.q);
-    assert_eq!(main_inst.cv, 0);
     // count down
     module.run::<_, ()>("main", &mut main_inst);
     assert!(main_inst.q);

--- a/tests/lit/single/function_blocks/counter_fb_should_not_count_after_removing_ld_or_r.st
+++ b/tests/lit/single/function_blocks/counter_fb_should_not_count_after_removing_ld_or_r.st
@@ -1,0 +1,28 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+FUNCTION main : DINT
+    VAR
+        cnt : CTD;
+    END_VAR
+
+    // Load counter with PV set to 100
+    cnt(LD := TRUE, PV := 100, CD := TRUE);
+
+    PRINTF('CD=%d, LD=%d, PV=%d, Q=%d, CV=%d$N', cnt.CD, cnt.LD, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK: CD=1, LD=1, PV=100, Q=0, CV=100
+
+    cnt(LD := FALSE);
+
+    PRINTF('CD=%d, LD=%d, PV=%d, Q=%d, CV=%d$N', cnt.CD, cnt.LD, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK-NEXT: CD=1, LD=0, PV=100, Q=0, CV=100
+
+    cnt(CD := FALSE, LD := FALSE);
+
+    PRINTF('CD=%d, LD=%d, PV=%d, Q=%d, CV=%d$N', cnt.CD, cnt.LD, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK-NEXT: CD=0, LD=0, PV=100, Q=0, CV=100
+
+    cnt(CD := TRUE);
+
+    PRINTF('CD=%d, LD=%d, PV=%d, Q=%d, CV=%d$N', cnt.CD, cnt.LD, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK: CD=1, LD=0, PV=100, Q=0, CV=99
+
+END_FUNCTION

--- a/tests/lit/single/function_blocks/counter_fb_should_not_count_after_reset.st
+++ b/tests/lit/single/function_blocks/counter_fb_should_not_count_after_reset.st
@@ -1,0 +1,27 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+FUNCTION main : DINT
+    VAR
+        cnt : CTU;
+    END_VAR
+
+    cnt(CU := TRUE, R := FALSE, PV := 100);
+
+    PRINTF('CU=%d, R=%d, PV=%d, Q=%d, CV=%d$N', cnt.CU, cnt.R, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK: CU=1, R=0, PV=100, Q=0, CV=1
+
+    cnt(CU := FALSE, R := FALSE);
+
+    PRINTF('CU=%d, R=%d, PV=%d, Q=%d, CV=%d$N', cnt.CU, cnt.R, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK-NEXT: CU=0, R=0, PV=100, Q=0, CV=1
+
+    cnt(CU := TRUE, R := TRUE);
+
+    PRINTF('CU=%d, R=%d, PV=%d, Q=%d, CV=%d$N', cnt.CU, cnt.R, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK-NEXT: CU=1, R=1, PV=100, Q=0, CV=0
+
+    cnt(CU := TRUE, R := FALSE);
+
+    PRINTF('CU=%d, R=%d, PV=%d, Q=%d, CV=%d$N', cnt.CU, cnt.R, cnt.PV, cnt.Q, cnt.CV);
+    // CHECK-NEXT: CU=1, R=0, PV=100, Q=0, CV=0
+
+END_FUNCTION


### PR DESCRIPTION
**Changed**
- Counter will no longer count after removing LD or R

**Testing**
- Added a specific lit test for both CTD and CTU to verify behaviour
- Adjusted existing unit tests to support modified timer behaviour

Refs: PRG-4615