### PR TITLE
fix(codegen): anchor debug locations to their own statement

### DIFF
--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -127,6 +127,10 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
         mut llvm_index: LlvmTypedIndex<'b>,
         statement: &AstNode,
     ) -> Result<LlvmTypedIndex<'b>, CodegenError> {
+        // Anchor the statement's own location so instructions that carry none of their own
+        // are not attributed to the previously generated statement.
+        self.register_debug_location(statement);
+
         match statement.get_stmt() {
             AstStatement::EmptyStatement(..) => {
                 //nothing to generate

--- a/src/codegen/generators/statement_generator.rs
+++ b/src/codegen/generators/statement_generator.rs
@@ -149,7 +149,6 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
                     self.generate_conditional_return(&llvm_index, statement, condition)?;
                 }
                 None => {
-                    self.register_debug_location(statement);
                     self.generate_return_statement()?;
                     self.generate_buffer_block(); // XXX(volsa): This is not needed on x86 but if removed segfaults on ARM
                 }
@@ -157,7 +156,6 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             AstStatement::LabelStatement(LabelStatement { name }) => {
                 if let Some(block) = self.function_context.blocks.get(name) {
                     //unconditionally jump to the label
-                    self.register_debug_location(statement);
                     self.llvm.builder.build_unconditional_branch(*block)?;
                     //Place the current instert block at the label statement
                     self.llvm.builder.position_at_end(*block);
@@ -197,7 +195,6 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
             }
             AstStatement::ExitStatement(_) => {
                 if let Some(exit_block) = &self.current_loop_exit {
-                    self.register_debug_location(statement);
                     self.llvm.builder.build_unconditional_branch(*exit_block)?;
                     self.generate_buffer_block();
                 } else {
@@ -479,6 +476,8 @@ impl<'a, 'b> StatementCodeGenerator<'a, 'b> {
 
         let basic_block = builder.get_insert_block().expect(INTERNAL_LLVM_ERROR);
         let exp_gen = self.create_expr_generator(llvm_index);
+        // The selector load and the switch below share the selector's location
+        self.register_debug_location(&stmt.selector);
         let selector_statement = exp_gen.generate_expression(&stmt.selector)?;
 
         let mut cases = Vec::new();

--- a/src/codegen/tests/debug_tests.rs
+++ b/src/codegen/tests/debug_tests.rs
@@ -561,30 +561,30 @@ fn switch_case_debug_info() {
       %tmpVar = add i32 %0, 1, !dbg !22
       %1 = trunc i32 %tmpVar to i16, !dbg !22
       store i16 %1, ptr %x1, align [filtered], !dbg !22
-      %load_x13 = load i16, ptr %x1, align [filtered], !dbg !22
+      %load_x13 = load i16, ptr %x1, align [filtered], !dbg !23
       switch i16 %load_x13, label %else [
         i16 1, label %case
         i16 2, label %case4
         i16 3, label %case5
-      ], !dbg !23
+      ], !dbg !24
 
     case:                                             ; preds = %continue1
-      store i16 1, ptr %x2, align [filtered], !dbg !24
-      br label %continue2, !dbg !25
+      store i16 1, ptr %x2, align [filtered], !dbg !25
+      br label %continue2, !dbg !26
 
     case4:                                            ; preds = %continue1
-      store i16 2, ptr %x2, align [filtered], !dbg !26
-      br label %continue2, !dbg !25
+      store i16 2, ptr %x2, align [filtered], !dbg !27
+      br label %continue2, !dbg !26
 
     case5:                                            ; preds = %continue1
-      store i16 3, ptr %x2, align [filtered], !dbg !27
-      br label %continue2, !dbg !25
+      store i16 3, ptr %x2, align [filtered], !dbg !28
+      br label %continue2, !dbg !26
 
     else:                                             ; preds = %continue1
-      store i16 0, ptr %x1, align [filtered], !dbg !28
-      store i16 1, ptr %x2, align [filtered], !dbg !29
-      store i16 2, ptr %x3, align [filtered], !dbg !30
-      br label %continue2, !dbg !25
+      store i16 0, ptr %x1, align [filtered], !dbg !29
+      store i16 1, ptr %x2, align [filtered], !dbg !30
+      store i16 2, ptr %x3, align [filtered], !dbg !31
+      br label %continue2, !dbg !26
 
     continue2:                                        ; preds = %else, %case5, %case4, %case
       br label %while_body, !dbg !21
@@ -616,14 +616,15 @@ fn switch_case_debug_info() {
     !20 = !DILocation(line: 24, column: 8, scope: !4)
     !21 = !DILocation(line: 0, scope: !4)
     !22 = !DILocation(line: 10, column: 12, scope: !4)
-    !23 = !DILocation(line: 12, column: 17, scope: !4)
-    !24 = !DILocation(line: 13, column: 19, scope: !4)
-    !25 = !DILocation(line: 20, column: 12, scope: !4)
-    !26 = !DILocation(line: 14, column: 19, scope: !4)
-    !27 = !DILocation(line: 15, column: 19, scope: !4)
-    !28 = !DILocation(line: 17, column: 20, scope: !4)
-    !29 = !DILocation(line: 18, column: 20, scope: !4)
-    !30 = !DILocation(line: 19, column: 20, scope: !4)
+    !23 = !DILocation(line: 12, column: 12, scope: !4)
+    !24 = !DILocation(line: 12, column: 17, scope: !4)
+    !25 = !DILocation(line: 13, column: 19, scope: !4)
+    !26 = !DILocation(line: 20, column: 12, scope: !4)
+    !27 = !DILocation(line: 14, column: 19, scope: !4)
+    !28 = !DILocation(line: 15, column: 19, scope: !4)
+    !29 = !DILocation(line: 17, column: 20, scope: !4)
+    !30 = !DILocation(line: 18, column: 20, scope: !4)
+    !31 = !DILocation(line: 19, column: 20, scope: !4)
     "#);
 }
 

--- a/src/codegen/tests/debug_tests.rs
+++ b/src/codegen/tests/debug_tests.rs
@@ -566,25 +566,25 @@ fn switch_case_debug_info() {
         i16 1, label %case
         i16 2, label %case4
         i16 3, label %case5
-      ], !dbg !24
+      ], !dbg !23
 
     case:                                             ; preds = %continue1
-      store i16 1, ptr %x2, align [filtered], !dbg !25
-      br label %continue2, !dbg !26
+      store i16 1, ptr %x2, align [filtered], !dbg !24
+      br label %continue2, !dbg !25
 
     case4:                                            ; preds = %continue1
-      store i16 2, ptr %x2, align [filtered], !dbg !27
-      br label %continue2, !dbg !26
+      store i16 2, ptr %x2, align [filtered], !dbg !26
+      br label %continue2, !dbg !25
 
     case5:                                            ; preds = %continue1
-      store i16 3, ptr %x2, align [filtered], !dbg !28
-      br label %continue2, !dbg !26
+      store i16 3, ptr %x2, align [filtered], !dbg !27
+      br label %continue2, !dbg !25
 
     else:                                             ; preds = %continue1
-      store i16 0, ptr %x1, align [filtered], !dbg !29
-      store i16 1, ptr %x2, align [filtered], !dbg !30
-      store i16 2, ptr %x3, align [filtered], !dbg !31
-      br label %continue2, !dbg !26
+      store i16 0, ptr %x1, align [filtered], !dbg !28
+      store i16 1, ptr %x2, align [filtered], !dbg !29
+      store i16 2, ptr %x3, align [filtered], !dbg !30
+      br label %continue2, !dbg !25
 
     continue2:                                        ; preds = %else, %case5, %case4, %case
       br label %while_body, !dbg !21
@@ -616,15 +616,14 @@ fn switch_case_debug_info() {
     !20 = !DILocation(line: 24, column: 8, scope: !4)
     !21 = !DILocation(line: 0, scope: !4)
     !22 = !DILocation(line: 10, column: 12, scope: !4)
-    !23 = !DILocation(line: 12, column: 12, scope: !4)
-    !24 = !DILocation(line: 12, column: 17, scope: !4)
-    !25 = !DILocation(line: 13, column: 19, scope: !4)
-    !26 = !DILocation(line: 20, column: 12, scope: !4)
-    !27 = !DILocation(line: 14, column: 19, scope: !4)
-    !28 = !DILocation(line: 15, column: 19, scope: !4)
-    !29 = !DILocation(line: 17, column: 20, scope: !4)
-    !30 = !DILocation(line: 18, column: 20, scope: !4)
-    !31 = !DILocation(line: 19, column: 20, scope: !4)
+    !23 = !DILocation(line: 12, column: 17, scope: !4)
+    !24 = !DILocation(line: 13, column: 19, scope: !4)
+    !25 = !DILocation(line: 20, column: 12, scope: !4)
+    !26 = !DILocation(line: 14, column: 19, scope: !4)
+    !27 = !DILocation(line: 15, column: 19, scope: !4)
+    !28 = !DILocation(line: 17, column: 20, scope: !4)
+    !29 = !DILocation(line: 18, column: 20, scope: !4)
+    !30 = !DILocation(line: 19, column: 20, scope: !4)
     "#);
 }
 

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__case_conditions_location_marked.snap
@@ -16,24 +16,24 @@ entry:
   switch i32 %load_myFunc, label %else [
     i32 1, label %case
     i32 2, label %case1
-  ], !dbg !12
+  ], !dbg !11
 
 case:                                             ; preds = %entry
-  store i32 1, ptr %myFunc, align [filtered], !dbg !13
-  br label %continue, !dbg !14
+  store i32 1, ptr %myFunc, align [filtered], !dbg !12
+  br label %continue, !dbg !13
 
 case1:                                            ; preds = %entry
-  store i32 1, ptr %myFunc, align [filtered], !dbg !15
-  br label %continue, !dbg !14
+  store i32 1, ptr %myFunc, align [filtered], !dbg !14
+  br label %continue, !dbg !13
 
 else:                                             ; preds = %entry
-  store i32 1, ptr %myFunc, align [filtered], !dbg !16
-  br label %continue, !dbg !14
+  store i32 1, ptr %myFunc, align [filtered], !dbg !15
+  br label %continue, !dbg !13
 
 continue:                                         ; preds = %else, %case1, %case
-  store i32 1, ptr %myFunc, align [filtered], !dbg !17
-  %myFunc_ret = load i32, ptr %myFunc, align [filtered], !dbg !18
-  ret i32 %myFunc_ret, !dbg !18
+  store i32 1, ptr %myFunc, align [filtered], !dbg !16
+  %myFunc_ret = load i32, ptr %myFunc, align [filtered], !dbg !17
+  ret i32 %myFunc_ret, !dbg !17
 }
 
 !llvm.module.flags = !{!0, !1}
@@ -50,11 +50,10 @@ continue:                                         ; preds = %else, %case1, %case
 !8 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !9, align [filtered])
 !9 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !10 = !DILocation(line: 2, column: 17, scope: !4)
-!11 = !DILocation(line: 3, column: 12, scope: !4)
-!12 = !DILocation(line: 3, column: 17, scope: !4)
-!13 = !DILocation(line: 5, column: 16, scope: !4)
-!14 = !DILocation(line: 10, column: 12, scope: !4)
-!15 = !DILocation(line: 7, column: 16, scope: !4)
-!16 = !DILocation(line: 9, column: 16, scope: !4)
-!17 = !DILocation(line: 11, column: 12, scope: !4)
-!18 = !DILocation(line: 12, column: 8, scope: !4)
+!11 = !DILocation(line: 3, column: 17, scope: !4)
+!12 = !DILocation(line: 5, column: 16, scope: !4)
+!13 = !DILocation(line: 10, column: 12, scope: !4)
+!14 = !DILocation(line: 7, column: 16, scope: !4)
+!15 = !DILocation(line: 9, column: 16, scope: !4)
+!16 = !DILocation(line: 11, column: 12, scope: !4)
+!17 = !DILocation(line: 12, column: 8, scope: !4)

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__for_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__for_conditions_location_marked.snap
@@ -18,7 +18,7 @@ entry:
   store i8 0, ptr %__is_incrementing_0, align [filtered], !dbg !11
   store i32 1, ptr %myFunc, align [filtered], !dbg !12
   store i8 1, ptr %__is_incrementing_0, align [filtered], !dbg !11
-  br label %while_body, !dbg !11
+  br label %while_body, !dbg !13
 
 while_body:                                       ; preds = %continue2, %entry
   %load___ran_once_0 = load i8, ptr %__ran_once_0, align [filtered], !dbg !11
@@ -26,8 +26,8 @@ while_body:                                       ; preds = %continue2, %entry
   br i1 %0, label %condition_body, label %continue1, !dbg !11
 
 continue:                                         ; preds = %condition_body11, %condition_body7
-  %myFunc_ret = load i32, ptr %myFunc, align [filtered], !dbg !13
-  ret i32 %myFunc_ret, !dbg !13
+  %myFunc_ret = load i32, ptr %myFunc, align [filtered], !dbg !14
+  ret i32 %myFunc_ret, !dbg !14
 
 condition_body:                                   ; preds = %while_body
   %load_myFunc = load i32, ptr %myFunc, align [filtered], !dbg !12
@@ -56,7 +56,7 @@ else:                                             ; preds = %continue1
   br i1 %5, label %condition_body11, label %continue8, !dbg !12
 
 continue2:                                        ; preds = %continue8, %continue4
-  store i32 1, ptr %myFunc, align [filtered], !dbg !14
+  store i32 1, ptr %myFunc, align [filtered], !dbg !15
   br label %while_body, !dbg !11
 
 condition_body7:                                  ; preds = %condition_body3
@@ -94,5 +94,6 @@ continue8:                                        ; preds = %buffer_block12, %el
 !10 = !DILocation(line: 2, column: 17, scope: !4)
 !11 = !DILocation(line: 0, scope: !4)
 !12 = !DILocation(line: 3, column: 16, scope: !4)
-!13 = !DILocation(line: 6, column: 8, scope: !4)
-!14 = !DILocation(line: 4, column: 16, scope: !4)
+!13 = !DILocation(line: 3, column: 12, scope: !4)
+!14 = !DILocation(line: 6, column: 8, scope: !4)
+!15 = !DILocation(line: 4, column: 16, scope: !4)

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_callable_expressions_have_no_location.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__non_callable_expressions_have_no_location.snap
@@ -31,5 +31,5 @@ entry:
 !8 = !DILocalVariable(name: "myFunc", scope: !4, file: !3, line: 2, type: !9, align [filtered])
 !9 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !10 = !DILocation(line: 2, column: 17, scope: !4)
-!11 = !DILocation(line: 3, column: 12, scope: !4)
+!11 = !DILocation(line: 4, column: 12, scope: !4)
 !12 = !DILocation(line: 5, column: 8, scope: !4)

--- a/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__repeat_conditions_location_marked.snap
+++ b/src/codegen/tests/debug_tests/snapshots/rusty__codegen__tests__debug_tests__expression_debugging__repeat_conditions_location_marked.snap
@@ -14,7 +14,7 @@ entry:
   store i32 0, ptr %myFunc, align [filtered]
   %__ran_once_0 = alloca i8, align [filtered]
   store i8 0, ptr %__ran_once_0, align [filtered], !dbg !11
-  br label %while_body, !dbg !11
+  br label %while_body, !dbg !12
 
 while_body:                                       ; preds = %continue1, %entry
   %load___ran_once_0 = load i8, ptr %__ran_once_0, align [filtered], !dbg !11
@@ -22,20 +22,20 @@ while_body:                                       ; preds = %continue1, %entry
   br i1 %0, label %condition_body, label %continue1, !dbg !11
 
 continue:                                         ; preds = %condition_body3
-  store i32 1, ptr %myFunc, align [filtered], !dbg !12
-  %myFunc_ret = load i32, ptr %myFunc, align [filtered], !dbg !13
-  ret i32 %myFunc_ret, !dbg !13
+  store i32 1, ptr %myFunc, align [filtered], !dbg !13
+  %myFunc_ret = load i32, ptr %myFunc, align [filtered], !dbg !14
+  ret i32 %myFunc_ret, !dbg !14
 
 condition_body:                                   ; preds = %while_body
-  %load_myFunc = load i32, ptr %myFunc, align [filtered], !dbg !14
-  %tmpVar = icmp sgt i32 %load_myFunc, 10, !dbg !14
-  %1 = zext i1 %tmpVar to i8, !dbg !14
-  %2 = icmp ne i8 %1, 0, !dbg !14
-  br i1 %2, label %condition_body3, label %continue2, !dbg !14
+  %load_myFunc = load i32, ptr %myFunc, align [filtered], !dbg !15
+  %tmpVar = icmp sgt i32 %load_myFunc, 10, !dbg !15
+  %1 = zext i1 %tmpVar to i8, !dbg !15
+  %2 = icmp ne i8 %1, 0, !dbg !15
+  br i1 %2, label %condition_body3, label %continue2, !dbg !15
 
 continue1:                                        ; preds = %continue2, %while_body
   store i8 1, ptr %__ran_once_0, align [filtered], !dbg !11
-  store i32 1, ptr %myFunc, align [filtered], !dbg !15
+  store i32 1, ptr %myFunc, align [filtered], !dbg !16
   br label %while_body, !dbg !11
 
 condition_body3:                                  ; preds = %condition_body
@@ -63,7 +63,8 @@ continue2:                                        ; preds = %buffer_block, %cond
 !9 = !DIBasicType(name: "DINT", size: 32, encoding: DW_ATE_signed, flags: DIFlagPublic)
 !10 = !DILocation(line: 2, column: 17, scope: !4)
 !11 = !DILocation(line: 0, scope: !4)
-!12 = !DILocation(line: 6, column: 12, scope: !4)
-!13 = !DILocation(line: 7, column: 8, scope: !4)
-!14 = !DILocation(line: 5, column: 18, scope: !4)
-!15 = !DILocation(line: 4, column: 16, scope: !4)
+!12 = !DILocation(line: 3, column: 12, scope: !4)
+!13 = !DILocation(line: 6, column: 12, scope: !4)
+!14 = !DILocation(line: 7, column: 8, scope: !4)
+!15 = !DILocation(line: 5, column: 18, scope: !4)
+!16 = !DILocation(line: 4, column: 16, scope: !4)

--- a/src/codegen/tests/oop_tests/debug_tests.rs
+++ b/src/codegen/tests/oop_tests/debug_tests.rs
@@ -515,7 +515,7 @@ fn write_to_parent_variable_in_instance() {
         #dbg_declare(ptr %fb, !40, !DIExpression(), !41)
       call void @llvm.memset.p0.i64(ptr align [filtered] %fb, i8 0, i64 ptrtoint (ptr getelementptr (%bar, ptr null, i32 1) to i64), i1 false)
       call void @bar__ctor(ptr %fb), !dbg !42
-      %__foo = getelementptr inbounds nuw %bar, ptr %fb, i32 0, i32 0, !dbg !42
+      %__foo = getelementptr inbounds nuw %bar, ptr %fb, i32 0, i32 0, !dbg !43
       call void @foo__baz(ptr %__foo), !dbg !43
       call void @bar(ptr %fb), !dbg !44
       ret void, !dbg !45

--- a/tests/lit/single/control_statements/debug_branch_body_locations.st
+++ b/tests/lit/single/control_statements/debug_branch_body_locations.st
@@ -1,0 +1,49 @@
+// RUN: %COMPILE_IR %s | %CHECK_IR %s
+
+// A branch body that starts with instructions carrying no location of their own (the
+// argument stores of a call) must be attributed to the body's own line, not to the
+// location of whatever was generated before it. A body that shares its line with the
+// enclosing condition or end keyword gets no line-table row of its own, and a debugger
+// cannot then place a breakpoint on it.
+
+FUNCTION_BLOCK Counter
+VAR_INPUT step : INT; END_VAR
+VAR_OUTPUT total : INT; END_VAR
+    total := total + step;
+END_FUNCTION_BLOCK
+
+PROGRAM branches
+VAR
+    c : Counter;
+    sel : INT;
+    out : INT;
+END_VAR
+    CASE sel OF
+        0: c(step := 1, total => out);
+        1: c(step := 2, total => out);
+    END_CASE
+    IF sel > 0 THEN
+        c(step := 3, total => out);
+    END_IF
+END_PROGRAM
+
+FUNCTION main
+    branches();
+END_FUNCTION
+
+// Every instruction of a body shares the body's own location, argument stores included.
+// CHECK-LABEL: define void @branches
+// CHECK: case:
+// CHECK: store i16 1, ptr %{{[0-9]+}}, align 2, !dbg ![[CASE0:[0-9]+]]
+// CHECK: call void @Counter(ptr %c), !dbg ![[CASE0]]
+// CHECK: case1:
+// CHECK: store i16 2, ptr %{{[0-9]+}}, align 2, !dbg ![[CASE1:[0-9]+]]
+// CHECK: call void @Counter(ptr %c), !dbg ![[CASE1]]
+// CHECK: condition_body:
+// CHECK: store i16 3, ptr %{{[0-9]+}}, align 2, !dbg ![[IFBODY:[0-9]+]]
+// CHECK: call void @Counter(ptr %c), !dbg ![[IFBODY]]
+
+// And that location is the body's source line.
+// CHECK-DAG: ![[CASE0]] = !DILocation(line: [[@LINE-25]]
+// CHECK-DAG: ![[CASE1]] = !DILocation(line: [[@LINE-25]]
+// CHECK-DAG: ![[IFBODY]] = !DILocation(line: [[@LINE-23]]


### PR DESCRIPTION
Problem: Instructions that carry no debug location of their own, such as the argument stores of a call, were attributed to the statement generated before them. A branch body then shared its line with the enclosing condition or end keyword, so it had no line-table row and a debugger could not place a breakpoint on it.

Solution: Register a statement's location before generating it, so every statement's instructions start out attributed to that statement. The existing per-arm registrations still refine this where they have a more precise location.

Refs: PRG-4711

## Testing

`cargo test --workspace`, the lit suite, `cargo fmt --all` and `cargo clippy --workspace -- -Dwarnings` are clean. A new lit test asserts that a CASE and an IF body share their location with the call they contain, and that the location is the body's own line; it fails without the change.

Five snapshots moved, all in the same direction: a CASE selector load, a `REPEAT` and a `FOR` entry branch that had carried line 0, the receiver of a method call, and a statement that emits no instructions no longer leaking its location onto the next statement.
