### PR TITLE
fix: keep struct-initializer parens when folding array elements

### DIFF
--- a/src/resolver/const_evaluator.rs
+++ b/src/resolver/const_evaluator.rs
@@ -407,7 +407,10 @@ fn evaluate_with_target_hint(
 
                 let inner_elements = AstNode::get_as_list(elements)
                     .iter()
-                    .map(|e| evaluate_with_target_hint(e, scope, index, tt, lhs))
+                    .map(|e| {
+                        evaluate_with_target_hint(e, scope, index, tt, lhs)
+                            .map(|folded| folded.map(|it| restore_element_parens(e, it)))
+                    })
                     .collect::<Result<Vec<Option<AstNode>>, UnresolvableKind>>()?
                     .into_iter()
                     .collect::<Option<Vec<AstNode>>>();
@@ -680,6 +683,17 @@ fn evaluate_with_target_hint(
         _ => return Err(UnresolvableKind::Misc(format!("Cannot resolve constant: {initial:#?}"))),
     };
     Ok(literal)
+}
+
+/// Folding drops parentheses, but inside an array literal they mark an element as a struct
+/// initializer, e.g. `[(a := 1, b := 2)]` against `[a, b]`. Restores the wrapper on every
+/// element that was declared with one.
+fn restore_element_parens(raw: &AstNode, folded: AstNode) -> AstNode {
+    if raw.is_paren() && !folded.is_paren() {
+        return AstFactory::create_paren_expression(folded, raw.get_location(), raw.get_id());
+    }
+
+    folded
 }
 
 /// attempts to resolve the inital value of this reference's target

--- a/src/validation/tests/array_validation_test.rs
+++ b/src/validation/tests/array_validation_test.rs
@@ -921,3 +921,80 @@ fn oversized_array_warning() {
       │             ^^^^ Array `huge` has 837_501_496_650 elements which exceeds the maximum supported array size of UDINT#4_294_967_295 elements.
     ");
 }
+
+/// Nested struct initializers are lowered into a constructor before validation runs, so this
+/// case only reproduces through the driver-backed helper; `parse_and_validate_buffered` above
+/// validates the raw AST and never sees the lowered form.
+#[test]
+fn nested_struct_array_initializers_are_accepted_after_lowering() {
+    let diagnostics = test_utils::parse_and_validate_buffered(
+        r#"
+        TYPE
+        InnerStruct : STRUCT
+            value : DWORD;
+        END_STRUCT;
+
+        StructArray : STRUCT
+            arr : ARRAY[0..2] OF InnerStruct;
+        END_STRUCT;
+        END_TYPE
+
+        FUNCTION main
+        VAR
+            varArr : ARRAY[0..2] OF StructArray := [
+                (arr := [(value := 1000), (value := 3000), (value := 7000)]),
+                (arr := [(value := 2000), (value := 4000), (value := 8000)]),
+                (arr := [(value := 3000), (value := 5000), (value := 9000)])
+            ];
+        END_VAR
+        END_FUNCTION
+        "#,
+    );
+
+    assert_snapshot!(diagnostics, @"");
+}
+
+#[test]
+fn nested_struct_array_initializers_without_parens_are_reported_after_lowering() {
+    let diagnostics = test_utils::parse_and_validate_buffered(
+        r#"
+        TYPE
+        InnerStruct : STRUCT
+            value : DWORD;
+        END_STRUCT;
+
+        StructArray : STRUCT
+            arr : ARRAY[0..2] OF InnerStruct;
+        END_STRUCT;
+        END_TYPE
+
+        FUNCTION main
+        VAR
+            varArr : ARRAY[0..2] OF StructArray := [
+                (arr := [value := 1000, value := 3000, value := 7000])
+            ];
+        END_VAR
+        END_FUNCTION
+        "#,
+    );
+
+    assert_snapshot!(diagnostics, @r"
+    error[E043]: Struct initializers within arrays have to be wrapped by `()`
+       ┌─ <internal>:15:26
+       │
+    15 │                 (arr := [value := 1000, value := 3000, value := 7000])
+       │                          ^^^^^^^^^^^^^ Struct initializers within arrays have to be wrapped by `()`
+
+    error[E043]: Struct initializers within arrays have to be wrapped by `()`
+       ┌─ <internal>:15:41
+       │
+    15 │                 (arr := [value := 1000, value := 3000, value := 7000])
+       │                                         ^^^^^^^^^^^^^ Struct initializers within arrays have to be wrapped by `()`
+
+    error[E043]: Struct initializers within arrays have to be wrapped by `()`
+       ┌─ <internal>:15:56
+       │
+    15 │                 (arr := [value := 1000, value := 3000, value := 7000])
+       │                                                        ^^^^^^^^^^^^^ Struct initializers within arrays have to be wrapped by `()`
+    ");
+}

--- a/tests/lit/single/init/nested_struct_array_init.st
+++ b/tests/lit/single/init/nested_struct_array_init.st
@@ -1,0 +1,36 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+//
+// An array of structs that hold an array of structs must accept a nested initializer.
+// The parenthesized struct initializers have to stay recognizable as such after the
+// initializer is const-folded into the generated constructor.
+
+TYPE
+    Inner : STRUCT
+        value : DINT;
+    END_STRUCT;
+
+    Outer : STRUCT
+        arr : ARRAY[0..1] OF Inner;
+    END_STRUCT;
+END_TYPE
+
+VAR_GLOBAL
+    gArr : ARRAY[0..1] OF Outer := [(arr := [(value := 50), (value := 60)]),
+                                    (arr := [(value := 70), (value := 80)])];
+END_VAR
+
+FUNCTION main : DINT
+VAR
+    varArr : ARRAY[0..1] OF Outer := [(arr := [(value := 10), (value := 20)]),
+                                      (arr := [(value := 30), (value := 40)])];
+END_VAR
+    // CHECK: varArr=10,20,30,40
+    printf('varArr=%d,%d,%d,%d$N', varArr[0].arr[0].value, varArr[0].arr[1].value,
+                                   varArr[1].arr[0].value, varArr[1].arr[1].value);
+
+    // CHECK: gArr=50,60,70,80
+    printf('gArr=%d,%d,%d,%d$N', gArr[0].arr[0].value, gArr[0].arr[1].value,
+                                 gArr[1].arr[0].value, gArr[1].arr[1].value);
+
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Problem: A nested initializer such as `[(arr := [(value := 1)])]` is rejected with E043, "Struct initializers within arrays have to be wrapped by `()`", although its elements are parenthesized. Array initializers are const-folded into the generated constructor, folding drops parentheses, and validation runs after lowering, so the rule sees bare assignments. `release/1.0.x` is not affected.

Solution: Restore the parentheses an array element was declared with when the const evaluator folds it. Elements declared without them stay unwrapped, so the diagnostic still reports initializers that really miss their parentheses. Restoring parens on every folded expression instead of array elements alone would cost struct constants their static initialization, because codegen reads a paren-wrapped folded initializer as "defer to the runtime constructor".

Closes #1833

Refs: PRG-4577

🤖 Generated with [Claude Code](https://claude.com/claude-code)