### PR TITLE
fix(stdlib): backport the no-panic hardening stack (1.0.x)

### DIFF
--- a/libs/stdlib/src/date_time_conversion.rs
+++ b/libs/stdlib/src/date_time_conversion.rs
@@ -1,17 +1,16 @@
-use chrono::{TimeZone, Timelike};
+const NANOS_PER_SECOND: i64 = 1_000 * 1_000 * 1_000;
+const SECONDS_PER_DAY: i64 = 60 * 60 * 24;
+const NANOS_PER_DAY: i64 = NANOS_PER_SECOND * SECONDS_PER_DAY;
 
 /// .
 /// Converts DT/LDT to DATE
+/// The midnight of the first representable day lies below the DATE range and
+/// saturates to the range minimum
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_DATE(input: i64) -> i64 {
-    let date_time = chrono::Utc.timestamp_nanos(input);
-
-    let new_date_time =
-        date_time.date_naive().and_hms_opt(0, 0, 0).expect("Cannot create date time from date");
-
-    new_date_time.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create DATE")
+    input.div_euclid(NANOS_PER_DAY).checked_mul(NANOS_PER_DAY).unwrap_or(i64::MIN)
 }
 
 /// .
@@ -20,15 +19,5 @@ pub extern "C" fn DATE_AND_TIME_TO_DATE(input: i64) -> i64 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn DATE_AND_TIME_TO_TIME_OF_DAY(input: i64) -> i64 {
-    let date_time = chrono::Utc.timestamp_nanos(input);
-    let hour = date_time.hour();
-    let min = date_time.minute();
-    let sec = date_time.second();
-    let nano = date_time.timestamp_subsec_nanos();
-
-    let new_date_time = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
-        .and_then(|date| date.and_hms_nano_opt(hour, min, sec, nano))
-        .expect("Cannot create date time from given parameters");
-
-    new_date_time.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create TOD")
+    input.rem_euclid(NANOS_PER_DAY)
 }

--- a/libs/stdlib/src/date_time_extra_functions.rs
+++ b/libs/stdlib/src/date_time_extra_functions.rs
@@ -1,23 +1,24 @@
 use chrono::{Datelike, NaiveDate, TimeZone, Timelike};
 
+const NANOS_PER_MILLISECOND: i64 = 1_000 * 1_000;
+const NANOS_PER_SECOND: i64 = 1_000 * 1_000 * 1_000;
+
+/// Narrows a year to the split output type. DATE/DT/LDT years span 1677-2262,
+/// so every target type fits; the default covers a future change of that
+/// representation.
+fn year_component<T: TryFrom<i32> + Default>(year: i32) -> T {
+    debug_assert!(T::try_from(year).is_ok(), "year out of range for the target type");
+    T::try_from(year).unwrap_or_default()
+}
+
 /// .
 /// Concatenates DATE and TOD to DT
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn CONCAT_DATE_TOD(in1: i64, in2: i64) -> i64 {
-    let date = chrono::Utc.timestamp_nanos(in1).date_naive();
-    let tod = chrono::Utc.timestamp_nanos(in2);
-    let hour = tod.hour();
-    let min = tod.minute();
-    let sec = tod.second();
-    let nano = tod.timestamp_subsec_nanos();
-
-    date.and_hms_nano_opt(hour, min, sec, nano)
-        .expect("Invalid input")
-        .and_utc()
-        .timestamp_nanos_opt()
-        .expect("Out of range, cannot create Date")
+    in1.wrapping_add(in2)
 }
 
 /// .
