### PR TITLE
fix(codegen): store struct literal members with assignment semantics (1.0.x)

### DIFF
--- a/src/codegen/generators/expression_generator.rs
+++ b/src/codegen/generators/expression_generator.rs
@@ -4,7 +4,7 @@ use crate::codegen::generators::data_type_generator::get_default_for;
 use inkwell::{
     attributes::AttributeLoc,
     builder::Builder,
-    types::{BasicType, BasicTypeEnum},
+    types::{BasicType, BasicTypeEnum, StructType},
     values::{
         ArrayValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallSiteValue, FloatValue, IntValue,
         PointerValue, ScalableVectorValue, StructValue, ValueKind, VectorValue,
@@ -2651,101 +2651,174 @@ impl<'ink, 'b> ExpressionCodeGenerator<'ink, 'b> {
 
     /// generates a struct literal value with the given value assignments (ExpressionList)
     fn generate_literal_struct(&self, assignments: &AstNode) -> Result<ExpressionValue<'ink>, CodegenError> {
-        if let DataTypeInformation::Struct { name: struct_name, members, .. } =
+        let DataTypeInformation::Struct { name: struct_name, members, .. } =
             self.get_type_hint_info_for(assignments)?
-        {
-            let mut uninitialized_members: FxHashSet<&VariableIndexEntry> = FxHashSet::from_iter(members);
-            let mut member_values: Vec<(u32, BasicValueEnum<'ink>)> = Vec::new();
-            for assignment in flatten_expression_list(assignments) {
-                if let AstStatement::Assignment(data) = assignment.get_stmt() {
-                    if let Some(StatementAnnotation::Variable { qualified_name, .. }) =
-                        self.annotations.get(data.left.as_ref())
-                    {
-                        let member: &VariableIndexEntry =
-                            self.index.find_fully_qualified_variable(qualified_name).ok_or_else(|| {
-                                Diagnostic::unresolved_reference(qualified_name, data.left.as_ref())
-                            })?;
-
-                        let index_in_parent = member.get_location_in_parent();
-                        let value = self.generate_expression(data.right.as_ref())?;
-
-                        uninitialized_members.remove(member);
-                        member_values.push((index_in_parent, value));
-                    } else {
-                        return Err(Diagnostic::codegen_error(
-                            "struct member lvalue required as left operand of assignment",
-                            data.left.as_ref(),
-                        )
-                        .into());
-                    }
-                } else {
-                    return Err(Diagnostic::codegen_error(
-                        "struct literal must consist of explicit assignments in the form of member := value",
-                        assignment,
-                    )
-                    .into());
-                }
-            }
-
-            //fill the struct with fields we didnt mention yet
-            for member in uninitialized_members {
-                let initial_value = self
-                    .llvm_index
-                    .find_associated_variable_value(member.get_qualified_name())
-                    // .or_else(|| self.index.find_associated_variable_value(name))
-                    .or_else(|| self.llvm_index.find_associated_initial_value(member.get_type_name()))
-                    .ok_or_else(|| {
-                        Diagnostic::cannot_generate_initializer(member.get_qualified_name(), assignments)
-                    })?;
-
-                member_values.push((member.get_location_in_parent(), initial_value));
-            }
-            let struct_type = self.llvm_index.get_associated_type(struct_name)?.into_struct_type();
-            if member_values.len() == struct_type.count_fields() as usize {
-                member_values.sort_by_key(|(a, _)| *a);
-                let ordered_values: Vec<BasicValueEnum<'ink>> =
-                    member_values.iter().map(|(_, v)| *v).collect();
-
-                if ordered_values.iter().all(|v| v.is_const()) {
-                    Ok(ExpressionValue::RValue(
-                        struct_type.const_named_struct(ordered_values.as_slice()).as_basic_value_enum(),
-                    ))
-                } else if self.function_context.is_none() {
-                    Err(Diagnostic::codegen_error(
-                        "Non-constant struct literal requires function context",
-                        assignments,
-                    )
-                    .into())
-                } else {
-                    let mut value = struct_type.get_undef();
-                    for (idx, field) in ordered_values.iter().enumerate() {
-                        value = self
-                            .llvm
-                            .builder
-                            .build_insert_value(value, *field, idx as u32, "")?
-                            .into_struct_value();
-                    }
-                    Ok(ExpressionValue::RValue(value.as_basic_value_enum()))
-                }
-            } else {
-                Err(Diagnostic::codegen_error(
-                    format!(
-                        "Expected {} fields for Struct {}, but found {}.",
-                        struct_type.count_fields(),
-                        struct_name,
-                        member_values.len()
-                    ),
-                    assignments,
-                )
-                .into())
-            }
-        } else {
-            Err(Diagnostic::codegen_error(
+        else {
+            return Err(Diagnostic::codegen_error(
                 format!("Expected Struct-literal, got {assignments:#?}"),
                 assignments,
             )
-            .into())
+            .into());
+        };
+        let member_assignments = self.collect_struct_literal_assignments(assignments)?;
+        let struct_type = self.llvm_index.get_associated_type(struct_name)?.into_struct_type();
+
+        // runtime member values need stores, everything else folds into a constant sized like a declaration
+        let has_runtime_values =
+            member_assignments.iter().any(|(_, value)| !Self::is_literal_struct_value(value));
+        if let (Some(function_context), true) = (self.function_context, has_runtime_values) {
+            return self.generate_struct_literal_in_memory(
+                function_context,
+                struct_name,
+                struct_type,
+                &member_assignments,
+                assignments,
+            );
         }
+        ExpressionCodeGenerator::new_context_free(self.llvm, self.index, self.annotations, self.llvm_index)
+            .generate_constant_struct_literal(
+                struct_name,
+                struct_type,
+                members,
+                &member_assignments,
+                assignments,
+            )
+    }
+
+    /// returns true if the struct literal value consists of literals only, including nested struct literals
+    fn is_literal_struct_value(value: &AstNode) -> bool {
+        match value.get_stmt() {
+            AstStatement::Literal(AstLiteral::Array(array)) => {
+                array.elements().is_none_or(Self::is_literal_struct_value)
+            }
+            AstStatement::Literal(_) => true,
+            AstStatement::MultipliedStatement(data) => Self::is_literal_struct_value(&data.element),
+            AstStatement::ParenExpression(inner) => Self::is_literal_struct_value(inner),
+            AstStatement::ExpressionList(values) => values.iter().all(Self::is_literal_struct_value),
+            AstStatement::Assignment(data) => Self::is_literal_struct_value(&data.right),
+            _ => false,
+        }
+    }
+
+    /// pairs every `member := value` of a struct literal with the member it assigns
+    fn collect_struct_literal_assignments<'a>(
+        &self,
+        assignments: &'a AstNode,
+    ) -> Result<Vec<(&'b VariableIndexEntry, &'a AstNode)>, CodegenError> {
+        let mut result = Vec::new();
+        for assignment in flatten_expression_list(assignments) {
+            let AstStatement::Assignment(data) = assignment.get_stmt() else {
+                return Err(Diagnostic::codegen_error(
+                    "struct literal must consist of explicit assignments in the form of member := value",
+                    assignment,
+                )
+                .into());
+            };
+            let Some(StatementAnnotation::Variable { qualified_name, .. }) =
+                self.annotations.get(data.left.as_ref())
+            else {
+                return Err(Diagnostic::codegen_error(
+                    "struct member lvalue required as left operand of assignment",
+                    data.left.as_ref(),
+                )
+                .into());
+            };
+            let member = self
+                .index
+                .find_fully_qualified_variable(qualified_name)
+                .ok_or_else(|| Diagnostic::unresolved_reference(qualified_name, data.left.as_ref()))?;
+            result.push((member, data.right.as_ref()));
+        }
+        Ok(result)
+    }
+
+    /// builds a struct literal in a stack temporary so every member is stored with assignment semantics
+    fn generate_struct_literal_in_memory(
+        &self,
+        function_context: &FunctionContext<'ink, 'b>,
+        struct_name: &str,
+        struct_type: StructType<'ink>,
+        member_assignments: &[(&VariableIndexEntry, &AstNode)],
+        assignments: &AstNode,
+    ) -> Result<ExpressionValue<'ink>, CodegenError> {
+        // start from the type's default value so unmentioned members and string tails are initialized
+        let temp = self.llvm.create_entry_local_variable(
+            function_context.function,
+            "struct_literal",
+            &struct_type.as_basic_type_enum(),
+        )?;
+        let default_value = self
+            .llvm_index
+            .find_associated_initial_value(struct_name)
+            .unwrap_or_else(|| get_default_for(struct_type.as_basic_type_enum()));
+        self.store_aggregate_via_memcpy(temp, default_value, assignments)?;
+
+        // store the mentioned members like regular assignments
+        for (member, value) in member_assignments {
+            let member_ptr = self.llvm.builder.build_struct_gep(
+                struct_type,
+                temp,
+                member.get_location_in_parent(),
+                member.get_name(),
+            )?;
+            let member_type =
+                self.index.get_effective_type_or_void_by_name(member.get_type_name()).get_type_information();
+            self.generate_store(member_ptr, member_type, value)?;
+        }
+        Ok(ExpressionValue::LValue(temp, struct_type.as_basic_type_enum()))
+    }
+
+    /// builds a struct literal as a constant, used where no function is available to emit stores
+    fn generate_constant_struct_literal(
+        &self,
+        struct_name: &str,
+        struct_type: StructType<'ink>,
+        members: &[VariableIndexEntry],
+        member_assignments: &[(&VariableIndexEntry, &AstNode)],
+        assignments: &AstNode,
+    ) -> Result<ExpressionValue<'ink>, CodegenError> {
+        let mut member_values: Vec<(u32, BasicValueEnum<'ink>)> = Vec::new();
+        for (member, value) in member_assignments {
+            member_values.push((member.get_location_in_parent(), self.generate_expression(value)?));
+        }
+
+        // fill the members we did not mention with their defaults
+        let assigned: FxHashSet<&VariableIndexEntry> =
+            member_assignments.iter().map(|(member, _)| *member).collect();
+        for member in members.iter().filter(|member| !assigned.contains(member)) {
+            let initial_value = self
+                .llvm_index
+                .find_associated_variable_value(member.get_qualified_name())
+                .or_else(|| self.llvm_index.find_associated_initial_value(member.get_type_name()))
+                .ok_or_else(|| {
+                    Diagnostic::cannot_generate_initializer(member.get_qualified_name(), assignments)
+                })?;
+            member_values.push((member.get_location_in_parent(), initial_value));
+        }
+
+        if member_values.len() != struct_type.count_fields() as usize {
+            return Err(Diagnostic::codegen_error(
+                format!(
+                    "Expected {} fields for Struct {}, but found {}.",
+                    struct_type.count_fields(),
+                    struct_name,
+                    member_values.len()
+                ),
+                assignments,
+            )
+            .into());
+        }
+        member_values.sort_by_key(|(index, _)| *index);
+        let ordered_values: Vec<BasicValueEnum<'ink>> =
+            member_values.into_iter().map(|(_, value)| value).collect();
+        if !ordered_values.iter().all(|value| value.is_const()) {
+            return Err(Diagnostic::codegen_error(
+                "Non-constant struct literal requires function context",
+                assignments,
+            )
+            .into());
+        }
+        Ok(ExpressionValue::RValue(struct_type.const_named_struct(&ordered_values).as_basic_value_enum()))
     }
 
     /// generates an array literal with the given optional elements (represented as an ExpressionList)

--- a/src/codegen/tests/initialization_test/complex_initializers.rs
+++ b/src/codegen/tests/initialization_test/complex_initializers.rs
@@ -3933,3 +3933,135 @@ fn constructors_only_emits_only_ctor_definitions() {
     }
     "#);
 }
+
+#[test]
+fn array_of_structs_with_sized_string_member_initializer() {
+    let result = generate_to_string(
+        "Test",
+        vec![SourceCode::from(
+            r#"
+            TYPE Motor : STRUCT
+                name  : STRING[20];
+                speed : REAL;
+            END_STRUCT END_TYPE
+
+            PROGRAM prg
+            VAR
+                motors : ARRAY[0..1] OF Motor := [
+                    (name := 'Motor1', speed := 10.5),
+                    (name := 'Motor2', speed := 20.5)
+                ];
+            END_VAR
+            END_PROGRAM
+            "#,
+        )],
+    )
+    .unwrap();
+
+    filtered_assert_snapshot!(result, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %prg = type { [2 x %Motor] }
+    %Motor = type { [21 x i8], float }
+
+    @prg_instance = global %prg zeroinitializer
+    @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @__unit___internal___[ctor-hash]__ctor, ptr null }]
+    @utf08_literal_0 = private unnamed_addr constant [7 x i8] c"Motor1\00"
+    @utf08_literal_1 = private unnamed_addr constant [7 x i8] c"Motor2\00"
+    @.const_init = private unnamed_addr constant %Motor { [21 x i8] c"Motor1\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", float 1.050000e+01 }
+    @.const_init.1 = private unnamed_addr constant %Motor { [21 x i8] c"Motor2\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", float 2.050000e+01 }
+
+    define void @prg(ptr %0) {
+    entry:
+      %motors = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 0
+      ret void
+    }
+
+    define void @prg__ctor(ptr %0) {
+    entry:
+      %self = alloca ptr, align [filtered]
+      store ptr %0, ptr %self, align [filtered]
+      %deref = load ptr, ptr %self, align [filtered]
+      %motors = getelementptr inbounds nuw %prg, ptr %deref, i32 0, i32 0
+      call void @__prg_motors__ctor(ptr %motors)
+      %deref1 = load ptr, ptr %self, align [filtered]
+      %motors2 = getelementptr inbounds nuw %prg, ptr %deref1, i32 0, i32 0
+      %tmpVar = getelementptr inbounds [2 x %Motor], ptr %motors2, i32 0, i32 0
+      call void @llvm.memcpy.p0.p0.i64(ptr align [filtered] %tmpVar, ptr align [filtered] @.const_init, i64 ptrtoint (ptr getelementptr (%Motor, ptr null, i32 1) to i64), i1 false)
+      %deref3 = load ptr, ptr %self, align [filtered]
+      %motors4 = getelementptr inbounds nuw %prg, ptr %deref3, i32 0, i32 0
+      %tmpVar5 = getelementptr inbounds [2 x %Motor], ptr %motors4, i32 0, i32 1
+      call void @llvm.memcpy.p0.p0.i64(ptr align [filtered] %tmpVar5, ptr align [filtered] @.const_init.1, i64 ptrtoint (ptr getelementptr (%Motor, ptr null, i32 1) to i64), i1 false)
+      ret void
+    }
+
+    define void @Motor__ctor(ptr %0) {
+    entry:
+      %self = alloca ptr, align [filtered]
+      store ptr %0, ptr %self, align [filtered]
+      %deref = load ptr, ptr %self, align [filtered]
+      %name = getelementptr inbounds nuw %Motor, ptr %deref, i32 0, i32 0
+      call void @__Motor_name__ctor(ptr %name)
+      ret void
+    }
+
+    define void @__prg_motors__ctor(ptr %0) {
+    entry:
+      %self = alloca ptr, align [filtered]
+      store ptr %0, ptr %self, align [filtered]
+      %__prg_motors__idx0 = alloca i32, align [filtered]
+      store i32 0, ptr %__prg_motors__idx0, align [filtered]
+      store i32 0, ptr %__prg_motors__idx0, align [filtered]
+      br label %while_body
+
+    while_body:                                       ; preds = %continue1, %entry
+      %load___prg_motors__idx0 = load i32, ptr %__prg_motors__idx0, align [filtered]
+      %tmpVar = icmp sgt i32 %load___prg_motors__idx0, 1
+      %1 = zext i1 %tmpVar to i8
+      %2 = icmp ne i8 %1, 0
+      br i1 %2, label %condition_body, label %continue1
+
+    continue:                                         ; preds = %condition_body
+      ret void
+
+    condition_body:                                   ; preds = %while_body
+      br label %continue
+
+    buffer_block:                                     ; No predecessors!
+      br label %continue1
+
+    continue1:                                        ; preds = %buffer_block, %while_body
+      %deref = load ptr, ptr %self, align [filtered]
+      %load___prg_motors__idx02 = load i32, ptr %__prg_motors__idx0, align [filtered]
+      %tmpVar3 = mul i32 1, %load___prg_motors__idx02
+      %tmpVar4 = add i32 %tmpVar3, 0
+      %tmpVar5 = getelementptr inbounds [2 x %Motor], ptr %deref, i32 0, i32 %tmpVar4
+      call void @Motor__ctor(ptr %tmpVar5)
+      %load___prg_motors__idx06 = load i32, ptr %__prg_motors__idx0, align [filtered]
+      %tmpVar7 = add i32 %load___prg_motors__idx06, 1
+      store i32 %tmpVar7, ptr %__prg_motors__idx0, align [filtered]
+      br label %while_body
+    }
+
+    define void @__Motor_name__ctor(ptr %0) {
+    entry:
+      %self = alloca ptr, align [filtered]
+      store ptr %0, ptr %self, align [filtered]
+      ret void
+    }
+
+    define void @__unit___internal___[ctor-hash]__ctor() {
+    entry:
+      call void @prg__ctor(ptr @prg_instance)
+      ret void
+    }
+
+    ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+    declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #0
+
+    attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+    "#);
+}

--- a/src/codegen/tests/statement_codegen_test.rs
+++ b/src/codegen/tests/statement_codegen_test.rs
@@ -513,3 +513,121 @@ fn real_conversion_with_pretty_syntax() {
     }
     "#);
 }
