### PR TITLE
feat(cfc): storage mode (REF= assignment)

### DIFF
--- a/compiler/plc_ast/src/ser.rs
+++ b/compiler/plc_ast/src/ser.rs
@@ -221,7 +221,7 @@ impl AstVisitor for AstSerializer<'_> {
                 }
             }
             DataTypeDeclaration::Definition { data_type, .. } => {
-                data_type.as_ref().walk(self);
+                self.visit_data_type(data_type);
             }
             DataTypeDeclaration::Aggregate { referenced_type, .. } => {
                 self.result.push_str(referenced_type);

--- a/compiler/plc_cfc/fixtures/variables/invalid/storage_reference_negated/README.md
+++ b/compiler/plc_cfc/fixtures/variables/invalid/storage_reference_negated/README.md
@@ -1,0 +1,9 @@
+What: negation bubbles on `Reference` sinks, one row per side. An address has
+no negation, so each row is rejected with E154 instead of transpiling to a
+`REF=` with a synthesized `NOT`.
+
+Illustrated:
+```
+a o-> [b |REF] (0)
+a --o [b |REF] (1)
+```

--- a/compiler/plc_cfc/fixtures/variables/invalid/storage_reference_negated/storage_reference_negated.cfc
+++ b/compiler/plc_cfc/fixtures/variables/invalid/storage_reference_negated/storage_reference_negated.cfc
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="storage_reference_negated">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM storage_reference_negated
+VAR
+    a : BOOL;
+    b : REFERENCE TO BOOL;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a" globalId="1">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation outNegated="true"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:StorageMode mode="Reference"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a" globalId="4">
+                    <ppx:RelPosition x="250" y="170"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="5">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b" globalId="6">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="1"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:Negation inNegated="true"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:StorageMode mode="Reference"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="170"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="5"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/fixtures/variables/valid/storage_reference/README.md
+++ b/compiler/plc_cfc/fixtures/variables/valid/storage_reference/README.md
@@ -1,0 +1,8 @@
+What: a sink with storage mode `Reference`. The sink re-points instead of
+assigning: it stores the source's address, `b REF= a`, so later reads of `b`
+see whatever value `a` holds at that time.
+
+Illustrated:
+```
+a --> [b |REF] (0)
+```

--- a/compiler/plc_cfc/fixtures/variables/valid/storage_reference/storage_reference.cfc
+++ b/compiler/plc_cfc/fixtures/variables/valid/storage_reference/storage_reference.cfc
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="storage_reference">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM storage_reference
+VAR
+    a : DINT;
+    b : REFERENCE TO DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:StorageMode mode="Reference"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>

--- a/compiler/plc_cfc/src/model.rs
+++ b/compiler/plc_cfc/src/model.rs
@@ -90,8 +90,9 @@ pub struct Negation {
     pub out_negated: bool,
 }
 
-// The Set/Reset latch behavior on a data sink: the incoming value no longer
-// assigns but guards a constant `TRUE` (Set) or `FALSE` (Reset) store.
+// The storage behavior on a data sink. Set/Reset latch: the incoming value no
+// longer assigns but guards a constant `TRUE` (Set) or `FALSE` (Reset) store.
+// Reference re-points: the sink stores the source's address (`REF=`).
 #[derive(Debug, Deserialize)]
 pub struct StorageMode {
     #[serde(rename = "@mode")]
@@ -102,6 +103,7 @@ pub struct StorageMode {
 pub enum Storage {
     Set,
     Reset,
+    Reference,
 }
 
 // The execution control flag: when set, the block's `EN` input pin guards its

--- a/compiler/plc_cfc/src/resolver.rs
+++ b/compiler/plc_cfc/src/resolver.rs
@@ -11,7 +11,7 @@ use plc_source::SourceCode;
 
 use plc::index::Index;
 
-use crate::model::{self, FbdObject, Pin};
+use crate::model::{self, FbdObject, Pin, Storage};
 use crate::network::{Argument, Network, Statement, Temporary};
 use crate::st;
 
@@ -96,6 +96,16 @@ impl<'index> Resolver<'index> {
 
             match Role::from(object) {
                 Role::Sink => match trace(consumes(object), &survey) {
+                    // An address has no inverse; a bubble anywhere on a
+                    // reference assignment's wire is rejected.
+                    Trace::Reached(source)
+                        if matches!(object.storage(), Some(Storage::Reference))
+                            && negated(object, &source) =>
+                    {
+                        let name = object.identifier().unwrap_or_default();
+                        self.diagnostics.push(Diagnostic::negated_reference_assignment(name, location));
+                    }
+
                     // The traced source becomes the sink's assigned value,
                     // negated once more by the sink's own inversion bubble.
                     Trace::Reached(source) => {
@@ -730,6 +740,17 @@ fn consumes(consumer: &FbdObject) -> Option<usize> {
     consumer.connection_in.as_ref()?.source_pin()
 }
 
+// Any inversion bubble between a producer and its consumer: the producer's,
+// the consumer's, or one synthesized by an EN hop on the way.
+fn negated(consumer: &FbdObject, source: &Source) -> bool {
+    let negated = match source {
+        Source::Variable { object, negated } => object.out_negated() || *negated,
+        Source::Output { pin, negated, .. } => pin.negated || *negated,
+    };
+
+    negated || consumer.in_negated()
+}
+
 #[cfg(test)]
 mod tests {
     use plc_ast::provider::IdProvider;
@@ -761,15 +782,13 @@ mod tests {
                     format!("{} := {}", AstSerializer::format(sink), AstSerializer::format(source))
                 }
                 Statement::Assignment { sink, source, storage: Some(storage) } => {
-                    let value = match storage {
-                        Storage::Set => "TRUE",
-                        Storage::Reset => "FALSE",
-                    };
-                    format!(
-                        "IF {} THEN {} := {value}",
-                        AstSerializer::format(source),
-                        AstSerializer::format(sink)
-                    )
+                    let sink = AstSerializer::format(sink);
+                    let source = AstSerializer::format(source);
+                    match storage {
+                        Storage::Set => format!("IF {source} THEN {sink} := TRUE"),
+                        Storage::Reset => format!("IF {source} THEN {sink} := FALSE"),
+                        Storage::Reference => format!("{sink} REF= {source}"),
+                    }
                 }
                 Statement::Return { condition, .. } => {
                     format!("RETURN {}", AstSerializer::format(condition))
@@ -875,6 +894,11 @@ mod tests {
             IF NOT a THEN b := TRUE
             IF NOT a THEN b := FALSE
             IF NOT NOT a THEN b := TRUE");
+        }
+
+        #[test]
+        fn storage_reference() {
+            insta::assert_snapshot!(resolve_project("variables/valid/storage_reference"), @"b REF= a");
         }
 
         #[test]
@@ -1399,6 +1423,17 @@ mod tests {
             insta::assert_snapshot!(transpile_project("blocks/invalid/function_stale_output").unwrap_err(), @r"
             error[E147]: Output `oldDoubled` is not declared by `myAdd`
              = function_stale_output.cfc: Block 5
+            ");
+        }
+
+        #[test]
+        fn storage_reference_negated() {
+            insta::assert_snapshot!(transpile_project("variables/invalid/storage_reference_negated").unwrap_err(), @r"
+            error[E154]: Reference assignment to `b` cannot be negated
+             = storage_reference_negated.cfc: Block 3
+
+            error[E154]: Reference assignment to `b` cannot be negated
+             = storage_reference_negated.cfc: Block 6
             ");
         }
     }

--- a/compiler/plc_cfc/src/transpiler.rs
+++ b/compiler/plc_cfc/src/transpiler.rs
@@ -50,6 +50,12 @@ impl Transpiler {
                 AstFactory::create_assignment(sink, source, self.ids.next_id())
             }
 
+            // A reference-mode sink re-points: it stores the source's address,
+            // `sink REF= source`, instead of assigning the source's value.
+            Statement::Assignment { sink, source, storage: Some(Storage::Reference) } => {
+                AstFactory::create_ref_assignment(sink, source, self.ids.next_id())
+            }
+
             // A storage-mode sink latches: the source guards a constant store,
             // `TRUE` for Set, `FALSE` for Reset; nothing is written otherwise.
             Statement::Assignment { sink, source, storage: Some(storage) } => {
@@ -317,6 +323,19 @@ mod tests {
                 IF NOT NOT a THEN
                     b := TRUE
                 END_IF;
+            END_PROGRAM
+            ");
+        }
+
+        #[test]
+        fn storage_reference() {
+            insta::assert_snapshot!(transpile_project("variables/valid/storage_reference").unwrap(), @r"
+            PROGRAM storage_reference
+            VAR
+                a : DINT;
+                b : REFERENCE TO DINT;
+            END_VAR
+                b REF= a;
             END_PROGRAM
             ");
         }

--- a/compiler/plc_diagnostics/src/diagnostics.rs
+++ b/compiler/plc_diagnostics/src/diagnostics.rs
@@ -498,6 +498,15 @@ impl Diagnostic {
             .with_location(location)
     }
 
+    pub fn negated_reference_assignment<T>(name: &str, location: T) -> Diagnostic
+    where
+        T: Into<SourceLocation>,
+    {
+        Diagnostic::new(format!("Reference assignment to `{name}` cannot be negated"))
+            .with_error_code("E154")
+            .with_location(location)
+    }
+
     pub fn disconnected_jump<T>(location: T) -> Diagnostic
     where
         T: Into<SourceLocation>,

--- a/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
+++ b/compiler/plc_diagnostics/src/diagnostics/diagnostics_registry.rs
@@ -255,6 +255,7 @@ lazy_static! {
         E151,   Error,      include_str!("./error_codes/E151.md"),  // Unary NOT with unsupported operand type
         E152,   Error,      include_str!("./error_codes/E152.md"),  // Unconnected CFC EN pin
         E153,   Error,      include_str!("./error_codes/E153.md"),  // CFC ENO cycle
+        E154,   Error,      include_str!("./error_codes/E154.md"),  // Negated CFC reference assignment
     );
 }
 

--- a/compiler/plc_diagnostics/src/diagnostics/error_codes/E154.md
+++ b/compiler/plc_diagnostics/src/diagnostics/error_codes/E154.md
@@ -1,0 +1,5 @@
+# Negated CFC reference assignment
+
+A data sink with the `REF=` storage mode stores the address of its source, and
+an address has no negation. A negation bubble anywhere on the wire, on the
+source, on the sink, or on a block output pin feeding it, is rejected.

--- a/tests/lit/cfc/variables/storage_reference/README.md
+++ b/tests/lit/cfc/variables/storage_reference/README.md
@@ -1,0 +1,3 @@
+End-to-end runtime check of the `Reference` storage mode: the sink transpiles
+to `b REF= a`, so after one cycle `b` points at `a` and reads through to
+whatever value `a` currently holds.

--- a/tests/lit/cfc/variables/storage_reference/main.st
+++ b/tests/lit/cfc/variables/storage_reference/main.st
@@ -1,0 +1,12 @@
+FUNCTION main : DINT
+    // The cycle points the reference at its source.
+    storage_reference.a := 5;
+    storage_reference();
+    // CHECK: ref: b = 5
+    printf('ref: b = %d$N', storage_reference.b);
+
+    // The reference reads through to the source's current value.
+    storage_reference.a := 7;
+    // CHECK: track: b = 7
+    printf('track: b = %d$N', storage_reference.b);
+END_FUNCTION

--- a/tests/lit/cfc/variables/storage_reference/plc.json
+++ b/tests/lit/cfc/variables/storage_reference/plc.json
@@ -1,0 +1,11 @@
+{
+	"name" : "cfc_storage_reference",
+	"files" : [
+		"storage_reference.cfc",
+		"main.st",
+		"../../../util/printf.pli"
+	],
+	"compile_type" : "Static",
+	"output" : "app",
+	"libraries" : []
+}

--- a/tests/lit/cfc/variables/storage_reference/run.test
+++ b/tests/lit/cfc/variables/storage_reference/run.test
@@ -1,0 +1,1 @@
+RUN: %COMPILE build plc.json && %RUN | %CHECK main.st

--- a/tests/lit/cfc/variables/storage_reference/storage_reference.cfc
+++ b/tests/lit/cfc/variables/storage_reference/storage_reference.cfc
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ppx:Program xmlns:bmx="http://www.bachmann.at/xml/PLC" xmlns:ppx="www.iec.ch/public/TC65SC65BWG7TF10" xmlns:rxt="www.iec.ch/public/TC65SC65BWG7TF10/Recommendation" name="storage_reference">
+    <ppx:AddData>
+        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+            <bmx:TextDeclaration>PROGRAM storage_reference
+VAR
+    a : DINT;
+    b : REFERENCE TO DINT;
+END_VAR</bmx:TextDeclaration>
+        </ppx:Data>
+    </ppx:AddData>
+    <ppx:MainBody>
+        <ppx:BodyContent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ppx:FBD">
+            <ppx:Network>
+                <ppx:FbdObject xsi:type="ppx:DataSource" identifier="a" globalId="1">
+                    <ppx:RelPosition x="250" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointOut connectionPointOutId="2">
+                        <ppx:RelPosition x="80" y="10"/>
+                    </ppx:ConnectionPointOut>
+                </ppx:FbdObject>
+                <ppx:FbdObject xsi:type="ppx:DataSink" identifier="b" globalId="3">
+                    <ppx:AddData>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <EvaluationPriority priorityInNetwork="0"/>
+                        </ppx:Data>
+                        <ppx:Data name="http://www.bachmann.at/xml/PLC" handleUnknown="implementation">
+                            <bmx:StorageMode mode="Reference"/>
+                        </ppx:Data>
+                    </ppx:AddData>
+                    <ppx:RelPosition x="400" y="140"/>
+                    <ppx:Size x="80" y="20"/>
+                    <ppx:ConnectionPointIn>
+                        <ppx:RelPosition x="0" y="10"/>
+                        <ppx:Connection refConnectionPointOutId="2"/>
+                    </ppx:ConnectionPointIn>
+                </ppx:FbdObject>
+            </ppx:Network>
+        </ppx:BodyContent>
+    </ppx:MainBody>
+</ppx:Program>


### PR DESCRIPTION
Problem: The IDE allows for a `REF=` storage mode similar to set/reset (see https://github.com/PLC-lang/rusty/pull/1851), the transpiler however does not support that case.

Solution: Adapt the data model, support `REF=` assignments for data sinks. Transpile such data sinks into a simple `<left> REF= <right>` assignment and (mostly) rely on the compilers validation for invalid cases.

Refs: PRG-4533