@@ -76,15 +77,15 @@ pub extern "C" fn CONCAT_DATE__ULINT(in1: u64, in2: u64, in3: u64) -> i64 {
 
 /// .
 /// Concatenates year, month and day to DATE
+/// Unrepresentable dates yield 0; results are clamped to the DATE range (1677-2262)
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn concat_date(in1: i32, in2: u32, in3: u32) -> i64 {
-    let dt = NaiveDate::from_ymd_opt(in1, in2, in3)
+    NaiveDate::from_ymd_opt(in1, in2, in3)
         .and_then(|date| date.and_hms_opt(0, 0, 0))
-        .expect("Invalid parameters, cannot create date");
-
-    dt.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create date")
+        .map(|dt| dt.and_utc().timestamp_nanos_opt().unwrap_or(if in1 < 1970 { i64::MIN } else { i64::MAX }))
+        .unwrap_or(0)
 }
 
 /// .
@@ -161,15 +162,22 @@ pub extern "C" fn CONCAT_TOD__ULINT(in1: u64, in2: u64, in3: u64, in4: u64) -> i
 
 /// .
 /// Concatenates hour, minute, second, millisecond to TOD
+/// Invalid time-of-day fields yield 0
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn concat_tod(in1: u32, in2: u32, in3: u32, in4: u32) -> i64 {
-    let dt = NaiveDate::from_ymd_opt(1970, 1, 1)
+    // the range check must run before the arithmetic; out-of-range fields
+    // (e.g. a negative SINT cast to a huge u32) would overflow the formula
+    let valid = NaiveDate::from_ymd_opt(1970, 1, 1)
         .and_then(|date| date.and_hms_milli_opt(in1, in2, in3, in4))
-        .expect("Invalid parameters, cannot create TOD");
+        .is_some();
+    if !valid {
+        return 0;
+    }
 
-    dt.and_utc().timestamp_nanos_opt().expect("Out of range, cannot create TOD")
+    (in1 as i64 * 3_600 + in2 as i64 * 60 + in3 as i64) * NANOS_PER_SECOND
+        + in4 as i64 * NANOS_PER_MILLISECOND
 }
 
 /// .
@@ -179,8 +187,7 @@ pub extern "C" fn concat_tod(in1: u32, in2: u32, in3: u32, in4: u32) -> i64 {
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__INT(in1: i64, out1: &mut i16, out2: &mut i16, out3: &mut i16) -> i16 {
     let date = chrono::Utc.timestamp_nanos(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month() as i16;
     *out3 = date.day() as i16;
 
@@ -189,14 +196,12 @@ pub extern "C" fn SPLIT_DATE__INT(in1: i64, out1: &mut i16, out2: &mut i16, out3
 
 /// .
 /// Splits DATE into year, month, day of type UINT
-/// Panics on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__UINT(in1: i64, out1: &mut u16, out2: &mut u16, out3: &mut u16) -> i16 {
     let date = chrono::Utc.timestamp_nanos(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month() as u16;
     *out3 = date.day() as u16;
 
@@ -224,8 +229,7 @@ pub extern "C" fn SPLIT_DATE__DINT(in1: i64, out1: &mut i32, out2: &mut i32, out
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__UDINT(in1: i64, out1: &mut u32, out2: &mut u32, out3: &mut u32) -> i16 {
     let date = chrono::Utc.timestamp_nanos(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month();
     *out3 = date.day();
 
@@ -239,7 +243,6 @@ pub extern "C" fn SPLIT_DATE__UDINT(in1: i64, out1: &mut u32, out2: &mut u32, ou
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__LINT(in1: i64, out1: &mut i64, out2: &mut i64, out3: &mut i64) -> i16 {
     let date = chrono::Utc.timestamp_nanos(in1).date_naive();
-    // if year does not fit in target data type -> panic
     *out1 = date.year().into();
     *out2 = date.month() as i64;
     *out3 = date.day() as i64;
@@ -249,14 +252,12 @@ pub extern "C" fn SPLIT_DATE__LINT(in1: i64, out1: &mut i64, out2: &mut i64, out
 
 /// .
 /// Splits DATE into year, month, day of type ULINT
-/// Panics on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn SPLIT_DATE__ULINT(in1: i64, out1: &mut u64, out2: &mut u64, out3: &mut u64) -> i16 {
     let date = chrono::Utc.timestamp_nanos(in1).date_naive();
-    // if year does not fit in target data type -> panic
-    *out1 = date.year().try_into().unwrap();
+    *out1 = year_component(date.year());
     *out2 = date.month() as u64;
     *out3 = date.day() as u64;
 
@@ -405,8 +406,7 @@ pub extern "C" fn SPLIT_DT__INT(
     out7: &mut i16,
 ) -> i16 {
     let dt = chrono::Utc.timestamp_nanos(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month() as i16;
     *out3 = dt.day() as i16;
     *out4 = dt.hour() as i16;
@@ -433,8 +433,7 @@ pub extern "C" fn SPLIT_DT__UINT(
     out7: &mut u16,
 ) -> i16 {
     let dt = chrono::Utc.timestamp_nanos(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month() as u16;
     *out3 = dt.day() as u16;
     *out4 = dt.hour() as u16;
@@ -488,8 +487,7 @@ pub extern "C" fn SPLIT_DT__UDINT(
     out7: &mut u32,
 ) -> i16 {
     let dt = chrono::Utc.timestamp_nanos(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month();
     *out3 = dt.day();
     *out4 = dt.hour();
@@ -516,7 +514,6 @@ pub extern "C" fn SPLIT_DT__LINT(
     out7: &mut i64,
 ) -> i16 {
     let dt = chrono::Utc.timestamp_nanos(in1);
-    // if year does not fit in target data type -> panic
     *out1 = dt.year().into();
     *out2 = dt.month() as i64;
     *out3 = dt.day() as i64;
@@ -544,8 +541,7 @@ pub extern "C" fn SPLIT_DT__ULINT(
     out7: &mut u64,
 ) -> i16 {
     let dt = chrono::Utc.timestamp_nanos(in1);
-    // if year does not fit in target data type -> panic
-    *out1 = dt.year().try_into().unwrap();
+    *out1 = year_component(dt.year());
     *out2 = dt.month() as u64;
     *out3 = dt.day() as u64;
     *out4 = dt.hour() as u64;

--- a/libs/stdlib/src/date_time_numeric_functions.rs
+++ b/libs/stdlib/src/date_time_numeric_functions.rs
@@ -1,833 +1,814 @@
-use chrono::TimeZone;
-
 /// .
 /// This operator returns the value of adding up two TIME operands.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD_TIME(in1: i64, in2: i64) -> i64 {
-    chrono::Duration::nanoseconds(in1)
-        .checked_add(&chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .num_nanoseconds()
-        .unwrap()
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// This operator returns the value of adding up TOD and TIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD_TOD_TIME(in1: i64, in2: i64) -> i64 {
-    add_datetime_time(in1, in2)
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// This operator returns the value of adding up DT and TIME.
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn ADD_DT_TIME(in1: i64, in2: i64) -> i64 {
-    add_datetime_time(in1, in2)
-}
-
-fn add_datetime_time(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .checked_add_signed(chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .timestamp_nanos_opt()
-        .unwrap()
+    in1.wrapping_add(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two TIME operands
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_TIME(in1: i64, in2: i64) -> i64 {
-    chrono::Duration::nanoseconds(in1)
-        .checked_sub(&chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .num_nanoseconds()
-        .unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two DATE operands
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DATE_DATE(in1: i64, in2: i64) -> i64 {
-    sub_datetimes(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of TOD and TIME
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_TOD_TIME(in1: i64, in2: i64) -> i64 {
-    sub_datetime_duration(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two TOD operands
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_TOD_TOD(in1: i64, in2: i64) -> i64 {
-    sub_datetimes(in1, in2)
-}
-
-fn sub_datetimes(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .signed_duration_since(chrono::Utc.timestamp_nanos(in2))
-        .num_nanoseconds()
-        .unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of DT and TIME
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DT_TIME(in1: i64, in2: i64) -> i64 {
-    sub_datetime_duration(in1, in2)
-}
-
-fn sub_datetime_duration(in1: i64, in2: i64) -> i64 {
-    chrono::Utc
-        .timestamp_nanos(in1)
-        .checked_sub_signed(chrono::Duration::nanoseconds(in2))
-        .unwrap()
-        .timestamp_nanos_opt()
-        .unwrap()
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// This operator produces the subtraction of two DT operands
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn SUB_DT_DT(in1: i64, in2: i64) -> i64 {
-    sub_datetimes(in1, in2)
+    in1.wrapping_sub(in2)
 }
 
 /// .
 /// Multiply TIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with SINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with DINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2.into())
+    mul_time_with_signed_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with LINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_mul_time_with_signed_int(in1, in2)
+    mul_time_with_signed_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME/LTIME with ANY_SIGNED_INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
-fn checked_mul_time_with_signed_int(in1: i64, in2: i64) -> i64 {
-    in1.checked_mul(in2).unwrap()
+fn mul_time_with_signed_int(in1: i64, in2: i64) -> i64 {
+    in1.wrapping_mul(in2)
 }
 
 /// .
 /// Multiply TIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply TIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with USINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with UINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with UDINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2.into())
+    mul_time_with_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Multiply LTIME with ULINT
-/// Panic on overflow
+/// Wraps on overflow
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_mul_time_with_unsigned_int(in1, in2)
+    mul_time_with_unsigned_int(in1, in2)
 }
 
 /// .
 /// Multiply TIME/LTIME with ANY_UNSIGNED_INT
-/// Panic on overflow
+/// Wraps on overflow
 ///
-fn checked_mul_time_with_unsigned_int(in1: i64, in2: u64) -> i64 {
-    // convert in2 [u64] to [i64]
-    // if in2 is to large for [i64] the multiplication will allways overflow -> panic on try_into()
-    in1.checked_mul(in2.try_into().unwrap()).unwrap()
+fn mul_time_with_unsigned_int(in1: i64, in2: u64) -> i64 {
+    // the u64 to i64 cast keeps the result correct modulo 2^64
+    in1.wrapping_mul(in2 as i64)
 }
 
 /// .
 /// Divide TIME by SINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by INT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by DINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by LINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_div_time_by_signed_int(in1, in2)
+    div_time_by_signed_int(in1, in2)
 }
 
 /// .
 /// Divide TIME by SINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by INT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by DINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by LINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_div_time_by_signed_int(in1, in2)
+    div_time_by_signed_int(in1, in2)
 }
 
 /// .
 /// Divide LTIME by SINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__SINT(in1: i64, in2: i8) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by INT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__INT(in1: i64, in2: i16) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by DINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__DINT(in1: i64, in2: i32) -> i64 {
-    checked_div_time_by_signed_int(in1, in2.into())
+    div_time_by_signed_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by LINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__LINT(in1: i64, in2: i64) -> i64 {
-    checked_div_time_by_signed_int(in1, in2)
+    div_time_by_signed_int(in1, in2)
 }
 
 /// .
 /// Divide TIME/LTIME with ANY_SIGNED_INT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
-fn checked_div_time_by_signed_int(in1: i64, in2: i64) -> i64 {
-    in1.checked_div(in2).unwrap()
+fn div_time_by_signed_int(in1: i64, in2: i64) -> i64 {
+    in1.wrapping_div(in2)
 }
 
 /// .
 /// Divide TIME by USINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UDINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by ULINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2)
+    div_time_by_unsigned_int(in1, in2)
 }
 
 /// .
 /// Divide TIME by USINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by UDINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide TIME by ULINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2)
+    div_time_by_unsigned_int(in1, in2)
 }
 
 /// .
 /// Divide LTIME by USINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__USINT(in1: i64, in2: u8) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by UINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__UINT(in1: i64, in2: u16) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by UDINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__UDINT(in1: i64, in2: u32) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2.into())
+    div_time_by_unsigned_int(in1, in2.into())
 }
 
 /// .
 /// Divide LTIME by ULINT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__ULINT(in1: i64, in2: u64) -> i64 {
-    checked_div_time_by_unsigned_int(in1, in2)
+    div_time_by_unsigned_int(in1, in2)
 }
 
 /// .
 /// Divide TIME/LTIME with ANY_UNSIGNED_INT
-/// Panic on overflow or division by zero
+/// Panics on division by zero
 ///
-fn checked_div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
-    // convert in2 [u64] to [i64]
-    // if in2 is to large for [i64] the division will allways fail -> panic on try_into()
-    in1.checked_div(in2.try_into().unwrap()).unwrap()
+fn div_time_by_unsigned_int(in1: i64, in2: u64) -> i64 {
+    // a divisor above the signed range always exceeds the dividend magnitude
+    match i64::try_from(in2) {
+        Ok(divisor) => in1.wrapping_div(divisor),
+        Err(_) => 0,
+    }
 }
 
 /// .
 /// Multiply TIME with REAL
-/// Panic on overflow
+/// A NaN factor yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_mul_time_with_f32(in1, in2)
+    mul_time_with_f32(in1, in2)
 }
 
 /// .
 /// Multiply TIME with REAL
-/// Panic on overflow
+/// A NaN factor yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_mul_time_with_f32(in1, in2)
+    mul_time_with_f32(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with REAL
-/// Panic on overflow
+/// A NaN factor yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_mul_time_with_f32(in1, in2)
+    mul_time_with_f32(in1, in2)
 }
 
-fn checked_mul_time_with_f32(in1: i64, in2: f32) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.mul_f32(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
+fn mul_time_with_f32(in1: i64, in2: f32) -> i64 {
+    if in2.is_nan() {
+        return 0;
+    }
+    let negative = in1.is_negative() ^ in2.is_sign_negative();
+    let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());
+    // pre-check in f64 so the Duration math below can never panic on overflow;
+    // NaN only occurs for zero times an infinite factor
+    let approx_nanos = magnitude.as_secs_f64() * f64::from(in2.abs()) * 1e9;
+    let res: i64 = if approx_nanos.is_nan() {
+        0
+    } else if approx_nanos >= i64::MAX as f64 {
+        i64::MAX
+    } else {
+        magnitude.mul_f32(in2.abs()).as_nanos().try_into().unwrap_or(i64::MAX)
+    };
+    if negative {
+        -res
+    } else {
+        res
     }
 }
 
 /// .
 /// Multiply TIME with LREAL
-/// Panic on overflow
+/// A NaN factor yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL__TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_mul_time_with_f64(in1, in2)
+    mul_time_with_f64(in1, in2)
 }
 
 /// .
 /// Multiply TIME with LREAL
-/// Panic on overflow
+/// A NaN factor yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_mul_time_with_f64(in1, in2)
+    mul_time_with_f64(in1, in2)
 }
 
 /// .
 /// Multiply LTIME with LREAL
-/// Panic on overflow
+/// A NaN factor yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn MUL_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_mul_time_with_f64(in1, in2)
+    mul_time_with_f64(in1, in2)
 }
 
-fn checked_mul_time_with_f64(in1: i64, in2: f64) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.mul_f64(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
+fn mul_time_with_f64(in1: i64, in2: f64) -> i64 {
+    if in2.is_nan() {
+        return 0;
+    }
+    let negative = in1.is_negative() ^ in2.is_sign_negative();
+    let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());
+    // pre-check in f64 so the Duration math below can never panic on overflow;
+    // NaN only occurs for zero times an infinite factor
+    let approx_nanos = magnitude.as_secs_f64() * in2.abs() * 1e9;
+    let res: i64 = if approx_nanos.is_nan() {
+        0
+    } else if approx_nanos >= i64::MAX as f64 {
+        i64::MAX
+    } else {
+        magnitude.mul_f64(in2.abs()).as_nanos().try_into().unwrap_or(i64::MAX)
+    };
+    if negative {
+        -res
+    } else {
+        res
     }
 }
 
 /// .
 /// Divide TIME by REAL
-/// Panic on overflow or division by zero
+/// A zero divisor saturates at the TIME range, a NaN divisor or result yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_div_time_by_f32(in1, in2)
+    div_time_by_f32(in1, in2)
 }
 
 /// .
 /// Divide TIME by REAL
-/// Panic on overflow or division by zero
+/// A zero divisor saturates at the TIME range, a NaN divisor or result yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_div_time_by_f32(in1, in2)
+    div_time_by_f32(in1, in2)
 }
 
 /// .
 /// Divide LTIME by REAL
-/// Panic on overflow or division by zero
+/// A zero divisor saturates at the TIME range, a NaN divisor or result yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__REAL(in1: i64, in2: f32) -> i64 {
-    checked_div_time_by_f32(in1, in2)
+    div_time_by_f32(in1, in2)
 }
 
-fn checked_div_time_by_f32(in1: i64, in2: f32) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.div_f32(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
+fn div_time_by_f32(in1: i64, in2: f32) -> i64 {
+    let negative = in1.is_negative() ^ in2.is_sign_negative();
+    let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());
+    // pre-check in f64 so the Duration math below can never panic on overflow;
+    // a NaN result here covers both a NaN divisor and zero divided by zero
+    let approx_nanos = magnitude.as_secs_f64() / f64::from(in2.abs()) * 1e9;
+    if approx_nanos.is_nan() {
+        return 0;
+    }
+    let res: i64 = if approx_nanos >= i64::MAX as f64 {
+        i64::MAX
+    } else {
+        magnitude.div_f32(in2.abs()).as_nanos().try_into().unwrap_or(i64::MAX)
+    };
+    if negative {
+        -res
+    } else {
+        res
     }
 }
 
 /// .
 /// Divide TIME by LREAL
-/// Panic on overflow or division by zero
+/// A zero divisor saturates at the TIME range, a NaN divisor or result yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV__TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_div_time_by_f64(in1, in2)
+    div_time_by_f64(in1, in2)
 }
 
 /// .
 /// Divide TIME by LREAL
-/// Panic on overflow or division by zero
+/// A zero divisor saturates at the TIME range, a NaN divisor or result yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_TIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_div_time_by_f64(in1, in2)
+    div_time_by_f64(in1, in2)
 }
 
 /// .
 /// Divide LTIME by LREAL
-/// Panic on overflow or division by zero
+/// A zero divisor saturates at the TIME range, a NaN divisor or result yields zero, overflow saturates
 ///
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C-unwind" fn DIV_LTIME__LREAL(in1: i64, in2: f64) -> i64 {
-    checked_div_time_by_f64(in1, in2)
+    div_time_by_f64(in1, in2)
 }
 
-fn checked_div_time_by_f64(in1: i64, in2: f64) -> i64 {
-    // std::time::Duration can't handle negatives
-    // we need to check for negative numbers and convert them to positives if necessary
-    let is_in1_negative = in1.is_negative();
-    let duration = std::time::Duration::from_nanos(in1.unsigned_abs());
-
-    // if overflows i64 return panic
-    let is_in2_negative = in2.is_sign_negative();
-    let res: i64 = duration.div_f64(in2.abs()).as_nanos().try_into().unwrap();
-
-    // convert to negative if necessary
-    let should_res_be_negative = is_in1_negative ^ is_in2_negative;
-    match should_res_be_negative {
-        true => -res,
-        false => res,
+fn div_time_by_f64(in1: i64, in2: f64) -> i64 {
+    let negative = in1.is_negative() ^ in2.is_sign_negative();
+    let magnitude = std::time::Duration::from_nanos(in1.unsigned_abs());
+    // pre-check in f64 so the Duration math below can never panic on overflow;
+    // a NaN result here covers both a NaN divisor and zero divided by zero
+    let approx_nanos = magnitude.as_secs_f64() / in2.abs() * 1e9;
+    if approx_nanos.is_nan() {
+        return 0;
+    }
+    let res: i64 = if approx_nanos >= i64::MAX as f64 {
+        i64::MAX
+    } else {
+        magnitude.div_f64(in2.abs()).as_nanos().try_into().unwrap_or(i64::MAX)
+    };
+    if negative {
+        -res
+    } else {
+        res
     }
 }

--- a/libs/stdlib/src/extra_functions.rs
+++ b/libs/stdlib/src/extra_functions.rs
@@ -18,7 +18,8 @@ const DEFAULT_STRING_LEN: usize = 81;
 // --------- x_TO_STRING
 
 /// Formats `args` into `dest` and appends the null terminator the IEC string layout
-/// requires. Returns the number of content bytes written (excluding the terminator).
+/// requires. Output that does not fit is truncated to `capacity - 1` content bytes.
+/// Returns the number of content bytes written (excluding the terminator).
 /// Writers must not rely on the destination being zero-initialized; the buffer may
 /// hold arbitrary bytes.
 ///
@@ -27,7 +28,8 @@ const DEFAULT_STRING_LEN: usize = 81;
 unsafe fn write_terminated(dest: *mut u8, capacity: usize, args: std::fmt::Arguments) -> usize {
     let content = core::slice::from_raw_parts_mut(dest, capacity - 1);
     let mut cursor = std::io::Cursor::new(content);
-    cursor.write_fmt(args).unwrap();
+    // an Err here means the output was cut off at the end of the buffer
+    let _ = cursor.write_fmt(args);
     let written = cursor.position() as usize;
     *dest.add(written) = 0;
     written
@@ -68,8 +70,10 @@ pub unsafe extern "C" fn LINT_TO_STRING_EXT(input: i64, dest: *mut u8) -> i32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn LREAL_TO_STRING_EXT(input: f64, dest: *mut u8) -> i32 {
-    // double: 52 bits are used for the mantissa (about 16 decimal digits)
-    if input.floor() < 1e14 {
+    // double: 52 bits are used for the mantissa (about 16 decimal digits);
+    // the magnitude decides the notation, so huge negative values take the
+    // scientific path instead of overflowing the buffer with plain digits
+    if input.abs() < 1e14 {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6}"));
     } else {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6e}"));
@@ -83,10 +87,9 @@ pub unsafe extern "C" fn LREAL_TO_STRING_EXT(input: f64, dest: *mut u8) -> i32 {
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn REAL_TO_STRING_EXT(input: f64, dest: *mut u8) -> i32 {
-    // float: 23 bits are used for the mantissa (about 7 decimal digits)
-
-    // TODO: discuss when scientific notation should be displayed
-    if input.floor() < 1e6 {
+    // float: 23 bits are used for the mantissa (about 7 decimal digits);
+    // the magnitude decides the notation, consistent with LREAL_TO_STRING_EXT
+    if input.abs() < 1e6 {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6}"));
     } else {
         write_terminated(dest, DEFAULT_STRING_LEN, format_args!("{input:.6e}"));
@@ -101,10 +104,12 @@ where
 {
     let slice = ptr_to_slice(src);
     let (string, radix) = match slice {
-        [b'1', b'6', b'#', ..] => (std::str::from_utf8(&slice[3..]), 16),
-        [b'0', b'x', ..] | [b'0', b'X', ..] => (std::str::from_utf8(&slice[2..]), 16),
-        [b'8', b'#', ..] => (std::str::from_utf8(&slice[2..]), 8), // support c-style octal prefixes? e.g. 010 -> 10 octal
-        [b'2', b'#', ..] | [b'0', b'b', ..] | [b'0', b'B', ..] => (std::str::from_utf8(&slice[2..]), 2),
+        [b'1', b'6', b'#', rest @ ..] => (std::str::from_utf8(rest), 16),
+        [b'0', b'x', rest @ ..] | [b'0', b'X', rest @ ..] => (std::str::from_utf8(rest), 16),
+        [b'8', b'#', rest @ ..] => (std::str::from_utf8(rest), 8), // support c-style octal prefixes? e.g. 010 -> 10 octal
+        [b'2', b'#', rest @ ..] | [b'0', b'b', rest @ ..] | [b'0', b'B', rest @ ..] => {
+            (std::str::from_utf8(rest), 2)
+        }
         _ => (std::str::from_utf8(slice), 10),
     };
 
@@ -121,10 +126,9 @@ where
 fn parse_longest_prefix<T: num::Zero>(s: &str, parse: impl Fn(&str) -> Option<T>) -> T {
     let mut end = s.len();
     while end > 0 {
-        if s.is_char_boundary(end) {
-            if let Some(number) = parse(&s[..end]) {
-                return number;
-            }
+        // `get` returns None between char boundaries
+        if let Some(number) = s.get(..end).and_then(&parse) {
+            return number;
         }
         end -= 1;
     }
@@ -402,6 +406,56 @@ mod test {
             std::str::from_utf8(unsafe { core::slice::from_raw_parts(dest_ptr, 81) }).unwrap();
 
         assert_eq!(format!("{e_notation:.6e}"), res_scientific.trim_end_matches('\0'));
+    }
+
+    #[test]
+    fn lreal_to_string_uses_scientific_notation_for_huge_negative_values() {
+        let mut dest = [0xAA_u8; 81];
+        let dest_ptr = dest.as_mut_ptr();
+
+        let _ = unsafe { LREAL_TO_STRING_EXT(-1.0e300, dest_ptr) };
+        assert_eq!("-1.000000e300", terminated_str(&dest));
+
+        // negative values below the threshold keep the plain notation
+        dest.fill(0xAA);
+        let _ = unsafe { LREAL_TO_STRING_EXT(-99_999_999_999_999.25, dest_ptr) };
+        assert_eq!("-99999999999999.250000", terminated_str(&dest));
+
+        dest.fill(0xAA);
+        let _ = unsafe { LREAL_TO_STRING_EXT(f64::NEG_INFINITY, dest_ptr) };
+        assert_eq!("-inf", terminated_str(&dest));
+
+        dest.fill(0xAA);
+        let _ = unsafe { LREAL_TO_STRING_EXT(f64::NAN, dest_ptr) };
+        assert_eq!("NaN", terminated_str(&dest));
+    }
+
+    #[test]
+    fn real_to_string_uses_scientific_notation_by_magnitude() {
+        let mut dest = [0xAA_u8; 81];
+        let dest_ptr = dest.as_mut_ptr();
+
+        let _ = unsafe { REAL_TO_STRING_EXT(-1.5e7, dest_ptr) };
+        assert_eq!("-1.500000e7", terminated_str(&dest));
+
+        dest.fill(0xAA);
+        let _ = unsafe { REAL_TO_STRING_EXT(1.5e7, dest_ptr) };
+        assert_eq!("1.500000e7", terminated_str(&dest));
+
+        // negative values below the threshold keep the plain notation
+        dest.fill(0xAA);
+        let _ = unsafe { REAL_TO_STRING_EXT(-999_999.25, dest_ptr) };
+        assert_eq!("-999999.250000", terminated_str(&dest));
+    }
+
+    #[test]
+    fn write_terminated_truncates_overlong_output() {
+        let mut dest = [0xAA_u8; 16];
+
+        let written = unsafe { write_terminated(dest.as_mut_ptr(), 16, format_args!("{:x<30}", "abc")) };
+
+        assert_eq!(15, written);
+        assert_eq!("abcxxxxxxxxxxxx", terminated_str(&dest));
     }
 
     #[test]

--- a/libs/stdlib/src/lib.rs
+++ b/libs/stdlib/src/lib.rs
@@ -1,5 +1,22 @@
 // Definitions of the core standard function modules for IEC61131-3
 
+// A panic in these functions aborts the whole runtime process (most are `extern "C"`),
+// so all panicking constructs are banned outside of tests.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::todo,
+        clippy::unimplemented,
+        clippy::unreachable,
+        clippy::indexing_slicing,
+        clippy::string_slice,
+        clippy::exit
+    )
+)]
+
 pub mod arithmetic_functions;
 pub mod bistable_functionblocks;
 pub mod bit_num_conversion;

--- a/libs/stdlib/src/string_conversion.rs
+++ b/libs/stdlib/src/string_conversion.rs
@@ -1,8 +1,11 @@
-use crate::string_functions::{CharsDecoder, CharsEncoder, EncodedCharsIter};
+use std::char::DecodeUtf16Error;
+
+use crate::string_functions::{CharsDecoder, CharsEncoder, EncodedCharsIter, STRING_RESULT_LEN};
 
 /// .
 /// Converts WSTRING to STRING
-/// Limited by a return type of 80 charachters
+/// Unpaired surrogates become U+FFFD; output is truncated at the
+/// result-buffer capacity
 ///
 /// # Safety
 ///
@@ -12,14 +15,17 @@ use crate::string_functions::{CharsDecoder, CharsEncoder, EncodedCharsIter};
 #[no_mangle]
 pub unsafe extern "C" fn WSTRING_TO_STRING_EXT(src: *const u16, dest: *mut u8) -> i32 {
     let mut dest = dest;
-    EncodedCharsIter::decode(src).map(|c| c.unwrap_or(char::REPLACEMENT_CHARACTER)).encode(&mut dest);
+    EncodedCharsIter::decode(src)
+        .map(|c| c.unwrap_or(char::REPLACEMENT_CHARACTER))
+        .encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
 
 /// .
 /// Converts STRING to WSTRING
-/// Limited by a return type of 80 charachters
+/// Invalid UTF-8 bytes become U+FFFD; output is truncated at the
+/// result-buffer capacity
 ///
 /// # Safety
 ///
@@ -29,16 +35,10 @@ pub unsafe extern "C" fn WSTRING_TO_STRING_EXT(src: *const u16, dest: *mut u8) -
 #[no_mangle]
 pub unsafe extern "C" fn STRING_TO_WSTRING_EXT(src: *const u8, dest: *mut u16) -> i32 {
     let mut dest = dest;
-    let mut buffer = [0_u16; 2];
-    for char in EncodedCharsIter::decode(src) {
-        let slice = char.encode_utf16(&mut buffer);
-        for word in slice {
-            *dest = *word;
-            dest = dest.add(1);
-        }
-    }
-    // Do not rely on the destination being zero-initialized.
-    *dest = 0;
+    // Wrapping each char in Ok selects the UTF-16 encoder; the decode itself is lossy.
+    EncodedCharsIter::decode(src)
+        .map(Ok::<char, DecodeUtf16Error>)
+        .encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -141,5 +141,27 @@ mod test {
         dest16.fill(0xAAAA);
         unsafe { STRING_TO_WSTRING_EXT("ab\0".as_ptr(), dest16.as_mut_ptr()) };
         assert_eq!(dest16[..3], ['a' as u16, 'b' as u16, 0]);
+    }
+
+    #[test]
+    fn string_to_wstring_replaces_invalid_bytes() {
+        let mut dest = [0xAAAA_u16; 81];
+        unsafe { STRING_TO_WSTRING_EXT(b"a\xFFb\0".as_ptr(), dest.as_mut_ptr()) };
+
+        // converting 'a<0xFF>b' must yield "a<U+FFFD>b": the invalid byte becomes U+FFFD
+        assert_eq!(dest[..4], [0x61, 0xFFFD, 0x62, 0]);
+    }
+
+    #[test]
+    fn wstring_to_string_truncates_at_result_capacity() {
+        // 2048 words of 3-UTF-8-byte characters would inflate to 6144 bytes;
+        // the result must truncate at the capacity on a character boundary
+        let mut src = [0x20AC_u16; 2049];
+        src[2048] = 0;
+        let mut dest = [0xAA_u8; 8192];
+        unsafe { WSTRING_TO_STRING_EXT(src.as_ptr(), dest.as_mut_ptr()) };
+        let written = dest.iter().position(|&byte| byte == 0).unwrap();
+        assert_eq!(written, 682 * 3);
+        assert!(dest[written + 1..].iter().all(|&byte| byte == 0xAA));
     }
 }

--- a/libs/stdlib/src/string_functions.rs
+++ b/libs/stdlib/src/string_functions.rs
@@ -9,7 +9,7 @@ use num::PrimInt;
 /// user-facing string builtins write into.
 /// Excess input is truncated on a character boundary instead.
 /// Keep this in sync with the `.st` declarations.
-const STRING_RESULT_LEN: usize = 2048;
+pub(crate) const STRING_RESULT_LEN: usize = 2048;
 
 /// # Helper function
 ///
@@ -44,12 +44,47 @@ pub unsafe fn ptr_to_slice<'a, T: PrimInt>(src: *const T) -> &'a [T] {
 }
 
 type Utf16Iterator<'a> = std::char::DecodeUtf16<std::iter::Copied<std::slice::Iter<'a, u16>>>;
-type Utf8Iterator<'a> = core::str::Chars<'a>;
+type Utf8Iterator<'a> = Utf8LossyChars<'a>;
+
+/// Lossy UTF-8 character iterator: each maximal invalid subpart decodes to one
+/// U+FFFD instead of failing, so buffers holding raw non-UTF-8 bytes (pointer
+/// writes, communication payloads) pass through every string function safely.
+pub struct Utf8LossyChars<'a> {
+    chunks: std::str::Utf8Chunks<'a>,
+    valid: core::str::Chars<'a>,
+    pending_replacement: bool,
+}
+
+impl<'a> Utf8LossyChars<'a> {
+    fn new(slice: &'a [u8]) -> Self {
+        Self { chunks: slice.utf8_chunks(), valid: "".chars(), pending_replacement: false }
+    }
+}
+
+impl Iterator for Utf8LossyChars<'_> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        loop {
+            if let Some(c) = self.valid.next() {
+                return Some(c);
+            }
+            if self.pending_replacement {
+                self.pending_replacement = false;
+                return Some(char::REPLACEMENT_CHARACTER);
+            }
+            let chunk = self.chunks.next()?;
+            self.valid = chunk.valid().chars();
+            self.pending_replacement = !chunk.invalid().is_empty();
+        }
+    }
+}
 
 pub trait CharsDecoder<T: PrimInt> {
     type IteratorType: Iterator;
     /// Decodes raw UTF-8 or UTF-16 codepoints into a character iterator. Does not account
-    /// for grapheme clusters.
+    /// for grapheme clusters. Invalid input never aborts: invalid UTF-8 decodes to U+FFFD
+    /// replacements, invalid UTF-16 yields `Err` items that encoders resolve to U+FFFD.
     ///
     /// # Safety
     ///
@@ -58,21 +93,12 @@ pub trait CharsDecoder<T: PrimInt> {
 }
 
 pub trait CharsEncoder<T: PrimInt>: Iterator {
-    /// Encodes UTF-8 or UTF-16 character iterator. Its raw codepoints are written
-    /// into given destination buffer address.
-    ///
-    /// # Safety
-    ///
-    /// Works on raw pointers, inherently unsafe. Does not ensure that the buffer at the
-    /// given address large enough. It will continue to write unchecked until all characters
-    /// have been processed and can therefore result in UB.
-    unsafe fn encode(self, dest: &mut *mut T);
-
-    /// Like [`CharsEncoder::encode`], but writes at most `max_elements` code units of
-    /// content (bytes for UTF-8, `u16` code units for UTF-16), always followed by a
-    /// null terminator. Truncation happens on a character boundary, so the written
-    /// string stays valid. Returns the number of content code units written (excluding
-    /// the terminator), allowing callers to keep a running budget across several inputs.
+    /// Encodes a character iterator into the given destination buffer address,
+    /// writing at most `max_elements` code units of content (bytes for UTF-8,
+    /// `u16` code units for UTF-16), always followed by a null terminator.
+    /// Truncation happens on a character boundary, so the written string stays
+    /// valid. Returns the number of content code units written (excluding the
+    /// terminator), allowing callers to keep a running budget across several inputs.
     ///
     /// # Safety
     ///
@@ -97,16 +123,11 @@ impl<T: Iterator> Iterator for EncodedCharsIter<T> {
 impl<'a> CharsDecoder<u8> for EncodedCharsIter<Utf8Iterator<'a>> {
     type IteratorType = Utf8Iterator<'a>;
     unsafe fn decode(src: *const u8) -> Self {
-        let slice = ptr_to_slice(src);
-        Self { iter: std::str::from_utf8(slice).unwrap().chars() }
+        Self { iter: Utf8LossyChars::new(ptr_to_slice(src)) }
     }
 }
 
 impl<I: Iterator<Item = char>> CharsEncoder<u8> for I {
-    unsafe fn encode(self, dest: &mut *mut u8) {
-        self.encode_bounded(dest, usize::MAX);
-    }
-
     unsafe fn encode_bounded(self, dest: &mut *mut u8, max_elements: usize) -> usize {
         let mut remaining = max_elements;
         let mut written = 0;
@@ -132,15 +153,11 @@ impl<I: Iterator<Item = char>> CharsEncoder<u8> for I {
 }
 
 impl<I: Iterator<Item = Result<char, DecodeUtf16Error>>> CharsEncoder<u16> for I {
-    unsafe fn encode(self, dest: &mut *mut u16) {
-        self.encode_bounded(dest, usize::MAX);
-    }
-
     unsafe fn encode_bounded(self, dest: &mut *mut u16, max_elements: usize) -> usize {
         let mut remaining = max_elements;
         let mut written = 0;
         for c in self {
-            let c = c.unwrap();
+            let c = c.unwrap_or(char::REPLACEMENT_CHARACTER);
             let len = c.len_utf16();
             // Stop before we would exceed the budget; never truncate mid-character.
             if len > remaining {
@@ -220,7 +237,7 @@ pub unsafe extern "C" fn FIND__STRING(src1: *const u8, src2: *const u8) -> i32 {
 
     if let Some(idx) = haystack.windows(needle.len()).position(|window| window == needle) {
         // get chars until byte index
-        let char_index = core::str::from_utf8(std::slice::from_raw_parts(src1, idx)).unwrap().chars().count();
+        let char_index = Utf8LossyChars::new(std::slice::from_raw_parts(src1, idx)).count();
         // correct for ST indexing
         char_index as i32 + 1
     } else {
@@ -262,22 +279,16 @@ pub unsafe extern "C" fn FIND__WSTRING(src1: *const u16, src2: *const u16) -> i3
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).take(substr_len);
-    chars.encode(&mut dest);
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -289,22 +300,16 @@ pub unsafe extern "C-unwind" fn LEFT_EXT__STRING(src: *const u8, substr_len: i32
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).take(substr_len);
-    chars.encode(&mut dest);
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -316,22 +321,16 @@ pub unsafe extern "C-unwind" fn LEFT_EXT__WSTRING(src: *const u16, substr_len: i
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i32, dest: *mut u8) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).skip(nchars - substr_len);
-    chars.encode(&mut dest);
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -343,22 +342,16 @@ pub unsafe extern "C-unwind" fn RIGHT_EXT__STRING(src: *const u8, substr_len: i3
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length is either negative or
-/// longer than the base string.
+/// The length is clamped to the string bounds; a negative length yields
+/// an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: i32, dest: *mut u16) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if nchars < substr_len {
-        panic!("Requested substring length exceeds string length.")
-    }
+    let substr_len = (substr_len.max(0) as usize).min(nchars);
     let chars = EncodedCharsIter::decode(src).skip(nchars - substr_len);
-    chars.encode(&mut dest);
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
     0
 }
 
@@ -369,9 +362,8 @@ pub unsafe extern "C-unwind" fn RIGHT_EXT__WSTRING(src: *const u16, substr_len: 
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length or position are negative
-/// or the substring length exceeds the remaining characters from the
-/// starting position of the base string.
+/// The length is clamped to the remaining characters; an out-of-range
+/// position yields an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn MID_EXT__STRING(
@@ -380,23 +372,18 @@ pub unsafe extern "C-unwind" fn MID_EXT__STRING(
     start_index: i32,
     dest: *mut u8,
 ) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
-    let start_index = start_index as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if start_index < 1 || start_index > nchars {
-        panic!("Position is out of bounds.")
+    if start_index < 1 || start_index > nchars as i32 {
+        // out-of-range positions yield an empty string
+        *dest = 0;
+        return 0;
     }
     // correct for 0-indexing
-    let start_index = start_index - 1;
-    if nchars < substr_len + start_index {
-        panic!("Requested substring length {substr_len} from position {start_index} exceeds string length.")
-    }
+    let start_index = start_index as usize - 1;
+    let substr_len = (substr_len.max(0) as usize).min(nchars - start_index);
     let chars = EncodedCharsIter::decode(src).skip(start_index).take(substr_len);
-    chars.encode(&mut dest);
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -408,9 +395,8 @@ pub unsafe extern "C-unwind" fn MID_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the requested substring length or position are negative
-/// or the substring length exceeds the remaining characters from the
-/// starting position of the base string.
+/// The length is clamped to the remaining characters; an out-of-range
+/// position yields an empty string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
@@ -419,23 +405,18 @@ pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
     start_index: i32,
     dest: *mut u16,
 ) -> i32 {
-    if substr_len < 0 {
-        panic!("Length parameter cannot be negative.");
-    }
     let mut dest = dest;
-    let substr_len = substr_len as usize;
-    let start_index = start_index as usize;
     let nchars = EncodedCharsIter::decode(src).count();
-    if start_index < 1 || start_index > nchars {
-        panic!("Position is out of bounds.")
+    if start_index < 1 || start_index > nchars as i32 {
+        // out-of-range positions yield an empty string
+        *dest = 0;
+        return 0;
     }
     // correct for 0-indexing
-    let start_index = start_index - 1;
-    if nchars < substr_len + start_index {
-        panic!("Requested substring length {substr_len} from position {start_index} exceeds string length.")
-    }
+    let start_index = start_index as usize - 1;
+    let substr_len = (substr_len.max(0) as usize).min(nchars - start_index);
     let chars = EncodedCharsIter::decode(src).skip(start_index).take(substr_len);
-    chars.encode(&mut dest);
+    chars.encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -448,8 +429,7 @@ pub unsafe extern "C-unwind" fn MID_EXT__WSTRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter exceeds the
-/// source array bounds.
+/// An out-of-range position returns the base string unchanged.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn INSERT_EXT__STRING(
@@ -461,7 +441,9 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__STRING(
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src_base).count();
     if pos < 0 || pos > nchars as i32 {
-        panic! {"Positional parameter is out of bounds."}
+        // out-of-range positions return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     let pos = pos as usize;
     // Truncate at the result-buffer capacity so we never overflow the caller's
@@ -483,8 +465,7 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter exceeds the
-/// source array bounds.
+/// An out-of-range position returns the base string unchanged.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn INSERT_EXT__WSTRING(
@@ -496,7 +477,9 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__WSTRING(
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src_base).count();
     if pos < 0 || pos > nchars as i32 {
-        panic! {"Positional parameter is out of bounds."}
+        // out-of-range positions return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     let pos = pos as usize;
     // Truncate at the result-buffer capacity so we never overflow the caller's
@@ -518,8 +501,8 @@ pub unsafe extern "C-unwind" fn INSERT_EXT__WSTRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter is out of bounds of the
-/// array or if trying to delete too many characters.
+/// An out-of-range position or a negative count returns the string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
@@ -530,26 +513,19 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
 ) -> i32 {
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src).count();
-    if pos < 1 || pos > nchars as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nchars as i32 || num_chars_to_delete < 0 {
+        // out-of-range positions and negative counts return the string unchanged
+        EncodedCharsIter::decode(src).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     // correct for 0-indexing
     let pos = pos as usize - 1;
-    let ndel = num_chars_to_delete as usize;
-    if ndel + pos > nchars {
-        panic!(
-            r#"Cannot delete {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            num_chars_to_delete,
-            pos + 1
-        )
-    }
+    let ndel = (num_chars_to_delete as usize).min(nchars - pos);
 
     EncodedCharsIter::decode(src)
         .take(pos)
         .chain(EncodedCharsIter::decode(src).skip(ndel + pos))
-        .encode(&mut dest);
+        .encode_bounded(&mut dest, STRING_RESULT_LEN);
     0
 }
 
@@ -561,8 +537,8 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if the position parameter is out of bounds of the
-/// array or if trying to delete too many characters.
+/// An out-of-range position or a negative count returns the string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
@@ -573,26 +549,19 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
 ) -> i32 {
     let mut dest = dest;
     let nchars = EncodedCharsIter::decode(src).count();
-    if pos < 1 || pos > nchars as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nchars as i32 || num_chars_to_delete < 0 {
+        // out-of-range positions and negative counts return the string unchanged
+        EncodedCharsIter::decode(src).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     // correct for 0-indexing
     let pos = pos as usize - 1;
-    let ndel = num_chars_to_delete as usize;
-    if ndel + pos > nchars {
-        panic!(
-            r#"Cannot delete {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            num_chars_to_delete,
-            pos + 1
-        )
-    }
+    let ndel = (num_chars_to_delete as usize).min(nchars - pos);
 
     EncodedCharsIter::decode(src)
         .take(pos)
         .chain(EncodedCharsIter::decode(src).skip(pos + ndel))
-        .encode(&mut dest);
+        .encode_bounded(&mut dest, STRING_RESULT_LEN);
 
     0
 }
@@ -605,8 +574,8 @@ pub unsafe extern "C-unwind" fn DELETE_EXT__WSTRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// An out-of-range position or a negative count returns the base string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn REPLACE_EXT__STRING(
@@ -618,22 +587,14 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__STRING(
 ) -> i32 {
     let mut dest = dest;
     let nbase = EncodedCharsIter::decode(src_base).count();
-    if pos < 1 || pos > nbase as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nbase as i32 || num_chars_to_replace < 0 {
+        // out-of-range positions and negative counts return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     // correct for 0-indexing
     let pos = (pos - 1) as usize;
-    let nreplace = num_chars_to_replace as usize;
-
-    if nreplace + pos > nbase {
-        panic!(
-            r#"Cannot replace {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            nreplace,
-            pos + 1
-        )
-    }
+    let nreplace = (num_chars_to_replace as usize).min(nbase - pos);
     // Truncate at the result-buffer capacity so we never overflow the caller's
     // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`).
     EncodedCharsIter::decode(src_base)
@@ -655,8 +616,8 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__STRING(
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// An out-of-range position or a negative count returns the base string
+/// unchanged; the count is clamped to the end of the string.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn REPLACE_EXT__WSTRING(
@@ -668,21 +629,14 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__WSTRING(
 ) -> i32 {
     let mut dest = dest;
     let nbase = EncodedCharsIter::decode(src_base).count();
-    if pos < 1 || pos > nbase as i32 {
-        panic!("Index out of bounds.")
+    if pos < 1 || pos > nbase as i32 || num_chars_to_replace < 0 {
+        // out-of-range positions and negative counts return the base string unchanged
+        EncodedCharsIter::decode(src_base).encode_bounded(&mut dest, STRING_RESULT_LEN);
+        return 0;
     }
     // correct for 0-indexing
     let pos = (pos - 1) as usize;
-    let nreplace = num_chars_to_replace as usize;
-    if nreplace + pos > nbase {
-        panic!(
-            r#"Cannot replace {} characters starting from index {}.
-            Index out of bounds.
-            "#,
-            nreplace,
-            pos + 1
-        )
-    }
+    let nreplace = (num_chars_to_replace as usize).min(nbase - pos);
     // Truncate at the result-buffer capacity so we never overflow the caller's
     // `STRING[2048]` / `WSTRING[2048]` destination (see `STRING_RESULT_LEN`).
     EncodedCharsIter::decode(src_base)
@@ -696,17 +650,40 @@ pub unsafe extern "C-unwind" fn REPLACE_EXT__WSTRING(
     0
 }
 
+/// Helper function for the variadic CONCAT functions. Copies the raw code units
+/// of each input, so payloads that are not valid UTF-8/UTF-16 survive unchanged.
+/// Output is truncated at the result-buffer capacity (see [`STRING_RESULT_LEN`]);
+/// the cut can split a multi-code-unit character, which every consumer tolerates.
+unsafe fn concat_transparent<T: PrimInt>(mut dest: *mut T, argc: i32, argv: *const *const T) -> i32 {
+    debug_assert!(!dest.is_null() && !argv.is_null(), "the compiler always passes valid pointers");
+    if dest.is_null() {
+        return 0;
+    }
+    let mut remaining = STRING_RESULT_LEN;
+    if !argv.is_null() {
+        for &arg in std::slice::from_raw_parts(argv, argc.max(0) as usize) {
+            let src = ptr_to_slice(arg);
+            let ncopy = src.len().min(remaining);
+            std::ptr::copy_nonoverlapping(src.as_ptr(), dest, ncopy);
+            dest = dest.add(ncopy);
+            remaining -= ncopy;
+        }
+    }
+    *dest = T::zero();
+
+    0
+}
+
 /// Concatenates all given strings in the order in which they are given.
 /// Strings are passed as pointer of pointer to u8, where each pointer represents
 /// the starting address of each string. The amount of strings must be passed as
 /// argument.
-/// Encoding: UTF-8
+/// Encoding: UTF-8. Bytes are copied unchanged, so invalid sequences survive.
 ///
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// Output is truncated at the result-buffer capacity.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn CONCAT__STRING(dest: *mut u8, argc: i32, argv: *const *const u8) {
@@ -717,44 +694,28 @@ pub unsafe extern "C" fn CONCAT__STRING(dest: *mut u8, argc: i32, argv: *const *
 /// Strings are passed as pointer of pointer to u8, where each pointer represents
 /// the starting address of each string. The amount of strings must be passed as
 /// argument.
-/// Encoding: UTF-8
+/// Encoding: UTF-8. Bytes are copied unchanged, so invalid sequences survive.
 ///
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// Output is truncated at the result-buffer capacity.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn CONCAT_EXT__STRING(dest: *mut u8, argc: i32, argv: *const *const u8) -> i32 {
-    if argv.is_null() || dest.is_null() {
-        panic!("Received null-pointer.")
-    }
-    let mut dest = dest;
-    let mut argv = argv;
-    // Truncate at the result-buffer capacity so we never overflow the caller's
-    // `STRING[2048]` destination (see `STRING_RESULT_LEN`).
-    let mut remaining = STRING_RESULT_LEN;
-    for _ in 0..argc {
-        let written = EncodedCharsIter::decode(*argv).encode_bounded(&mut dest, remaining);
-        remaining -= written;
-        argv = argv.add(1);
-    }
-
-    0
+    concat_transparent(dest, argc, argv)
 }
 
 /// Concatenates all given strings in the order in which they are given.
-/// Strings are passed as pointer of pointer to u8, where each pointer represents
+/// Strings are passed as pointer of pointer to u16, where each pointer represents
 /// the starting address of each string. The amount of strings must be passed as
 /// argument.
-/// Encoding: UTF-16
+/// Encoding: UTF-16. Code units are copied unchanged, so invalid sequences survive.
 ///
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// Output is truncated at the result-buffer capacity.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C" fn CONCAT__WSTRING(dest: *mut u16, argc: i32, argv: *const *const u16) {
@@ -762,16 +723,15 @@ pub unsafe extern "C" fn CONCAT__WSTRING(dest: *mut u16, argc: i32, argv: *const
 }
 
 /// Concatenates all given strings in the order in which they are given.
-/// Strings are passed as pointer of pointer to u8, where each pointer represents
+/// Strings are passed as pointer of pointer to u16, where each pointer represents
 /// the starting address of each string. The amount of strings must be passed as
 /// argument.
-/// Encoding: UTF-16
+/// Encoding: UTF-16. Code units are copied unchanged, so invalid sequences survive.
 ///
 /// # Safety
 ///
 /// Works on raw pointers, inherently unsafe.
-/// Will panic if trying to index outside of the array or trying
-/// to replace more characters than remaining.
+/// Output is truncated at the result-buffer capacity.
 #[allow(non_snake_case)]
 #[no_mangle]
 pub unsafe extern "C-unwind" fn CONCAT_EXT__WSTRING(
@@ -779,21 +739,7 @@ pub unsafe extern "C-unwind" fn CONCAT_EXT__WSTRING(
     argc: i32,
     argv: *const *const u16,
 ) -> i32 {
-    if argv.is_null() || dest.is_null() {
-        panic!("Received null-pointer.")
-    }
-    let mut dest = dest;
-    let mut argv = argv;
-    // Truncate at the result-buffer capacity so we never overflow the caller's
-    // `WSTRING[2048]` destination (see `STRING_RESULT_LEN`).
-    let mut remaining = STRING_RESULT_LEN;
-    for _ in 0..argc {
-        let written = EncodedCharsIter::decode(*argv).encode_bounded(&mut dest, remaining);
-        remaining -= written;
-        argv = argv.add(1);
-    }
-
-    0
+    concat_transparent(dest, argc, argv)
 }
 
 /// Helper function for generic, variadic string equality functions.
@@ -801,8 +747,9 @@ fn compare<T>(argc: i32, argv: *const *const T, predicate_func: fn(Ordering) -> 
 where
     T: Ord + PrimInt,
 {
+    debug_assert!(argc >= 2, "the compiler always passes at least two arguments");
     if argc < 2 {
-        panic!("Too few arguments for function call.")
+        return false;
     }
     let mut argv = argv;
     unsafe {
@@ -1013,13 +960,25 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_left_ext_str_len_out_of_range() {
+    fn test_left_ext_str_len_clamps_to_string_bounds() {
         let src = "hello\0 world";
-        let len = 7;
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
-            LEFT_EXT__STRING(src.as_ptr(), len, dest.as_mut_ptr());
+            LEFT_EXT__STRING(src.as_ptr(), 7, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello", string);
+
+            LEFT_EXT__STRING(src.as_ptr(), -1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            RIGHT_EXT__STRING(src.as_ptr(), 7, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello", string);
+
+            RIGHT_EXT__STRING(src.as_ptr(), -1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
         }
     }
 
@@ -1074,13 +1033,23 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_mid_ext_str_start_index_out_of_range() {
+    fn test_mid_ext_str_out_of_range_position_yields_empty_string() {
         let src = "hello world\0";
-        let len = 5;
-        let start_index = 12;
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe { MID_EXT__STRING(src.as_ptr(), len, start_index, dest.as_mut_ptr()) };
+        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0xAA; DEFAULT_STRING_SIZE];
+        unsafe {
+            MID_EXT__STRING(src.as_ptr(), 5, 12, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            MID_EXT__STRING(src.as_ptr(), 5, 0, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            // a valid position clamps the length to the remaining characters
+            MID_EXT__STRING(src.as_ptr(), 10, 7, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("world", string);
+        }
     }
 
     #[test]
@@ -1120,24 +1089,18 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_insert_ext_str_pos_out_of_range() {
+    fn test_insert_ext_str_out_of_range_position_returns_base() {
         let base = "hello world\0";
         let insert = "brave new \0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             INSERT_EXT__STRING(base.as_ptr(), insert.as_ptr(), base.len() as i32, dest.as_mut_ptr());
-        }
-    }
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
 
-    #[test]
-    #[should_panic]
-    fn test_insert_ext_str_pos_negative() {
-        let base = "hello world\0";
-        let insert = "brave new \0";
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             INSERT_EXT__STRING(base.as_ptr(), insert.as_ptr(), -2, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
         }
     }
 
@@ -1187,32 +1150,36 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_str_too_many_del_chars() {
+    fn test_delete_ext_str_count_clamps_to_end_of_string() {
         let src = "hello world\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__STRING(src.as_ptr(), 12, 1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("", string);
+
+            DELETE_EXT__STRING(src.as_ptr(), 12, 4, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hel", string);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_str_pos_out_of_range_lower() {
+    fn test_delete_ext_str_out_of_range_position_returns_base() {
         let src = "hello world\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__STRING(src.as_ptr(), 11, 0, dest.as_mut_ptr());
-        }
-    }
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
 
-    #[test]
-    #[should_panic]
-    fn test_delete_ext_str_pos_out_of_range_upper() {
-        let src = "hello world\0";
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             DELETE_EXT__STRING(src.as_ptr(), 11, 12, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
+
+            DELETE_EXT__STRING(src.as_ptr(), -1, 2, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
         }
     }
 
@@ -1253,35 +1220,34 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_str_replace_too_many_chars() {
+    fn test_replace_ext_str_count_clamps_to_end_of_string() {
         let base = "hello world\0";
         let replacement = "aldo, how are you\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), 12, 1, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("aldo, how are you", string);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_str_pos_out_of_bounds_lower() {
+    fn test_replace_ext_str_out_of_range_position_returns_base() {
         let base = "hello world\0";
         let replacement = "aldo, how are you\0";
         let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), 8, 0, dest.as_mut_ptr());
-        }
-    }
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
 
-    #[test]
-    #[should_panic]
-    fn test_replace_ext_str_pos_out_of_bounds_upper() {
-        let base = "hello world\0";
-        let replacement = "aldo, how are you\0";
-        let mut dest: [u8; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), 8, 12, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
+
+            REPLACE_EXT__STRING(base.as_ptr(), replacement.as_ptr(), -1, 2, dest.as_mut_ptr());
+            let string = CStr::from_ptr(dest.as_ptr() as *const _).to_str().unwrap();
+            assert_eq!("hello world", string);
         }
     }
 
@@ -1321,6 +1287,99 @@ mod test {
             assert_eq!("", string)
         }
     }
+    // -----------------------------------lossy decoding and result capacity
+    #[test]
+    fn len_counts_one_replacement_char_per_maximal_invalid_subpart() {
+        unsafe {
+            // standalone junk bytes count individually
+            assert_eq!(LEN__STRING(b"a\xFFbc\0".as_ptr()), 4);
+            assert_eq!(LEN__STRING(b"\xFF\xFF\0".as_ptr()), 2);
+            // a truncated multi-byte sequence collapses into one replacement char
+            assert_eq!(LEN__STRING(b"\xE2\x82\0".as_ptr()), 1);
+            assert_eq!(LEN__STRING(b"\xE2\x82a\0".as_ptr()), 2);
+        }
+    }
+
+    #[test]
+    fn find_counts_prefix_chars_of_invalid_utf8() {
+        unsafe {
+            // finding 'b' in 'a<0xFF>b': the prefix counts as 'a' + U+FFFD, so position 3
+            assert_eq!(FIND__STRING(b"a\xFFb\0".as_ptr(), b"b\0".as_ptr()), 3);
+        }
+    }
+
+    #[test]
+    fn left_replaces_invalid_bytes_and_truncates_at_capacity() {
+        // 1000 junk bytes decode to 1000 replacement chars of 3 bytes each; the
+        // 3000-byte result must truncate at the capacity on a character boundary
+        let mut src = [0xFF_u8; 1001];
+        src[1000] = 0;
+        let mut dest = [0xAA_u8; 4096];
+        unsafe {
+            LEFT_EXT__STRING(src.as_ptr(), 1000, dest.as_mut_ptr());
+            let written = ptr_to_slice(dest.as_ptr());
+            assert_eq!(written.len(), 682 * 3);
+            assert!(written.chunks(3).all(|chunk| chunk == [0xEF, 0xBF, 0xBD]));
+        }
+    }
+
+    #[test]
+    fn concat_preserves_raw_bytes() {
+        let argv = [b"a\xFF\0".as_ptr(), b"b\0".as_ptr()];
+        let mut dest = [0xAA_u8; DEFAULT_STRING_SIZE];
+        unsafe {
+            CONCAT_EXT__STRING(dest.as_mut_ptr(), argv.len() as i32, argv.as_ptr());
+
+            // 'a<0xFF>' + 'b' keeps the raw 0xFF byte; CONCAT must not rewrite it to U+FFFD
+            assert_eq!(ptr_to_slice(dest.as_ptr()), b"a\xFFb");
+        }
+    }
+
+    #[test]
+    fn concat_truncates_at_capacity() {
+        let mut first = [b'a'; 1501];
+        first[1500] = 0;
+        let mut second = [b'b'; 1501];
+        second[1500] = 0;
+        let argv = [first.as_ptr(), second.as_ptr()];
+        let mut dest = [0xAA_u8; 4096];
+        unsafe {
+            CONCAT_EXT__STRING(dest.as_mut_ptr(), argv.len() as i32, argv.as_ptr());
+            let written = ptr_to_slice(dest.as_ptr());
+
+            // 1500 'a's + 1500 'b's cap at the 2048-byte capacity, so only 548 'b's survive
+            assert_eq!(written.len(), 2048);
+            assert!(written[..1500].iter().all(|&byte| byte == b'a'));
+            assert!(written[1500..].iter().all(|&byte| byte == b'b'));
+        }
+    }
+
+    #[test]
+    fn wstring_left_replaces_unpaired_surrogate() {
+        let src: [u16; 4] = [0x61, 0xD800, 0x62, 0];
+        let mut dest = [0xAAAA_u16; DEFAULT_STRING_SIZE];
+        unsafe {
+            LEFT_EXT__WSTRING(src.as_ptr(), 3, dest.as_mut_ptr());
+
+            // 0xD800 is an unpaired high surrogate; rebuilding the string yields U+FFFD
+            assert_eq!(ptr_to_slice(dest.as_ptr()), [0x61, 0xFFFD, 0x62]);
+        }
+    }
+
+    #[test]
+    fn concat_wstring_preserves_unpaired_surrogates() {
+        let first: [u16; 3] = [0x61, 0xD800, 0];
+        let second: [u16; 2] = [0x62, 0];
+        let argv = [first.as_ptr(), second.as_ptr()];
+        let mut dest = [0xAAAA_u16; DEFAULT_STRING_SIZE];
+        unsafe {
+            CONCAT_EXT__WSTRING(dest.as_mut_ptr(), argv.len() as i32, argv.as_ptr());
+
+            // 'a<0xD800>' + 'b' keeps the raw surrogate word; CONCAT must not rewrite it
+            assert_eq!(ptr_to_slice(dest.as_ptr()), [0x61, 0xD800, 0x62]);
+        }
+    }
+
     #[test]
     fn test_greater_than_string_is_false_for_equal_strings() {
         let argv = ["hællø wørlÞ\0".as_ptr(), "hællø wørlÞ\0".as_ptr()];
@@ -1445,13 +1504,24 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_left_ext_wstring_len_out_of_range() {
+    fn test_left_ext_wstring_len_clamps_to_string_bounds() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             LEFT_EXT__WSTRING(src_ptr, 14, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
+
+            LEFT_EXT__WSTRING(src_ptr, -1, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("", res);
         }
     }
 
@@ -1503,13 +1573,17 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_mid_ext_wstring_index_out_of_range() {
+    fn test_mid_ext_wstring_out_of_range_position_yields_empty_string() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
-        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
+        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0xAA; DEFAULT_STRING_SIZE];
         unsafe {
             MID_EXT__WSTRING(src_ptr, 4, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("", res);
         }
     }
 
@@ -1565,8 +1639,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_insert_ext_wstring_pos_out_of_range() {
+    fn test_insert_ext_wstring_out_of_range_position_returns_base() {
         let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let base_ptr = base.as_slice().as_ptr();
         let to_insert = "brave new \0".encode_utf16().collect::<Vec<u16>>();
@@ -1574,6 +1647,11 @@ mod test {
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             INSERT_EXT__WSTRING(base_ptr, to_insert_ptr, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
         }
     }
 
@@ -1609,35 +1687,39 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_wstring_too_many_del_chars() {
+    fn test_delete_ext_wstring_count_clamps_to_end_of_string() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__WSTRING(src_ptr, 10, 3, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("he", res);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_delete_ext_wstring_pos_out_of_range_lower() {
+    fn test_delete_ext_wstring_out_of_range_position_returns_base() {
         let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let src_ptr = src.as_slice().as_ptr();
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             DELETE_EXT__WSTRING(src_ptr, 9, 0, dest.as_mut_ptr());
-        }
-    }
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
 
-    #[test]
-    #[should_panic]
-    fn test_delete_ext_wstring_pos_out_of_range_upper() {
-        let src = "hello world\0".encode_utf16().collect::<Vec<u16>>();
-        let src_ptr = src.as_slice().as_ptr();
-        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             DELETE_EXT__WSTRING(src_ptr, 9, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
         }
     }
 
@@ -1695,8 +1777,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_wstring_replace_too_many_chars() {
+    fn test_replace_ext_wstring_count_clamps_to_end_of_string() {
         let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let base_ptr = base.as_slice().as_ptr();
         let replacement = " is out of this \0".encode_utf16().collect::<Vec<u16>>();
@@ -1704,12 +1785,16 @@ mod test {
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__WSTRING(base_ptr, replacement_ptr, 12, 1, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!(" is out of this ", res);
         }
     }
 
     #[test]
-    #[should_panic]
-    fn test_replace_ext_wstring_pos_out_of_bounds_lower() {
+    fn test_replace_ext_wstring_out_of_range_position_returns_base() {
         let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
         let base_ptr = base.as_slice().as_ptr();
         let replacement = " is out of this \0".encode_utf16().collect::<Vec<u16>>();
@@ -1717,19 +1802,18 @@ mod test {
         let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
         unsafe {
             REPLACE_EXT__WSTRING(base_ptr, replacement_ptr, 8, 0, dest.as_mut_ptr());
-        }
-    }
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
 
-    #[test]
-    #[should_panic]
-    fn test_replace_ext_wstring_pos_out_of_bounds_upper() {
-        let base = "hello world\0".encode_utf16().collect::<Vec<u16>>();
-        let base_ptr = base.as_slice().as_ptr();
-        let replacement = " is out of this \0".encode_utf16().collect::<Vec<u16>>();
-        let replacement_ptr = replacement.as_slice().as_ptr();
-        let mut dest: [u16; DEFAULT_STRING_SIZE] = [0; DEFAULT_STRING_SIZE];
-        unsafe {
             REPLACE_EXT__WSTRING(base_ptr, replacement_ptr, 8, 12, dest.as_mut_ptr());
+            let res = String::from_utf16_lossy(std::slice::from_raw_parts(
+                dest.as_ptr(),
+                get_null_terminated_len(dest.as_ptr()),
+            ));
+            assert_eq!("hello world", res);
         }
     }
 

--- a/libs/stdlib/src/timers.rs
+++ b/libs/stdlib/src/timers.rs
@@ -52,9 +52,10 @@ impl TimerParams {
     /// Sets the elapsed time to either the preset time or the real elapsed time, whatever is smaller
     fn update_elapsed_time(&mut self) {
         if self.is_running() {
+            debug_assert!(self.start_time.is_some(), "a running timer must have a start time");
             self.set_elapsed_time(std::cmp::min(
                 self.preset_time,
-                self.get_run_time().expect("Timer should be running").as_nanos() as i64,
+                self.get_run_time().unwrap_or_default().as_nanos() as i64,
             ));
         }
     }

--- a/libs/stdlib/src/types.rs
+++ b/libs/stdlib/src/types.rs
@@ -16,28 +16,26 @@ macro_rules! define_float_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $max_name(size: u32, value: *const $rust_type) -> $rust_type {
-            // Declare array for value
-            let arr = if !value.is_null() {
-                slice::from_raw_parts(value, size as usize)
-            } else {
-                panic!("Null pointer for value");
-            };
+            debug_assert!(!value.is_null() && size > 0, "MAX requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
+            }
 
-            arr.iter().map(|it| *it).reduce(<$rust_type>::max).expect("A max will always exist")
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().map(|it| *it).reduce(<$rust_type>::max).unwrap_or_default()
         }
         /// # Safety
         /// Dealing with raw pointers
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $min_name(size: u32, value: *const $rust_type) -> $rust_type {
-            // Declare array for value
-            let arr = if !value.is_null() {
-                slice::from_raw_parts(value, size as usize)
-            } else {
-                panic!("Null pointer for value");
-            };
+            debug_assert!(!value.is_null() && size > 0, "MIN requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
+            }
 
-            arr.iter().map(|it| *it).reduce(<$rust_type>::min).expect("A max will always exist")
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().map(|it| *it).reduce(<$rust_type>::min).unwrap_or_default()
         }
 
         //Limit
@@ -58,12 +56,13 @@ macro_rules! define_order_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $max_name(size: u32, value: *const $rust_type) -> $rust_type {
-            if !value.is_null() {
-                let arr = slice::from_raw_parts(value, size as usize);
-                *arr.iter().max().expect("A max will always exist")
-            } else {
-                panic!("Null pointer for value");
+            debug_assert!(!value.is_null() && size > 0, "MAX requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
             }
+
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().max().copied().unwrap_or_default()
         }
         //Min impl
         /// # Safety
@@ -71,12 +70,13 @@ macro_rules! define_order_type {
         #[allow(non_snake_case)]
         #[no_mangle]
         pub unsafe extern "C" fn $min_name(size: u32, value: *const $rust_type) -> $rust_type {
-            if !value.is_null() {
-                let arr = slice::from_raw_parts(value, size as usize);
-                *arr.iter().min().expect("A min will always exist")
-            } else {
-                panic!("Null pointer for value");
+            debug_assert!(!value.is_null() && size > 0, "MIN requires at least one element");
+            if value.is_null() || size == 0 {
+                return <$rust_type>::default();
             }
+
+            let arr = slice::from_raw_parts(value, size as usize);
+            arr.iter().min().copied().unwrap_or_default()
         }
 
         //Limit

--- a/libs/stdlib/tests/date_time_conversion_tests.rs
+++ b/libs/stdlib/tests/date_time_conversion_tests.rs
@@ -1,4 +1,5 @@
 use common::{compile_and_run, get_includes};
+use iec61131std::date_time_conversion as dtc;
 
 // Import common functionality into the integration tests
 mod common;
@@ -259,4 +260,51 @@ fn tod_to_ltod_conversion() {
             .timestamp_nanos_opt()
             .unwrap()
     );
+}
+
+// The conversions are total integer arithmetic; these tests pin the values the
+// previous chrono-based implementation produced and the saturation at the DATE
+// range minimum (midnight of the first representable day lies below i64::MIN).
+#[test]
+fn date_and_time_to_date_saturates_on_the_first_representable_day() {
+    assert_eq!(dtc::DATE_AND_TIME_TO_DATE(i64::MIN), i64::MIN);
+
+    let noon_first_day = i64::MIN + 12 * 3_600 * 1_000_000_000;
+    assert_eq!(dtc::DATE_AND_TIME_TO_DATE(noon_first_day), i64::MIN);
+}
+
+#[test]
+fn date_and_time_to_date_returns_midnight() {
+    let datetime = chrono::NaiveDate::from_ymd_opt(2024, 5, 5)
+        .and_then(|date| date.and_hms_opt(13, 30, 15))
+        .expect("valid date");
+    let midnight = chrono::NaiveDate::from_ymd_opt(2024, 5, 5)
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .expect("valid date");
+
+    assert_eq!(
+        dtc::DATE_AND_TIME_TO_DATE(datetime.and_utc().timestamp_nanos_opt().expect("in range")),
+        midnight.and_utc().timestamp_nanos_opt().expect("in range")
+    );
+
+    // pre-1970 values floor to the day boundary below, not toward zero
+    let before_epoch = chrono::NaiveDate::from_ymd_opt(1969, 12, 31)
+        .and_then(|date| date.and_hms_opt(23, 0, 0))
+        .expect("valid date");
+    let before_epoch_midnight = chrono::NaiveDate::from_ymd_opt(1969, 12, 31)
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .expect("valid date");
+
+    assert_eq!(
+        dtc::DATE_AND_TIME_TO_DATE(before_epoch.and_utc().timestamp_nanos_opt().expect("in range")),
+        before_epoch_midnight.and_utc().timestamp_nanos_opt().expect("in range")
+    );
+}
+
+#[test]
+fn date_and_time_to_time_of_day_matches_previous_values() {
+    let noon_nanos = 12 * 3_600 * 1_000_000_000_i64;
+    assert_eq!(dtc::DATE_AND_TIME_TO_TIME_OF_DAY(noon_nanos), noon_nanos);
+    // one hour before the epoch is 23:00 on the previous day
+    assert_eq!(dtc::DATE_AND_TIME_TO_TIME_OF_DAY(-3_600 * 1_000_000_000), 23 * 3_600 * 1_000_000_000);
 }

--- a/libs/stdlib/tests/date_time_extra_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_extra_functions_tests.rs
@@ -1,4 +1,5 @@
 use common::{compile_and_run, get_includes};
+use iec61131std::date_time_extra_functions as dtef;
 
 // Import common functionality into the integration tests
 mod common;
@@ -1092,4 +1093,39 @@ fn day_of_week() {
     assert_eq!(maintype.a, 2);
     assert_eq!(maintype.b, 0);
     assert_eq!(maintype.c, 6);
+}
+
+// Unrepresentable constructor inputs yield 0 (epoch / midnight) instead of panicking;
+// dates outside the representable range clamp to the nearest bound.
+#[test]
+fn concat_date_with_invalid_fields_yields_epoch() {
+    assert_eq!(dtef::concat_date(2024, 13, 45), 0);
+    assert_eq!(dtef::concat_date(2023, 2, 29), 0);
+    assert_eq!(dtef::CONCAT_DATE__INT(2024, -1, 1), 0);
+}
+
+#[test]
+fn concat_date_clamps_to_date_range() {
+    assert_eq!(dtef::concat_date(1500, 1, 1), i64::MIN);
+    assert_eq!(dtef::concat_date(2500, 1, 1), i64::MAX);
+}
+
+#[test]
+fn concat_date_with_valid_fields_is_unchanged() {
+    assert_eq!(dtef::concat_date(2024, 2, 29), 1_709_164_800_000_000_000);
+    // pre-1970 dates stay representable in the signed range
+    assert_eq!(dtef::concat_date(1969, 6, 1), -18_489_600_000_000_000);
+}
+
+#[test]
+fn concat_tod_with_invalid_fields_yields_midnight() {
+    assert_eq!(dtef::concat_tod(25, 0, 0, 0), 0);
+    assert_eq!(dtef::concat_tod(0, 60, 0, 0), 0);
+    assert_eq!(dtef::CONCAT_TOD__SINT(-1, 0, 0, 0), 0);
+}
+
+#[test]
+fn concat_date_tod_wraps_on_overflow() {
+    assert_eq!(dtef::CONCAT_DATE_TOD(86_400_000_000_000, 3_600_000_000_000), 90_000_000_000_000);
+    assert_eq!(dtef::CONCAT_DATE_TOD(i64::MAX, 1), i64::MIN);
 }

--- a/libs/stdlib/tests/date_time_numeric_functions_tests.rs
+++ b/libs/stdlib/tests/date_time_numeric_functions_tests.rs
@@ -1,6 +1,7 @@
 use chrono::DurationRound;
 use chrono::TimeZone;
 use common::{compile_and_run, get_includes};
+use iec61131std::date_time_numeric_functions as dtf;
 
 // Import common functionality into the integration tests
 mod common;
@@ -909,4 +910,143 @@ fn date_time_overloaded_add_and_numerical_add_compile_correctly() {
 
     assert_eq!(tod_23h_56m, maintype.a);
     assert_eq!(18.0, maintype.b);
+}
+
+macro_rules! wrapping_tests {
+    ($(($name:ident, $func:path, $lhs:expr, $rhs:expr, $expected:expr)),+ $(,)?) => {
+        $(
+            #[test]
+            fn $name() {
+                assert_eq!($func($lhs, $rhs), $expected);
+            }
+        )+
+    };
+}
+
+// Overflow at the top of the range: MAX + 1 rolls over to i64::MIN.
+wrapping_tests!(
+    (add_time_wraps_on_overflow, dtf::ADD_TIME, i64::MAX, 1, i64::MIN),
+    (add_tod_time_wraps_on_overflow, dtf::ADD_TOD_TIME, i64::MAX, 1, i64::MIN),
+    (add_dt_time_wraps_on_overflow, dtf::ADD_DT_TIME, i64::MAX, 1, i64::MIN),
+);
+
+// Underflow below the minimum: the deficit reappears at the top of the range;
+// the largest delta MAX - MIN wraps to -1.
+wrapping_tests!(
+    (sub_time_wraps_on_underflow, dtf::SUB_TIME, i64::MIN, 1, i64::MAX),
+    (sub_date_date_wraps_on_large_delta, dtf::SUB_DATE_DATE, i64::MAX, i64::MIN, -1),
+    (sub_tod_time_wraps_on_underflow, dtf::SUB_TOD_TIME, i64::MIN, 1, i64::MAX),
+    (sub_tod_tod_wraps_on_large_delta, dtf::SUB_TOD_TOD, i64::MAX, i64::MIN, -1),
+    (sub_dt_time_wraps_on_underflow, dtf::SUB_DT_TIME, i64::MIN, 1, i64::MAX),
+    (sub_dt_dt_wraps_on_large_delta, dtf::SUB_DT_DT, i64::MAX, i64::MIN, -1),
+);
+
+// MUL: i64::MAX * 2 wraps to -2 for every factor width. The last case uses a factor
+// above i64::MAX to check that the u64 to i64 cast keeps the result correct mod 2^64.
+wrapping_tests!(
+    (mul_time_sint_wraps_on_overflow, dtf::MUL__TIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_time_sint_alias_wraps_on_overflow, dtf::MUL_TIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_ltime_sint_wraps_on_overflow, dtf::MUL_LTIME__SINT, i64::MAX, 2_i8, -2),
+    (mul_time_int_wraps_on_overflow, dtf::MUL__TIME__INT, i64::MAX, 2_i16, -2),
+    (mul_time_int_alias_wraps_on_overflow, dtf::MUL_TIME__INT, i64::MAX, 2_i16, -2),
+    (mul_ltime_int_wraps_on_overflow, dtf::MUL_LTIME__INT, i64::MAX, 2_i16, -2),
+    (mul_time_dint_wraps_on_overflow, dtf::MUL__TIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_time_dint_alias_wraps_on_overflow, dtf::MUL_TIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_ltime_dint_wraps_on_overflow, dtf::MUL_LTIME__DINT, i64::MAX, 2_i32, -2),
+    (mul_time_lint_wraps_on_overflow, dtf::MUL__TIME__LINT, i64::MAX, 2, -2),
+    (mul_time_lint_alias_wraps_on_overflow, dtf::MUL_TIME__LINT, i64::MAX, 2, -2),
+    (mul_ltime_lint_wraps_on_overflow, dtf::MUL_LTIME__LINT, i64::MAX, 2, -2),
+    (mul_time_usint_wraps_on_overflow, dtf::MUL__TIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_time_usint_alias_wraps_on_overflow, dtf::MUL_TIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_ltime_usint_wraps_on_overflow, dtf::MUL_LTIME__USINT, i64::MAX, 2_u8, -2),
+    (mul_time_uint_wraps_on_overflow, dtf::MUL__TIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_time_uint_alias_wraps_on_overflow, dtf::MUL_TIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_ltime_uint_wraps_on_overflow, dtf::MUL_LTIME__UINT, i64::MAX, 2_u16, -2),
+    (mul_time_udint_wraps_on_overflow, dtf::MUL__TIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_time_udint_alias_wraps_on_overflow, dtf::MUL_TIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_ltime_udint_wraps_on_overflow, dtf::MUL_LTIME__UDINT, i64::MAX, 2_u32, -2),
+    (mul_time_ulint_wraps_on_overflow, dtf::MUL__TIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_time_ulint_alias_wraps_on_overflow, dtf::MUL_TIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_ltime_ulint_wraps_on_overflow, dtf::MUL_LTIME__ULINT, i64::MAX, 2_u64, -2),
+    (mul_time_ulint_wraps_when_factor_exceeds_lint, dtf::MUL__TIME__ULINT, 1, u64::MAX, -1),
+);
+
+// Integer division is total except for a zero divisor: i64::MIN / -1 wraps and a
+// u64 divisor above the signed range always exceeds the dividend magnitude, so the
+// quotient is zero.
+#[test]
+fn div_time_min_by_minus_one_wraps() {
+    assert_eq!(dtf::DIV__TIME__LINT(i64::MIN, -1), i64::MIN);
+    assert_eq!(dtf::DIV_LTIME__LINT(i64::MIN, -1), i64::MIN);
+}
+
+#[test]
+fn div_time_by_unsigned_divisor_above_lint_range_yields_zero() {
+    assert_eq!(dtf::DIV__TIME__ULINT(i64::MAX, u64::MAX), 0);
+    assert_eq!(dtf::DIV_LTIME__ULINT(i64::MIN, u64::MAX), 0);
+}
+
+// Float factors: a NaN yields zero and oversized results saturate at the TIME range
+// (sign-aware), instead of panicking inside std::time::Duration.
+#[test]
+fn mul_time_with_nan_factor_yields_zero() {
+    assert_eq!(dtf::MUL__TIME__REAL(1_000, f32::NAN), 0);
+    assert_eq!(dtf::MUL_TIME__REAL(1_000, f32::NAN), 0);
+    assert_eq!(dtf::MUL_LTIME__REAL(1_000, f32::NAN), 0);
+    assert_eq!(dtf::MUL__TIME__LREAL(1_000, f64::NAN), 0);
+    assert_eq!(dtf::MUL_TIME__LREAL(1_000, f64::NAN), 0);
+    assert_eq!(dtf::MUL_LTIME__LREAL(1_000, f64::NAN), 0);
+}
+
+#[test]
+fn mul_time_with_oversized_float_factor_saturates() {
+    assert_eq!(dtf::MUL__TIME__REAL(i64::MAX, 2.0), i64::MAX);
+    assert_eq!(dtf::MUL_TIME__REAL(i64::MAX, 2.0), i64::MAX);
+    assert_eq!(dtf::MUL_LTIME__REAL(i64::MAX, 2.0), i64::MAX);
+    assert_eq!(dtf::MUL__TIME__LREAL(i64::MAX, 2.0), i64::MAX);
+    assert_eq!(dtf::MUL_TIME__LREAL(i64::MAX, 2.0), i64::MAX);
+    assert_eq!(dtf::MUL_LTIME__LREAL(i64::MAX, 2.0), i64::MAX);
+}
+
+#[test]
+fn mul_time_with_oversized_float_factor_saturates_negative() {
+    assert_eq!(dtf::MUL__TIME__REAL(i64::MAX, -2.0), -i64::MAX);
+    assert_eq!(dtf::MUL__TIME__LREAL(i64::MIN, 2.0), -i64::MAX);
+}
+
+#[test]
+fn mul_zero_time_with_infinite_factor_yields_zero() {
+    assert_eq!(dtf::MUL__TIME__REAL(0, f32::INFINITY), 0);
+    assert_eq!(dtf::MUL__TIME__LREAL(0, f64::INFINITY), 0);
+}
+
+#[test]
+fn div_time_by_nan_yields_zero() {
+    assert_eq!(dtf::DIV__TIME__REAL(1_000, f32::NAN), 0);
+    assert_eq!(dtf::DIV__TIME__LREAL(1_000, f64::NAN), 0);
+}
+
+#[test]
+fn div_time_by_tiny_float_saturates() {
+    assert_eq!(dtf::DIV__TIME__REAL(i64::MAX, 0.5), i64::MAX);
+    assert_eq!(dtf::DIV__TIME__LREAL(i64::MAX, 0.5), i64::MAX);
+    assert_eq!(dtf::DIV__TIME__LREAL(i64::MAX, -0.5), -i64::MAX);
+}
+
+#[test]
+fn div_time_by_zero_float_saturates() {
+    assert_eq!(dtf::DIV__TIME__REAL(1, 0.0), i64::MAX);
+    assert_eq!(dtf::DIV_TIME__REAL(1, 0.0), i64::MAX);
+    assert_eq!(dtf::DIV_LTIME__REAL(1, 0.0), i64::MAX);
+    assert_eq!(dtf::DIV__TIME__LREAL(1, 0.0), i64::MAX);
+    assert_eq!(dtf::DIV_TIME__LREAL(1, 0.0), i64::MAX);
+    assert_eq!(dtf::DIV_LTIME__LREAL(1, 0.0), i64::MAX);
+    assert_eq!(dtf::DIV__TIME__REAL(-1, 0.0), -i64::MAX);
+    assert_eq!(dtf::DIV__TIME__LREAL(1, -0.0), -i64::MAX);
+}
+
+#[test]
+fn div_zero_time_by_zero_float_yields_zero() {
+    assert_eq!(dtf::DIV__TIME__REAL(0, 0.0), 0);
+    assert_eq!(dtf::DIV__TIME__LREAL(0, 0.0), 0);
 }

--- a/tests/lit/single/stdlib_overflow/README.md
+++ b/tests/lit/single/stdlib_overflow/README.md
@@ -1,10 +1,10 @@
 # Standard Library Overflow Tests
 
-This directory contains integration tests for stdlib functions that are expected to panic on overflow or division by zero conditions.
+This directory contains integration tests for stdlib functions on overflow, underflow, and division-by-zero inputs.
 
 ## Background
 
-These tests were originally part of the Rust integration test suite in `libs/stdlib/tests/date_time_numeric_functions_tests.rs`, but they could not be properly tested there because:
+These tests were originally part of the Rust integration test suite in `libs/stdlib/tests/date_time_numeric_functions_tests.rs`, but panic behavior could not be tested there because:
 
 1. The Rust test infrastructure compiles PLC code into a shared library and loads it dynamically using `libloading`
 2. When a panic occurs in dynamically loaded code, Rust's panic unwinding mechanism cannot cross the FFI boundary
@@ -13,73 +13,64 @@ These tests were originally part of the Rust integration test suite in `libs/std
    fatal runtime error: Rust cannot catch foreign exceptions, aborting
    ```
 
-## Solution
-
-These tests have been moved to the lit test framework where they can be marked with `XFAIL: *` to indicate they are expected to fail at runtime. This properly documents the expected panic behavior without breaking the test suite.
-
 ## Test Coverage
 
-The following overflow/panic conditions are tested:
+### TIME Arithmetic (wrapping)
 
-### TIME Arithmetic Overflow
-- `add_time_overflow.st` - Adding to max TIME value
-- `sub_time_overflow.st` - Subtracting from min TIME value
+The stdlib ADD/SUB/MUL date and time functions wrap on overflow. TIME and the other
+date/time types are signed 64-bit on this branch, so wrapping happens mod 2^64 at the
+i64 range bounds and deficits below zero stay plain negative values. These tests run
+to completion and check the wrapped values:
 
-### TIME Multiplication Overflow
-- `mul_time_signed_overflow.st` - Multiplying TIME by max LINT
-- `mul_time_unsigned_overflow.st` - Multiplying TIME by max ULINT
-- `mul_time_real_overflow.st` - Multiplying TIME by max REAL
-- `mul_time_lreal_overflow.st` - Multiplying TIME by large LREAL
+- `add_time_overflow.st` - ADD/ADD_TIME past the TIME range wraps mod 2^64
+- `sub_time_overflow.st` - SUB/SUB_TIME below the range minimum wraps mod 2^64, SUB_DATE_DATE yields the signed difference
+- `mul_time_signed_overflow.st` - MUL with a signed integer wraps mod 2^64
+- `mul_time_unsigned_overflow.st` - MUL with an unsigned integer wraps mod 2^64
+- `dt_tod_overflow.st` - ADD_DT_TIME past the DT range wraps mod 2^64, SUB_DT_TIME/SUB_TOD_TOD below zero yield signed values
+- `concat_invalid_inputs.st` - CONCAT_DATE/CONCAT_TOD yield 0 for unrepresentable inputs and clamp to the DATE range
+- `lreal_to_string_huge_negative.st` - LREAL_TO_STRING picks scientific notation by magnitude instead of overflowing the buffer
+- `dt_to_date_first_day.st` - DATE_AND_TIME_TO_DATE saturates at the DATE range minimum on the first representable day
 
-### Division by Zero
-- `div_time_by_zero.st` - Dividing TIME by zero (LINT)
+### Float Factors (saturating)
+
+MUL and DIV with a REAL/LREAL factor cannot wrap meaningfully; the functions follow float semantics mapped to the TIME range. Oversized and infinite results (including division by zero) saturate at the TIME range, and a NaN factor or NaN result (zero divided by zero) yields zero:
+
+- `mul_time_real_overflow.st` - Multiplying TIME by an oversized or NaN REAL
+- `mul_time_lreal_overflow.st` - Multiplying TIME by an oversized or NaN LREAL
 - `div_time_by_real_zero.st` - Dividing TIME by zero (REAL)
 - `div_time_by_lreal_zero.st` - Dividing TIME by zero (LREAL)
 
-## Test Format
+### String Parameters (clamping)
 
-All tests follow this pattern:
+Out-of-range string function parameters clamp or leave the base string unchanged, matching CODESYS:
 
-```st
-// RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test description
+- `string_param_clamping.st` - LEFT/MID/INSERT/DELETE/REPLACE with out-of-range lengths and positions
+- `right_string_substring_too_long.st` / `right_wstring_substring_too_long.st` - RIGHT with a length above the string length clamps to the whole string
 
-PROGRAM main
-VAR
-    a : TIME;
-END_VAR
-    // Operation that causes overflow/panic
-    a := <operation>;
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
-```
+### Invalid String Content (lossy decoding)
 
-The `XFAIL: *` directive tells lit that this test is expected to fail (panic), so a non-zero exit code is treated as success.
+Strings can carry bytes that are not valid UTF-8/UTF-16 (pointer writes, comms buffers, C interop). The string functions decode them lossily (invalid parts become U+FFFD) instead of aborting the process; CONCAT copies raw code units unchanged:
+
+- `lossy_string_decoding.st` - LEN/FIND/CONCAT/STRING_TO_WSTRING on a `16#FF`-patched STRING, LEN/LEFT on a WSTRING holding an unpaired surrogate
+
+### Panic Conditions (`XFAIL: *`)
+
+The remaining conditions panic at runtime by design (integer division by zero is treated as a programming error). Their tests carry `XFAIL: *`, so a non-zero exit code is treated as success:
+
+- `div_time_by_zero.st` - Dividing TIME by zero (LINT)
+
+### FFI Return Width Tests
+
+- `sub32_ffi_return_byte.st` / `sub32_ffi_return_signed.st` / `sub32_ffi_return_word.st` - sub-32-bit FFI return handling
 
 ## Running the Tests
 
 To run all stdlib overflow tests:
 ```bash
-lit -v tests/lit/single/stdlib_overflow/
+lit -v -DLIB=output -DCOMPILER=target/debug/plc tests/lit/single/stdlib_overflow/
 ```
 
 Or run the entire lit test suite:
 ```bash
-./scripts/build.sh --build --lit
+./scripts/build.sh --lit
 ```
-
-## Expected Output
-
-When running these tests, you should see:
-```
-XFAIL: <unnamed> :: single/stdlib_overflow/add_time_overflow.st
-XFAIL: <unnamed> :: single/stdlib_overflow/sub_time_overflow.st
-...
-
-Total Discovered Tests: 9
-  Expectedly Failed: 9 (100.00%)
-```
-
-This indicates all tests behaved as expected (they panicked).

--- a/tests/lit/single/stdlib_overflow/add_time_overflow.st
+++ b/tests/lit/single/stdlib_overflow/add_time_overflow.st
@@ -1,13 +1,22 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that ADD with TIME overflow causes a panic
+// Test that ADD with TIME wraps mod 2^64 on overflow.
+// The maximum TIME value is built at runtime because TIME literals saturate
+// at 4294967295ns in this parser.
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
+    max : TIME;
     a : TIME;
+    b : TIME;
 END_VAR
-    // Adding 1ms to max TIME value should overflow and panic
-    a := ADD(TIME#9223372036854775807ms, TIME#1ms);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    max := MUL(TIME#1ns, LINT#9223372036854775807);
+    a := ADD(max, TIME#1ns);
+    // CHECK: -9223372036854775808
+    printf('%lld$N', a);
+
+    b := ADD_TIME(max, TIME#10ns);
+    // CHECK: -9223372036854775799
+    printf('%lld$N', b);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/concat_invalid_inputs.st
+++ b/tests/lit/single/stdlib_overflow/concat_invalid_inputs.st
@@ -1,0 +1,36 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that date/time constructors yield 0 for unrepresentable inputs
+// and clamp out-of-range dates to the DATE range
+
+FUNCTION main : DINT
+VAR
+    a : DATE;
+    b : TOD;
+    c : DATE;
+    d : DATE;
+    e : DATE;
+END_VAR
+    a := CONCAT_DATE(INT#2024, INT#13, INT#45);
+    // CHECK: 0
+    printf('%lld$N', a);
+
+    b := CONCAT_TOD(INT#25, INT#0, INT#0, INT#0);
+    // CHECK: 0
+    printf('%lld$N', b);
+
+    // pre-1970 dates stay representable in the signed range
+    c := CONCAT_DATE(INT#1969, INT#6, INT#1);
+    // CHECK: -18489600000000000
+    printf('%lld$N', c);
+
+    d := CONCAT_DATE(INT#2024, INT#2, INT#29);
+    // CHECK: 1709164800000000000
+    printf('%lld$N', d);
+
+    // beyond the representable range clamps to the range maximum
+    e := CONCAT_DATE(INT#2500, INT#1, INT#1);
+    // CHECK: 9223372036854775807
+    printf('%lld$N', e);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/div_time_by_lreal_zero.st
+++ b/tests/lit/single/stdlib_overflow/div_time_by_lreal_zero.st
@@ -1,13 +1,19 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that DIV with TIME by LREAL zero causes a panic
+// Test that DIV with TIME by LREAL zero saturates at the TIME range
+// and a zero dividend yields zero
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
+    b : TIME;
 END_VAR
-    // Dividing TIME by zero (LREAL) should panic
-    a := DIV(TIME#10ns, LREAL#0.0);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := DIV(TIME#1s, LREAL#0.0);
+    // CHECK: 9223372036854775807
+    printf('%lld$N', a);
+
+    b := DIV(TIME#0s, LREAL#0.0);
+    // CHECK: 0
+    printf('%lld$N', b);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/div_time_by_real_zero.st
+++ b/tests/lit/single/stdlib_overflow/div_time_by_real_zero.st
@@ -1,13 +1,19 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that DIV with TIME by REAL zero causes a panic
+// Test that DIV with TIME by REAL zero saturates at the TIME range
+// and a zero dividend yields zero
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
+    b : TIME;
 END_VAR
-    // Dividing TIME by zero (REAL) should panic
-    a := DIV(TIME#10ns, REAL#0.0);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := DIV(TIME#1s, REAL#0.0);
+    // CHECK: 9223372036854775807
+    printf('%lld$N', a);
+
+    b := DIV(TIME#0s, REAL#0.0);
+    // CHECK: 0
+    printf('%lld$N', b);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/dt_to_date_first_day.st
+++ b/tests/lit/single/stdlib_overflow/dt_to_date_first_day.st
@@ -1,0 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that DATE_AND_TIME_TO_DATE saturates at the DATE range minimum for
+// values on the first representable day (its midnight lies below the range)
+// instead of aborting the process
+
+FUNCTION main : DINT
+VAR
+    a : DATE;
+    b : DATE;
+END_VAR
+    a := DATE_AND_TIME_TO_DATE(DT#1677-09-21-12:00:00);
+    // CHECK: -9223372036854775808
+    printf('%lld$N', a);
+
+    b := DATE_AND_TIME_TO_DATE(DT#2024-05-05-13:30:15);
+    IF b = DATE#2024-05-05 THEN
+        // CHECK: midnight_ok
+        printf('midnight_ok$N');
+    END_IF
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/dt_tod_overflow.st
+++ b/tests/lit/single/stdlib_overflow/dt_tod_overflow.st
@@ -1,0 +1,24 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that DT and TOD arithmetic wraps mod 2^64 on overflow and yields plain
+// signed values below zero
+
+FUNCTION main : DINT
+VAR
+    a : DT;
+    b : DT;
+    c : TIME;
+END_VAR
+    a := ADD_DT_TIME(DT#2262-04-11-23:47:16, TIME#1d);
+    // CHECK: -9223285637709551616
+    printf('%lld$N', a);
+
+    b := SUB_DT_TIME(DT#1970-01-01-01:00:00, TIME#2h);
+    // CHECK: -3600000000000
+    printf('%lld$N', b);
+
+    c := SUB_TOD_TOD(TOD#01:00:00, TOD#02:00:00);
+    // CHECK: -3600000000000
+    printf('%lld$N', c);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/lossy_string_decoding.st
+++ b/tests/lit/single/stdlib_overflow/lossy_string_decoding.st
@@ -1,0 +1,45 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that string functions tolerate invalid UTF-8/UTF-16 content
+// (bytes written through pointers, comms buffers or C interop)
+// instead of aborting the process
+
+FUNCTION main : DINT
+VAR
+    s : STRING := 'abc';
+    t : STRING;
+    w : WSTRING;
+    ws : WSTRING := "abc";
+    p : REF_TO BYTE;
+    pw : REF_TO WORD;
+END_VAR
+    // invalid UTF-8: patch the first byte of 'abc'
+    p := REF(s);
+    p^ := 16#FF;
+
+    // CHECK: len_counts_invalid_byte 3
+    printf('len_counts_invalid_byte %d$N', LEN(s));
+
+    // CHECK: find_positions_across_invalid_byte 3
+    printf('find_positions_across_invalid_byte %d$N', FIND(s, 'c'));
+
+    t := CONCAT(s, 'd');
+    // CHECK: concat_keeps_raw_bytes 4
+    printf('concat_keeps_raw_bytes %d$N', LEN(t));
+
+    w := STRING_TO_WSTRING(s);
+    // CHECK: string_to_wstring_replaces 3
+    printf('string_to_wstring_replaces %d$N', LEN(w));
+
+    // invalid UTF-16: patch an unpaired surrogate into "abc"
+    pw := REF(ws);
+    pw^ := WORD#16#D800;
+
+    // CHECK: wstring_len_counts_surrogate 3
+    printf('wstring_len_counts_surrogate %d$N', LEN(ws));
+
+    w := LEFT(ws, 2);
+    // CHECK: left_replaces_surrogate 2
+    printf('left_replaces_surrogate %d$N', LEN(w));
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/lreal_to_string_huge_negative.st
+++ b/tests/lit/single/stdlib_overflow/lreal_to_string_huge_negative.st
@@ -1,0 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that LREAL_TO_STRING uses scientific notation for huge negative values
+// instead of overflowing the 80-byte string buffer
+
+FUNCTION main : DINT
+VAR
+    s : STRING;
+END_VAR
+    s := LREAL_TO_STRING(LREAL#-1.0E300);
+    // CHECK: -1.000000e300
+    printf('%s$N', REF(s));
+
+    s := LREAL_TO_STRING(LREAL#1.0E300);
+    // CHECK: 1.000000e300
+    printf('%s$N', REF(s));
+
+    s := LREAL_TO_STRING(LREAL#-42.5);
+    // CHECK: -42.500000
+    printf('%s$N', REF(s));
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_lreal_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_lreal_overflow.st
@@ -1,13 +1,21 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and LREAL overflow causes a panic
+// Test that MUL with TIME and an oversized LREAL factor saturates at the TIME range
+// and a NaN factor yields zero
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
+    b : TIME;
+    lr : LREAL;
 END_VAR
-    // Multiplying TIME by large LREAL value should overflow and panic
-    a := MUL(TIME#-2s700ms, LREAL#3.40282347e38);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := MUL(TIME#1000d, LREAL#1.7e308);
+    // CHECK: 9223372036854775807
+    printf('%lld$N', a);
+
+    lr := 0.0;
+    b := MUL(TIME#1s, lr / lr);
+    // CHECK: 0
+    printf('%lld$N', b);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_real_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_real_overflow.st
@@ -1,13 +1,21 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and REAL overflow causes a panic
+// Test that MUL with TIME and an oversized REAL factor saturates at the TIME range
+// and a NaN factor yields zero
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
+    b : TIME;
+    r : REAL;
 END_VAR
-    // Multiplying TIME by max REAL value should overflow and panic
-    a := MUL(TIME#-2s700ms, REAL#3.40282347e38);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := MUL(TIME#1000d, REAL#3.4e38);
+    // CHECK: 9223372036854775807
+    printf('%lld$N', a);
+
+    r := 0.0;
+    b := MUL(TIME#1s, r / r);
+    // CHECK: 0
+    printf('%lld$N', b);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_signed_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_signed_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and signed integer overflow causes a panic
+// Test that MUL with TIME and a signed integer wraps mod 2^64 on overflow
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by max LINT value should overflow and panic
-    a := MUL(TIME#10ns, LINT#9223372036854775807);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := MUL(TIME#2ns, LINT#9223372036854775807);
+    // CHECK: -2
+    printf('%lld$N', a);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/mul_time_unsigned_overflow.st
+++ b/tests/lit/single/stdlib_overflow/mul_time_unsigned_overflow.st
@@ -1,13 +1,13 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that MUL with TIME and unsigned integer overflow causes a panic
+// Test that MUL with TIME and an unsigned integer wraps mod 2^64 on overflow
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     a : TIME;
 END_VAR
-    // Multiplying TIME by max ULINT value should overflow and panic
-    a := MUL(TIME#1ns, ULINT#9223372036854775808);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    a := MUL(TIME#1ns, ULINT#18446744073709551615);
+    // CHECK: -1
+    printf('%lld$N', a);
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/right_string_substring_too_long.st
+++ b/tests/lit/single/stdlib_overflow/right_string_substring_too_long.st
@@ -1,16 +1,20 @@
-// RUN: (%COMPILE %s && %RUN 2>&1) | %CHECK %s
-// XFAIL: *
-// Test that RIGHT with substring length > string length causes a panic
-// Expected failure message: Requested substring length exceeds string length.
-// CHECK: Requested substring length exceeds string length.
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that RIGHT with a substring length above the string length clamps
+// to the whole string, matching CODESYS
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
     s : STRING;
 END_VAR
-    s := 'sample text';
-    // Length 12 exceeds string length 11 -> should panic
-    s := RIGHT(s, 12);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    s := RIGHT('sample text', 12);
+    // CHECK: sample text
+    printf('%s$N', REF(s));
+
+    s := RIGHT('sample text', -1);
+    // CHECK: negative_length_yields_empty
+    IF s = '' THEN
+        printf('negative_length_yields_empty$N');
+    END_IF
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/right_wstring_substring_too_long.st
+++ b/tests/lit/single/stdlib_overflow/right_wstring_substring_too_long.st
@@ -1,17 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that RIGHT with a substring length above the string length clamps
+// to the whole string for WSTRING, matching the STRING behavior
 
-// RUN: (%COMPILE %s && %RUN 2>&1) | %CHECK %s
-// XFAIL: *
-// Test that RIGHT with substring length > string length causes a panic
-// Expected failure message: Requested substring length exceeds string length.
-// CHECK: Requested substring length exceeds string length.
-
-PROGRAM main
+FUNCTION main : DINT
 VAR
     s : WSTRING;
 END_VAR
-    s := "sa𝄞ple text";
-    // Length 12 exceeds string length 11 -> should panic
-    s := RIGHT(s, 12);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    s := RIGHT(WSTRING#"sa𝄞ple text", 12);
+    // CHECK: length_clamps_to_string
+    IF s = "sa𝄞ple text" THEN
+        printf('length_clamps_to_string$N');
+    END_IF
+
+    s := RIGHT(WSTRING#"sa𝄞ple text", -1);
+    // CHECK: negative_length_yields_empty
+    IF s = "" THEN
+        printf('negative_length_yields_empty$N');
+    END_IF
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/string_param_clamping.st
+++ b/tests/lit/single/stdlib_overflow/string_param_clamping.st
@@ -1,0 +1,45 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// Test that out-of-range string function parameters clamp or leave the
+// base string unchanged, matching CODESYS (except the position-0 quirk
+// of DELETE/REPLACE, which is treated as an invalid position here)
+
+FUNCTION main : DINT
+VAR
+    s : STRING;
+END_VAR
+    s := LEFT('hello', 10);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    s := MID('hello', 10, 3);
+    // CHECK: llo
+    printf('%s$N', REF(s));
+
+    s := MID('hello', 2, 10);
+    // CHECK: mid_invalid_position_yields_empty
+    IF s = '' THEN
+        printf('mid_invalid_position_yields_empty$N');
+    END_IF
+
+    s := INSERT('hello', 'XX', 10);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    s := DELETE('hello', 3, 4);
+    // CHECK: hel
+    printf('%s$N', REF(s));
+
+    s := DELETE('hello', 2, 10);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    s := REPLACE('hello', 'X', 3, 4);
+    // CHECK: helX
+    printf('%s$N', REF(s));
+
+    s := REPLACE('hello', 'X', 2, 0);
+    // CHECK: hello
+    printf('%s$N', REF(s));
+
+    main := 0;
+END_FUNCTION

--- a/tests/lit/single/stdlib_overflow/sub_time_overflow.st
+++ b/tests/lit/single/stdlib_overflow/sub_time_overflow.st
@@ -1,13 +1,30 @@
 // RUN: (%COMPILE %s && %RUN) | %CHECK %s
-// XFAIL: *
-// Test that SUB with TIME overflow causes a panic
+// Test that SUB with TIME wraps mod 2^64 on underflow and SUB_DATE_DATE
+// yields the plain signed difference.
+// The maximum TIME value is built at runtime because TIME literals saturate
+// at 4294967295ns in this parser.
 
-PROGRAM main
+FUNCTION main : DINT
 VAR
+    max : TIME;
     a : TIME;
+    b : TIME;
+    c : TIME;
 END_VAR
-    // Subtracting from minimum TIME value should overflow and panic
-    a := SUB(TIME#-9223372036854775807ms, TIME#1ms);
-    // CHECK: Should not reach here
-    printf('Should not reach here$N');
-END_PROGRAM
+    // TIME is signed, so small deficits stay plain negative values
+    a := SUB(TIME#1s, TIME#5s);
+    // CHECK: -4000000000
+    printf('%lld$N', a);
+
+    // pushing below the range minimum wraps to the top of the range
+    max := MUL(TIME#1ns, LINT#9223372036854775807);
+    b := SUB_TIME(SUB(TIME#0s, max), TIME#2ns);
+    // CHECK: 9223372036854775807
+    printf('%lld$N', b);
+
+    c := SUB_DATE_DATE(DATE#2024-06-01, DATE#2024-01-01);
+    // CHECK: 13132800000000000
+    printf('%lld$N', c);
+
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
Backport of the following 8 PRs to `release/1.0.x`: #1866, #1867, #1870, #1871, #1872, #1873, #1874, #1875.

The string functions apply verbatim. The date/time functions are adapted to this branch's signed 64-bit TIME representation, keeping master's behavior policy: never panic, wrap on overflow (mod 2^64), invalid constructor inputs yield 0, oversized float factors saturate at the TIME range, NaN yields zero. The clippy no-panic lints from #1875 are enforced crate-wide and pass.

Refs: PRG-4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)