+
+#[test]
+fn struct_literal_assignment_with_sized_string_member() {
+    let result = codegen(
+        r#"
+        TYPE Motor : STRUCT
+            name  : STRING[20];
+            speed : REAL;
+        END_STRUCT END_TYPE
+
+        PROGRAM prg
+        VAR
+            motor  : Motor;
+            motors : ARRAY[0..1] OF Motor;
+        END_VAR
+            motor := (name := 'Motor1', speed := 10.5);
+            motors[1] := (name := 'Motor2', speed := 20.5);
+        END_PROGRAM
+        "#,
+    );
+    filtered_assert_snapshot!(result, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %prg = type { %Motor, [2 x %Motor] }
+    %Motor = type { [21 x i8], float }
+
+    @prg_instance = global %prg zeroinitializer
+    @utf08_literal_0 = private unnamed_addr constant [7 x i8] c"Motor1\00"
+    @utf08_literal_1 = private unnamed_addr constant [7 x i8] c"Motor2\00"
+    @.const_init = private unnamed_addr constant %Motor { [21 x i8] c"Motor1\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", float 1.050000e+01 }
+    @.const_init.1 = private unnamed_addr constant %Motor { [21 x i8] c"Motor2\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", float 2.050000e+01 }
+
+    define void @prg(ptr %0) {
+    entry:
+      %motor = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 0
+      %motors = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 1
+      call void @llvm.memcpy.p0.p0.i64(ptr align [filtered] %motor, ptr align [filtered] @.const_init, i64 ptrtoint (ptr getelementptr (%Motor, ptr null, i32 1) to i64), i1 false)
+      %tmpVar = getelementptr inbounds [2 x %Motor], ptr %motors, i32 0, i32 1
+      call void @llvm.memcpy.p0.p0.i64(ptr align [filtered] %tmpVar, ptr align [filtered] @.const_init.1, i64 ptrtoint (ptr getelementptr (%Motor, ptr null, i32 1) to i64), i1 false)
+      ret void
+    }
+
+    ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+    declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #0
+
+    attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+    "#);
+}
+
+#[test]
+fn struct_literal_member_from_string_variable_of_different_size() {
+    let result = codegen(
+        r#"
+        TYPE Motor : STRUCT
+            name  : STRING[20];
+            speed : REAL;
+        END_STRUCT END_TYPE
+
+        PROGRAM prg
+        VAR
+            motor      : Motor;
+            long_name  : STRING;
+            short_name : STRING[5];
+        END_VAR
+            motor := (name := long_name, speed := 1.0);
+            motor := (name := short_name, speed := 2.0);
+        END_PROGRAM
+        "#,
+    );
+    filtered_assert_snapshot!(result, @r#"
+    ; ModuleID = '<internal>'
+    source_filename = "<internal>"
+    target datalayout = "[filtered]"
+    target triple = "[filtered]"
+
+    %prg = type { %Motor, [81 x i8], [6 x i8] }
+    %Motor = type { [21 x i8], float }
+
+    @prg_instance = global %prg zeroinitializer
+    @.const_init = private unnamed_addr constant %Motor zeroinitializer
+    @.const_init.1 = private unnamed_addr constant %Motor zeroinitializer
+
+    define void @prg(ptr %0) {
+    entry:
+      %motor = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 0
+      %long_name = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 1
+      %short_name = getelementptr inbounds nuw %prg, ptr %0, i32 0, i32 2
+      %struct_literal = alloca %Motor, align [filtered]
+      call void @llvm.memcpy.p0.p0.i64(ptr align [filtered] %struct_literal, ptr align [filtered] @.const_init, i64 ptrtoint (ptr getelementptr (%Motor, ptr null, i32 1) to i64), i1 false)
+      %name = getelementptr inbounds nuw %Motor, ptr %struct_literal, i32 0, i32 0
+      call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] %name, ptr align [filtered] %long_name, i32 20, i1 false)
+      %speed = getelementptr inbounds nuw %Motor, ptr %struct_literal, i32 0, i32 1
+      store float 1.000000e+00, ptr %speed, align [filtered]
+      %1 = load %Motor, ptr %struct_literal, align [filtered]
+      store %Motor %1, ptr %motor, align [filtered]
+      %struct_literal1 = alloca %Motor, align [filtered]
+      call void @llvm.memcpy.p0.p0.i64(ptr align [filtered] %struct_literal1, ptr align [filtered] @.const_init.1, i64 ptrtoint (ptr getelementptr (%Motor, ptr null, i32 1) to i64), i1 false)
+      %name2 = getelementptr inbounds nuw %Motor, ptr %struct_literal1, i32 0, i32 0
+      call void @llvm.memcpy.p0.p0.i32(ptr align [filtered] %name2, ptr align [filtered] %short_name, i32 6, i1 false)
+      %speed3 = getelementptr inbounds nuw %Motor, ptr %struct_literal1, i32 0, i32 1
+      store float 2.000000e+00, ptr %speed3, align [filtered]
+      %2 = load %Motor, ptr %struct_literal1, align [filtered]
+      store %Motor %2, ptr %motor, align [filtered]
+      ret void
+    }
+
+    ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+    declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #0
+
+    ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+    declare void @llvm.memcpy.p0.p0.i32(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i32, i1 immarg) #0
+
+    attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+    "#);
+}

