### PR TITLE
fix(driver): flatten build artifact paths (#1894)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "siphasher",
  "tempfile",
  "toml 0.8.23",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ generational-arena = { version = "0.2.8", features = ["serde"] }
 shell-words = "1.1.0"
 plc_derive = { path = "./compiler/plc_derive", version = "1.0.4" }
 which.workspace = true
-siphasher = "1"
+siphasher.workspace = true
 log.workspace = true
 inkwell.workspace = true
 chrono.workspace = true
@@ -111,3 +111,4 @@ regex = "1"
 glob = "0.3"
 cc = "1.0"
 which = "8.0"
+siphasher = "1"

--- a/compiler/plc_driver/Cargo.toml
+++ b/compiler/plc_driver/Cargo.toml
@@ -34,6 +34,7 @@ encoding_rs.workspace = true
 encoding_rs_io.workspace = true
 anyhow.workspace = true
 itertools.workspace = true
+siphasher.workspace = true
 plc_util = { path = "../plc_util", version = "1.0.4" }
 
 [dev-dependencies]

--- a/compiler/plc_driver/src/artifacts.rs
+++ b/compiler/plc_driver/src/artifacts.rs
@@ -1,0 +1,59 @@
+//! Naming of the intermediate build artifacts (object, bitcode and IR files).
+//!
+//! All artifacts of a build land in one flat directory. A layout that mirrors the
+//! source tree instead carries the full path of every source file into the build
+//! directory, and for sources outside of the project (libraries, for example) that
+//! path goes past the limits of the Windows file system.
+
+use std::{hash::Hasher, path::Path};
+
+/// Upper limit for the readable part of an artifact name. The digest keeps names
+/// unique, so a longer file name has nothing to add.
+const NAME_LIMIT: usize = 32;
+
+/// Used when the unit has no file name, for example because it comes from a source
+/// container that is not a file.
+const FALLBACK_NAME: &str = "unit";
+
+/// Builds the flat artifact name for the unit that `key` identifies.
+///
+/// The name keeps the file name of the unit, which makes artifacts and linker
+/// messages readable, and adds a digest of the full `key`. The digest is what makes
+/// the name unique: two units with the same file name in different directories share
+/// one flat directory and must not overwrite each other.
+pub fn file_name(key: &Path, extension: &str) -> String {
+    format!("{}-{:016x}.{extension}", readable_name(key), digest(key))
+}
+
+/// Keeps the characters that are safe in a file name on every platform and replaces
+/// all others, so a key that holds separators or a drive letter cannot escape the
+/// artifact directory.
+fn readable_name(key: &Path) -> String {
+    let name: String = key
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .chars()
+        .map(|it| if it.is_ascii_alphanumeric() || matches!(it, '.' | '-' | '_') { it } else { '_' })
+        .take(NAME_LIMIT)
+        .collect();
+
+    if name.is_empty() {
+        FALLBACK_NAME.to_string()
+    } else {
+        name
+    }
+}
+
+/// SipHash-1-3 with a fixed zero key, so the name of an artifact is the same on every
+/// run, process and platform. The full 64 bits are used because a collision would let
+/// one unit overwrite the artifact of another.
+///
+/// The separators are normalized first, so the same unit keeps its name no matter
+/// which separator the caller used.
+fn digest(key: &Path) -> u64 {
+    let normalized = key.to_string_lossy().replace('\\', "/");
+    let mut hasher = siphasher::sip::SipHasher13::new_with_keys(0, 0);
+    hasher.write(normalized.as_bytes());
+    hasher.finish()
+}

--- a/compiler/plc_driver/src/lib.rs
+++ b/compiler/plc_driver/src/lib.rs
@@ -32,6 +32,7 @@ use plc_index::GlobalContext;
 use project::project::Project;
 use source_code::SourceContainer;
 
+pub mod artifacts;
 pub mod cli;
 pub mod pipelines;
 

--- a/compiler/plc_driver/src/pipelines.rs
+++ b/compiler/plc_driver/src/pipelines.rs
@@ -1004,7 +1004,7 @@ impl AnnotatedProject {
             let obj: Object = module?
                 .unwrap()
                 .persist(
-                    Some(&compile_directory),
+                    Some(&target_compile_dir(&compile_directory, target)),
                     &compile_options.output,
                     compile_options.output_format,
                     compile_options.relocation_preference,
@@ -1075,12 +1075,18 @@ impl AnnotatedProject {
 /// Ensures the directores for the various targets have been created
 fn ensure_compile_dirs(targets: &[Target], compile_directory: &Path) -> Result<(), Diagnostic> {
     for target in targets {
-        if let Some(name) = target.try_get_name() {
-            let dir = compile_directory.join(name);
-            fs::create_dir_all(dir)?;
-        }
+        fs::create_dir_all(target_compile_dir(compile_directory, target))?;
     }
     Ok(())
+}
+
+/// The artifacts of a target land in a directory of their own, so that builds for
+/// several targets do not overwrite each other.
+fn target_compile_dir(compile_directory: &Path, target: &Target) -> PathBuf {
+    match target.try_get_name() {
+        Some(name) => compile_directory.join(name),
+        None => compile_directory.to_path_buf(),
+    }
 }
 
 /// A project that has been transformed into a binary representation

--- a/compiler/plc_driver/src/pipelines/participant.rs
+++ b/compiler/plc_driver/src/pipelines/participant.rs
@@ -28,6 +28,8 @@ use plc_lowering::{
 use project::{object::Object, project::LibraryInformation};
 use source_code::SourceContainer;
 
+use crate::artifacts;
+
 use super::{AnnotatedProject, AnnotatedUnit, GeneratedProject, IndexedProject, ParsedProject};
 
 /// A Build particitpant for different steps in the pipeline
@@ -114,14 +116,34 @@ impl<T: SourceContainer> CodegenParticipant<T> {
             let tempdir = tempfile::tempdir().expect("Could not create tempdir");
             tempdir.keep()
         });
-        if let Some(name) = self.target.try_get_name() {
-            let dir = compile_directory.join(name);
-            fs::create_dir_all(&dir)?;
-            self.compile_dirs.insert(self.target.clone(), dir);
-        } else {
-            self.compile_dirs.insert(self.target.clone(), compile_directory);
-        }
+        let dir = super::target_compile_dir(&compile_directory, &self.target);
+        fs::create_dir_all(&dir)?;
+        self.compile_dirs.insert(self.target.clone(), dir);
         Ok(())
+    }
+
+    /// Identifies a compiled unit for the naming of its artifact. Units inside the project
+    /// are identified by their path relative to the project, so that the name of the
+    /// artifact does not change with the location of the project.
+    fn unit_key(&self, unit_location: &Path) -> Result<PathBuf, Diagnostic> {
+        let unit_location = if unit_location.exists() {
+            fs::canonicalize(unit_location)?
+        } else {
+            unit_location.to_path_buf()
+        };
+
+        let root = match self.compile_options.root.clone() {
+            Some(root) => root,
+            None => env::current_dir()?,
+        };
+        // The unit location is canonical, so the root has to be canonical as well for the
+        // comparison to hold.
+        let root = fs::canonicalize(&root).unwrap_or(root);
+
+        match unit_location.strip_prefix(&root) {
+            Ok(relative) => Ok(relative.to_path_buf()),
+            Err(_) => Ok(unit_location),
+        }
     }
     pub fn read_got_layout(location: &str, format: ConfigFormat) -> Result<HashMap<String, u64>, Diagnostic> {
         let path = Path::new(location);
@@ -157,28 +179,13 @@ impl<T: SourceContainer + Send> PipelineParticipant for CodegenParticipant<T> {
     }
 
     fn generate(&self, module: &GeneratedModule) -> Result<(), Diagnostic> {
-        let current_dir = env::current_dir()?;
-        let current_dir = self.compile_options.root.as_deref().unwrap_or(&current_dir);
-        let unit_location = module.get_unit_location();
-        let unit_location =
-            if unit_location.exists() { fs::canonicalize(unit_location)? } else { unit_location.into() };
-        let output_name = if unit_location.starts_with(current_dir) {
-            unit_location.strip_prefix(current_dir).map_err(|it| {
-                Diagnostic::new(format!("Could not strip prefix for {}", current_dir.to_string_lossy()))
-                    .with_internal_error(it.into())
-            })?
-        } else if unit_location.has_root() {
-            let root = unit_location.ancestors().last().expect("Should exist?");
-            unit_location.strip_prefix(root).expect("The root directory should exist")
-        } else {
-            unit_location.as_path()
+        let unit_key = self.unit_key(module.get_unit_location())?;
+        let extension = match self.compile_options.output_format {
+            FormatOption::IR => "ll",
+            FormatOption::Bitcode => "bc",
+            _ => "o",
         };
-
-        let output_name = match self.compile_options.output_format {
-            FormatOption::IR => format!("{}.ll", output_name.to_string_lossy()),
-            FormatOption::Bitcode => format!("{}.bc", output_name.to_string_lossy()),
-            _ => format!("{}.o", output_name.to_string_lossy()),
-        };
+        let output_name = artifacts::file_name(&unit_key, extension);
 
         let target = &self.target;
         let compile_directory = self.compile_dirs.get(target).expect("Required dir");

--- a/compiler/plc_driver/src/tests.rs
+++ b/compiler/plc_driver/src/tests.rs
@@ -15,6 +15,7 @@ use crate::{
     CompileOptions,
 };
 
+mod artifact_names;
 mod debug_paths;
 mod external_files;
 mod header_generator;

--- a/compiler/plc_driver/src/tests/artifact_names.rs
+++ b/compiler/plc_driver/src/tests/artifact_names.rs
@@ -132,6 +132,22 @@ fn units_whose_file_name_is_cut_stay_apart() {
     assert_ne!(first, second);
 }
 
+/// A library is pulled in with one glob per extension, `include/*.st` and
+/// `include/*.pli` for the standard library, so two units can share a stem and differ
+/// only in their extension. Once the stem is long enough to be cut at the limit, the
+/// readable part of both names is the same and the digest is all that is left to tell
+/// the two artifacts apart.
+#[test]
+fn units_cut_at_the_limit_that_differ_only_in_their_extension_stay_apart() {
+    let structured_text = artifacts::file_name(Path::new("include/endianness_conversion_functions.st"), "o");
+    let interface = artifacts::file_name(Path::new("include/endianness_conversion_functions.pli"), "o");
+
+    // The cut falls on the dot of the source extension, so neither name keeps it.
+    assert!(structured_text.starts_with("endianness_conversion_functions.-"), "{structured_text}");
+    assert!(interface.starts_with("endianness_conversion_functions.-"), "{interface}");
+    assert_ne!(structured_text, interface);
+}
+
 #[test]
 fn a_key_without_a_file_name_gets_a_fallback_name() {
     let name = artifacts::file_name(Path::new(""), "o");

--- a/compiler/plc_driver/src/tests/artifact_names.rs
+++ b/compiler/plc_driver/src/tests/artifact_names.rs
@@ -172,6 +172,12 @@ mod linux {
     }
 }
 
+// The scenarios below have no mirror in `linux`, and the reason is the same for all of
+// them: they are about what the host reads as a path prefix. Linux does not split on
+// `\`, so every one of these keys is a single file name there, which
+// `a_windows_key_is_sanitized_into_a_single_name` already covers. The two scenarios that
+// are not about a prefix, the reserved device name and the casing, say in their own
+// comment why they belong to this platform.
 #[cfg(windows)]
 mod windows {
     use super::{artifacts, Path};
@@ -199,5 +205,64 @@ mod windows {
         let name = artifacts::file_name(Path::new("C:string.st"), "o");
 
         assert!(name.starts_with("string.st-"), "{name}");
+    }
+
+    /// A UNC path names a host and a share instead of a drive, and neither may reach the
+    /// name of the artifact.
+    #[test]
+    fn a_unc_key_keeps_only_the_file_name() {
+        let name = artifacts::file_name(Path::new(r"\\server\share\lib\util.st"), "o");
+
+        assert!(name.starts_with("util.st-"), "{name}");
+    }
+
+    /// `fs::canonicalize` returns the verbatim form of a UNC path, which carries the
+    /// `UNC` literal on top of the prefix.
+    #[test]
+    fn a_verbatim_unc_key_keeps_only_the_file_name() {
+        let name = artifacts::file_name(Path::new(r"\\?\UNC\server\share\lib\util.st"), "o");
+
+        assert!(name.starts_with("util.st-"), "{name}");
+    }
+
+    /// A drive that a share is mapped to is a drive like any other for the naming.
+    #[test]
+    fn a_key_on_a_mapped_drive_keeps_only_the_file_name() {
+        let name = artifacts::file_name(Path::new(r"Z:\lib\util.st"), "o");
+
+        assert!(name.starts_with("util.st-"), "{name}");
+    }
+
+    /// A source named like one of the device names this platform reserves (`con`, `nul`,
+    /// `aux`, ...); no other platform reserves them, so the scenario has no mirror. What
+    /// the system resolves to a device is the bare name, so the readable part keeps the
+    /// file name of the source, and the digest and the extension that follow leave an
+    /// ordinary file name. `a_source_named_like_a_reserved_device_builds` in the
+    /// integration tests confirms that against a real file system.
+    #[test]
+    fn a_key_named_like_a_reserved_device_gets_a_name_that_is_not_a_device() {
+        for device in ["con", "nul", "aux", "prn", "com1", "lpt1"] {
+            let name = artifacts::file_name(Path::new(&format!(r"C:\lib\{device}.st")), "o");
+
+            // The device name is followed by the extension of the source, the digest and
+            // the extension of the artifact, so the name is not a bare device name.
+            assert!(name.starts_with(&format!("{device}.st-")), "{name}");
+            assert!(name.ends_with(".o"), "{name}");
+        }
+    }
+
+    /// Paths are case insensitive on this platform, so two spellings of one path name one
+    /// unit, and the scenario has no mirror on a platform where they name two. The digest
+    /// is taken over the characters of the key and tells the spellings apart; what keeps
+    /// the unit at one artifact is the canonicalization of the key before it arrives here,
+    /// which normalizes the casing to the one on the file system.
+    /// `a_source_referenced_with_another_casing_keeps_its_artifact` in the integration
+    /// tests covers that end to end.
+    #[test]
+    fn the_digest_does_not_normalize_the_casing_by_itself() {
+        let lower = artifacts::file_name(Path::new(r"src\main.st"), "o");
+        let upper = artifacts::file_name(Path::new(r"SRC\MAIN.ST"), "o");
+
+        assert_ne!(lower, upper);
     }
 }

--- a/compiler/plc_driver/src/tests/artifact_names.rs
+++ b/compiler/plc_driver/src/tests/artifact_names.rs
@@ -1,0 +1,203 @@
+// The name of a build artifact must stay flat and short. A build directory that
+// mirrors the source tree carries the full path of every source file into the build
+// directory, and for sources outside of the project (libraries, for example) the
+// result goes past the limits of the Windows file system.
+//
+// # Mirroring policy
+//
+// Like the `debug_paths` tests, the platform dependent scenarios live in two sibling
+// modules: `linux` (compiled with `cfg(not(windows))`) and `windows` (compiled with
+// `cfg(windows)`). `Path::file_name` splits on the separators of the host, so the
+// readable part of a name depends on the platform. When you add a test to one side,
+// add a mirror with the same name to the other side, or document why the scenario
+// fits one platform only.
+
+use std::path::Path;
+
+use insta::assert_snapshot;
+
+use crate::artifacts;
+
+/// Longest name the scheme can produce: 32 characters of file name, the separator,
+/// 16 characters of digest, the dot and the extension.
+fn name_limit(extension: &str) -> usize {
+    32 + 1 + 16 + 1 + extension.len()
+}
+
+/// Returns the digest of an artifact name, which is the part between the last `-` and
+/// the extension.
+fn digest_of(name: &str) -> &str {
+    let (name, _) = name.rsplit_once('.').expect("an artifact name has an extension");
+    let (_, digest) = name.rsplit_once('-').expect("an artifact name has a digest");
+    digest
+}
+
+#[test]
+fn name_keeps_the_file_name_of_the_unit() {
+    let name = artifacts::file_name(Path::new("app/prg/main.st"), "o");
+
+    assert!(name.starts_with("main.st-"), "{name}");
+    assert!(name.ends_with(".o"), "{name}");
+}
+
+/// The extension of the source file is part of the readable name. Without it, a
+/// `const.st` and a `const.dt` next to each other claim the same artifact.
+#[test]
+fn units_that_differ_only_in_their_extension_get_different_names() {
+    let structured_text = artifacts::file_name(Path::new("app/const.st"), "o");
+    let data_types = artifacts::file_name(Path::new("app/const.dt"), "o");
+
+    assert_ne!(structured_text, data_types);
+}
+
+#[test]
+fn units_with_the_same_file_name_get_different_names() {
+    let first = artifacts::file_name(Path::new("a/util.st"), "o");
+    let second = artifacts::file_name(Path::new("b/util.st"), "o");
+
+    assert_ne!(first, second);
+}
+
+/// The digest covers the whole key, not the parent directory alone: `b/util.st` and
+/// `a/b/util.st` are different units.
+#[test]
+fn a_deeper_unit_with_the_same_file_name_gets_a_different_name() {
+    let shallow = artifacts::file_name(Path::new("b/util.st"), "o");
+    let deep = artifacts::file_name(Path::new("a/b/util.st"), "o");
+
+    assert_ne!(shallow, deep);
+}
+
+/// The name of an artifact must not change between runs or between platforms; a build
+/// that renames its artifacts leaves the artifacts of the run before it behind.
+#[test]
+fn the_name_of_a_unit_stays_the_same() {
+    assert_snapshot!(artifacts::file_name(Path::new("app/prg/main.st"), "o"), @"main.st-116b35a8828869ac.o");
+}
+
+#[test]
+fn the_extension_of_the_artifact_follows_the_argument() {
+    let key = Path::new("app/main.st");
+
+    assert!(artifacts::file_name(key, "o").ends_with(".o"));
+    assert!(artifacts::file_name(key, "ll").ends_with(".ll"));
+    assert!(artifacts::file_name(key, "bc").ends_with(".bc"));
+}
+
+/// The name is a single file name in a flat directory, so nothing in it may be read as
+/// a directory or as a drive.
+#[test]
+fn the_name_holds_no_path_separators() {
+    for key in ["a/b/main.st", r"a\b\main.st", "C:/a/main.st", r"C:\a\main.st", "../a/main.st"] {
+        let name = artifacts::file_name(Path::new(key), "o");
+
+        assert!(!name.contains(['/', '\\', ':']), "{key} produced {name}");
+    }
+}
+
+#[test]
+fn characters_that_windows_reserves_are_replaced() {
+    let name = artifacts::file_name(Path::new(r#"we*ird<na>me|?.st"#), "o");
+
+    assert!(name.starts_with("we_ird_na_me__.st-"), "{name}");
+}
+
+/// Names on a file system can hold characters that no compiler should have to reason
+/// about; the artifact name stays plain ASCII.
+#[test]
+fn characters_outside_of_ascii_are_replaced() {
+    let name = artifacts::file_name(Path::new("m\u{fc}ll\u{e4}imer.st"), "o");
+
+    assert!(name.starts_with("m_ll_imer.st-"), "{name}");
+    assert!(name.is_ascii(), "{name}");
+}
+
+#[test]
+fn long_file_names_are_cut_to_the_limit() {
+    let key = format!("{}.st", "a".repeat(200));
+
+    let name = artifacts::file_name(Path::new(&key), "o");
+
+    assert!(name.len() <= name_limit("o"), "{} characters: {name}", name.len());
+}
+
+/// Two long file names can end up with the same readable part. The digest is what
+/// keeps their artifacts apart.
+#[test]
+fn units_whose_file_name_is_cut_stay_apart() {
+    let prefix = "a".repeat(64);
+    let first = artifacts::file_name(Path::new(&format!("{prefix}_first.st")), "o");
+    let second = artifacts::file_name(Path::new(&format!("{prefix}_second.st")), "o");
+
+    assert_ne!(first, second);
+}
+
+#[test]
+fn a_key_without_a_file_name_gets_a_fallback_name() {
+    let name = artifacts::file_name(Path::new(""), "o");
+
+    assert!(name.starts_with("unit-"), "{name}");
+}
+
+/// The same project is built on Linux and on Windows, where the callers hand in the
+/// separator of their platform. The digest ignores that difference, so a unit keeps
+/// the name of its artifact.
+#[test]
+fn the_digest_ignores_the_separator_style() {
+    let unix = artifacts::file_name(Path::new("a/b/main.st"), "o");
+    let windows = artifacts::file_name(Path::new(r"a\b\main.st"), "o");
+
+    assert_eq!(digest_of(&unix), digest_of(&windows));
+}
+
+#[cfg(not(windows))]
+mod linux {
+    use super::{artifacts, Path};
+
+    #[test]
+    fn an_absolute_key_keeps_only_the_file_name() {
+        let name = artifacts::file_name(Path::new("/opt/lib/iec61131std/include/string.st"), "o");
+
+        assert!(name.starts_with("string.st-"), "{name}");
+    }
+
+    /// A Windows path is not a path here: the host does not split on `\`, so the whole
+    /// key becomes the readable part and only the sanitizing keeps the name legal.
+    /// Windows does split on `/`, so this scenario has no mirror there.
+    #[test]
+    fn a_windows_key_is_sanitized_into_a_single_name() {
+        let name = artifacts::file_name(Path::new(r"C:\lib\include\string.st"), "o");
+
+        assert!(name.starts_with("C__lib_include_string.st-"), "{name}");
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::{artifacts, Path};
+
+    #[test]
+    fn an_absolute_key_keeps_only_the_file_name() {
+        let name = artifacts::file_name(Path::new(r"C:\lib\iec61131std\include\string.st"), "o");
+
+        assert!(name.starts_with("string.st-"), "{name}");
+    }
+
+    /// `fs::canonicalize` returns paths with a verbatim prefix on Windows, and that
+    /// prefix must not reach the name either.
+    #[test]
+    fn a_verbatim_key_keeps_only_the_file_name() {
+        let name = artifacts::file_name(Path::new(r"\\?\C:\lib\include\string.st"), "o");
+
+        assert!(name.starts_with("string.st-"), "{name}");
+    }
+
+    /// A drive relative key has no directory component, and the drive letter must not
+    /// reach the name.
+    #[test]
+    fn a_drive_relative_key_keeps_only_the_file_name() {
+        let name = artifacts::file_name(Path::new("C:string.st"), "o");
+
+        assert!(name.starts_with("string.st-"), "{name}");
+    }
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -487,7 +487,7 @@ impl<'ink> GeneratedModule<'ink> {
         target: &Target,
         optimization_level: OptimizationLevel,
     ) -> Result<PathBuf, CodegenError> {
-        let output = Self::get_output_file(output_dir, output_name, target);
+        let output = Self::get_output_file(output_dir, output_name);
         //ensure output exists
         if let Some(parent) = output.parent() {
             std::fs::create_dir_all(parent)?;
@@ -528,14 +528,10 @@ impl<'ink> GeneratedModule<'ink> {
         }
     }
 
-    fn get_output_file(output_dir: Option<&Path>, output_name: &str, target: &Target) -> PathBuf {
-        let output_dir = output_dir.map(Path::to_path_buf).unwrap_or_else(|| PathBuf::from(""));
-        let output = if let Some(name) = target.try_get_name() {
-            output_dir.join(name).join(output_name)
-        } else {
-            output_dir.join(output_name)
-        };
-        output
+    /// The caller decides where the artifacts of a target land, see `target_compile_dir`
+    /// in the driver.
+    fn get_output_file(output_dir: Option<&Path>, output_name: &str) -> PathBuf {
+        output_dir.map(Path::to_path_buf).unwrap_or_default().join(output_name)
     }
 
     pub fn get_unit_location(&self) -> &Path {

--- a/tests/integration/build_artifacts.rs
+++ b/tests/integration/build_artifacts.rs
@@ -161,3 +161,169 @@ fn artifact_paths_stay_within_the_windows_path_limit() {
         assert!(length(&artifact) < WINDOWS_PATH_LIMIT, "{} characters: {artifact:?}", length(&artifact));
     }
 }
+
+/// Name that the test projects give to their final output. That output is not an
+/// intermediate artifact: it keeps the name the project description asks for and lands
+/// in the directory of the target next to the artifacts.
+const PROJECT_OUTPUT: &str = "proj.out";
+
+/// Writes a project with a `plc.json`. The `build` subcommand takes the root of the
+/// project from the location of that file rather than from the current directory, and
+/// that root is what an artifact name is relative to.
+fn write_project(project: &Path, files: &[&str]) -> PathBuf {
+    for (index, file) in files.iter().enumerate() {
+        write_source(&project.join(file), &format!("FUNCTION unit_{index} : DINT END_FUNCTION"));
+    }
+
+    let names = files.iter().map(|it| format!("{it:?}")).collect::<Vec<_>>().join(", ");
+    let config = project.join("plc.json");
+    let description = format!(r#"{{"name": "proj", "files": [{names}], "output": "{PROJECT_OUTPUT}"}}"#);
+    fs::write(&config, description).expect("plc.json");
+    config
+}
+
+/// Builds through the `build` subcommand. Uses `--ir`, so no linker takes part and the
+/// test runs on every platform.
+fn build_project(config: &Path, build_directory: &Path) {
+    compile(&[
+        "plc",
+        "build",
+        &config.to_string_lossy(),
+        "--ir",
+        "--build-location",
+        &build_directory.to_string_lossy(),
+        "--target",
+        TARGET,
+    ])
+    .expect("build succeeded");
+}
+
+/// The intermediate artifacts of a build, by name and without the final output of the
+/// project, sorted.
+fn artifact_names_in(directory: &Path) -> Vec<String> {
+    let mut names: Vec<String> = intermediate_artifacts_in(directory)
+        .iter()
+        .map(|it| it.file_name().expect("an artifact has a file name").to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+
+fn intermediate_artifacts_in(directory: &Path) -> Vec<PathBuf> {
+    artifacts_in(directory).into_iter().filter(|it| it.file_name() != Some(PROJECT_OUTPUT.as_ref())).collect()
+}
+
+/// The key of a unit inside the project is its path relative to the project, and the
+/// name of its artifact follows from that key alone. So one project produces the same
+/// artifact names wherever it is checked out and on whichever platform it is built.
+///
+/// On Windows this is what the canonicalization of the project root buys: `canonicalize`
+/// returns a verbatim path (`\\?\C:\...`) for the unit, so a root that is not
+/// canonicalized never prefixes it and the absolute path becomes the key.
+#[test]
+#[serial]
+fn artifacts_of_a_project_build_are_named_after_the_path_relative_to_the_project() {
+    let project = tempfile::tempdir().unwrap();
+    let build_directory = tempfile::tempdir().unwrap();
+
+    let config = write_project(project.path(), &["src/main.st", "src/nested/util.st"]);
+    build_project(&config, build_directory.path());
+
+    let mut expected = vec![
+        driver::artifacts::file_name(Path::new("src/main.st"), "ll"),
+        driver::artifacts::file_name(Path::new("src/nested/util.st"), "ll"),
+    ];
+    expected.sort();
+    assert_eq!(artifact_names_in(build_directory.path()), expected);
+
+    let target_directory = build_directory.path().join(TARGET);
+    for artifact in intermediate_artifacts_in(build_directory.path()) {
+        assert_eq!(artifact.parent(), Some(target_directory.as_path()), "{artifact:?} is not flat");
+    }
+}
+
+/// A source file named like one of the device names Windows reserves (`con`, `nul`,
+/// ...). The system resolves a bare device name to the device, so the artifact of such a
+/// source must keep the digest and the extension that make it an ordinary file name.
+#[test]
+#[serial]
+fn a_source_named_like_a_reserved_device_builds() {
+    let project = tempfile::tempdir().unwrap();
+    let build_directory = tempfile::tempdir().unwrap();
+
+    let config = write_project(project.path(), &["src/con.st", "src/nul.st"]);
+    build_project(&config, build_directory.path());
+
+    let names = artifact_names_in(build_directory.path());
+    assert_eq!(names.len(), 2, "{names:?}");
+    assert!(names.iter().any(|it| it.starts_with("con.st-")), "{names:?}");
+    assert!(names.iter().any(|it| it.starts_with("nul.st-")), "{names:?}");
+}
+
+/// A source file whose name is not ASCII. The artifact name is plain ASCII by
+/// construction, so it does not depend on the code page of the workspace.
+#[test]
+#[serial]
+fn a_source_with_a_non_ascii_name_builds() {
+    let project = tempfile::tempdir().unwrap();
+    let build_directory = tempfile::tempdir().unwrap();
+
+    let config = write_project(project.path(), &["src/pr\u{fc}f.st"]);
+    build_project(&config, build_directory.path());
+
+    let names = artifact_names_in(build_directory.path());
+    assert_eq!(names.len(), 1, "{names:?}");
+    assert!(names[0].is_ascii(), "{:?}", names[0]);
+    assert!(names[0].starts_with("pr_f.st-"), "{:?}", names[0]);
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::fs;
+
+    use super::{artifact_names_in, build_project, extend_to_length, write_project, WINDOWS_PATH_LIMIT};
+
+    /// Paths are case insensitive on Windows, so a project that spells the name of a
+    /// source differently must not get a second artifact for it. The casing that reaches
+    /// the digest is the one on the file system, because the key of a unit is
+    /// canonicalized first; `the_digest_does_not_normalize_the_casing_by_itself` in the
+    /// driver tests shows that the naming alone would not do it.
+    #[test]
+    #[serial]
+    fn a_source_referenced_with_another_casing_keeps_its_artifact() {
+        let project = tempfile::tempdir().unwrap();
+        let build_directory = tempfile::tempdir().unwrap();
+
+        let config = write_project(project.path(), &["src/main.st"]);
+        build_project(&config, build_directory.path());
+        let first = artifact_names_in(build_directory.path());
+
+        // The same source, spelled the way it is not spelled on disk.
+        let config = write_project(project.path(), &["SRC/MAIN.ST"]);
+        build_project(&config, build_directory.path());
+        let second = artifact_names_in(build_directory.path());
+
+        assert_eq!(first.len(), 1, "{first:?}");
+        assert_eq!(first, second);
+    }
+
+    /// A build directory that is past the limit before the compiler adds anything. The
+    /// standard library hands absolute paths to the file system in their verbatim form,
+    /// which is not bound by the limit, so the build goes through and there is nothing
+    /// for the compiler to report. What fails on such a path are the tools around the
+    /// compiler, and that is the reason the artifacts have to stay short.
+    #[test]
+    #[serial]
+    fn a_build_directory_past_the_path_limit_still_builds() {
+        let project = tempfile::tempdir().unwrap();
+        let build_root = tempfile::tempdir().unwrap();
+
+        let build_directory = extend_to_length(build_root.path(), WINDOWS_PATH_LIMIT + 10);
+        fs::create_dir_all(&build_directory).expect("build directory");
+
+        let config = write_project(project.path(), &["src/main.st"]);
+        build_project(&config, &build_directory);
+
+        assert_eq!(artifact_names_in(&build_directory).len(), 1);
+    }
+}

--- a/tests/integration/build_artifacts.rs
+++ b/tests/integration/build_artifacts.rs
@@ -1,0 +1,163 @@
+// The build keeps its artifacts in one flat directory. A layout that mirrors the
+// source tree carries the path of every source file into the build directory, and as
+// soon as a source lives outside of the project (an installed library, for example)
+// the result goes past the path limit of the Windows file system.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use driver::compile;
+
+/// Longest artifact name the compiler produces: 32 characters of file name, the
+/// separator, 16 characters of digest, the dot and the extension.
+const ARTIFACT_NAME_LIMIT: usize = 32 + 1 + 16 + 1 + 2;
+
+/// Path limit of the Windows file system for programs that do not opt into long paths.
+const WINDOWS_PATH_LIMIT: usize = 260;
+
+const TARGET: &str = "x86_64-linux-gnu";
+
+fn write_source(path: &Path, source: &str) {
+    fs::create_dir_all(path.parent().expect("a source file has a parent")).expect("source directory");
+    fs::write(path, source).expect("source file");
+}
+
+/// Pushes directories onto `base` until the path is at least `length` characters long,
+/// which is how the tests get the long build and source paths of a real workspace
+/// without depending on where the temporary directory of the platform lives.
+fn extend_to_length(base: &Path, length: usize) -> PathBuf {
+    let mut path = base.to_path_buf();
+    while path.to_string_lossy().chars().count() < length {
+        path.push("padding");
+    }
+    path
+}
+
+fn artifacts_in(directory: &Path) -> Vec<PathBuf> {
+    let mut artifacts = Vec::new();
+    let Ok(entries) = fs::read_dir(directory) else {
+        return artifacts;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            artifacts.extend(artifacts_in(&path));
+        } else {
+            artifacts.push(path);
+        }
+    }
+    artifacts.sort();
+    artifacts
+}
+
+fn length(path: &Path) -> usize {
+    path.to_string_lossy().chars().count()
+}
+
+/// Compiles a unit inside the project and two units that live outside of it and share
+/// a file name. Uses `--ir`, so no linker takes part and the test runs on every
+/// platform.
+fn compile_project_with_external_sources(build_directory: &Path, sources: &Path) {
+    let project = sources.join("workspace/MyProject");
+    let library = sources.join("libraries/iec61131std/include/generated/nested");
+
+    let main = project.join("main.st");
+    let first = library.join("first/util.st");
+    let second = library.join("second/util.st");
+
+    write_source(&main, "FUNCTION main : DINT END_FUNCTION");
+    write_source(&first, "FUNCTION util_a : DINT END_FUNCTION");
+    write_source(&second, "FUNCTION util_b : DINT END_FUNCTION");
+
+    let output = sources.join("out.ll");
+
+    compile(&[
+        "plc",
+        &main.to_string_lossy(),
+        &first.to_string_lossy(),
+        &second.to_string_lossy(),
+        "--ir",
+        "-o",
+        &output.to_string_lossy(),
+        "--build-location",
+        &build_directory.to_string_lossy(),
+        "--target",
+        TARGET,
+    ])
+    .expect("compile succeeded");
+}
+
+#[test]
+fn artifacts_of_external_sources_land_flat_in_the_target_directory() {
+    let sources = tempfile::tempdir().unwrap();
+    let build_directory = tempfile::tempdir().unwrap();
+
+    compile_project_with_external_sources(build_directory.path(), sources.path());
+
+    let target_directory = build_directory.path().join(TARGET);
+    let artifacts = artifacts_in(build_directory.path());
+
+    // One artifact per unit: the two units that share the file name `util.st` must not
+    // claim the same artifact.
+    assert_eq!(artifacts.len(), 3, "{artifacts:?}");
+    for artifact in &artifacts {
+        assert_eq!(artifact.parent(), Some(target_directory.as_path()), "{artifact:?} is not flat");
+    }
+}
+
+#[test]
+fn artifact_paths_do_not_grow_with_the_path_of_their_source() {
+    let sources = tempfile::tempdir().unwrap();
+    let build_directory = tempfile::tempdir().unwrap();
+
+    compile_project_with_external_sources(build_directory.path(), sources.path());
+
+    // Everything the compiler adds to the build directory: the directory of the target
+    // and one artifact name, both with a separator.
+    let limit = TARGET.len() + ARTIFACT_NAME_LIMIT + 2;
+    for artifact in artifacts_in(build_directory.path()) {
+        let added = length(&artifact) - length(build_directory.path());
+        assert!(added <= limit, "{added} characters added by {artifact:?}, limit is {limit}");
+    }
+}
+
+/// A build that renames its artifacts leaves the artifacts of the run before it
+/// behind, and every rebuild grows the build directory.
+#[test]
+fn a_second_build_reuses_the_artifact_names_of_the_first() {
+    let sources = tempfile::tempdir().unwrap();
+    let build_directory = tempfile::tempdir().unwrap();
+
+    compile_project_with_external_sources(build_directory.path(), sources.path());
+    let first = artifacts_in(build_directory.path());
+
+    compile_project_with_external_sources(build_directory.path(), sources.path());
+    let second = artifacts_in(build_directory.path());
+
+    assert_eq!(first, second);
+}
+
+/// A long build directory together with sources outside of the project is the case
+/// that used to produce paths the Windows file system cannot handle.
+#[test]
+fn artifact_paths_stay_within_the_windows_path_limit() {
+    let sources = tempfile::tempdir().unwrap();
+    let build_root = tempfile::tempdir().unwrap();
+
+    // The source tree stays well within the limit on its own, so that only the artifact
+    // paths are under test here.
+    let build_directory = extend_to_length(build_root.path(), 150);
+    fs::create_dir_all(&build_directory).expect("build directory");
+    let source_root = extend_to_length(sources.path(), 120);
+
+    compile_project_with_external_sources(&build_directory, &source_root);
+
+    let artifacts = artifacts_in(&build_directory);
+    assert_eq!(artifacts.len(), 3, "{artifacts:?}");
+    for artifact in artifacts {
+        assert!(length(&artifact) < WINDOWS_PATH_LIMIT, "{} characters: {artifact:?}", length(&artifact));
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,6 +49,7 @@ mod correctness {
     }
 }
 mod integration {
+    mod build_artifacts;
     mod build_description_tests;
     mod cfc;
     mod command_line_compile;


### PR DESCRIPTION
> **Attribution:** this branch, its tests and this description were produced by Claude
> (Claude Code) working in my repository, not written directly by me. I have reviewed the
> change, but please review it as machine-authored work. The commits carry a
> `Co-Authored-By: Claude` trailer.

**Draft on purpose.** We are in feature freeze, so this needs a team decision before it goes
anywhere. Opening it now so the assessment below is on the record.

Backport of #1894 to `release/1.0.x`. Fixes PRG-4448 on the v1 line.

## What it does

Intermediate artifacts get a flat name, `<file name>-<digest>.<extension>`, all directly in
`<build>/<target>/`, instead of being named after the source path and nested under it. The
target directory is also no longer added twice. See #1894 for the full rationale.

## Why it is wanted on v1

PRG-4448 is reported against a shipped workspace. With the standard library delivered outside
the workspace at a realistic path, the longest artifact path measured 445 characters, and an
`xcopy` of the build output copied 3 of 31 files while returning exit code 0. The user-visible
symptom is a File Explorer copy of the workspace that silently loses files.

## Port risk

Low. The port is mechanical:

- Every source file auto-merged: `pipelines.rs`, `participant.rs`, `codegen.rs`, and both test
  harnesses. `src/codegen.rs` is byte-identical between `master` and `release/1.0.x`.
- One conflict, in `compiler/plc_driver/Cargo.toml`, over the `plc_util` version string only.
  Resolved by keeping `1.0.4`.
- No new third-party code. `siphasher` is already a workspace dependency on this branch; the
  manifest change only moves it to `[workspace.dependencies]` so `plc_driver` can use it.

Verified on this branch on Windows: clean build, 2742 lib tests, 83 integration, 352
correctness, all green, including `debug_paths` and the 31 new tests.

A release build of this branch, run against the Eclipse tool's real compile command, produces
output **byte-identical** to #1894 — same 233-character longest path and the same digests. So
a v1 and a v1.1 toolchain name artifacts identically, and switching between them against a
shared build directory causes no churn.

## What reviewers should weigh

- Artifact file names change. Anything outside this repo that hardcodes an intermediate `.o`
  path would break. The Eclipse builder resolves only `<compile>/<target>/<output>.so` and
  `usr/lib/...`, both unchanged and confirmed unchanged in a real build, but packaging or
  debug tooling elsewhere is worth a second look.
- Existing build directories keep their old mirrored trees until one clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
