### PR TITLE
test(lit): make included_struct_ctor order independent

### DIFF
--- a/tests/lit/ir_tests/included_struct_ctor.st
+++ b/tests/lit/ir_tests/included_struct_ctor.st
@@ -6,7 +6,9 @@ VAR
 END_VAR
 END_PROGRAM
 
-// CHECK: define void @Main__ctor(ptr %0) {
-// CHECK: call void @IncludedStruct__ctor(ptr %s)
-// CHECK: declare void @IncludedStruct__ctor(ptr)
+// The declaration may precede or follow Main__ctor depending on the unit order
+// CHECK-NOT: define{{.*}}@IncludedStruct__ctor
+// CHECK-DAG: define void @Main__ctor(ptr %0) {
+// CHECK-DAG: call void @IncludedStruct__ctor(ptr %s)
+// CHECK-DAG: declare void @IncludedStruct__ctor(ptr)
 // CHECK-NOT: define{{.*}}@IncludedStruct__ctor


### PR DESCRIPTION
Problem: The test asserts that the declaration of `IncludedStruct__ctor` follows the definition of `Main__ctor`. The compiler does not guarantee this order; inside the dev container the declaration is emitted first, so the test fails there while it passes in CI.

Solution: Match the definition, the call and the declaration with `CHECK-DAG`, and keep `CHECK-NOT` guards on both sides so a definition of the included constructor still fails the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)