--- a/tests/lit/single/init/array_of_structs_with_sized_string_init.st
+++ b/tests/lit/single/init/array_of_structs_with_sized_string_init.st
@@ -1,0 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+TYPE Motor : STRUCT
+    name  : STRING[20];
+    speed : REAL;
+    id    : DINT;
+END_STRUCT END_TYPE
+
+FUNCTION main : DINT
+    VAR
+        motors : ARRAY[0..1] OF Motor := [
+            (name := 'Motor1', speed := 10.5, id := 1),
+            (name := 'Motor2', speed := 20.5, id := 2)
+        ];
+    END_VAR
+
+    // CHECK: Motor1 1
+    printf('%s %d$N', motors[0].name, motors[0].id);
+
+    // CHECK: Motor2 2
+    printf('%s %d$N', motors[1].name, motors[1].id);
+END_FUNCTION

--- a/tests/lit/single/init/struct_literal_assignment_with_sized_string.st
+++ b/tests/lit/single/init/struct_literal_assignment_with_sized_string.st
@@ -1,0 +1,23 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+TYPE Motor : STRUCT
+    name  : STRING[20];
+    speed : REAL;
+    id    : DINT;
+END_STRUCT END_TYPE
+
+FUNCTION main : DINT
+    VAR
+        motor  : Motor;
+        motors : ARRAY[0..1] OF Motor;
+    END_VAR
+
+    motor := (name := 'Motor1', speed := 10.5, id := 1);
+    motors[1] := (name := 'Motor2', speed := 20.5, id := 2);
+
+    // CHECK: Motor1 1
+    printf('%s %d$N', motor.name, motor.id);
+
+    // CHECK: Motor2 2
+    printf('%s %d$N', motors[1].name, motors[1].id);
+END_FUNCTION

