### PR TITLE
fix(lowering): resolve array ctor bounds through the index (#1897)

### DIFF
--- a/compiler/plc_lowering/src/initializer.rs
+++ b/compiler/plc_lowering/src/initializer.rs
@@ -48,11 +48,12 @@ use plc::{
         create_ref_assignment_with_index, extract_ref_call_argument, get_unit_name, new_constructor,
         new_unit_constructor,
     },
+    typesystem::DataTypeInformation,
 };
 use plc_ast::{
     ast::{
         AstFactory, AstNode, AstStatement, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration,
-        LinkageType, Operator, PouType, RangeStatement, Variable, VariableBlockType,
+        LinkageType, Operator, PouType, Variable, VariableBlockType,
     },
     provider::IdProvider,
     visitor::{AstVisitor, Walker},
@@ -389,9 +390,8 @@ impl AstVisitor for Initializer {
     /// For array types, generates a loop calling the element type's constructor on every
     /// element so that defaults, vtable pointers, and `FB_INIT` reach each array element.
     fn visit_data_type(&mut self, data_type: &plc_ast::ast::DataType) {
-        if let plc_ast::ast::DataType::ArrayType {
-            bounds, referenced_type, is_variable_length: false, ..
-        } = data_type
+        if let plc_ast::ast::DataType::ArrayType { referenced_type, is_variable_length: false, .. } =
+            data_type
         {
             let index = self.index.as_ref().expect("index is set at this stage");
 
@@ -406,7 +406,7 @@ impl AstVisitor for Initializer {
             }
 
             let Some(array_type) = self.context.current_datatype.clone() else { return };
-            if let Some(ctor_loop) = self.create_element_ctor_loop(&array_type, element_type, bounds) {
+            if let Some(ctor_loop) = self.create_element_ctor_loop(&array_type, element_type) {
                 self.add_to_current_constructor(ctor_loop);
             }
         }
@@ -806,21 +806,41 @@ impl Initializer {
     /// ```
     /// The loops are emitted in the canonical `WHILE TRUE` form directly because the
     /// `LoopDesugarer` pass has already run by the time constructors are generated.
-    /// Returns `None` when the bounds are not ranges (invalid declarations are left
-    /// to validation).
-    fn create_element_ctor_loop(
-        &mut self,
-        array_type: &str,
-        element_type: &str,
-        bounds: &AstNode,
-    ) -> Option<Vec<AstNode>> {
-        // One range and one counter per dimension. The counter names carry the array type
-        // name: allocation scopes are resolved by name across implementations, so they must
-        // be unique per constructor.
-        let dimensions: Vec<&AstNode> = match bounds.get_stmt() {
-            AstStatement::ExpressionList(expressions) => expressions.iter().collect(),
-            _ => vec![bounds],
+    /// Returns `None` when the bounds cannot be resolved to constants (invalid declarations
+    /// are left to validation).
+    fn create_element_ctor_loop(&mut self, array_type: &str, element_type: &str) -> Option<Vec<AstNode>> {
+        // The bounds come from the index rather than from the declaration, because the
+        // declaration may name a constant of the declaring POU (`ARRAY[1..five]`). The
+        // constructor is a POU of its own, so such a name does not resolve inside it, and
+        // copying the expression here left a comparison against an unresolvable operand.
+        // The index holds the bounds already const-evaluated, so literals can be emitted.
+        let dimensions: Vec<(i64, i64)> = {
+            let index = self.index.as_ref()?;
+            let DataTypeInformation::Array { dimensions, .. } =
+                index.find_effective_type_by_name(array_type)?.get_type_information()
+            else {
+                return None;
+            };
+
+            dimensions
+                .iter()
+                .map(|dimension| {
+                    // `as_int_value` reports an undetermined bound as the pointer size, which
+                    // would silently produce a loop over the wrong range.
+                    if dimension.is_undetermined() {
+                        return None;
+                    }
+                    Some((
+                        dimension.start_offset.as_int_value(index).ok()?,
+                        dimension.end_offset.as_int_value(index).ok()?,
+                    ))
+                })
+                .collect::<Option<Vec<_>>>()?
         };
+
+        // One counter per dimension. The counter names carry the array type name: allocation
+        // scopes are resolved by name across implementations, so they must be unique per
+        // constructor.
         let counters: Vec<(AstNode, AstNode)> = (0..dimensions.len())
             .map(|dim| {
                 loop_helper::create_alloca(&mut self.id_provider, "DINT", format!("{array_type}__idx{dim}"))
@@ -855,18 +875,14 @@ impl Initializer {
 
         // Wrap the call in one loop per dimension, innermost dimension first.
         let mut statements = vec![call];
-        for ((alloca, counter), dimension) in counters.into_iter().zip(dimensions.iter()).rev() {
-            let AstStatement::RangeStatement(RangeStatement { start, end }) = dimension.get_stmt() else {
-                return None;
-            };
-
+        for ((alloca, counter), (start, end)) in counters.into_iter().zip(dimensions.iter()).rev() {
             // IF __idx > <hi> THEN EXIT; END_IF
             let bound_guard = loop_helper::create_if_then_exit(
                 self.id_provider.clone(),
                 loop_helper::create_internal_binary_expression(
                     counter.clone(),
                     Operator::Greater,
-                    end.as_ref().clone(),
+                    loop_helper::create_literal_integer(&mut self.id_provider, *end as i128),
                     &mut self.id_provider,
                 ),
             );
@@ -891,7 +907,7 @@ impl Initializer {
                 alloca,
                 loop_helper::create_internal_assignment(
                     counter,
-                    start.as_ref().clone(),
+                    loop_helper::create_literal_integer(&mut self.id_provider, *start as i128),
                     &mut self.id_provider,
                 ),
                 loop_helper::create_while_true_loop(&mut self.id_provider, body),

--- a/compiler/plc_lowering/src/initializer.rs
+++ b/compiler/plc_lowering/src/initializer.rs
@@ -52,8 +52,8 @@ use plc::{
 };
 use plc_ast::{
     ast::{
-        AstFactory, AstNode, AstStatement, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration,
-        LinkageType, Operator, PouType, Variable, VariableBlockType,
+        AstFactory, AstNode, AutoDerefType, CompilationUnit, DataType, DataTypeDeclaration, LinkageType,
+        Operator, PouType, Variable, VariableBlockType,
     },
     provider::IdProvider,
     visitor::{AstVisitor, Walker},

--- a/compiler/plc_lowering/src/tests/array_lowering_tests.rs
+++ b/compiler/plc_lowering/src/tests/array_lowering_tests.rs
@@ -608,3 +608,164 @@ fn multi_segment_above_threshold_is_unrolled_per_segment() {
     // 40 indexed assignments + `v := 1` + `main := 0`
     assert_eq!(count_assignments(stmts), 42);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Element construction loop bounds (PRG-4730)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// The bounds the generated element construction loop was built with, read back out of the
+/// constructor body. The body has the shape
+///
+/// ```st
+/// __idx0 := <lo>;
+/// WHILE TRUE DO
+///     IF __idx0 > <hi> THEN EXIT; END_IF
+///     ...
+/// END_WHILE
+/// ```
+///
+/// so the lower bound is the counter initialization and the upper bound is the right hand
+/// side of the exit guard. Both must be literals: the constructor is a POU of its own, and a
+/// bound that still named a constant of the declaring POU would not resolve inside it.
+fn element_ctor_loop_bounds(stmts: &[plc_ast::ast::AstNode]) -> (i128, i128) {
+    use plc_ast::ast::AstStatement;
+    use plc_ast::control_statements::AstControlStatement;
+    use plc_ast::literals::AstLiteral;
+
+    let literal_int = |node: &plc_ast::ast::AstNode| match node.get_stmt() {
+        AstStatement::Literal(AstLiteral::Integer(value)) => Some(*value),
+        _ => None,
+    };
+
+    let start = stmts
+        .iter()
+        .find_map(|statement| match statement.get_stmt() {
+            AstStatement::Assignment(data) => literal_int(&data.right),
+            _ => None,
+        })
+        .expect("the counter is initialized with a literal lower bound");
+
+    let while_loop = stmts
+        .iter()
+        .find_map(|statement| match statement.get_stmt() {
+            AstStatement::ControlStatement(AstControlStatement::WhileLoop(data)) => Some(data),
+            _ => None,
+        })
+        .expect("the element construction loop is a WHILE loop");
+
+    let end = while_loop
+        .body
+        .iter()
+        .find_map(|statement| match statement.get_stmt() {
+            AstStatement::ControlStatement(AstControlStatement::If(data)) => {
+                let condition = data.blocks.first()?.condition.as_ref();
+                match condition.get_stmt() {
+                    AstStatement::BinaryExpression(binary) => literal_int(&binary.right),
+                    _ => None,
+                }
+            }
+            _ => None,
+        })
+        .expect("the exit guard compares the counter against a literal upper bound");
+
+    (start, end)
+}
+
+/// A bound naming a POU-local `VAR CONSTANT` has to reach the generated constructor as a
+/// literal. It used to be copied over as the identifier, which does not resolve there, and
+/// the resulting comparison was annotated as a call to a non-existent `DINT_GREATER`.
+#[test]
+fn element_ctor_loop_resolves_a_pou_local_constant_bound() {
+    let project = lower(
+        "
+        PROGRAM prog
+        VAR CONSTANT five : DINT := 5; END_VAR
+        VAR arr : ARRAY[1..five] OF STRING[63]; END_VAR
+        END_PROGRAM
+        ",
+    );
+
+    let stmts = find_impl_stmts(&project, "__prog_arr__ctor");
+    assert_eq!(element_ctor_loop_bounds(stmts), (1, 5));
+}
+
+/// The same for a global constant, which resolved before this fix as well. Kept so that a
+/// change to the bound resolution shows up for both kinds of constant.
+#[test]
+fn element_ctor_loop_resolves_a_global_constant_bound() {
+    let project = lower(
+        "
+        VAR_GLOBAL CONSTANT five : DINT := 5; END_VAR
+
+        PROGRAM prog
+        VAR arr : ARRAY[1..five] OF STRING[63]; END_VAR
+        END_PROGRAM
+        ",
+    );
+
+    let stmts = find_impl_stmts(&project, "__prog_arr__ctor");
+    assert_eq!(element_ctor_loop_bounds(stmts), (1, 5));
+}
+
+/// A bound given as an expression over a POU-local constant is const-evaluated by the index,
+/// so the constructor sees the computed value.
+#[test]
+fn element_ctor_loop_resolves_an_expression_over_a_local_constant() {
+    let project = lower(
+        "
+        PROGRAM prog
+        VAR CONSTANT two : DINT := 2; END_VAR
+        VAR arr : ARRAY[two..two * 3] OF STRING[63]; END_VAR
+        END_PROGRAM
+        ",
+    );
+
+    let stmts = find_impl_stmts(&project, "__prog_arr__ctor");
+    assert_eq!(element_ctor_loop_bounds(stmts), (2, 6));
+}
+
+/// One loop per dimension, each with its own resolved bounds. The outer loop is the one that
+/// appears at the top level of the constructor body; the inner one sits in its body.
+#[test]
+fn element_ctor_loops_resolve_every_dimension() {
+    use plc_ast::ast::AstStatement;
+    use plc_ast::control_statements::AstControlStatement;
+
+    let project = lower(
+        "
+        PROGRAM prog
+        VAR CONSTANT two : DINT := 2; five : DINT := 5; END_VAR
+        VAR arr : ARRAY[1..two, 2..five] OF STRING[63]; END_VAR
+        END_PROGRAM
+        ",
+    );
+
+    let stmts = find_impl_stmts(&project, "__prog_arr__ctor");
+    assert_eq!(element_ctor_loop_bounds(stmts), (1, 2), "outer dimension");
+
+    let outer = stmts
+        .iter()
+        .find_map(|statement| match statement.get_stmt() {
+            AstStatement::ControlStatement(AstControlStatement::WhileLoop(data)) => Some(data),
+            _ => None,
+        })
+        .expect("the outer dimension is a WHILE loop");
+    assert_eq!(element_ctor_loop_bounds(&outer.body), (2, 5), "inner dimension");
+}
+
+/// An array of a type that needs no construction still gets a constructor, but its body
+/// carries no element construction loop, so a local constant bound has nowhere to leak to.
+#[test]
+fn an_array_of_a_type_without_a_constructor_gets_no_element_ctor_loop() {
+    let project = lower(
+        "
+        PROGRAM prog
+        VAR CONSTANT five : DINT := 5; END_VAR
+        VAR arr : ARRAY[1..five] OF DINT; END_VAR
+        END_PROGRAM
+        ",
+    );
+
+    let stmts = find_impl_stmts(&project, "__prog_arr__ctor");
+    assert!(!has_while_loop(stmts), "an array of DINT needs no per-element construction");
+}

--- a/src/codegen/tests/initialization_test/pou_initializers.rs
+++ b/src/codegen/tests/initialization_test/pou_initializers.rs
@@ -461,3 +461,31 @@ fn unary_plus_in_initializer() {
     }
     "#);
 }
+
+/// A POU-local `VAR CONSTANT` used as an array bound, for an element type that needs
+/// construction. Regression test for PRG-4730: the generated element constructor is a POU of
+/// its own, so the bound cannot be the identifier `five`, which is a member of `prog` and does
+/// not resolve there. It used to be copied over verbatim, and the resulting comparison was
+/// annotated as a call to a `DINT_GREATER` function that does not exist, which failed codegen
+/// with "cannot generate call statement".
+#[test]
+fn pou_local_constant_as_array_bound_of_a_constructed_element_type() {
+    // `test_utils::codegen` runs the full pipeline, including the initializer lowering that
+    // generates the element constructor. The crate-local helper stops short of it.
+    let result = test_utils::codegen(
+        r#"
+        PROGRAM prog
+        VAR CONSTANT
+            five : DINT := 5;
+        END_VAR
+        VAR
+            arr : ARRAY[1..five] OF STRING[63];
+        END_VAR
+        END_PROGRAM
+        "#,
+    );
+
+    // The bound arrives as a literal and is compared natively, rather than through a call.
+    assert!(result.contains("icmp sgt i32 %load___prog_arr__idx0, 5"), "{result}");
+    assert!(!result.contains("DINT_GREATER"), "{result}");
+}

--- a/src/codegen/tests/string_tests.rs
+++ b/src/codegen/tests/string_tests.rs
@@ -560,3 +560,93 @@ fn assigning_utf8_literal_to_wstring() {
     // THEN
     filtered_assert_snapshot!(result);
 }
+
+/// The string fields of a generated struct type, as LLVM array types in declaration order.
+/// Comparing these rather than whole IR keeps the assertion on the sizes themselves, which is
+/// what a constant in a type position decides.
+fn string_fields(ir: &str, type_name: &str) -> Vec<String> {
+    let prefix = format!("%{type_name} = type");
+    let line = ir
+        .lines()
+        .find(|line| line.trim_start().starts_with(&prefix))
+        .unwrap_or_else(|| panic!("no type definition for '{type_name}' in:\n{ir}"));
+
+    // Drop the `%prg = type {` prefix so that the first field does not carry it.
+    let fields = line.split_once('{').map(|(_, rest)| rest).unwrap_or(line);
+    fields
+        .split(',')
+        .filter(|field| field.contains(" x i8]") || field.contains(" x i16]"))
+        .map(|field| field.trim().trim_end_matches('}').trim().to_string())
+        .collect()
+}
+
+/// A POU-local `VAR CONSTANT` must size a string exactly like the literal it stands for, on
+/// its own and inside an expression. The global form is covered by
+/// `variable_length_strings_using_constants_can_be_created`; this is the local counterpart,
+/// added with PRG-4730 where a local constant in a type position turned out to be treated
+/// differently from a global one.
+#[test]
+fn strings_sized_by_a_pou_local_constant_match_the_literal_size() {
+    let from_constant = codegen(
+        r#"
+        PROGRAM prg
+        VAR CONSTANT
+            five : DINT := 5;
+        END_VAR
+        VAR
+            s  : STRING[five];
+            ws : WSTRING[five];
+            e  : STRING[five * 2 + 1];
+        END_VAR
+        END_PROGRAM
+        "#,
+    );
+
+    let from_literal = codegen(
+        r#"
+        PROGRAM prg
+        VAR
+            s  : STRING[5];
+            ws : WSTRING[5];
+            e  : STRING[11];
+        END_VAR
+        END_PROGRAM
+        "#,
+    );
+
+    // One byte more than the declared length in every case, for the terminator.
+    assert_eq!(string_fields(&from_literal, "prg"), ["[6 x i8]", "[6 x i16]", "[12 x i8]"]);
+    assert_eq!(string_fields(&from_constant, "prg"), string_fields(&from_literal, "prg"));
+}
+
+/// An array of strings where a POU-local `VAR CONSTANT` gives both the bound and the element
+/// length. This is the shape that PRG-4730 was reported against.
+#[test]
+fn an_array_of_strings_sized_by_pou_local_constants_matches_the_literal_size() {
+    let from_constant = codegen(
+        r#"
+        PROGRAM prg
+        VAR CONSTANT
+            len   : DINT := 63;
+            count : DINT := 5;
+        END_VAR
+        VAR
+            arr : ARRAY[1..count] OF STRING[len];
+        END_VAR
+        END_PROGRAM
+        "#,
+    );
+
+    let from_literal = codegen(
+        r#"
+        PROGRAM prg
+        VAR
+            arr : ARRAY[1..5] OF STRING[63];
+        END_VAR
+        END_PROGRAM
+        "#,
+    );
+
+    assert_eq!(string_fields(&from_literal, "prg"), ["[5 x [64 x i8]]"]);
+    assert_eq!(string_fields(&from_constant, "prg"), string_fields(&from_literal, "prg"));
+}

--- a/tests/lit/single/init/array_local_const_bound.st
+++ b/tests/lit/single/init/array_local_const_bound.st
@@ -1,0 +1,44 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// A POU-local `VAR CONSTANT` used as an array bound. The generated element constructor is a
+// POU of its own, so a bound naming a member of the declaring POU does not resolve inside it
+// and has to be taken from the index as a literal. Regression test for PRG-4730: element
+// types that need construction (sized strings, structs) previously failed to generate.
+//
+// The last element of every array is checked as well as the first, so a bound that resolved
+// to the wrong value would be caught rather than only a bound that failed to compile.
+TYPE Point : STRUCT
+    x : DINT := 11;
+    y : DINT := 22;
+END_STRUCT END_TYPE
+
+PROGRAM prog
+VAR CONSTANT
+    five : DINT := 5;
+    two  : DINT := 2;
+END_VAR
+VAR
+    strings : ARRAY[1..five] OF STRING[63];
+    points  : ARRAY[1..five] OF Point;
+    multi   : ARRAY[1..two, 1..five] OF Point;
+    nested  : ARRAY[1..two] OF ARRAY[1..five] OF Point;
+END_VAR
+    strings[1] := 'first';
+    strings[five] := 'last';
+
+    printf('%s$N', REF(strings[1]));      // CHECK: first
+    printf('%s$N', REF(strings[five]));   // CHECK: last
+
+    // Struct defaults must reach every element, including the last one the bound admits.
+    printf('%d$N', points[1].x);          // CHECK: 11
+    printf('%d$N', points[five].y);       // CHECK: 22
+
+    printf('%d$N', multi[1, 1].x);        // CHECK: 11
+    printf('%d$N', multi[two, five].y);   // CHECK: 22
+
+    printf('%d$N', nested[1][1].x);       // CHECK: 11
+    printf('%d$N', nested[two][five].y);  // CHECK: 22
+END_PROGRAM
+
+FUNCTION main : DINT
+    prog();
+END_FUNCTION

--- a/tests/lit/single/init/local_const_in_type_positions.st
+++ b/tests/lit/single/init/local_const_in_type_positions.st
@@ -1,0 +1,47 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+// A POU-local `VAR CONSTANT` is a constant like any other and must be usable everywhere a
+// constant is allowed in a type: as a string length, as an array bound, in an expression
+// forming either, and as the bound of an array whose element type is itself sized by one.
+// Companion to array_local_const_bound.st, which covers element construction.
+FUNCTION main : DINT
+VAR CONSTANT
+    len   : DINT := 16;
+    lo    : DINT := 2;
+    hi    : DINT := 4;
+END_VAR
+VAR
+    // string length from a local constant, and from an expression over one
+    sized      : STRING[len];
+    computed   : STRING[len * 2];
+    wide       : WSTRING[len];
+
+    // array bounds from local constants, including a non-zero lower bound
+    bounded    : ARRAY[lo..hi] OF DINT;
+    expression : ARRAY[1..len / 4] OF DINT;
+
+    // both at once: bound and element length from local constants
+    both       : ARRAY[lo..hi] OF STRING[len];
+END_VAR
+    sized := 'sixteen chars ..';
+    computed := 'thirty two characters, exactly!!';
+    bounded[lo] := 100;
+    bounded[hi] := 400;
+    expression[1] := 1;
+    expression[len / 4] := 4;
+    both[lo] := 'low';
+    both[hi] := 'high';
+
+    printf('%s$N', REF(sized));            // CHECK: sixteen chars ..
+    printf('%s$N', REF(computed));         // CHECK: thirty two characters, exactly!!
+
+    printf('%d$N', bounded[lo]);           // CHECK: 100
+    printf('%d$N', bounded[hi]);           // CHECK: 400
+
+    printf('%d$N', expression[1]);         // CHECK: 1
+    printf('%d$N', expression[len / 4]);   // CHECK: 4
+
+    printf('%s$N', REF(both[lo]));         // CHECK: low
+    printf('%s$N', REF(both[hi]));         // CHECK: high
+
+    main := 0;
+END_FUNCTION


### PR DESCRIPTION
> **Attribution:** this branch, its tests and this description were produced by Claude
> (Claude Code) working in my repository, not written directly by me. I have reviewed the
> change, but please review it as machine-authored work. The commits carry a
> `Co-Authored-By: Claude` trailer.

Backport of #1897 to `release/1.0.x`. Fixes PRG-4730 on the v1 line.

## Why it is wanted on v1

The bug is present on this branch. An array whose bound names a constant of the declaring POU
fails to compile when the element type needs construction:

```iecst
PROGRAM mainProg
VAR CONSTANT five : DINT := 5; END_VAR
VAR arr : ARRAY[1..five] OF STRING[63]; END_VAR
END_PROGRAM
```

```
error: cannot generate call statement for ReferenceExpr {
    kind: Member(Identifier { name: "DINT_GREATER" }), base: None }
```

Reproduced on `release/1.0.x` before porting. Note that #1831, which introduced the loop on
master, is not on this branch; an equivalent element construction loop is, so the branch is
affected independently rather than through that commit.

See #1897 for the full cause and reasoning. In short: the loop bounds were copied out of the
declaration into the generated constructor, which is a POU of its own where a member of the
declaring POU does not resolve. The bounds now come from the index, already const-evaluated,
and are emitted as literals.

## Port risk

Low. Both commits cherry-picked with **no conflicts**.

Verified on this branch on Windows: the repro compiles, and 2582 + 91 + 50 lib, 170 lowering,
352 correctness tests pass, with `fmt` clean. The lit tests were not run locally (`lit` needs
Python and that suite runs on Linux in CI).

## What reviewers should weigh

- The change only affects the bounds of the generated element construction loop; a bound that
  was already a literal produces the same loop as before.
- Arrays of scalar types are unaffected, since they generate no element construction loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
