### PR TITLE
refactor(cfc): simplify resolver and transpiler internals

### DIFF
--- a/compiler/plc_cfc/src/infer.rs
+++ b/compiler/plc_cfc/src/infer.rs
@@ -116,6 +116,7 @@ pub fn infer_temporary_types(unit: &mut CompilationUnit, index: &mut Index, ids:
     if open.is_empty() {
         return false;
     }
+
     log::trace!("round starts with {} open temporaries: {:?}", open.len(), {
         let mut names = open.iter().collect::<Vec<_>>();
         names.sort();
@@ -129,42 +130,34 @@ pub fn infer_temporary_types(unit: &mut CompilationUnit, index: &mut Index, ids:
     // Harvest the concrete type each open temporary's capture resolved to.
     let mut resolved = HashMap::new();
     for statement in unit.implementations.iter().flat_map(|implementation| &implementation.statements) {
-        // `callee(...)`, bare or behind `temporary := callee(...)`.
-        let (call_node, return_capture) = match statement.get_stmt() {
-            AstStatement::Assignment(assignment) => {
-                (assignment.right.as_ref(), assignment.left.get_flat_reference_name())
+        let Some((call_node, call, return_capture)) = captured_call(statement) else { continue };
+
+        // The capture takes its annotated node's concrete type, once the
+        // call's evidence is complete (see `is_ready`).
+        let mut record = |name: &str, annotated: &AstNode, kind: &str| {
+            if !(open.contains(name) && is_ready(call, name, &open)) {
+                return;
             }
-            AstStatement::CallStatement(_) => (statement, None),
-            _ => continue,
+
+            match resolved_type(annotations.get_type(annotated, index), call, &annotations, index) {
+                Some(data_type) => {
+                    log::trace!("`{name}` resolved to `{data_type}` ({kind})");
+                    resolved.insert(name.to_string(), data_type);
+                }
+                None => log::trace!("`{name}`: no concrete annotation ({kind})"),
+            }
         };
-        let AstStatement::CallStatement(call) = call_node.get_stmt() else { continue };
 
         // `temporary := callee(...)`: the temporary takes the call's annotated (return) type.
         if let Some(name) = return_capture {
-            if open.contains(name) && is_ready(call, name, &open) {
-                match resolved_type(annotations.get_type(call_node, index), call, &annotations, index) {
-                    Some(data_type) => {
-                        log::trace!("`{name}` resolved to `{data_type}` (return capture)");
-                        resolved.insert(name.to_string(), data_type);
-                    }
-                    None => log::trace!("`{name}`: call has no concrete annotation"),
-                }
-            }
+            record(name, call_node, "return capture");
         }
 
         // `parameter => temporary`: the temporary takes the output parameter's annotated type.
         for argument in arguments(call) {
             let AstStatement::OutputAssignment(inner) = argument.get_stmt() else { continue };
             let Some(name) = base_reference(&inner.right) else { continue };
-            if open.contains(name) && is_ready(call, name, &open) {
-                match resolved_type(annotations.get_type(&inner.left, index), call, &annotations, index) {
-                    Some(data_type) => {
-                        log::trace!("`{name}` resolved to `{data_type}` (output capture)");
-                        resolved.insert(name.to_string(), data_type);
-                    }
-                    None => log::trace!("`{name}`: output parameter has no concrete annotation"),
-                }
-            }
+            record(name, &inner.left, "output capture");
         }
     }
 
@@ -243,8 +236,8 @@ fn is_ready(call: &CallStatement, own: &str, open: &HashSet<String>) -> bool {
 }
 
 /// The concrete type behind an annotated capture: the annotator's answer when it is already
-/// concrete (see [`concrete_type`]). When it is still generic — the annotator no longer resolves
-/// non-builtin generic calls, that happens in the later `GenericLowerer` phase — the binding is
+/// concrete (see [`concrete_type`]). When it is still generic (the annotator no longer resolves
+/// non-builtin generic calls, that happens in the later `GenericLowerer` phase), the binding is
 /// derived from the call's concrete arguments instead; arguments that are themselves still
 /// generic carry no vote, so a resolved external input decides even in feedback shapes.
 fn resolved_type(
@@ -282,14 +275,7 @@ fn concrete_type(data_type: Option<&DataType>, index: &Index) -> Option<String> 
 // The callee whose return or output is captured into the given temporary.
 fn producer<'unit>(unit: &'unit CompilationUnit, temporary: &str) -> Option<&'unit str> {
     unit.implementations.iter().flat_map(|implementation| &implementation.statements).find_map(|statement| {
-        // `callee(...)`, bare or behind `temporary := callee(...)`.
-        let (call_node, return_capture) = match statement.get_stmt() {
-            AstStatement::Assignment(assignment) => {
-                (assignment.right.as_ref(), assignment.left.get_flat_reference_name())
-            }
-            _ => (statement, None),
-        };
-        let AstStatement::CallStatement(call) = call_node.get_stmt() else { return None };
+        let (_, call, return_capture) = captured_call(statement)?;
 
         let captures = return_capture == Some(temporary)
             || arguments(call).iter().any(|argument| match argument.get_stmt() {
@@ -299,6 +285,20 @@ fn producer<'unit>(unit: &'unit CompilationUnit, temporary: &str) -> Option<&'un
 
         captures.then(|| call.operator.get_flat_reference_name()).flatten()
     })
+}
+
+// `callee(...)`, bare or behind `temporary := callee(...)`: the call node, the
+// call itself, and the name capturing its return value, if any.
+fn captured_call(statement: &AstNode) -> Option<(&AstNode, &CallStatement, Option<&str>)> {
+    let (call_node, return_capture) = match statement.get_stmt() {
+        AstStatement::Assignment(assignment) => {
+            (assignment.right.as_ref(), assignment.left.get_flat_reference_name())
+        }
+        _ => (statement, None),
+    };
+
+    let AstStatement::CallStatement(call) = call_node.get_stmt() else { return None };
+    Some((call_node, call, return_capture))
 }
 
 // `NOT (x)` -> `x`: the referenced name behind negation/parentheses.

--- a/compiler/plc_cfc/src/lib.rs
+++ b/compiler/plc_cfc/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! A `.cfc` document is deserialized into the raw `model` types, then resolved
 //! into a `network::Network`: the `Resolver` surveys the diagram, traces the
-//! wiring, orders and validates the statements — every decision and diagnostic
-//! in one stage — so the `Transpiler` renders the final `CompilationUnit`
+//! wiring, orders and validates the statements (every decision and diagnostic
+//! in one stage), so the `Transpiler` renders the final `CompilationUnit`
 //! without making any decisions of its own.
 //!
 //! The driver enters twice: [`parse_file`] during the parse step, yielding an
@@ -79,29 +79,30 @@ pub fn transpile_file(
 
 #[cfg(test)]
 mod test_utils {
-    use plc_ast::ast::LinkageType;
+    use plc::index::{indexer, Index};
+    use plc::{builtins, lexer, parser, typesystem};
+    use plc_ast::ast::{pre_process, CompilationUnit, LinkageType};
     use plc_ast::provider::IdProvider;
     use plc_ast::ser::AstSerializer;
     use plc_diagnostics::diagnostician::Diagnostician;
-    use plc_diagnostics::diagnostics::Severity;
+    use plc_diagnostics::diagnostics::{Diagnostic, Severity};
     use plc_diagnostics::reporter::DiagnosticReporter;
+    use plc_source::source_location::SourceLocationFactory;
     use plc_source::SourceCode;
 
     // Indexes every POU a fixture involves: the interface, any companion `.st`
     // beside the `.cfc` declaring the fixture's callees, and the builtin types.
-    pub(crate) fn fixture_index(
-        fixture: &str,
-        interface: &plc_ast::ast::CompilationUnit,
-    ) -> plc::index::Index {
-        let mut index = plc::index::indexer::index(interface);
-        for data_type in plc::typesystem::get_builtin_types() {
+    pub(crate) fn fixture_index(fixture: &str, interface: &CompilationUnit) -> Index {
+        let mut index = indexer::index(interface);
+        for data_type in typesystem::get_builtin_types() {
             index.register_type(data_type);
         }
 
         // Builtin POUs (ADD, SEL, ...) join the index like in the driver.
-        let builtins = plc::builtins::parse_built_ins(IdProvider::default());
-        index.import(plc::index::indexer::index(&builtins));
+        let callees = builtins::parse_built_ins(IdProvider::default());
+        index.import(indexer::index(&callees));
 
+        // Index the companion `.st` callees beside the fixture's `.cfc`.
         let dir = format!("{}/fixtures/{fixture}", env!("CARGO_MANIFEST_DIR"));
         for entry in std::fs::read_dir(dir).unwrap() {
             let path = entry.unwrap().path();
@@ -110,13 +111,13 @@ mod test_utils {
             }
 
             let source = std::fs::read_to_string(&path).unwrap();
-            let factory = plc_source::source_location::SourceLocationFactory::internal(&source);
-            let session = plc::lexer::lex_with_ids(&source, IdProvider::default(), factory);
-            let (mut unit, _) = plc::parser::parse(session, LinkageType::Internal, "<callees>");
+            let factory = SourceLocationFactory::internal(&source);
+            let session = lexer::lex_with_ids(&source, IdProvider::default(), factory);
+            let (mut unit, _) = parser::parse(session, LinkageType::Internal, "<callees>");
 
             // Pre-process like the driver, so e.g. generic bindings index correctly.
-            plc_ast::ast::pre_process(&mut unit, IdProvider::default());
-            index.import(plc::index::indexer::index(&unit));
+            pre_process(&mut unit, IdProvider::default());
+            index.import(indexer::index(&unit));
         }
 
         index
@@ -125,6 +126,7 @@ mod test_utils {
     pub(crate) fn fixture_source(fixture: &str) -> SourceCode {
         let name = fixture.rsplit('/').next().unwrap();
         let disk = format!("{}/fixtures/{fixture}/{name}.cfc", env!("CARGO_MANIFEST_DIR"));
+
         // A stable name, so snapshots don't embed absolute paths.
         SourceCode {
             source: std::fs::read_to_string(&disk).unwrap(),
@@ -132,20 +134,8 @@ mod test_utils {
         }
     }
 
-    // Mimics the driver participant's fixed-point loop: index once (now with
-    // the temporaries), patch what resolved, repeat until quiescent. Returns
-    // the diagnostics for whatever stayed unresolved.
-    fn infer(
-        fixture: &str,
-        unit: &mut plc_ast::ast::CompilationUnit,
-        ids: IdProvider,
-    ) -> Vec<plc_diagnostics::diagnostics::Diagnostic> {
-        let mut index = fixture_index(fixture, unit);
-        while crate::infer_temporary_types(unit, &mut index, ids.clone()) {}
-
-        crate::unresolved_temporaries(unit, &index)
-    }
-
+    // Runs the full driver pipeline on a fixture; the serialized unit, or the
+    // rendered diagnostics when an error aborts.
     pub(crate) fn transpile_project(fixture: &str) -> Result<String, String> {
         let source = fixture_source(fixture);
         let ids = IdProvider::default();
@@ -184,6 +174,17 @@ mod test_utils {
             diagnostics.extend(infer(fixture, &mut unit, ids));
             diagnostician.handle(&diagnostics);
         }
+
         diagnostician.buffer().unwrap_or_default()
+    }
+
+    // Mimics the driver participant's fixed-point loop: index once (now with
+    // the temporaries), patch what resolved, repeat until quiescent. Returns
+    // the diagnostics for whatever stayed unresolved.
+    fn infer(fixture: &str, unit: &mut CompilationUnit, ids: IdProvider) -> Vec<Diagnostic> {
+        let mut index = fixture_index(fixture, unit);
+        while crate::infer_temporary_types(unit, &mut index, ids.clone()) {}
+
+        crate::unresolved_temporaries(unit, &index)
     }
 }

--- a/compiler/plc_cfc/src/model.rs
+++ b/compiler/plc_cfc/src/model.rs
@@ -1,3 +1,5 @@
+//! The serde model of the `.cfc` document, the shape of the XML format itself.
+
 // quick-xml's serde support strips namespace prefixes and matches on the local
 // name, so the `rename`s use bare names (`Function`, `type`) rather than their
 // `ppx:` / `xsi:` prefixed forms, and attributes take a leading `@`.
@@ -304,10 +306,17 @@ impl FbdObject {
 
 impl Pin {
     pub fn source_pin(&self) -> Option<usize> {
-        self.connection_in.as_ref()?.connections.first().map(|connection| connection.ref_out_id)
+        self.connection_in.as_ref()?.source_pin()
     }
 
     pub fn output_pin(&self) -> Option<usize> {
         self.connection_out.as_ref().map(|out| out.id)
+    }
+}
+
+impl ConnectionPointIn {
+    // The producing pin a consumer reads: the first (and only) connection.
+    pub fn source_pin(&self) -> Option<usize> {
+        self.connections.first().map(|connection| connection.ref_out_id)
     }
 }

--- a/compiler/plc_cfc/src/network.rs
+++ b/compiler/plc_cfc/src/network.rs
@@ -1,3 +1,5 @@
+//! The resolved intermediate representation a network transpiles through.
+
 use plc_ast::ast::AstNode;
 use plc_source::source_location::SourceLocation;
 

--- a/compiler/plc_cfc/src/resolver.rs
+++ b/compiler/plc_cfc/src/resolver.rs
@@ -1,3 +1,5 @@
+//! Traces the diagram's wiring into ordered, validated network statements.
+
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
@@ -41,12 +43,20 @@ enum Source<'model> {
 
 // Everything the linking pass needs to know up front.
 struct Survey<'model> {
+    /// Every `<ConnectionPointOut connectionPointOutId="4">` to its owning element
     by_pin: HashMap<usize, &'model FbdObject>,
+
+    /// Block `<OutputVariable parameterName="out">` pins by out-id
     block_output: HashMap<usize, &'model Pin>,
+
+    /// The connector owning each `<Connector label="x">`
     connector_by_label: HashMap<&'model str, &'model FbdObject>,
+
+    /// Every `<CfcLabel label="top">` name
     labels: HashSet<&'model str>,
+
+    /// Every `<CfcJump targetLabel="top">`
     targets: HashSet<&'model str>,
-    consumed: HashSet<usize>,
 }
 
 enum Trace<'model> {
@@ -71,19 +81,22 @@ impl<'index> Resolver<'index> {
     }
 
     pub fn resolve(mut self, network: &model::Network) -> (Network, Vec<Diagnostic>) {
-        let mut survey = self.survey(network);
-        survey.consumed = consumed(network, &survey);
+        // Chart the wiring up front; `consumed` decides which outputs need temporaries.
+        let survey = self.survey(network);
+        let consumed = consumed(network, &survey);
 
+        // Turn each element into its statement(s), tagged with its priority.
         let mut statements = Vec::new();
         let mut temporaries = Vec::new();
         let mut broken = Vec::new();
         for object in network.elements() {
+            let location = self.factory.create_block_location(object.global_id);
+
             match Role::from(object) {
                 Role::Sink => match trace(consumes(object), &survey) {
                     // The traced source becomes the sink's assigned value,
                     // negated once more by the sink's own inversion bubble.
                     Trace::Reached(source) => {
-                        let location = self.factory.create_block_location(object.global_id);
                         let sink = self.expression(object, &location);
                         let source = self.value(&source, &location);
                         let source = self.negate_if(source, &location, object.in_negated());
@@ -102,7 +115,6 @@ impl<'index> Resolver<'index> {
                 Role::Return => match trace(consumes(object), &survey) {
                     // The traced source guards the return.
                     Trace::Reached(source) => {
-                        let location = self.factory.create_block_location(object.global_id);
                         let condition = self.condition(object, &source, &location);
 
                         let statement = Statement::Return { condition, location };
@@ -114,13 +126,11 @@ impl<'index> Resolver<'index> {
 
                     // A return without a condition is rejected; drop it.
                     Trace::Unwired => {
-                        let location = self.factory.create_block_location(object.global_id);
                         self.diagnostics.push(Diagnostic::disconnected_return(location));
                     }
                 },
 
                 Role::Jump => {
-                    let location = self.factory.create_block_location(object.global_id);
                     let target = object.target_label().unwrap_or_default().to_string();
 
                     // A jump to a name no label defines has nowhere to land.
@@ -151,7 +161,6 @@ impl<'index> Resolver<'index> {
                 }
 
                 Role::Label => {
-                    let location = self.factory.create_block_location(object.global_id);
                     let name = object.label().unwrap_or_default().to_string();
 
                     // A label no jump targets is dead routing; keep it, but flag it.
@@ -165,7 +174,6 @@ impl<'index> Resolver<'index> {
 
                 // A callee the index doesn't know can't be classified; reject it.
                 Role::Block if block::is_unknown(object, self.index) => {
-                    let location = self.factory.create_block_location(object.global_id);
                     let name = object.type_name().unwrap_or_default();
 
                     self.diagnostics.push(Diagnostic::unknown_block_type(name, location));
@@ -173,7 +181,6 @@ impl<'index> Resolver<'index> {
 
                 // Stateless blocks (functions and sort of methods); temporaries for outputs
                 Role::Block if block::is_stateless(object, self.index) => {
-                    let location = self.factory.create_block_location(object.global_id);
                     let variadic = block::is_variadic(object, self.index);
 
                     let mut arguments = Vec::new();
@@ -206,8 +213,8 @@ impl<'index> Resolver<'index> {
                     // Consumed outputs are captured into temporaries
                     let mut capture = None;
                     for pin in object.output_pins() {
-                        let consumed = pin.output_pin().is_some_and(|id| survey.consumed.contains(&id));
-                        let name = consumed.then(|| block::temp_name(object, pin));
+                        let read = pin.output_pin().is_some_and(|id| consumed.contains(&id));
+                        let name = read.then(|| block::temp_name(object, pin));
 
                         if let Some(name) = &name {
                             if let Some(temporary) = self.temporary(name, object, pin, &location) {
@@ -234,8 +241,6 @@ impl<'index> Resolver<'index> {
 
                 // A stateful call passes only its wired inputs; outputs read back as members.
                 Role::Block => {
-                    let location = self.factory.create_block_location(object.global_id);
-
                     let mut arguments = Vec::new();
                     for pin in block::inputs(object) {
                         match trace(pin.source_pin(), &survey) {
@@ -260,7 +265,6 @@ impl<'index> Resolver<'index> {
 
                 // Placed but never wired; warn and ignore.
                 Role::Unconnected => {
-                    let location = self.factory.create_block_location(object.global_id);
                     let name = object.identifier().unwrap_or("<unnamed>");
 
                     self.diagnostics.push(Diagnostic::unconnected_element(name, location));
@@ -337,64 +341,68 @@ impl<'index> Resolver<'index> {
         let mut targets = HashSet::new();
 
         for object in network.elements() {
-            // A label name claimed twice makes its jump target ambiguous.
-            if matches!(Role::from(object), Role::Label) {
-                if let Some(label) = object.label() {
-                    if !labels.insert(label) {
-                        let location = self.factory.create_block_location(object.global_id);
-                        self.diagnostics.push(Diagnostic::duplicate_label(label, location));
-                    }
-                }
-            }
-
-            if matches!(Role::from(object), Role::Jump) {
-                if let Some(target) = object.target_label() {
-                    targets.insert(target);
-                }
-            }
-
-            // Register every output pin an incoming wire could reference; a block exposes one per output parameter.
+            // Register every output pin an incoming wire could reference.
             if let Some(out) = &object.connection_out {
                 by_pin.insert(out.id, object);
             }
 
-            if matches!(Role::from(object), Role::Block) {
-                for pin in object.output_pins() {
-                    if let Some(id) = pin.output_pin() {
-                        by_pin.insert(id, object);
-                        block_output.insert(id, pin);
-                    }
-                }
-            }
-
-            if matches!(Role::from(object), Role::Connector) {
-                if let Some(label) = object.label() {
-                    match connector_by_label.entry(label) {
-                        // The first connector to claim a label owns it.
-                        Entry::Vacant(entry) => {
-                            entry.insert(object);
-                        }
-
-                        // A later one reusing the label is a duplicate.
-                        Entry::Occupied(_) => {
+            match Role::from(object) {
+                // A label name claimed twice makes its jump target ambiguous.
+                Role::Label => {
+                    if let Some(label) = object.label() {
+                        if !labels.insert(label) {
                             let location = self.factory.create_block_location(object.global_id);
-                            self.diagnostics.push(Diagnostic::duplicate_connector(label, location));
+                            self.diagnostics.push(Diagnostic::duplicate_label(label, location));
                         }
                     }
                 }
+
+                Role::Jump => {
+                    if let Some(target) = object.target_label() {
+                        targets.insert(target);
+                    }
+                }
+
+                // A block exposes one pin per output parameter.
+                Role::Block => {
+                    for pin in object.output_pins() {
+                        if let Some(id) = pin.output_pin() {
+                            by_pin.insert(id, object);
+                            block_output.insert(id, pin);
+                        }
+                    }
+                }
+
+                Role::Connector => {
+                    if let Some(label) = object.label() {
+                        match connector_by_label.entry(label) {
+                            // The first connector to claim a label owns it.
+                            Entry::Vacant(entry) => {
+                                entry.insert(object);
+                            }
+
+                            // A later one reusing the label is a duplicate.
+                            Entry::Occupied(_) => {
+                                let location = self.factory.create_block_location(object.global_id);
+                                self.diagnostics.push(Diagnostic::duplicate_connector(label, location));
+                            }
+                        }
+                    }
+                }
+
+                _ => {}
             }
         }
 
-        Survey { by_pin, block_output, connector_by_label, labels, targets, consumed: HashSet::new() }
+        Survey { by_pin, block_output, connector_by_label, labels, targets }
     }
 
     fn expression(&mut self, object: &FbdObject, location: &SourceLocation) -> AstNode {
         let node = self.parse(object, location);
 
-        // Expressions other than literals and references defined in the text declaration of a CFC graph node
-        // are unsupported. A variable node element should only contain a literal or reference, not a call
-        // for example (calls must use a block element instead).
-        if !is_supported(&node.stmt) {
+        // A variable element may only hold a literal or a reference; anything
+        // else (a call, arithmetic) must be modeled as a block element instead.
+        if !is_supported(&node) {
             let location = self.factory.create_block_location(object.global_id);
             let text = object.identifier().unwrap_or_default();
             self.diagnostics.push(Diagnostic::unsupported_cfc_expression(text, location));
@@ -418,21 +426,21 @@ impl<'index> Resolver<'index> {
     // Creates an AST node, wrapped in a NOT expression for each inversion
     // bubble on the wire: the producer's, then the consumer's on top.
     fn condition(&mut self, consumer: &FbdObject, source: &Source, location: &SourceLocation) -> AstNode {
-        // Unvetted; a condition may be any ST expression.
         let node = match source {
+            // Unvetted; a condition may be any ST expression.
             Source::Variable(object) => {
                 let node = self.parse(object, location);
                 self.negate_if(node, location, object.out_negated())
             }
-            Source::Output { block, pin } => self.member_read(block, pin, location),
+            Source::Output { .. } => self.value(source, location),
         };
 
         self.negate_if(node, location, consumer.in_negated())
     }
 
     fn member_read(&mut self, block: &FbdObject, pin: &Pin, location: &SourceLocation) -> AstNode {
-        let mut node = st::parse_expression(&block::read_target(block, pin, self.index), self.ids.clone());
-        node.location = location.clone();
+        let target = block::read_target(block, pin, self.index);
+        let node = st::parse_expression_at(&target, self.ids.clone(), location);
 
         self.negate_if(node, location, pin.negated)
     }
@@ -445,9 +453,7 @@ impl<'index> Resolver<'index> {
     }
 
     fn parse(&mut self, object: &FbdObject, location: &SourceLocation) -> AstNode {
-        let mut node = st::parse_expression(object.identifier().unwrap_or_default(), self.ids.clone());
-        node.location = location.clone();
-        node
+        st::parse_expression_at(object.identifier().unwrap_or_default(), self.ids.clone(), location)
     }
 }
 
@@ -516,16 +522,12 @@ fn trace<'model>(start: Option<usize>, survey: &Survey<'model>) -> Trace<'model>
     }
 }
 
-fn is_supported(statement: &AstStatement) -> bool {
-    match statement {
-        // See through parentheses, e.g. `(foo)` or `((5))`.
-        AstStatement::ParenExpression(inner) => is_supported(&inner.stmt),
-        AstStatement::Literal(_) | AstStatement::ReferenceExpr(_) => true,
-        _ => false,
-    }
+// Sees through parentheses, e.g. `(foo)` or `((5))`.
+fn is_supported(node: &AstNode) -> bool {
+    matches!(node.get_stmt_peeled(), AstStatement::Literal(_) | AstStatement::ReferenceExpr(_))
 }
 
-// Block related helpers
+// Classification, naming, and call-target helpers for block elements.
 mod block {
     use plc::index::Index;
 
@@ -629,11 +631,7 @@ fn consumed(network: &model::Network, survey: &Survey) -> HashSet<usize> {
 }
 
 fn consumes(consumer: &FbdObject) -> Option<usize> {
-    consumer
-        .connection_in
-        .as_ref()
-        .and_then(|it| it.connections.first())
-        .map(|connection| connection.ref_out_id)
+    consumer.connection_in.as_ref()?.source_pin()
 }
 
 #[cfg(test)]
@@ -657,6 +655,7 @@ mod tests {
         render(&network)
     }
 
+    // One line per statement, in the network's final evaluation order.
     fn render(network: &Network) -> String {
         network
             .statements

--- a/compiler/plc_cfc/src/st.rs
+++ b/compiler/plc_cfc/src/st.rs
@@ -1,9 +1,11 @@
+//! Parses embedded structured-text fragments with the main compiler's parser.
+
 use plc::lexer;
 use plc::parser::{self, expressions_parser};
 use plc_ast::ast::{AstNode, CompilationUnit, LinkageType};
 use plc_ast::provider::IdProvider;
 use plc_diagnostics::diagnostics::Diagnostic;
-use plc_source::source_location::SourceLocationFactory;
+use plc_source::source_location::{SourceLocation, SourceLocationFactory};
 use plc_source::{SourceCode, SourceContainer};
 
 use crate::model::{Pou, PouKind};
@@ -13,6 +15,14 @@ pub fn parse_expression(text: &str, ids: IdProvider) -> AstNode {
     let mut session = lexer::lex_with_ids(text, ids, factory);
 
     expressions_parser::parse_expression(&mut session)
+}
+
+// A parsed expression relocated to where the network places it, so
+// diagnostics point at the diagram element rather than the parsed text.
+pub fn parse_expression_at(text: &str, ids: IdProvider, location: &SourceLocation) -> AstNode {
+    let mut node = parse_expression(text, ids);
+    node.location = location.clone();
+    node
 }
 
 pub fn parse_interface(
@@ -28,6 +38,7 @@ pub fn parse_interface(
     };
     let declaration = format!("{}\n{end_keyword}", pou.content().declaration().unwrap_or_default());
 
+    // Parse the completed declaration like any ST source.
     let declaration = SourceCode { source: declaration, path: source.path.clone() };
     let factory = SourceLocationFactory::for_source(&declaration);
     let session = lexer::lex_with_ids(&declaration.source, ids, factory);

--- a/compiler/plc_cfc/src/transpiler.rs
+++ b/compiler/plc_cfc/src/transpiler.rs
@@ -1,3 +1,5 @@
+//! Renders the resolved network into the interface unit's AST body.
+
 use plc_ast::ast::{AstFactory, AstNode, CompilationUnit, DataTypeDeclaration, Variable, VariableBlock};
 use plc_ast::control_statements::{ConditionalBlock, IfStatement};
 use plc_ast::literals::AstLiteral;
@@ -28,7 +30,7 @@ impl Transpiler {
             implementation.statements = statements;
         }
 
-        // Declare the captured function outputs in an own VAR block.
+        // Declare the captured function outputs in their own VAR block.
         let mut temporaries = Vec::new();
         for temporary in network.temporaries {
             let data_type = DataTypeDeclaration::reference(temporary.data_type, temporary.location.clone());
@@ -53,23 +55,17 @@ impl Transpiler {
             Statement::Assignment { sink, source, storage: Some(storage) } => {
                 let location = sink.location.clone();
 
-                let value = AstLiteral::Bool(matches!(storage, Storage::Set));
-                let value = AstFactory::create_literal(value, location.clone(), self.ids.next_id());
+                let value = self.boolean(matches!(storage, Storage::Set), &location);
                 let store = AstFactory::create_assignment(sink, value, self.ids.next_id());
 
-                let statement = IfStatement {
-                    blocks: vec![ConditionalBlock { condition: Box::new(source), body: vec![store] }],
-                    else_block: Vec::new(),
-                    end_location: location.clone(),
-                };
-                AstFactory::create_if_statement(statement, location, self.ids.next_id())
+                self.guard(source, store, location)
             }
             Statement::Return { condition, location } => {
                 AstFactory::create_return_statement(Some(condition), location, self.ids.next_id())
             }
             Statement::Jump { condition, target, location } => {
                 // No wired condition lowers to a guard the jump can never pass.
-                let condition = condition.unwrap_or_else(|| self.reference("FALSE", &location));
+                let condition = condition.unwrap_or_else(|| self.boolean(false, &location));
                 let target = self.reference(&target, &location);
 
                 AstFactory::create_jump_statement(
@@ -116,6 +112,22 @@ impl Transpiler {
         }
     }
 
+    // `IF condition THEN body END_IF`; the shape shared by storage-mode
+    // latches and EN guards.
+    fn guard(&mut self, condition: AstNode, body: AstNode, location: SourceLocation) -> AstNode {
+        let statement = IfStatement {
+            blocks: vec![ConditionalBlock { condition: Box::new(condition), body: vec![body] }],
+            else_block: Vec::new(),
+            end_location: location.clone(),
+        };
+
+        AstFactory::create_if_statement(statement, location, self.ids.next_id())
+    }
+
+    fn boolean(&mut self, value: bool, location: &SourceLocation) -> AstNode {
+        AstFactory::create_literal(AstLiteral::Bool(value), location.clone(), self.ids.next_id())
+    }
+
     fn argument(&mut self, argument: Argument, location: &SourceLocation) -> AstNode {
         match argument {
             // `parameter := value`
@@ -141,9 +153,7 @@ impl Transpiler {
     }
 
     fn reference(&mut self, name: &str, location: &SourceLocation) -> AstNode {
-        let mut node = st::parse_expression(name, self.ids.clone());
-        node.location = location.clone();
-        node
+        st::parse_expression_at(name, self.ids.clone(), location)
     }
 }
 


### PR DESCRIPTION
Problem: The plc_cfc crate carried derivable survey state, duplicated wire-tracing and guard-building logic, and undocumented modules, which makes changes to the crate noisier than they need to be.

Solution: Behavior-preserving cleanup: single owners for the wire rule and the IF guard shape, a survey without two-phase state, deduplicated lowering helpers, shared parse helpers, and module plus survey documentation. All snapshots are unchanged. Groundwork for the EN/ENO PR stacked on top.

Refs: PRG-4506

🤖 Generated with [Claude Code](https://claude.com/claude-code)