--- a/tests/lit/single/init/struct_literal_member_from_string_variable.st
+++ b/tests/lit/single/init/struct_literal_member_from_string_variable.st
@@ -1,0 +1,22 @@
+// RUN: (%COMPILE %s && %RUN) | %CHECK %s
+
+TYPE Motor : STRUCT
+    name : STRING[20];
+    id   : DINT;
+END_STRUCT END_TYPE
+
+FUNCTION main : DINT
+    VAR
+        motor      : Motor;
+        long_name  : STRING := 'Motor3';
+        short_name : STRING[5] := 'M4';
+    END_VAR
+
+    motor := (name := long_name, id := 3);
+    // CHECK: Motor3 3
+    printf('%s %d$N', motor.name, motor.id);
+
+    motor := (name := short_name, id := 4);
+    // CHECK: M4 4
+    printf('%s %d$N', motor.name, motor.id);
+END_FUNCTION


### PR DESCRIPTION
Backport of #1912 to `release/1.0.x`.

Problem: A struct literal used as a value (array-of-struct initializers, or `x := (a := ..., b := ...)` in a body) inserted string members with the size of the value instead of the declared member size. The resulting IR is invalid; at `-Onone` LLVM corrupts the heap while lowering it, so `plc` crashes or panics at an unrelated place instead of reporting an error.

Solution: Struct literals with runtime member values are now materialized in a stack temporary and every member is written through the regular assignment path, so strings follow the same size rules as any assignment. Literal-only struct literals still fold into a single constant, now with strings sized to the declared member length.

Refs: PRG-4799

🤖 Generated with [Claude Code](https://claude.com/claude-code)
